### PR TITLE
updates to embedder service

### DIFF
--- a/.ai/README.md
+++ b/.ai/README.md
@@ -1,0 +1,161 @@
+# AI Assistant Integration for Kamiwaza SDK
+
+This directory implements a "Rules as Code" pattern for AI-assisted development on the Kamiwaza Python SDK, providing tool-agnostic guidance that works across Claude, Cursor, Windsurf, GitHub Copilot, and other AI coding assistants.
+
+## Overview
+
+The `.ai/` directory complements the existing CLAUDE.md documentation with:
+- **Tool-agnostic rules** that any AI assistant can reference
+- **SDK-specific prompts** for common development tasks
+- **Knowledge capture** of successful patterns and pitfalls in SDK development
+
+## Directory Structure
+
+```
+.ai/
+├── rules/              # SDK coding standards and patterns
+│   ├── core-principles.md    # YAGNI, KISS, and fundamental principles
+│   ├── style.md             # Python style and SDK conventions
+│   ├── sdk-patterns.md      # Architecture and design patterns
+│   └── testing.md           # Testing requirements and patterns
+├── prompts/            # Task-specific prompt templates
+│   ├── add-service.md       # Template for adding new API services
+│   ├── add-mixin.md         # Template for extending services with mixins
+│   ├── fix-test.md          # Template for debugging test failures
+│   ├── debug-auth.md        # Template for auth troubleshooting
+│   └── optimize-performance.md # Template for performance improvements
+└── knowledge/          # Captured SDK development knowledge
+    ├── successful/     # Proven patterns that work well
+    │   └── service-patterns.md  # Successful SDK design patterns
+    └── failures/       # Known pitfalls and how to avoid them
+        └── common-pitfalls.md   # Common SDK development mistakes
+```
+
+## How Different AI Tools Use This
+
+### Claude (via Claude Code)
+- Reads CLAUDE.md files for context automatically
+- Reference specific rules: "Follow the rules in @.ai/rules/sdk-patterns.md"
+- Use prompts as conversation starters: "Use @.ai/prompts/add-service.md template"
+
+### Cursor
+- Automatically indexes the .ai/ directory
+- Reference rules with `@.ai/rules/style.md`
+- Include prompts with `@.ai/prompts/add-mixin.md`
+
+### Windsurf
+- Similar to Cursor, indexes .ai/ directory
+- Can reference files directly in chat
+- Rules provide context for code generation
+
+### GitHub Copilot
+- Workspace includes .ai/ directory
+- Rules influence code suggestions
+- Comments can reference rule files
+
+### VS Code with Other Extensions
+- Most AI extensions can read workspace files
+- Reference rules in comments or chat
+- Copy prompts into extension interfaces
+
+## SDK-Specific Usage Examples
+
+### 1. Adding a New Service
+```bash
+# Reference the prompt template
+"I need to add a new service following @.ai/prompts/add-service.md"
+
+# Fill in the template variables:
+- SERVICE_NAME: embeddings
+- DESCRIPTION: handles text embedding generation
+- METHOD: POST
+- PATH: /embeddings/generate
+```
+
+### 2. Extending a Service with Mixins
+```bash
+# Use the mixin template
+"Add batch processing to models service using @.ai/prompts/add-mixin.md"
+
+# The AI will:
+- Create a new mixin following SDK patterns
+- Add it to the service composition
+- Include proper type hints and tests
+```
+
+### 3. Debugging Authentication Issues
+```bash
+# Reference auth debugging guide
+"I'm getting 401 errors, help me debug using @.ai/prompts/debug-auth.md"
+```
+
+### 4. Fixing Test Failures
+```bash
+# Get help with failing tests
+"Test test_download_model is failing with @.ai/prompts/fix-test.md"
+```
+
+## Key SDK Patterns to Remember
+
+### Service Architecture
+- **Lazy Loading**: Services created on first access
+- **Mixin Composition**: Complex services built from focused mixins  
+- **BaseService**: All services inherit common functionality
+
+### Data Models
+- **Pydantic Everywhere**: All API contracts use Pydantic models
+- **Forward Compatibility**: Models allow extra fields with `extra = "allow"`
+- **Type Safety**: Comprehensive type hints throughout
+
+### Error Handling
+- **Semantic Exceptions**: HTTP errors mapped to meaningful exceptions
+- **Automatic Retry**: Transient errors retried with backoff
+- **Auth Refresh**: 401s trigger automatic token refresh
+
+## Benefits of This Approach
+
+1. **Consistency**: Same patterns across all AI tools
+2. **Discoverability**: Easy to find relevant guidance
+3. **Learning**: Captured knowledge prevents repeated mistakes
+4. **Efficiency**: Prompt templates speed up common tasks
+5. **Quality**: Rules ensure SDK best practices
+
+## Relationship to CLAUDE.md
+
+This `.ai/` directory structure complements the existing CLAUDE.md files:
+
+- **CLAUDE.md**: High-level architecture and development commands
+- **.ai/rules/**: Concrete SDK patterns and standards
+- **.ai/prompts/**: Task-specific templates for SDK work
+- **.ai/knowledge/**: Lessons learned from SDK development
+
+Together, they create a comprehensive AI assistance framework for SDK development.
+
+## Contributing
+
+When adding new content:
+
+1. **Rules**: Focus on SDK-specific patterns and standards
+2. **Prompts**: Create templates for repetitive SDK tasks
+3. **Knowledge**: Document real issues and solutions
+4. **Keep it DRY**: Don't duplicate content between files
+
+## Quick Reference
+
+### Most Important Rules
+- @.ai/rules/core-principles.md - YAGNI, KISS, one task at a time
+- @.ai/rules/sdk-patterns.md - Service architecture and patterns
+- @.ai/rules/style.md - Python style and conventions
+
+### Common Tasks
+- @.ai/prompts/add-service.md - Adding new API services
+- @.ai/prompts/add-mixin.md - Extending services
+- @.ai/prompts/fix-test.md - Debugging test failures
+
+### Learn from Experience
+- @.ai/knowledge/successful/service-patterns.md - What works well
+- @.ai/knowledge/failures/common-pitfalls.md - What to avoid
+
+---
+
+*This is a living system. As we learn what works in SDK development, we'll evolve these patterns.*

--- a/.ai/knowledge/failures/common-pitfalls.md
+++ b/.ai/knowledge/failures/common-pitfalls.md
@@ -1,0 +1,221 @@
+# Common SDK Development Pitfalls
+
+## Returning Raw Dictionaries Instead of Pydantic Models
+
+### The Problem
+Early versions returned raw API responses:
+```python
+# ❌ Bad: Returns dict, no validation
+def get_model(self, model_id: str) -> dict:
+    return self._request("GET", f"/models/{model_id}")
+```
+
+### What Went Wrong
+- No IDE autocomplete
+- No runtime validation
+- API changes broke client code silently
+- Type hints were lies
+
+### The Fix
+```python
+# ✅ Good: Returns validated Pydantic model
+def get_model(self, model_id: str) -> Model:
+    response = self._request("GET", f"/models/{model_id}")
+    return Model(**response)
+```
+
+## Forgetting Forward Compatibility
+
+### The Problem
+Strict Pydantic models broke when API added fields:
+```python
+# ❌ Bad: Breaks when API adds new fields
+class Model(BaseModel):
+    id: str
+    name: str
+    # No Config, so extra fields cause errors
+```
+
+### What Happened
+- API added `description` field
+- All SDK calls started failing with ValidationError
+- Required emergency SDK update
+
+### The Fix
+```python
+# ✅ Good: Allows extra fields
+class Model(BaseModel):
+    id: str
+    name: str
+    
+    class Config:
+        extra = "allow"  # Future-proof
+```
+
+## Circular Import Issues
+
+### The Problem
+Services importing from client module:
+```python
+# ❌ In services/models.py
+from kamiwaza_client.client import KamiwazaClient  # Circular!
+
+class ModelsService:
+    def __init__(self, client: KamiwazaClient):
+        self.client = client
+```
+
+### Why It Failed
+- `client.py` imports `ModelsService`
+- `ModelsService` imports `KamiwazaClient`
+- Python import fails
+
+### The Fix
+```python
+# ✅ Good: Type hints only, no runtime import
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from kamiwaza_client.client import KamiwazaClient
+
+class ModelsService:
+    def __init__(self, client: "KamiwazaClient"):
+        self.client = client
+```
+
+## Mutable Default Arguments
+
+### The Problem
+```python
+# ❌ Bad: Mutable default
+def list_models(self, tags: list = []):
+    tags.append("user-tag")  # Modifies shared list!
+    return self._request("GET", "/models", params={"tags": tags})
+```
+
+### What Went Wrong
+- All calls shared the same list
+- Tags accumulated across calls
+- Extremely hard to debug
+
+### The Fix
+```python
+# ✅ Good: None default
+def list_models(self, tags: Optional[List[str]] = None):
+    if tags is None:
+        tags = []
+    return self._request("GET", "/models", params={"tags": tags})
+```
+
+## Not Handling Pagination
+
+### The Problem
+```python
+# ❌ Bad: Assumes all results fit in one page
+def list_all_models(self) -> List[Model]:
+    response = self._request("GET", "/models")
+    return [Model(**m) for m in response["items"]]
+```
+
+### What Happened
+- Worked in dev with 10 models
+- Failed in prod with 1000+ models
+- Only returned first 20 results
+
+### The Fix
+```python
+# ✅ Good: Handle pagination
+def list_all_models(self) -> List[Model]:
+    all_models = []
+    page = 1
+    while True:
+        response = self._request("GET", "/models", params={"page": page})
+        all_models.extend([Model(**m) for m in response["items"]])
+        if len(all_models) >= response["total"]:
+            break
+        page += 1
+    return all_models
+```
+
+## Synchronous File Operations in Async Context
+
+### The Problem
+```python
+# ❌ Bad: Blocks event loop
+async def download_model(self, model_id: str, path: Path):
+    content = await self._async_request("GET", f"/models/{model_id}/download")
+    path.write_bytes(content)  # Blocks!
+```
+
+### The Issue
+- Blocked entire async event loop
+- Other concurrent operations stalled
+- Performance degraded severely
+
+### The Fix
+```python
+# ✅ Good: Use async file I/O
+import aiofiles
+
+async def download_model(self, model_id: str, path: Path):
+    content = await self._async_request("GET", f"/models/{model_id}/download")
+    async with aiofiles.open(path, 'wb') as f:
+        await f.write(content)
+```
+
+## Memory Issues with Large Downloads
+
+### The Problem
+```python
+# ❌ Bad: Loads entire file into memory
+def download_file(self, url: str, path: Path):
+    response = requests.get(url)
+    path.write_bytes(response.content)  # Could be GBs!
+```
+
+### What Went Wrong
+- 2GB model file caused OOM
+- Process crashed
+- No progress indication
+
+### The Fix
+```python
+# ✅ Good: Stream in chunks
+def download_file(self, url: str, path: Path):
+    with requests.get(url, stream=True) as response:
+        with open(path, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+```
+
+## Race Conditions in Token Refresh
+
+### The Problem
+```python
+# ❌ Bad: Multiple threads refresh simultaneously
+def _ensure_authenticated(self):
+    if self._token_expired():
+        self._refresh_token()  # Race condition!
+```
+
+### What Happened
+- Thread A sees token expired, starts refresh
+- Thread B sees token expired, starts refresh
+- Double refresh causes errors
+
+### The Fix
+```python
+# ✅ Good: Use lock
+import threading
+
+class AuthManager:
+    def __init__(self):
+        self._refresh_lock = threading.Lock()
+    
+    def _ensure_authenticated(self):
+        if self._token_expired():
+            with self._refresh_lock:
+                # Check again inside lock
+                if self._token_expired():
+                    self._refresh_token()
+```

--- a/.ai/knowledge/successful/service-patterns.md
+++ b/.ai/knowledge/successful/service-patterns.md
@@ -1,0 +1,159 @@
+# Successful Service Patterns in Kamiwaza SDK
+
+## Lazy-Loading Services
+
+The SDK's lazy-loading pattern has proven highly effective:
+
+```python
+class KamiwazaClient:
+    @property
+    def models(self) -> ModelsService:
+        if not hasattr(self, '_models'):
+            self._models = ModelsService(self._client)
+        return self._models
+```
+
+### Why It Works
+1. **Reduced startup time** - Services only initialized when needed
+2. **Lower memory footprint** - Unused services never instantiated
+3. **Clean API** - Accessing services feels natural: `client.models.list()`
+4. **Single instance guarantee** - Each service created once per client
+
+## Mixin Composition for Complex Services
+
+The models service successfully uses mixins to organize ~20 methods:
+
+```python
+class ModelsService(
+    BaseService,
+    SearchMixin,
+    DownloadMixin, 
+    FileMixin,
+    ConfigMixin,
+    CompatibilityMixin
+):
+    pass
+```
+
+### Benefits Observed
+- Each mixin stays focused (50-100 lines)
+- Easy to find functionality
+- Simple to test in isolation
+- New features added without touching existing code
+
+## Progress Tracking with Context Managers
+
+Download operations use context managers for clean progress tracking:
+
+```python
+with DownloadTracker(total_size=file_size) as tracker:
+    for chunk in response.iter_content(chunk_size=8192):
+        file.write(chunk)
+        tracker.update(len(chunk))
+```
+
+### Why This Pattern Succeeds
+- Automatic cleanup on errors
+- Works with or without TTY
+- Easy to disable for CI/CD
+- Minimal performance overhead
+
+## Pydantic for API Contracts
+
+Using Pydantic models for all API interactions has prevented numerous bugs:
+
+```python
+class Model(BaseModel):
+    id: str
+    name: str = Field(..., min_length=1)
+    created_at: datetime
+    
+    class Config:
+        extra = "allow"  # Forward compatibility
+```
+
+### Benefits in Production
+1. **Automatic validation** catches API changes
+2. **IDE autocomplete** improves developer experience
+3. **Forward compatibility** with `extra = "allow"`
+4. **Automatic JSON serialization** for requests
+
+## Centralized Authentication
+
+Having `AuthenticationManager` handle all auth concerns works well:
+
+```python
+class AuthenticationManager:
+    def get_headers(self) -> dict:
+        if self.api_key:
+            return {"X-API-Key": self.api_key}
+        elif self.token:
+            return {"Authorization": f"Bearer {self.token}"}
+```
+
+### Advantages
+- Single place to update auth logic
+- Easy to add new auth methods
+- Automatic token refresh hidden from services
+- Consistent error handling
+
+## Error Hierarchy
+
+The exception hierarchy maps HTTP errors to semantic exceptions:
+
+```python
+try:
+    response = self._request(...)
+except HTTPError as e:
+    if e.response.status_code == 404:
+        raise ResourceNotFoundError(...)
+    elif e.response.status_code == 401:
+        raise AuthenticationError(...)
+```
+
+### Why It Works
+- Callers can catch specific errors
+- Error messages are user-friendly
+- Original context preserved
+- Easy to handle errors appropriately
+
+## Request Retry Logic
+
+The SDK implements smart retry logic in `BaseService`:
+
+```python
+def _request_with_retry(self, method, url, **kwargs):
+    for attempt in range(self.max_retries):
+        try:
+            return self._request(method, url, **kwargs)
+        except (Timeout, ConnectionError) as e:
+            if attempt == self.max_retries - 1:
+                raise
+            time.sleep(2 ** attempt)  # Exponential backoff
+```
+
+### Success Factors
+- Only retries transient errors
+- Exponential backoff prevents thundering herd
+- Configurable max retries
+- Preserves original error on final failure
+
+## Type-Safe Configuration
+
+Using Pydantic Settings for configuration has prevented many bugs:
+
+```python
+class SDKConfig(BaseSettings):
+    api_key: Optional[str] = None
+    base_url: str = "https://api.kamiwaza.ai"
+    timeout: int = 30
+    
+    class Config:
+        env_prefix = "KAMIWAZA_"
+```
+
+### Benefits
+- Environment variables automatically loaded
+- Type validation at startup
+- Clear documentation of all settings
+- Easy to test with different configs

--- a/.ai/prompts/add-mixin.md
+++ b/.ai/prompts/add-mixin.md
@@ -1,0 +1,73 @@
+# Add Mixin to Existing Service
+
+I need to add a new mixin for the `{SERVICE_NAME}` service that adds {FEATURE} functionality.
+
+## Context
+
+The {SERVICE_NAME} service currently has these mixins:
+- {EXISTING_MIXINS}
+
+I need to add a new mixin that will:
+- {MIXIN_PURPOSE}
+
+## Implementation Steps
+
+Please:
+1. Review existing mixins in `kamiwaza_client/services/{SERVICE_NAME}/`
+2. Create new mixin file: `kamiwaza_client/services/{SERVICE_NAME}/{MIXIN_NAME}.py`
+3. Add mixin to service class inheritance
+4. Update schemas if new models are needed
+5. Add unit tests for new functionality
+6. Ensure proper type hints throughout
+
+## Mixin Template
+
+```python
+# services/{SERVICE_NAME}/{MIXIN_NAME}.py
+from typing import List, Optional, Dict, Any
+from kamiwaza_client.schemas.{SERVICE_NAME} import {NewSchema}
+
+class {MixinName}Mixin:
+    """Mixin for {FEATURE} functionality."""
+    
+    def {method_name}(self, **kwargs) -> {ReturnType}:
+        """{METHOD_DESCRIPTION}
+        
+        Args:
+            {ARG_NAME}: {ARG_DESCRIPTION}
+            
+        Returns:
+            {RETURN_DESCRIPTION}
+            
+        Raises:
+            {ERROR_TYPE}: {ERROR_CONDITION}
+        """
+        # Implementation using self._request()
+        response = self._request("POST", f"/{SERVICE_NAME}/{ENDPOINT}", json=kwargs)
+        return {ReturnType}(**response)
+```
+
+## Integration Example
+
+```python
+# services/{SERVICE_NAME}/base.py
+from kamiwaza_client.services.base_service import BaseService
+from .{EXISTING_MIXIN} import {ExistingMixin}
+from .{MIXIN_NAME} import {MixinName}Mixin  # Add new import
+
+class {ServiceName}Service(
+    BaseService,
+    {ExistingMixin},
+    {MixinName}Mixin  # Add to inheritance
+):
+    """Service with all mixins."""
+    pass
+```
+
+## Testing Requirements
+
+Tests should cover:
+- Normal operation of new methods
+- Error handling (404, 400, etc.)
+- Edge cases specific to the feature
+- Integration with existing functionality

--- a/.ai/prompts/add-service.md
+++ b/.ai/prompts/add-service.md
@@ -1,0 +1,95 @@
+# Add New Service to SDK
+
+I need to add a new service for `{SERVICE_NAME}` that will handle {DESCRIPTION}.
+
+## Requirements
+
+The service should:
+- Follow the SDK's lazy-loading service pattern
+- Include proper Pydantic schemas for all API contracts
+- Implement comprehensive error handling
+- Add appropriate type hints
+- Include unit tests with mocked HTTP calls
+
+## API Endpoints to Implement
+
+The service will implement these endpoints:
+- `{METHOD} /api/v1/{PATH}` - {ENDPOINT_DESCRIPTION}
+
+## Implementation Checklist
+
+Please:
+1. First check if similar services exist in `kamiwaza_client/services/`
+2. Review the base service pattern in `base_service.py`
+3. Create schema models in `kamiwaza_client/schemas/{SERVICE_NAME}.py`
+4. Implement service in `kamiwaza_client/services/{SERVICE_NAME}.py`
+5. Add service property to `KamiwazaClient` class
+6. Create unit tests in `tests/unit/services/test_{SERVICE_NAME}.py`
+7. Update `__init__.py` exports as needed
+
+## Schema Structure Example
+
+```python
+# schemas/{SERVICE_NAME}.py
+from pydantic import BaseModel
+from typing import Optional, List
+from datetime import datetime
+
+class {ResourceName}(BaseModel):
+    """Single resource representation."""
+    id: str
+    name: str
+    # Add fields based on API response
+    
+    class Config:
+        extra = "allow"  # Forward compatibility
+
+class {ResourceName}List(BaseModel):
+    """Paginated list response."""
+    items: List[{ResourceName}]
+    total: int
+    page: int = 1
+    per_page: int = 20
+```
+
+## Service Structure Example
+
+```python
+# services/{SERVICE_NAME}.py
+from typing import List, Optional
+from kamiwaza_client.services.base_service import BaseService
+from kamiwaza_client.schemas.{SERVICE_NAME} import {ResourceName}, {ResourceName}List
+
+class {ServiceName}Service(BaseService):
+    """Service for {SERVICE_NAME} operations."""
+    
+    def list(self, **kwargs) -> {ResourceName}List:
+        """List {RESOURCES}."""
+        response = self._request("GET", "/{SERVICE_NAME}", params=kwargs)
+        return {ResourceName}List(**response)
+    
+    def get(self, resource_id: str) -> {ResourceName}:
+        """Get specific {RESOURCE}."""
+        response = self._request("GET", f"/{SERVICE_NAME}/{resource_id}")
+        return {ResourceName}(**response)
+```
+
+## Testing Template
+
+```python
+# tests/unit/services/test_{SERVICE_NAME}.py
+import pytest
+from unittest.mock import Mock
+from kamiwaza_client.services.{SERVICE_NAME} import {ServiceName}Service
+from kamiwaza_client.schemas.{SERVICE_NAME} import {ResourceName}
+
+class Test{ServiceName}Service:
+    @pytest.fixture
+    def service(self):
+        client = Mock()
+        return {ServiceName}Service(client)
+    
+    def test_list_{RESOURCES}(self, service):
+        # Test implementation
+        pass
+```

--- a/.ai/prompts/debug-auth.md
+++ b/.ai/prompts/debug-auth.md
@@ -1,0 +1,90 @@
+# Debug Authentication Issue
+
+I'm experiencing an authentication issue with the SDK. The error is:
+```
+{ERROR_MESSAGE}
+```
+
+## Context
+
+- **Authentication Method**: [API Key / OAuth]
+- **Environment**: [Production / Development]
+- **SDK Version**: {VERSION}
+
+## Investigation Steps
+
+Please help me:
+1. Check the AuthenticationManager setup
+2. Verify credential format and validity
+3. Review request headers being sent
+4. Check for token expiration (OAuth)
+5. Identify any recent changes
+
+## Common Authentication Issues
+
+### API Key Issues
+```python
+# ❌ Wrong: Using Bearer format for API key
+client = KamiwazaClient(api_key="Bearer sk-...")
+
+# ✅ Correct: Just the key
+client = KamiwazaClient(api_key="sk-...")
+
+# ❌ Wrong: Wrong header name
+headers = {"Authorization": api_key}
+
+# ✅ Correct: SDK uses X-API-Key
+headers = {"X-API-Key": api_key}
+```
+
+### OAuth Token Issues
+```python
+# Check token expiration
+if auth_manager.token_expired():
+    auth_manager.refresh_token()
+
+# Enable debug logging
+import logging
+logging.basicConfig(level=logging.DEBUG)
+```
+
+### Environment Variable Issues
+```bash
+# ❌ Wrong: Quotes in .env file
+KAMIWAZA_API_KEY="sk-12345"
+
+# ✅ Correct: No quotes
+KAMIWAZA_API_KEY=sk-12345
+```
+
+## Debug Helpers
+
+### Log Request Headers
+```python
+# Enable request logging
+import requests
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+requests_log = logging.getLogger("requests.packages.urllib3")
+requests_log.setLevel(logging.DEBUG)
+```
+
+### Test Authentication
+```python
+# Minimal test to verify auth
+client = KamiwazaClient(api_key="your-key")
+try:
+    models = client.models.list(limit=1)
+    print("Auth successful!")
+except AuthenticationError as e:
+    print(f"Auth failed: {e}")
+```
+
+## Resolution Steps
+
+1. Verify credentials are correct
+2. Check credential format matches expected
+3. Ensure environment variables are loaded
+4. Test with curl to isolate SDK issues
+5. Enable debug logging for more details

--- a/.ai/prompts/fix-test.md
+++ b/.ai/prompts/fix-test.md
@@ -1,0 +1,64 @@
+# Fix Failing Test
+
+I have a failing test in `{TEST_FILE}` with this error:
+```
+{ERROR_OUTPUT}
+```
+
+## Investigation Steps
+
+Please:
+1. Read the failing test to understand what it's testing
+2. Check the implementation being tested
+3. Determine if the issue is:
+   - Test is outdated (implementation changed)
+   - Implementation has a bug
+   - Mock setup is incorrect
+   - Schema validation issue
+
+## Common SDK Test Issues
+
+### Mock Setup Problems
+```python
+# ❌ Wrong: Mock returns wrong structure
+mock_client.request.return_value = ["item1", "item2"]
+
+# ✅ Correct: Return dict matching API response
+mock_client.request.return_value = {
+    "items": [{"id": "1", "name": "item1"}],
+    "total": 2
+}
+```
+
+### Schema Validation Errors
+```python
+# ❌ Wrong: Missing required fields
+response = {"name": "Test"}  # Missing 'id' field
+
+# ✅ Correct: Include all required fields
+response = {"id": "123", "name": "Test"}
+```
+
+### Async Test Issues
+```python
+# ❌ Wrong: Not awaiting async method
+result = service.async_method()
+
+# ✅ Correct: Await or use pytest-asyncio
+result = await service.async_method()
+```
+
+## Fix Approach
+
+Based on the error type:
+1. **AssertionError**: Check test expectations vs actual behavior
+2. **ValidationError**: Ensure mock data matches Pydantic schema
+3. **AttributeError**: Verify mock setup and method names
+4. **ImportError**: Check module paths and dependencies
+
+## Verification
+
+After fixing:
+1. Run the specific test: `pytest {TEST_FILE}::{test_name} -v`
+2. Run related tests: `pytest {TEST_DIRECTORY} -k {PATTERN}`
+3. Ensure no regression: `pytest`

--- a/.ai/prompts/optimize-performance.md
+++ b/.ai/prompts/optimize-performance.md
@@ -1,0 +1,125 @@
+# Optimize SDK Performance
+
+I need to optimize the performance of {OPERATION} which is currently {ISSUE_DESCRIPTION}.
+
+## Performance Metrics
+
+- **Current latency**: {CURRENT_METRICS}
+- **Target latency**: {TARGET_METRICS}
+- **Bottleneck**: {IDENTIFIED_BOTTLENECK}
+
+## Investigation Steps
+
+Please:
+1. Profile the current implementation
+2. Identify performance bottlenecks
+3. Propose optimizations following SDK patterns
+4. Implement changes incrementally
+5. Measure improvement after each change
+
+## Common SDK Performance Issues
+
+### Lazy Loading Not Working
+```python
+# ❌ Wrong: Service initialized eagerly
+class KamiwazaClient:
+    def __init__(self, **kwargs):
+        self.models = ModelsService(self._client)  # Eager
+
+# ✅ Correct: Service initialized on access
+class KamiwazaClient:
+    @property
+    def models(self):
+        if not hasattr(self, '_models'):
+            self._models = ModelsService(self._client)
+        return self._models
+```
+
+### N+1 Query Pattern
+```python
+# ❌ Wrong: Multiple API calls
+models = []
+for model_id in model_ids:
+    model = client.models.get(model_id)  # N API calls
+    models.append(model)
+
+# ✅ Correct: Batch operation
+models = client.models.list(ids=model_ids)  # 1 API call
+```
+
+### Large Response Handling
+```python
+# ❌ Wrong: Load everything into memory
+all_models = client.models.list(limit=10000)
+
+# ✅ Correct: Use pagination
+for page in client.models.iter_pages(per_page=100):
+    for model in page.items:
+        process(model)  # Process incrementally
+```
+
+### Connection Pooling
+```python
+# ✅ Use session for connection reuse
+class BaseService:
+    def __init__(self, client):
+        self._session = requests.Session()
+        self._session.headers.update(client.get_headers())
+```
+
+## Optimization Techniques
+
+### 1. Request Optimization
+- Batch multiple operations
+- Use appropriate page sizes
+- Implement request caching
+- Reuse HTTP connections
+
+### 2. Data Processing
+- Stream large responses
+- Use generators for iteration
+- Process data incrementally
+- Avoid loading all data into memory
+
+### 3. Async Operations
+```python
+# For concurrent operations
+import asyncio
+
+async def download_multiple(model_ids):
+    tasks = [download_model(mid) for mid in model_ids]
+    return await asyncio.gather(*tasks)
+```
+
+### 4. Caching Strategy
+```python
+from functools import lru_cache
+
+class ModelsService:
+    @lru_cache(maxsize=128)
+    def get_model_cached(self, model_id: str):
+        return self.get(model_id)
+```
+
+## Measurement
+
+### Before/After Timing
+```python
+import time
+
+start = time.time()
+result = operation()
+duration = time.time() - start
+print(f"Operation took {duration:.2f} seconds")
+```
+
+### Memory Profiling
+```python
+import tracemalloc
+
+tracemalloc.start()
+result = operation()
+current, peak = tracemalloc.get_traced_memory()
+print(f"Memory: current={current/1024/1024:.1f}MB, peak={peak/1024/1024:.1f}MB")
+tracemalloc.stop()
+```

--- a/.ai/rules/core-principles.md
+++ b/.ai/rules/core-principles.md
@@ -1,0 +1,200 @@
+# Core Engineering Principles for Kamiwaza SDK
+
+## The Prime Directives
+1. **Think First, Code Second** - Always plan before implementing
+2. **One Task at a Time** - Complete vertically before moving horizontally  
+3. **Search Before Creating** - Existing code is your friend
+4. **Simple Beats Clever** - YAGNI, KISS, and boring solutions win
+5. **Tests Are Mandatory** - No exceptions, no "fix it later"
+
+## YAGNI (You Aren't Gonna Need It)
+Only build what's required RIGHT NOW. Don't add features "just in case."
+
+### SDK Examples
+```python
+# ❌ Wrong: Adding unnecessary abstractions
+class AbstractModelDownloader(ABC):
+    """We only have one downloader, this is premature"""
+    
+# ✅ Correct: Direct implementation
+class ModelDownloader:
+    """Simple, works, can abstract later if needed"""
+```
+
+## KISS (Keep It Simple, Stupid)
+The best solution is the most boring solution. If you can't explain it in one sentence, it's too complex.
+
+### SDK Examples
+```python
+# ❌ Wrong: Over-engineered
+def get_model(self, id: str) -> Model:
+    return self._execute_with_retry(
+        lambda: self._cache.get_or_fetch(
+            id, lambda: self._fetch_with_transform(id)
+        )
+    )
+
+# ✅ Correct: Simple and clear
+def get_model(self, id: str) -> Model:
+    response = self._request("GET", f"/models/{id}")
+    return Model(**response)
+```
+
+## The Rule of Three (DRY with Discipline)
+1. First occurrence: Write it
+2. Second occurrence: Copy it, note duplication  
+3. Third occurrence: Extract to shared function
+
+### SDK Example
+```python
+# First service: Write auth header logic
+headers = {"Authorization": f"Bearer {self.token}"}
+
+# Second service: Copy it, note duplication
+headers = {"Authorization": f"Bearer {self.token}"}  # TODO: Duplicated
+
+# Third service: Now extract
+def _get_auth_headers(self) -> dict:
+    return {"Authorization": f"Bearer {self.token}"}
+```
+
+## Walking Skeleton (Incremental Development)
+Start with the thinnest working version. Add flesh incrementally.
+
+### SDK Development Flow
+```python
+# Step 1: Skeleton - Just make it work
+def download_model(self, model_id: str) -> str:
+    url = f"{self.base_url}/models/{model_id}/download"
+    response = requests.get(url)
+    return response.json()["download_url"]
+
+# Step 2: Add error handling
+def download_model(self, model_id: str) -> str:
+    try:
+        response = self._request("GET", f"/models/{model_id}/download")
+        return response["download_url"]
+    except HTTPError as e:
+        if e.response.status_code == 404:
+            raise ModelNotFoundError(f"Model {model_id} not found")
+        raise
+
+# Step 3: Add progress tracking (only after basics work)
+def download_model(self, model_id: str, progress_callback=None) -> str:
+    # ... existing logic plus progress
+```
+
+## Vertical Slices Only
+Complete one feature fully before starting another.
+
+### SDK Example
+```
+✅ Correct: Complete models.get() fully
+1. Implement ModelsService.get()
+2. Add Model schema
+3. Add error handling  
+4. Write tests
+5. Document method
+
+❌ Wrong: Implement all methods partially
+1. Stub out all ModelsService methods
+2. Then add schemas for everything
+3. Then add tests for everything
+```
+
+## Checkpoint Every 30 Minutes
+Regular verification prevents drift:
+```bash
+pwd                    # Still in right directory?
+python -m pytest      # Tests still passing?
+git diff              # What changed?
+# Am I still on task?
+```
+
+## Scope Creep Prevention
+When tempted to add "improvements":
+```
+STOP. 
+1. Complete current task
+2. Document improvement separately
+3. Get approval before implementing
+```
+
+### SDK Example
+```python
+# Task: Add model download
+# Temptation: "While I'm here, let me add caching"
+# Action: STOP. Complete download first. Note caching idea.
+```
+
+## Recovery Procedures
+
+### When Lost in Code
+```bash
+# STOP and reorient
+pwd
+git status
+git diff
+# Reread task definition
+# Confirm next action
+```
+
+### When Tests Fail
+```bash
+# STOP and isolate
+git diff HEAD  # What changed?
+git stash      # Save work
+git checkout HEAD~1  # Go to last working state
+# Apply changes incrementally
+```
+
+### When Overengineering
+1. Comment out abstractions
+2. Write direct implementation
+3. Verify it works
+4. Only add complexity if truly needed
+
+## Red Flags - Stop Immediately
+
+### Phrases That Signal Problems
+- "Let me create a base class for future use"
+- "I'll implement all endpoints first"
+- "While I'm here, I'll also..."
+- "I'll fix the tests later"
+- "This might be useful someday"
+
+### Actions That Signal Problems
+- Creating interfaces with single implementation
+- Adding features not in requirements
+- Skipping tests to "save time"
+- Refactoring working code without reason
+- Adding abstraction layers "just in case"
+
+## Quality Gates
+
+### Cannot Start Coding Until
+1. ✅ Task defined clearly
+2. ✅ Existing code searched
+3. ✅ Test approach planned
+4. ✅ Success criteria clear
+
+### Must Stop and Review If
+- Method exceeds 50 lines
+- Class exceeds 300 lines
+- Can't explain purpose in one sentence
+- Tests start failing
+- Scope expanding beyond original task
+
+### Cannot Complete Task Until
+1. ✅ Tests written and passing
+2. ✅ Type hints complete
+3. ✅ Error handling in place
+4. ✅ Original requirement met (nothing more)
+5. ✅ Code formatted (black/isort)
+
+## Daily Affirmations
+- Boring code is good code
+- Working code beats clever code
+- Simple today, refactor tomorrow (if needed)
+- YAGNI until YAGNI
+- Tests are not optional

--- a/.ai/rules/sdk-patterns.md
+++ b/.ai/rules/sdk-patterns.md
@@ -1,0 +1,302 @@
+# SDK Architecture and Patterns
+
+## Client-Service Architecture
+
+The SDK follows a lazy-loading service pattern:
+
+```python
+# Main client acts as orchestrator
+class KamiwazaClient:
+    @property
+    def models(self) -> ModelsService:
+        # Services instantiated only when accessed
+        if not hasattr(self, '_models'):
+            self._models = ModelsService(self._client)
+        return self._models
+```
+
+### Key Principles
+1. **Lazy Loading**: Services created on first access
+2. **Single Instance**: One service instance per client
+3. **Shared HTTP Client**: All services share authenticated client
+4. **Clean Separation**: Client orchestrates, services implement
+
+## Service Layer Pattern
+
+Every service MUST follow this structure:
+
+```python
+from kamiwaza_client.services.base_service import BaseService
+from kamiwaza_client.schemas.models import Model, ModelList
+
+class ModelsService(BaseService):
+    """Service for model-related operations."""
+    
+    def list(self, **kwargs) -> ModelList:
+        """Public method returns Pydantic models."""
+        response = self._request("GET", "/models", params=kwargs)
+        return ModelList(**response)
+    
+    def get(self, model_id: str) -> Model:
+        """Always use domain objects, not raw dicts."""
+        response = self._request("GET", f"/models/{model_id}")
+        return Model(**response)
+```
+
+### Service Rules
+1. Inherit from `BaseService`
+2. Use `self._request()` for HTTP calls
+3. Return Pydantic models, not raw responses
+4. Handle service-specific errors
+5. Keep business logic in service, not in schemas
+
+## Mixin Pattern for Complex Services
+
+For services with many features, use mixins:
+
+```python
+# services/models/base.py
+class ModelsService(
+    BaseService,
+    SearchMixin,
+    DownloadMixin,
+    FileMixin,
+    ConfigMixin
+):
+    """Composed from focused mixins."""
+    pass
+
+# services/models/search.py
+class SearchMixin:
+    """Search-specific functionality."""
+    
+    def search(self, query: str, **kwargs) -> ModelSearchResults:
+        response = self._request("POST", "/models/search", json={
+            "query": query,
+            **kwargs
+        })
+        return ModelSearchResults(**response)
+```
+
+### Mixin Guidelines
+1. One mixin per feature area
+2. Mixins can depend on `BaseService` methods
+3. Keep mixins focused and cohesive
+4. Document mixin dependencies
+
+## Schema Design Patterns
+
+### Request/Response Models
+```python
+from pydantic import BaseModel, Field
+from typing import Optional, List
+from datetime import datetime
+
+class Model(BaseModel):
+    """Single model representation."""
+    id: str
+    name: str
+    family: str
+    created_at: datetime
+    metadata: Optional[dict] = Field(default_factory=dict)
+    
+    class Config:
+        # Allow field population from API responses
+        extra = "allow"
+
+class ModelList(BaseModel):
+    """Paginated list response."""
+    items: List[Model]
+    total: int
+    page: int = 1
+    per_page: int = 20
+```
+
+### Schema Rules
+1. Use Pydantic for all API contracts
+2. Allow `extra` fields for forward compatibility
+3. Provide sensible defaults where appropriate
+4. Use `Field()` for validation constraints
+5. Keep schemas in dedicated modules
+
+## Authentication Pattern
+
+Authentication is handled centrally:
+
+```python
+class AuthenticationManager:
+    """Manages all authentication concerns."""
+    
+    def get_headers(self) -> dict:
+        """Returns current auth headers."""
+        if self.api_key:
+            return {"X-API-Key": self.api_key}
+        elif self.token:
+            return {"Authorization": f"Bearer {self.token}"}
+    
+    def handle_auth_error(self, response):
+        """Refresh token if needed."""
+        if response.status_code == 401 and self.refresh_token:
+            self._refresh_access_token()
+            return True  # Retry request
+        return False
+```
+
+### Auth Guidelines
+1. Never expose credentials in logs
+2. Support both API key and OAuth
+3. Auto-refresh OAuth tokens
+4. Centralize auth logic
+5. Make auth transparent to services
+
+## Error Handling Hierarchy
+
+```python
+# exceptions.py
+class KamiwazaError(Exception):
+    """Base exception for all SDK errors."""
+    pass
+
+class KamiwazaAPIError(KamiwazaError):
+    """API request failed."""
+    pass
+
+class AuthenticationError(KamiwazaAPIError):
+    """401/403 responses."""
+    pass
+
+class ResourceNotFoundError(KamiwazaAPIError):
+    """404 responses."""
+    pass
+
+class ValidationError(KamiwazaAPIError):
+    """400/422 responses."""
+    pass
+```
+
+### Error Handling Rules
+1. Map HTTP codes to semantic exceptions
+2. Preserve original error context
+3. Provide helpful error messages
+4. Allow errors to bubble up
+5. Don't catch and re-wrap unnecessarily
+
+## Progress Tracking Pattern
+
+For long-running operations:
+
+```python
+from kamiwaza_client.utils.progress import ProgressTracker
+
+def download_model(self, model_id: str, path: Path) -> Path:
+    """Download with progress tracking."""
+    
+    # Get download metadata
+    info = self._get_download_info(model_id)
+    
+    # Create progress tracker
+    with ProgressTracker(total=info.size, desc=f"Downloading {info.name}") as tracker:
+        # Download in chunks
+        for chunk in self._download_chunks(info.url):
+            path.write_bytes(chunk)
+            tracker.update(len(chunk))
+    
+    return path
+```
+
+### Progress Guidelines
+1. Use for operations > 5 seconds
+2. Provide meaningful descriptions
+3. Update regularly but not too frequently
+4. Support both TTY and non-TTY environments
+5. Make progress tracking optional
+
+## Configuration Pattern
+
+```python
+from pydantic import BaseSettings
+
+class SDKConfig(BaseSettings):
+    """SDK-wide configuration."""
+    
+    api_key: Optional[str] = None
+    base_url: str = "https://api.kamiwaza.ai"
+    timeout: int = 30
+    max_retries: int = 3
+    
+    class Config:
+        env_prefix = "KAMIWAZA_"  # KAMIWAZA_API_KEY, etc.
+```
+
+### Config Rules
+1. Use Pydantic Settings for validation
+2. Support environment variables
+3. Provide sensible defaults
+4. Document all settings
+5. Keep config immutable after init
+
+## Testing Patterns
+
+### Service Testing
+```python
+import pytest
+from unittest.mock import Mock, patch
+
+class TestModelsService:
+    @pytest.fixture
+    def service(self):
+        client = Mock()
+        return ModelsService(client)
+    
+    @patch('requests.request')
+    def test_list_models(self, mock_request, service):
+        # Mock response
+        mock_request.return_value.json.return_value = {
+            "items": [{"id": "1", "name": "model1"}],
+            "total": 1
+        }
+        
+        # Test
+        result = service.list()
+        
+        # Verify
+        assert len(result.items) == 1
+        assert result.items[0].name == "model1"
+```
+
+### Testing Guidelines
+1. Mock HTTP calls, don't hit real API
+2. Test both success and error paths
+3. Verify request construction
+4. Test schema validation
+5. Keep tests fast and isolated
+
+## OpenAI Compatibility Layer
+
+Special pattern for drop-in compatibility:
+
+```python
+class OpenAIService:
+    """OpenAI-compatible interface."""
+    
+    @property
+    def chat(self):
+        return ChatCompletions(self._client)
+    
+    @property  
+    def completions(self):
+        return Completions(self._client)
+
+# Usage matches OpenAI SDK
+response = client.openai.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=[{"role": "user", "content": "Hello"}]
+)
+```
+
+### Compatibility Rules
+1. Match OpenAI method signatures exactly
+2. Convert between formats transparently
+3. Document any differences
+4. Support streaming responses
+5. Maintain backward compatibility

--- a/.ai/rules/style.md
+++ b/.ai/rules/style.md
@@ -1,0 +1,208 @@
+# Code Style Rules for Kamiwaza SDK
+
+## General Python Style
+
+### Formatting
+- **Black**: Line length 88 characters
+- **isort**: Black-compatible profile
+- **Type hints**: Required for all public methods and functions
+- **Docstrings**: Google style for complex methods
+
+### Naming Conventions
+- **Classes**: PascalCase (e.g., `KamiwazaClient`, `ModelsService`)
+- **Functions/Methods**: snake_case (e.g., `download_model`, `get_deployment`)
+- **Constants**: UPPER_SNAKE_CASE (e.g., `DEFAULT_TIMEOUT`, `API_VERSION`)
+- **Private methods**: Leading underscore (e.g., `_request`, `_validate_config`)
+
+## SDK-Specific Style
+
+### Service Method Patterns
+```python
+# Public methods return domain objects
+def list_models(self, **kwargs) -> List[Model]:
+    response = self._request("GET", "/models", params=kwargs)
+    return [Model(**item) for item in response["items"]]
+
+# Private methods handle internals
+def _request(self, method: str, path: str, **kwargs) -> dict:
+    # Implementation details
+```
+
+### Progress Tracking Pattern
+```python
+# Use context managers for progress
+with ProgressTracker() as tracker:
+    for item in items:
+        tracker.update(item)
+        # Process item
+```
+
+### Error Handling Pattern
+```python
+try:
+    response = self._request(...)
+except requests.HTTPError as e:
+    if e.response.status_code == 404:
+        raise ResourceNotFoundError(f"Model {model_id} not found")
+    raise KamiwazaAPIError(f"API request failed: {e}")
+```
+
+## Code Complexity Limits
+
+### Size Restrictions
+- **Functions**: 50 lines max (including docstring)
+- **Classes**: 300 lines max
+- **Files**: 500 lines max
+- **Methods per class**: 15 public methods max
+
+### Cyclomatic Complexity
+- **Per function**: Maximum 10
+- **Nested depth**: Maximum 4 levels
+
+When limits are exceeded:
+1. Extract helper methods
+2. Create mixins for related functionality
+3. Split into multiple modules
+
+## Import Organization
+
+```python
+# Standard library
+import os
+from typing import Optional, List, Dict, Any
+from pathlib import Path
+
+# Third-party
+import requests
+from pydantic import BaseModel, Field
+
+# Kamiwaza SDK
+from kamiwaza_client.exceptions import KamiwazaAPIError
+from kamiwaza_client.schemas.models import Model
+from kamiwaza_client.services.base_service import BaseService
+
+# Relative imports (within same package)
+from .mixins import SearchMixin
+from .utils import format_response
+```
+
+## Documentation Standards
+
+### Module Docstrings
+```python
+"""
+Module description in one line.
+
+Longer description explaining the module's purpose,
+main classes, and usage examples if relevant.
+"""
+```
+
+### Class Docstrings
+```python
+class ServiceClass:
+    """One-line summary.
+    
+    Longer description if needed.
+    
+    Attributes:
+        client: HTTP client instance
+        base_url: API base URL
+    """
+```
+
+### Method Docstrings (Complex Methods Only)
+```python
+def complex_method(self, param1: str, param2: Optional[int] = None) -> Dict[str, Any]:
+    """One-line summary.
+    
+    Args:
+        param1: Description of param1
+        param2: Description of param2 (default: None)
+        
+    Returns:
+        Description of return value
+        
+    Raises:
+        ValueError: When param1 is invalid
+        APIError: When API request fails
+    """
+```
+
+## Type Annotation Rules
+
+### Always Annotate
+- All public method parameters and returns
+- Class attributes in `__init__`
+- Module-level constants
+
+### Common Patterns
+```python
+# Optional parameters
+def method(self, required: str, optional: Optional[str] = None) -> bool:
+
+# Variable arguments
+def method(self, *args: str, **kwargs: Any) -> None:
+
+# Complex returns
+def method(self) -> Dict[str, List[Model]]:
+
+# Async methods
+async def method(self) -> List[Model]:
+```
+
+## Testing Style
+
+### Test Naming
+```python
+def test_should_return_models_when_valid_request():
+def test_should_raise_error_when_model_not_found():
+def test_should_handle_pagination_correctly():
+```
+
+### Test Organization
+```python
+class TestModelsService:
+    """Group related tests in classes."""
+    
+    def test_list_models(self):
+        """Each test method tests one behavior."""
+        
+    def test_download_model(self):
+        """Keep tests focused and independent."""
+```
+
+## Anti-Patterns to Avoid
+
+### Don't Use
+- `print()` statements (use logging)
+- Mutable default arguments
+- Bare `except:` clauses
+- Global variables
+- Hard-coded credentials or URLs
+
+### Don't Create
+- God classes (doing too much)
+- Deep inheritance hierarchies
+- Circular imports
+- Side effects in property getters
+
+## Performance Considerations
+
+### Lazy Loading
+```python
+@property
+def expensive_resource(self):
+    if not hasattr(self, '_expensive_resource'):
+        self._expensive_resource = self._load_resource()
+    return self._expensive_resource
+```
+
+### Batch Operations
+```python
+# Good: Single request for multiple items
+models = client.models.list(ids=model_ids)
+
+# Bad: Multiple requests
+models = [client.models.get(id) for id in model_ids]
+```

--- a/.ai/rules/testing.md
+++ b/.ai/rules/testing.md
@@ -1,0 +1,320 @@
+# Testing Standards for Kamiwaza SDK
+
+## Test Structure
+
+```
+tests/
+├── unit/
+│   ├── test_client.py
+│   ├── test_authentication.py
+│   ├── services/
+│   │   ├── test_models.py
+│   │   ├── test_serving.py
+│   │   └── test_openai.py
+│   └── schemas/
+│       ├── test_model_schemas.py
+│       └── test_serving_schemas.py
+├── integration/
+│   ├── test_api_endpoints.py
+│   └── test_auth_flow.py
+└── conftest.py
+```
+
+## Testing Principles
+
+### Test Categories
+1. **Unit Tests**: Fast, isolated, no external dependencies
+2. **Integration Tests**: Test against real API (marked with `@pytest.mark.integration`)
+3. **No E2E Tests**: SDK doesn't need end-to-end tests
+
+### Coverage Requirements
+- Minimum 80% coverage for new code
+- 100% coverage for error paths
+- All public methods must have tests
+
+## Unit Testing Patterns
+
+### Basic Service Test
+```python
+import pytest
+from unittest.mock import Mock, patch
+from kamiwaza_client.services.models import ModelsService
+from kamiwaza_client.exceptions import ResourceNotFoundError
+
+class TestModelsService:
+    @pytest.fixture
+    def mock_client(self):
+        """Create mock HTTP client."""
+        client = Mock()
+        client.request = Mock()
+        return client
+    
+    @pytest.fixture
+    def service(self, mock_client):
+        """Create service with mocked client."""
+        return ModelsService(mock_client)
+    
+    def test_get_model_success(self, service, mock_client):
+        """Test successful model retrieval."""
+        # Arrange
+        mock_client.request.return_value = {
+            "id": "model-123",
+            "name": "Test Model",
+            "family": "llama"
+        }
+        
+        # Act
+        model = service.get("model-123")
+        
+        # Assert
+        assert model.id == "model-123"
+        assert model.name == "Test Model"
+        mock_client.request.assert_called_once_with(
+            "GET", "/models/model-123"
+        )
+    
+    def test_get_model_not_found(self, service, mock_client):
+        """Test 404 handling."""
+        # Arrange
+        mock_client.request.side_effect = ResourceNotFoundError(
+            "Model not found"
+        )
+        
+        # Act & Assert
+        with pytest.raises(ResourceNotFoundError):
+            service.get("nonexistent")
+```
+
+### Schema Testing
+```python
+import pytest
+from datetime import datetime
+from kamiwaza_client.schemas.models import Model, ModelList
+
+class TestModelSchemas:
+    def test_model_from_dict(self):
+        """Test model creation from API response."""
+        data = {
+            "id": "model-123",
+            "name": "Test Model",
+            "family": "llama",
+            "created_at": "2024-01-01T00:00:00Z",
+            "extra_field": "ignored"  # Forward compatibility
+        }
+        
+        model = Model(**data)
+        
+        assert model.id == "model-123"
+        assert isinstance(model.created_at, datetime)
+        assert hasattr(model, "extra_field")  # Extra fields preserved
+    
+    def test_model_validation(self):
+        """Test schema validation."""
+        with pytest.raises(ValueError):
+            Model(id="123", name="")  # Empty name should fail
+```
+
+### Authentication Testing
+```python
+@pytest.fixture
+def auth_manager():
+    """Create auth manager for testing."""
+    return AuthenticationManager(api_key="test-key")
+
+def test_api_key_headers(auth_manager):
+    """Test API key authentication."""
+    headers = auth_manager.get_headers()
+    assert headers == {"X-API-Key": "test-key"}
+
+def test_oauth_token_refresh(auth_manager, mock_requests):
+    """Test OAuth token refresh flow."""
+    # Setup expired token
+    auth_manager.token = "expired"
+    auth_manager.refresh_token = "refresh"
+    
+    # Mock refresh endpoint
+    mock_requests.post.return_value.json.return_value = {
+        "access_token": "new-token",
+        "expires_in": 3600
+    }
+    
+    # Trigger refresh
+    auth_manager.handle_auth_error(Mock(status_code=401))
+    
+    # Verify
+    assert auth_manager.token == "new-token"
+```
+
+## Mocking Patterns
+
+### Mock HTTP Responses
+```python
+@pytest.fixture
+def mock_response():
+    """Create mock response object."""
+    def _mock(status_code=200, json_data=None, text=""):
+        response = Mock()
+        response.status_code = status_code
+        response.json.return_value = json_data or {}
+        response.text = text
+        response.raise_for_status = Mock()
+        if status_code >= 400:
+            response.raise_for_status.side_effect = HTTPError()
+        return response
+    return _mock
+```
+
+### Mock Progress Tracking
+```python
+@patch('kamiwaza_client.utils.progress.tqdm')
+def test_download_with_progress(mock_tqdm, service):
+    """Test progress tracking during download."""
+    # Progress should be updated
+    service.download_model("model-123", Path("/tmp/model"))
+    
+    # Verify progress bar created
+    mock_tqdm.assert_called_once()
+    mock_tqdm.return_value.update.assert_called()
+```
+
+## Test Fixtures
+
+### Common Fixtures
+```python
+# conftest.py
+import pytest
+from kamiwaza_client import KamiwazaClient
+
+@pytest.fixture
+def client():
+    """Create test client."""
+    return KamiwazaClient(api_key="test-key")
+
+@pytest.fixture
+def mock_requests(monkeypatch):
+    """Mock requests library."""
+    import requests
+    mock = Mock()
+    monkeypatch.setattr(requests, "request", mock)
+    return mock
+
+@pytest.fixture
+def temp_dir(tmp_path):
+    """Create temporary directory for downloads."""
+    return tmp_path / "kamiwaza_test"
+```
+
+## Testing Best Practices
+
+### Do's
+- ✅ Test one behavior per test
+- ✅ Use descriptive test names
+- ✅ Mock external dependencies
+- ✅ Test error conditions
+- ✅ Use fixtures for common setup
+
+### Don'ts
+- ❌ Don't test implementation details
+- ❌ Don't make actual API calls in unit tests
+- ❌ Don't use sleep() in tests
+- ❌ Don't depend on test order
+- ❌ Don't share state between tests
+
+## Error Path Testing
+
+### Required Error Tests
+```python
+def test_network_timeout(service, mock_client):
+    """Test timeout handling."""
+    mock_client.request.side_effect = TimeoutError()
+    
+    with pytest.raises(KamiwazaAPIError) as exc_info:
+        service.get("model-123")
+    
+    assert "timeout" in str(exc_info.value).lower()
+
+def test_invalid_json_response(service, mock_client):
+    """Test malformed response handling."""
+    mock_client.request.return_value = "not json"
+    
+    with pytest.raises(KamiwazaAPIError):
+        service.get("model-123")
+
+def test_rate_limit_handling(service, mock_client):
+    """Test 429 rate limit response."""
+    mock_client.request.side_effect = KamiwazaAPIError(
+        "Rate limit exceeded", status_code=429
+    )
+    
+    with pytest.raises(KamiwazaAPIError) as exc_info:
+        service.get("model-123")
+    
+    assert exc_info.value.status_code == 429
+```
+
+## Integration Testing
+
+### Mark Integration Tests
+```python
+@pytest.mark.integration
+class TestModelsIntegration:
+    """Tests that hit real API."""
+    
+    @pytest.fixture
+    def real_client(self):
+        """Create client with real credentials."""
+        # Get from env or skip test
+        api_key = os.getenv("KAMIWAZA_TEST_API_KEY")
+        if not api_key:
+            pytest.skip("No test API key")
+        return KamiwazaClient(api_key=api_key)
+    
+    def test_list_models_real(self, real_client):
+        """Test actual API call."""
+        models = real_client.models.list()
+        assert isinstance(models.items, list)
+        assert models.total >= 0
+```
+
+### Integration Test Guidelines
+1. Skip if credentials not available
+2. Use test/staging environment
+3. Clean up created resources
+4. Don't depend on specific data
+5. Mark clearly with `@pytest.mark.integration`
+
+## Test Commands
+
+```bash
+# Run all tests
+pytest
+
+# Run with coverage
+pytest --cov=kamiwaza_client --cov-report=html
+
+# Run only unit tests
+pytest -m "not integration"
+
+# Run specific test file
+pytest tests/unit/services/test_models.py
+
+# Run with verbose output
+pytest -v
+
+# Run failed tests from last run
+pytest --lf
+```
+
+## Continuous Integration
+
+### GitHub Actions Example
+```yaml
+- name: Run tests
+  run: |
+    pytest --cov=kamiwaza_client --cov-report=xml
+    
+- name: Upload coverage
+  uses: codecov/codecov-action@v3
+  with:
+    file: ./coverage.xml
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Kamiwaza SDK is a Python client library for the Kamiwaza AI Platform. It provides a type-safe, object-oriented interface to all Kamiwaza API endpoints with built-in authentication, error handling, and resource management.
 
+## AI Development Guidance
+
+This project uses a comprehensive AI assistance framework:
+- **Core principles**: Follow @.ai/rules/core-principles.md for YAGNI, KISS, and fundamental practices
+- **Code style**: Apply @.ai/rules/style.md for Python conventions and SDK patterns
+- **Architecture patterns**: Use @.ai/rules/sdk-patterns.md for service design
+- **Testing standards**: Follow @.ai/rules/testing.md for test requirements
+- **Task templates**: Use prompts in @.ai/prompts/ for common tasks
+
+See @.ai/README.md for the complete AI assistance framework.
+
 ## Common Development Commands
 
 ### Installation and Setup
@@ -18,113 +29,84 @@ Kamiwaza SDK is a Python client library for the Kamiwaza AI Platform. It provide
 - **Sort imports**: `isort kamiwaza_client/`
 - **Type checking**: `mypy kamiwaza_client/` (type stubs may need configuration)
 
-## Architecture and Code Organization
+### Testing
+- **Run all tests**: `pytest`
+- **Run with coverage**: `pytest --cov=kamiwaza_client --cov-report=html`
+- **Run unit tests only**: `pytest -m "not integration"`
+- **Run specific test**: `pytest tests/unit/services/test_models.py::TestModelsService::test_list_models`
 
-### Client-Service Architecture
-The SDK uses a lazy-loading service pattern where the main `KamiwazaClient` class acts as an orchestrator:
+## Architecture Overview
 
-```python
-# kamiwaza_client/client.py
-class KamiwazaClient:
-    @property
-    def models(self) -> ModelsService:
-        # Services are instantiated only when accessed
+### Client-Service Pattern
+The SDK uses a lazy-loading service architecture where `KamiwazaClient` orchestrates access to individual service modules. Services are instantiated only when first accessed, reducing memory footprint and startup time.
+
+For detailed patterns, see @.ai/rules/sdk-patterns.md.
+
+### Key Components
+
+1. **KamiwazaClient** (`client.py`): Main entry point, provides lazy-loaded service properties
+2. **BaseService** (`services/base_service.py`): Common functionality for all services
+3. **AuthenticationManager** (`authentication.py`): Handles API keys, OAuth tokens, and refresh
+4. **Schemas** (`schemas/`): Pydantic models for all API contracts
+5. **Exceptions** (`exceptions.py`): Semantic error hierarchy mapping HTTP codes
+
+### Service Composition
+Complex services use mixin composition for modularity:
+- `ModelsService` = BaseService + SearchMixin + DownloadMixin + FileMixin + ConfigMixin
+- Each mixin handles a specific feature area
+- See @.ai/knowledge/successful/service-patterns.md for why this works well
+
+## Quick Start for New Contributors
+
+### Adding a New Service
+Use @.ai/prompts/add-service.md template:
+```bash
+"Add a new service for embeddings following @.ai/prompts/add-service.md"
 ```
 
-### Service Layer Pattern
-Every service inherits from `BaseService` and follows this structure:
-- **Service Class**: Business logic and API endpoint methods
-- **Schema Module**: Pydantic models for request/response validation
-- **Mixins** (for complex services): Modular functionality (see `services/models/`)
-
-### Authentication Flow
-1. `KamiwazaClient` accepts API key or OAuth credentials
-2. `AuthenticationManager` handles token refresh and retry logic
-3. Each service inherits authenticated HTTP client from `BaseService`
-4. 401 errors trigger automatic token refresh
-
-### Key Architectural Decisions
-
-#### Mixin-Based Service Design
-The `models` service demonstrates sophisticated mixin composition:
-```
-ModelsService = BaseService + SearchMixin + DownloadMixin + FileMixin + ConfigMixin + CompatibilityMixin
-```
-This pattern allows modular feature composition while keeping individual mixins focused.
-
-#### Type Safety Throughout
-- All API contracts defined as Pydantic models in `schemas/`
-- Comprehensive type hints for IDE support
-- Runtime validation of inputs and outputs
-
-#### Error Handling Hierarchy
-Custom exceptions in `exceptions.py` map HTTP errors to semantic exceptions:
-- `KamiwazaAPIError` - Base exception
-- `AuthenticationError` - 401/403 responses
-- `ResourceNotFoundError` - 404 responses
-- `ValidationError` - 400/422 responses
-
-## Development Patterns
-
-### Adding New Service Endpoints
-1. Define Pydantic schemas in `schemas/{service_name}/`
-2. Add method to service class with proper type hints
-3. Use `self._request()` for HTTP calls (handles auth/retry)
-4. Update service documentation in `docs/services/`
-
-### Progress Tracking
-The SDK includes sophisticated progress tracking:
-- `DownloadTracker` - Tracks multi-file downloads
-- `ProgressFormatter` - Rich terminal output
-- Used for user feedback during long operations
-
-## Testing Guidelines
-
-**Current State**: No test infrastructure exists. When adding tests:
-
-### Recommended Test Structure
-```
-tests/
-├── unit/
-│   ├── services/
-│   │   ├── test_models.py
-│   │   └── test_serving.py
-│   ├── test_client.py
-│   └── test_authentication.py
-├── integration/
-│   └── test_api_endpoints.py
-└── conftest.py
+### Extending Existing Service
+Use @.ai/prompts/add-mixin.md template:
+```bash
+"Add batch operations to models service using @.ai/prompts/add-mixin.md"
 ```
 
-### Testing Patterns
-- Mock HTTP responses using `responses` or `httpx` test client
-- Test both success and error scenarios
-- Validate Pydantic schema serialization/deserialization
+### Debugging Issues
+- **Test failures**: @.ai/prompts/fix-test.md
+- **Auth problems**: @.ai/prompts/debug-auth.md
+- **Performance**: @.ai/prompts/optimize-performance.md
 
 ## Important Implementation Notes
 
-### Service Lazy Loading
-Services are properties that instantiate on first access. This pattern:
-- Reduces initial client creation overhead
-- Allows partial SDK usage without loading all services
-- Maintains single instance per service per client
+### Forward Compatibility
+All Pydantic models must use `Config.extra = "allow"` to handle new API fields gracefully. See @.ai/knowledge/failures/common-pitfalls.md for what happens without this.
 
-### Authentication State
-- API keys stored in `AuthenticationManager`
-- OAuth tokens cached with automatic refresh
-- Never log or expose authentication credentials
+### Progress Tracking
+Long-running operations (downloads, batch processing) should use the progress tracking framework with context managers. See examples in @.ai/knowledge/successful/service-patterns.md.
 
 ### OpenAI Compatibility
-The `openai` service provides drop-in compatibility:
-```python
-# Can be used with OpenAI client libraries
-client.openai.chat.completions.create(...)
-```
+The `openai` service provides drop-in compatibility with OpenAI's client library, translating between Kamiwaza and OpenAI formats transparently.
 
-## Code Style
+## Testing Philosophy
 
-- **Black**: 88 character line length
-- **isort**: Black-compatible profile
-- **Type hints**: Required for all public methods
-- **Docstrings**: Google style for complex methods
-- **No print statements**: Use logging
+Tests are mandatory - no exceptions. See @.ai/rules/testing.md for comprehensive testing standards.
+
+Key points:
+- Mock all HTTP calls in unit tests
+- Test both success and error paths
+- Maintain > 80% coverage on new code
+- Integration tests marked with `@pytest.mark.integration`
+
+## Common Pitfalls
+
+Before implementing, review @.ai/knowledge/failures/common-pitfalls.md to avoid:
+- Returning raw dicts instead of Pydantic models
+- Forgetting pagination handling
+- Mutable default arguments
+- Missing forward compatibility
+
+## Release Process
+
+1. Update version in `setup.py`
+2. Run full test suite: `pytest`
+3. Build distribution: `python setup.py sdist bdist_wheel`
+4. Use `release.sh` for automated release (requires proper PyPI credentials)

--- a/docs/services/embedding/README.md
+++ b/docs/services/embedding/README.md
@@ -1,102 +1,200 @@
 # Embedding Service
 
 ## Overview
-The Embedding Service (`EmbeddingService`) provides comprehensive text embedding functionality for the Kamiwaza AI Platform. Located in `kamiwaza_client/services/embedding.py`, this service handles text chunking, embedding generation, and provider management.
+The Embedding Service (`EmbeddingService`) provides comprehensive text embedding functionality for the Kamiwaza AI Platform. Located in `kamiwaza_client/services/embedding.py`, this service uses a provider-based architecture for text chunking and embedding generation.
 
 ## Key Features
-- Text Chunking
+- Provider-Based Architecture
+- Text Chunking with Metadata
 - Embedding Generation
-- Multiple Provider Support
 - Batch Processing
-- Model Management
-- Provider Initialization
+- Multiple Provider Support
+- Stateless Design
+
+## Getting Started
+
+The embedding service requires initializing a provider before use:
+
+```python
+from kamiwaza_client import KamiwazaClient
+
+client = KamiwazaClient(api_key="your-key")
+
+# Get an embedder instance (required first step)
+embedder = client.embedding.get_embedder(
+    model="nomic-ai/nomic-embed-text-v1.5",  # optional, this is default
+    provider_type="sentencetransformers",     # optional, this is default  
+    device="cuda"                             # optional, auto-detect if None
+)
+```
 
 ## Text Processing
 
 ### Available Methods
-- `chunk_text(text: str, chunk_size: int = 512) -> List[str]`: Split text into chunks
-- `embed_chunks(chunks: List[str]) -> List[List[float]]`: Generate embeddings for chunks
-- `create_embedding(text: str) -> List[float]`: Create embedding for text
-- `get_embedding(embedding_id: UUID) -> Embedding`: Get existing embedding
+- `chunk_text(text: str, max_length: int = 1024, overlap: int = 102, preamble_text: str = "", return_metadata: bool = False) -> Union[List[str], ChunkResponse]`: Split text into chunks
+- `embed_chunks(text_chunks: List[str], batch_size: int = 64) -> List[List[float]]`: Generate embeddings for chunks
+- `create_embedding(text: str, max_length: int = 1024, overlap: int = 102, preamble_text: str = "") -> EmbeddingOutput`: Create embedding for text
+- `get_embedding(text: str, return_offset: bool = False) -> EmbeddingOutput`: Generate embedding for text
 
 ```python
+# Initialize embedder first
+embedder = client.embedding.get_embedder()
+
 # Split text into chunks
-chunks = client.embedding.chunk_text(
+chunks = embedder.chunk_text(
     text="Long document text...",
-    chunk_size=512
+    max_length=1024,
+    overlap=102
 )
+
+# Or get chunks with metadata
+chunk_response = embedder.chunk_text(
+    text="Long document text...",
+    max_length=1024,
+    overlap=102,
+    return_metadata=True
+)
+# Access: chunk_response.chunks, chunk_response.offsets, chunk_response.token_counts
 
 # Generate embeddings for chunks
-embeddings = client.embedding.embed_chunks(chunks)
+embeddings = embedder.embed_chunks(chunks, batch_size=64)
 
 # Create single embedding
-embedding = client.embedding.create_embedding("Sample text")
+result = embedder.create_embedding("Sample text")
+embedding_vector = result.embedding  # List[float]
 
-# Retrieve existing embedding
-stored_embedding = client.embedding.get_embedding(embedding_id)
+# Generate embedding (alternative method)
+result = embedder.get_embedding("Sample text")
+embedding_vector = result.embedding
 ```
 
-## Model Management
+## Provider Management
 
-### Available Methods
-- `reset_model()`: Reset embedding model
-- `call(texts: List[str]) -> List[List[float]]`: Generate batch embeddings
-- `initialize_provider(provider: str, **kwargs)`: Initialize embedding provider
-- `HuggingFaceEmbedding(model_name: str)`: Create HuggingFace embedder
-- `get_providers() -> List[str]`: List available providers
+### Getting an Embedder
+The primary method for working with embeddings is through `get_embedder()`:
 
 ```python
-# Reset model
-client.embedding.reset_model()
+# Get embedder with default settings
+embedder = client.embedding.get_embedder()
 
-# Batch embedding generation
-embeddings = client.embedding.call(["text1", "text2", "text3"])
-
-# Initialize provider
-client.embedding.initialize_provider(
-    provider="huggingface",
-    model_name="sentence-transformers/all-mpnet-base-v2"
-)
-
-# Create HuggingFace embedder
-embedder = client.embedding.HuggingFaceEmbedding(
-    model_name="sentence-transformers/all-mpnet-base-v2"
+# Get embedder with custom model
+embedder = client.embedding.get_embedder(
+    model="sentence-transformers/all-mpnet-base-v2",
+    provider_type="sentencetransformers",
+    device="cuda"  # or "cpu", "mps", None for auto-detect
 )
 
 # List available providers
 providers = client.embedding.get_providers()
 ```
 
-## Error Handling
-The service includes built-in error handling for common scenarios:
+### Default Configuration
+- **Default Model**: `nomic-ai/nomic-embed-text-v1.5`
+- **Default Provider**: `sentencetransformers`
+- **Default Device**: Auto-detected based on availability
+
+## Return Types
+
+The service returns Pydantic models for structured data:
+
+### EmbeddingOutput
 ```python
+class EmbeddingOutput:
+    embedding: List[float]  # The embedding vector
+    offset: Optional[int]   # Offset in original text (if requested)
+```
+
+### ChunkResponse
+```python
+class ChunkResponse:
+    chunks: List[str]                    # Text chunks
+    offsets: Optional[List[int]]         # Start positions in original text
+    token_counts: Optional[List[int]]    # Token count per chunk
+    metadata: Optional[List[dict]]       # Additional metadata per chunk
+```
+
+## Error Handling
+The service uses a unified error handling approach:
+```python
+from kamiwaza_client.exceptions import APIError
+
 try:
-    embedding = client.embedding.create_embedding("text")
-except ModelNotFoundError:
-    print("Embedding model not found")
-except ProviderError as e:
-    print(f"Provider error: {e}")
+    embedder = client.embedding.get_embedder()
+    result = embedder.create_embedding("text")
 except APIError as e:
     print(f"Operation failed: {e}")
 ```
 
-## Best Practices
-1. Choose appropriate chunk sizes for your use case
-2. Use batch processing for better performance
-3. Initialize providers with appropriate models
-4. Handle model resets properly
-5. Monitor embedding quality
-6. Use appropriate error handling
-7. Consider memory usage for large batches
-8. Cache frequently used embeddings
+## Deprecated Methods
 
-## Provider Configuration
-The service supports multiple embedding providers:
-1. HuggingFace
-   - Supports various model architectures
-   - Customizable model selection
-   - Local and remote inference
-2. Custom Providers
-   - Extensible provider interface
-   - Custom model integration
-   - Provider-specific configurations
+The following methods are deprecated and should not be used:
+
+### HuggingFaceEmbedding()
+- **Status**: Deprecated
+- **Replacement**: Use `get_embedder()` instead
+- **Warning**: Logs deprecation warning when called
+
+### reset_model()
+- **Status**: Deprecated (no-op in stateless design)
+- **Returns**: `{"status": "no-op"}`
+- **Note**: Model state is now handled per request
+
+### call()
+- **Status**: Deprecated
+- **Replacement**: Use `get_embedder()` then call methods on the provider
+- **Raises**: `DeprecationWarning`
+
+## Best Practices
+
+1. **Always initialize an embedder first** using `get_embedder()`
+2. **Choose appropriate chunk sizes** based on your model's context window
+3. **Use batch processing** for multiple texts to improve performance
+4. **Handle overlaps properly** to maintain context between chunks
+5. **Consider memory usage** when processing large batches
+6. **Cache embeddings** when possible to avoid recomputation
+7. **Use return_metadata=True** when you need chunk offsets or token counts
+
+## Complete Example
+
+```python
+from kamiwaza_client import KamiwazaClient
+from kamiwaza_client.exceptions import APIError
+
+# Initialize client
+client = KamiwazaClient(api_key="your-key")
+
+# Get embedder
+embedder = client.embedding.get_embedder(
+    model="nomic-ai/nomic-embed-text-v1.5",
+    provider_type="sentencetransformers"
+)
+
+try:
+    # Process a document
+    document = "Your long document text here..."
+    
+    # Chunk with metadata
+    chunk_response = embedder.chunk_text(
+        text=document,
+        max_length=512,
+        overlap=50,
+        return_metadata=True
+    )
+    
+    # Generate embeddings
+    embeddings = embedder.embed_chunks(
+        chunk_response.chunks,
+        batch_size=32
+    )
+    
+    # Process results
+    for i, (chunk, embedding) in enumerate(zip(chunk_response.chunks, embeddings)):
+        print(f"Chunk {i}: {len(embedding)} dimensions")
+        if chunk_response.offsets:
+            print(f"  Offset: {chunk_response.offsets[i]}")
+        if chunk_response.token_counts:
+            print(f"  Tokens: {chunk_response.token_counts[i]}")
+            
+except APIError as e:
+    print(f"Embedding operation failed: {e}")
+```

--- a/kamiwaza_client/__init__.py
+++ b/kamiwaza_client/__init__.py
@@ -1,4 +1,4 @@
 # kamiwaza_client/__init__.py
 from .client import KamiwazaClient
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#kamiwaza/kamiwaza-sdk/setup.py
+# kamiwaza/kamiwaza-sdk/setup.py
 
 from setuptools import setup, find_packages
 
@@ -6,12 +6,14 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 with open("requirements.txt", "r", encoding="utf-8") as f:
-    requirements = [line.strip() for line in f if line.strip() and not line.startswith("#")]
+    requirements = [
+        line.strip() for line in f if line.strip() and not line.startswith("#")
+    ]
 
 
 setup(
-    name="kamiwaza",
-    version="0.5.0",
+    name="kamiwaza-sdk",
+    version="0.5.1",
     author="Kamiwaza Team",
     author_email="tyler@kamiwaza.ai",
     description="Python client library for the Kamiwaza AI Platform",
@@ -36,7 +38,4 @@ setup(
     package_data={
         "kamiwaza_client": ["py.typed"],
     },
-) # end
-
-
-
+)  # end


### PR DESCRIPTION
Problem

  The embedding service was failing in production because it used stateful in-memory storage (_embedders = {} dictionary) which
  doesn't work with Ray Serve's distributed architecture. When requests were load-balanced across multiple replicas, the embedder
  initialized on one replica couldn't be found on another, causing 404 errors.

  Solution

  Made the embedding service completely stateless by passing configuration with each request instead of storing embedder instances.
