### PR TITLE
Add stale VDB cleanup to integration test startup

### DIFF
--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -249,7 +249,9 @@ def _is_stale_sdk_resource(resource: dict, max_age: timedelta) -> bool:
     if not created_at:
         return True  # No timestamp — assume stale
     try:
-        age = datetime.now(timezone.utc) - datetime.fromisoformat(created_at)
+        age = datetime.now(timezone.utc) - datetime.fromisoformat(
+            created_at.replace("Z", "+00:00")
+        )
     except (TypeError, ValueError):
         return True
     return age >= max_age

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -240,6 +240,30 @@ def context_required_llm(context_llm_prerequisite: str) -> str:
     return context_llm_prerequisite
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_stale_sdk_vdbs(shared_context_service: ContextService) -> None:
+    """Delete leftover sdk-* VDB/ontology instances from prior crashed runs."""
+    service = shared_context_service
+    for workroom_id in (None, DEFAULT_WORKROOM_ID):
+        try:
+            vdbs = service.list_vectordbs(workroom_id=workroom_id)
+        except APIError:
+            continue
+        for vdb in vdbs:
+            name = vdb.get("name", "")
+            if name.startswith("sdk-"):
+                _safe_delete_vectordb(
+                    service, vdb["id"], workroom_id=workroom_id
+                )
+        try:
+            ontologies = service.list_ontologies(workroom_id=workroom_id)
+        except APIError:
+            continue
+        for ont in ontologies:
+            if ont.get("name", "").startswith("sdk-"):
+                _safe_delete_ontology(service, ont["id"])
+
+
 @pytest.fixture(scope="session")
 def shared_vectordb(shared_context_service: ContextService) -> str:
     """Shared global VectorDB instance for non-destructive vector tests."""

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import os
 import time
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
@@ -240,27 +241,47 @@ def context_required_llm(context_llm_prerequisite: str) -> str:
     return context_llm_prerequisite
 
 
+def _is_stale_sdk_resource(resource: dict, max_age: timedelta) -> bool:
+    """Return True if resource has an sdk-* name and is older than *max_age*."""
+    if not resource.get("name", "").startswith("sdk-") or not resource.get("id"):
+        return False
+    created_at = resource.get("created_at", "")
+    if not created_at:
+        return True  # No timestamp — assume stale
+    try:
+        age = datetime.now(timezone.utc) - datetime.fromisoformat(created_at)
+    except (TypeError, ValueError):
+        return True
+    return age >= max_age
+
+
+_STALE_THRESHOLD = timedelta(minutes=15)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _cleanup_stale_sdk_vdbs(shared_context_service: ContextService) -> None:
-    """Delete leftover sdk-* VDB/ontology instances from prior crashed runs."""
+    """Delete leftover sdk-* VDB/ontology instances from prior crashed runs.
+
+    Only targets resources older than 15 minutes to avoid interfering with
+    concurrent test sessions or manually-created resources.
+    """
     service = shared_context_service
     for workroom_id in (None, DEFAULT_WORKROOM_ID):
         try:
             vdbs = service.list_vectordbs(workroom_id=workroom_id)
         except APIError:
-            continue
+            vdbs = []
         for vdb in vdbs:
-            name = vdb.get("name", "")
-            if name.startswith("sdk-"):
+            if _is_stale_sdk_resource(vdb, _STALE_THRESHOLD):
                 _safe_delete_vectordb(
                     service, vdb["id"], workroom_id=workroom_id
                 )
         try:
             ontologies = service.list_ontologies(workroom_id=workroom_id)
         except APIError:
-            continue
+            ontologies = []
         for ont in ontologies:
-            if ont.get("name", "").startswith("sdk-"):
+            if _is_stale_sdk_resource(ont, _STALE_THRESHOLD):
                 _safe_delete_ontology(service, ont["id"])
 
 


### PR DESCRIPTION
## Summary

Integration tests create real Kubernetes resources (Milvus VDB pods via KamiwazaExtension CRs) through session-scoped fixtures with try/finally teardown. If the test process is killed (timeout, agent interruption, OOM), teardown never runs and orphaned VDB instances accumulate.

Each VDB deploys 3 pods (etcd + minio + standalone), so a few interrupted runs can exhaust cluster CPU on a single-node Kind cluster. We hit this when an agent ran the tests 4 times (retrying due to output capture issues), leaving 12 orphaned VDB instances (36 pods) that saturated all 9 CPU cores on the node.

**Fix:** Add a `_cleanup_stale_sdk_vdbs` session-scoped autouse fixture that runs at the start of every test session. It lists all VDB and ontology instances, and deletes any with the `sdk-` name prefix left over from prior crashed runs. This makes the test suite self-healing without changing the existing per-fixture teardown logic.

- Uses existing `_safe_delete_vectordb` and `_safe_delete_ontology` helpers
- Checks both global and workroom-scoped resources
- Silently ignores API errors (resource may already be gone)

## Test plan

- [x] Verified fixture runs at session start before any tests
- [x] Verified `list_vectordbs` API returns orphaned instances
- [x] Verified `delete_vectordb` API successfully removes them
- [x] Confirmed fixture silently handles API errors without blocking test execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)