### PR TITLE
ENG-3062: Add kz-ext dev remote deploy pipeline (Phase 2)

### DIFF
--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -14,7 +14,7 @@ app = typer.Typer(
     help="Kamiwaza extension developer tools.",
 )
 
-dev_app = typer.Typer(help="Local development commands.")
+dev_app = typer.Typer(help="Development commands (local and remote deploy).")
 app.add_typer(dev_app, name="dev")
 
 console = Console(stderr=True)
@@ -147,6 +147,37 @@ def create(
     """Scaffold a new extension project."""
     from kamiwaza_extensions.commands.create import run_create
     run_create(type_=type_, name=name)
+
+
+@dev_app.callback(invoke_without_command=True)
+def dev_callback(
+    ctx: typer.Context,
+    no_build: bool = typer.Option(False, "--no-build", help="Skip image build"),
+    no_push: bool = typer.Option(False, "--no-push", help="Skip registry push"),
+    service: Optional[str] = typer.Option(None, "--service", "-s", help="Build/push one service only"),
+    revision: Optional[str] = typer.Option(None, "--revision", "-r", help="Custom revision tag"),
+) -> None:
+    """Build, push, and deploy extension to Kamiwaza cluster.
+
+    With no subcommand, runs the full remote deploy pipeline.
+    Use 'kz-ext dev local' for local Docker Compose development.
+    """
+    if ctx.invoked_subcommand is not None:
+        return
+    # No subcommand → run remote deploy
+    from kamiwaza_extensions.commands.dev import run_dev_remote
+    try:
+        run_dev_remote(
+            no_build=no_build,
+            no_push=no_push,
+            service=service,
+            revision=revision,
+            verbose=_state.verbose,
+        )
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        _handle_exception(exc)
 
 
 @dev_app.command("local")

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -3,12 +3,48 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from typing import Optional
+from urllib.parse import urlparse
 
 import typer
 from rich.console import Console
 
 console = Console(stderr=True)
+
+
+def _detect_kind_registry() -> Optional[str]:
+    """Auto-detect a Kind local registry via the ``local-registry-hosting`` configmap.
+
+    Returns ``localhost:<port>`` if found, else ``None``.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "kubectl", "get", "configmap", "local-registry-hosting",
+                "-n", "kube-public",
+                "-o", "jsonpath={.data.localRegistryHosting\\.v1}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+
+        # Parse the YAML-ish output: host: "host.docker.internal:5001"
+        for line in result.stdout.strip().splitlines():
+            line = line.strip()
+            if line.startswith("host:"):
+                host_val = line.split(":", 1)[1].strip().strip('"').strip("'")
+                # Map host.docker.internal to localhost (it may not resolve on the host)
+                parsed = urlparse(f"//{host_val}")
+                port = parsed.port or 5001
+                console.print(f"[dim]Auto-detected Kind local registry: localhost:{port}[/dim]")
+                return f"localhost:{port}"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return None
 
 
 def run_dev_remote(
@@ -74,10 +110,10 @@ def run_dev_remote(
     # 4. Derive registry
     registry = os.environ.get("KAMIWAZA_REGISTRY")
     if not registry:
-        # Convention: registry.{cluster-domain}
+        registry = _detect_kind_registry()
+    if not registry:
+        # Fallback: convention registry.{cluster-domain}
         cluster_url = connection.url.removesuffix("/api")
-        # Extract domain from URL
-        from urllib.parse import urlparse
         parsed = urlparse(cluster_url)
         registry = f"registry.{parsed.hostname}"
 

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -227,7 +227,7 @@ def run_dev_remote(
             raise typer.Exit(code=1) from exc
 
     # 10. Poll for readiness
-    timeout = int(os.environ.get("KAMIWAZA_DEV_TIMEOUT", "120"))
+    timeout = int(os.environ.get("KAMIWAZA_DEV_TIMEOUT", "300"))
     poller = DeploymentPoller()
     try:
         ext = poller.wait_for_ready(

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -160,6 +160,8 @@ def run_dev_remote(
 
     # 9. Deploy: create or replace
     console.print(f"Deploying to {connection.url}...")
+    if not connection.verify_ssl:
+        os.environ["KAMIWAZA_VERIFY_SSL"] = "false"
     client = KamiwazaClient(
         base_url=connection.url,
         api_key=token.access_token,

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -1,0 +1,212 @@
+"""Dev remote command — build, push, and deploy to Kamiwaza cluster."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import typer
+from rich.console import Console
+
+console = Console(stderr=True)
+
+
+def run_dev_remote(
+    *,
+    no_build: bool = False,
+    no_push: bool = False,
+    service: Optional[str] = None,
+    revision: Optional[str] = None,
+    verbose: bool = False,
+) -> None:
+    """Build, push, and deploy extension to a Kamiwaza cluster."""
+    from kamiwaza_sdk import KamiwazaClient
+    from kamiwaza_sdk.exceptions import APIError
+
+    from kamiwaza_extensions.compose_transformer import ComposeTransformer
+    from kamiwaza_extensions.connections import ConnectionManager
+    from kamiwaza_extensions.deployment_poller import (
+        DeploymentFailedError,
+        DeploymentPoller,
+        DeploymentTimeoutError,
+    )
+    from kamiwaza_extensions.extension_detector import ExtensionDetector
+    from kamiwaza_extensions.image_builder import ImageBuilder, ImageBuildError
+    from kamiwaza_extensions.image_pusher import ImagePusher, ImagePushError
+    from kamiwaza_extensions.payload_builder import PayloadBuilder
+    from kamiwaza_extensions.revision_tagger import RevisionTagger
+
+    # 1. Detect extension
+    detector = ExtensionDetector()
+    info = detector.detect()
+
+    if info.compose_data is None:
+        console.print("[red]Error:[/red] No docker-compose.yml found.")
+        raise typer.Exit(code=1)
+
+    # 2. Resolve connection + auth
+    conn_mgr = ConnectionManager()
+    connection = conn_mgr.get_active_connection()
+    if connection is None:
+        console.print("[red]Error:[/red] No Kamiwaza connection configured.")
+        console.print("  Run: [bold]kz-ext login <url>[/bold]")
+        raise typer.Exit(code=1)
+
+    token = conn_mgr.get_token()
+    if token is None:
+        console.print("[red]Error:[/red] Connection token expired or missing.")
+        console.print("  Run: [bold]kz-ext login[/bold] to re-authenticate.")
+        raise typer.Exit(code=1)
+
+    # 3. Generate revision tag
+    tagger = RevisionTagger()
+    rev_tag = tagger.generate_tag(info.version, custom=revision)
+
+    # Warn about dirty tree
+    if revision is None:
+        sha, dirty = tagger.get_git_info()
+        if dirty:
+            console.print(
+                "[yellow]Warning:[/yellow] Working tree has uncommitted changes "
+                "-- image tagged with 'dirty'."
+            )
+
+    # 4. Derive registry
+    registry = os.environ.get("KAMIWAZA_REGISTRY")
+    if not registry:
+        # Convention: registry.{cluster-domain}
+        cluster_url = connection.url.removesuffix("/api")
+        # Extract domain from URL
+        from urllib.parse import urlparse
+        parsed = urlparse(cluster_url)
+        registry = f"registry.{parsed.hostname}"
+
+    # Print header
+    console.print(f"  Extension:  [bold]{info.name}[/bold] ({info.version})")
+    console.print(f"  Connection: {connection.name} ({connection.url})")
+    console.print(f"  Revision:   {rev_tag}")
+    console.print()
+
+    # 5. Transform compose
+    transformer = ComposeTransformer()
+    transformed = transformer.transform(
+        info.compose_data,
+        extension_name=info.name,
+        revision_tag=rev_tag,
+        registry=registry,
+    )
+
+    # 6. Build images
+    if not no_build:
+        console.print("Building images...")
+        try:
+            builder = ImageBuilder()
+            image_refs = builder.build(
+                extension_dir=info.path,
+                compose_data=info.compose_data,  # Original compose (has build contexts)
+                extension_name=info.name,
+                revision_tag=rev_tag,
+                registry=registry,
+                service_filter=service,
+                verbose=verbose,
+            )
+        except ImageBuildError as exc:
+            console.print(f"\n[red]Error:[/red] {exc}")
+            raise typer.Exit(code=1) from exc
+
+        if not image_refs:
+            console.print("[yellow]Warning:[/yellow] No images to build (no services with build contexts).")
+        console.print()
+    else:
+        console.print("[dim]Skipping build (--no-build)[/dim]")
+        # Collect expected image refs for push
+        image_refs = []
+        for svc_name, svc in (info.compose_data.get("services") or {}).items():
+            if service and svc_name != service:
+                continue
+            if "build" in svc:
+                image_refs.append(f"{registry}/{info.name}-{svc_name}:{rev_tag}")
+        console.print()
+
+    # 7. Push images
+    if not no_push and image_refs:
+        console.print(f"Pushing to {registry}...")
+        try:
+            pusher = ImagePusher()
+            pusher.push(
+                image_refs,
+                registry=registry,
+                token=token.access_token,
+                verbose=verbose,
+            )
+        except ImagePushError as exc:
+            console.print(f"\n[red]Error:[/red] {exc}")
+            console.print("  Run: [bold]kz-ext doctor[/bold] to check connection and registry access.")
+            raise typer.Exit(code=1) from exc
+        console.print()
+    elif no_push:
+        console.print("[dim]Skipping push (--no-push)[/dim]\n")
+
+    # 8. Build API payload
+    payload_builder = PayloadBuilder()
+    dev_name = PayloadBuilder.make_dev_name(info.name)
+    payload = payload_builder.build(
+        metadata=info.metadata,
+        transformed_compose=transformed,
+        connection=connection,
+        dev_name=dev_name,
+    )
+
+    # 9. Deploy: create or replace
+    console.print(f"Deploying to {connection.url}...")
+    client = KamiwazaClient(
+        base_url=connection.url,
+        api_key=token.access_token,
+    )
+
+    try:
+        ext = client.extensions.create_extension(payload)
+        console.print("  [green]\u2713[/green] Extension created")
+    except APIError as exc:
+        if exc.status_code == 409:
+            # Replace: delete existing, then re-create
+            console.print("  [dim]Replacing existing deployment...[/dim]")
+            try:
+                client.extensions.delete_extension(dev_name)
+            except Exception:
+                pass  # Best-effort delete
+            import time
+            time.sleep(2)  # Brief wait for deletion to propagate
+            try:
+                ext = client.extensions.create_extension(payload)
+                console.print("  [green]\u2713[/green] Extension replaced")
+            except APIError as create_exc:
+                console.print(f"[red]Error:[/red] Deploy failed: {create_exc}")
+                raise typer.Exit(code=1) from create_exc
+        else:
+            console.print(f"[red]Error:[/red] Deploy failed: {exc}")
+            raise typer.Exit(code=1) from exc
+
+    # 10. Poll for readiness
+    timeout = int(os.environ.get("KAMIWAZA_DEV_TIMEOUT", "120"))
+    poller = DeploymentPoller()
+    try:
+        ext = poller.wait_for_ready(
+            client, dev_name, timeout=timeout
+        )
+    except DeploymentTimeoutError as exc:
+        console.print(f"\n[red]Error:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    except DeploymentFailedError as exc:
+        console.print(f"\n[red]Error:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    # 11. Print URL
+    url = ext.endpoints.external if ext.endpoints else None
+    console.print(f"\n  [green]\u2713[/green] Rollout complete")
+    console.print()
+    console.print(f"[bold]{info.name}[/bold] is running at:")
+    if url:
+        console.print(f"  [blue]{url}[/blue]")
+    else:
+        console.print(f"  [dim](no external URL reported — check kz-ext status)[/dim]")

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -137,6 +137,7 @@ def run_dev_remote(
                 image_refs,
                 registry=registry,
                 token=token.access_token,
+                insecure=not connection.verify_ssl,
                 verbose=verbose,
             )
         except ImagePushError as exc:

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -115,7 +115,11 @@ def run_dev_remote(
         # Fallback: convention registry.{cluster-domain}
         cluster_url = connection.url.removesuffix("/api")
         parsed = urlparse(cluster_url)
-        registry = f"registry.{parsed.hostname}"
+        if parsed.hostname:
+            registry = f"registry.{parsed.hostname}"
+        else:
+            console.print("[red]Error:[/red] Could not derive registry from connection URL.")
+            raise typer.Exit(code=1)
 
     # Print header
     console.print(f"  Extension:  [bold]{info.name}[/bold] ({info.version})")
@@ -186,7 +190,7 @@ def run_dev_remote(
 
     # 8. Build API payload
     payload_builder = PayloadBuilder()
-    dev_name = PayloadBuilder.make_dev_name(info.name)
+    dev_name = PayloadBuilder.make_dev_name(info.name, user_id=token.access_token)
     payload = payload_builder.build(
         metadata=info.metadata,
         transformed_compose=transformed,
@@ -212,10 +216,16 @@ def run_dev_remote(
             console.print("  [dim]Replacing existing deployment...[/dim]")
             try:
                 client.extensions.delete_extension(dev_name)
-            except Exception:
-                pass  # Best-effort delete
+            except Exception as del_exc:
+                console.print(f"  [dim]Delete failed: {del_exc}[/dim]")
+            # Wait for deletion to complete
             import time
-            time.sleep(2)  # Brief wait for deletion to propagate
+            for _ in range(10):
+                time.sleep(1)
+                try:
+                    client.extensions.get_extension(dev_name)
+                except Exception:
+                    break  # Extension is gone
             try:
                 ext = client.extensions.create_extension(payload)
                 console.print("  [green]\u2713[/green] Extension replaced")
@@ -227,7 +237,11 @@ def run_dev_remote(
             raise typer.Exit(code=1) from exc
 
     # 10. Poll for readiness
-    timeout = int(os.environ.get("KAMIWAZA_DEV_TIMEOUT", "300"))
+    try:
+        timeout = int(os.environ.get("KAMIWAZA_DEV_TIMEOUT", "300"))
+    except ValueError:
+        console.print("[yellow]Warning:[/yellow] Invalid KAMIWAZA_DEV_TIMEOUT, using 300s")
+        timeout = 300
     poller = DeploymentPoller()
     try:
         ext = poller.wait_for_ready(

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -68,8 +68,9 @@ def _extract_user_id(access_token: str) -> str:
             return sub
     except Exception:
         pass
-    # Fallback: hash the token itself
-    return access_token
+    # Fallback: hash the token so it's never exposed downstream
+    import hashlib
+    return hashlib.sha256(access_token.encode()).hexdigest()
 
 
 def run_dev_remote(
@@ -223,84 +224,81 @@ def run_dev_remote(
         dev_name=dev_name,
     )
 
-    # 9. Deploy: create or replace
+    # 9. Deploy, poll, and print URL — wrapped in try/finally for SSL env restore
     console.print(f"Deploying to {connection.url}...")
     old_verify_ssl = os.environ.get("KAMIWAZA_VERIFY_SSL")
     if not connection.verify_ssl:
         os.environ["KAMIWAZA_VERIFY_SSL"] = "false"
-    client = KamiwazaClient(
-        base_url=connection.url,
-        api_key=token.access_token,
-    )
-
     try:
-        ext = client.extensions.create_extension(payload)
-        console.print("  [green]\u2713[/green] Extension created")
-    except APIError as exc:
-        if exc.status_code == 409:
-            # Replace: delete existing, then re-create
-            console.print("  [dim]Replacing existing deployment...[/dim]")
-            try:
-                client.extensions.delete_extension(dev_name)
-            except Exception as del_exc:
-                console.print(f"  [dim]Delete failed: {del_exc}[/dim]")
-            # Wait for deletion, then retry create with backoff
-            import time
-            ext = None
-            for attempt in range(15):
-                time.sleep(2)
+        client = KamiwazaClient(
+            base_url=connection.url,
+            api_key=token.access_token,
+        )
+
+        # Create or replace
+        try:
+            ext = client.extensions.create_extension(payload)
+            console.print("  [green]\u2713[/green] Extension created")
+        except APIError as exc:
+            if exc.status_code == 409:
+                # Replace: delete existing, then re-create with retry
+                console.print("  [dim]Replacing existing deployment...[/dim]")
                 try:
-                    client.extensions.get_extension(dev_name)
-                    # Still exists — keep waiting
-                    continue
-                except Exception:
-                    pass  # Deleted
-                try:
-                    ext = client.extensions.create_extension(payload)
-                    console.print("  [green]\u2713[/green] Extension replaced")
-                    break
-                except APIError as retry_exc:
-                    if retry_exc.status_code == 409 and attempt < 14:
-                        continue  # Finalizer still running, retry
-                    console.print(f"[red]Error:[/red] Deploy failed: {retry_exc}")
-                    raise typer.Exit(code=1) from retry_exc
-            if ext is None:
-                console.print("[red]Error:[/red] Timed out waiting for old deployment to be removed")
-                raise typer.Exit(code=1)
-        else:
-            console.print(f"[red]Error:[/red] Deploy failed: {exc}")
+                    client.extensions.delete_extension(dev_name)
+                except Exception as del_exc:
+                    console.print(f"  [dim]Delete failed: {del_exc}[/dim]")
+                import time
+                ext = None
+                for attempt in range(15):
+                    time.sleep(2)
+                    try:
+                        client.extensions.get_extension(dev_name)
+                        continue  # Still exists — keep waiting
+                    except Exception:
+                        pass  # Deleted
+                    try:
+                        ext = client.extensions.create_extension(payload)
+                        console.print("  [green]\u2713[/green] Extension replaced")
+                        break
+                    except APIError as retry_exc:
+                        if retry_exc.status_code == 409 and attempt < 14:
+                            continue  # Finalizer still running, retry
+                        console.print(f"[red]Error:[/red] Deploy failed: {retry_exc}")
+                        raise typer.Exit(code=1) from retry_exc
+                if ext is None:
+                    console.print("[red]Error:[/red] Timed out waiting for old deployment to be removed")
+                    raise typer.Exit(code=1)
+            else:
+                console.print(f"[red]Error:[/red] Deploy failed: {exc}")
+                raise typer.Exit(code=1) from exc
+
+        # 10. Poll for readiness
+        try:
+            timeout = int(os.environ.get("KAMIWAZA_DEV_TIMEOUT", "300"))
+        except ValueError:
+            console.print("[yellow]Warning:[/yellow] Invalid KAMIWAZA_DEV_TIMEOUT, using 300s")
+            timeout = 300
+        poller = DeploymentPoller()
+        try:
+            ext = poller.wait_for_ready(client, dev_name, timeout=timeout)
+        except DeploymentTimeoutError as exc:
+            console.print(f"\n[red]Error:[/red] {exc}")
+            raise typer.Exit(code=1) from exc
+        except DeploymentFailedError as exc:
+            console.print(f"\n[red]Error:[/red] {exc}")
             raise typer.Exit(code=1) from exc
 
-    # 10. Poll for readiness
-    try:
-        timeout = int(os.environ.get("KAMIWAZA_DEV_TIMEOUT", "300"))
-    except ValueError:
-        console.print("[yellow]Warning:[/yellow] Invalid KAMIWAZA_DEV_TIMEOUT, using 300s")
-        timeout = 300
-    poller = DeploymentPoller()
-    try:
-        ext = poller.wait_for_ready(
-            client, dev_name, timeout=timeout
-        )
-    except DeploymentTimeoutError as exc:
-        console.print(f"\n[red]Error:[/red] {exc}")
-        raise typer.Exit(code=1) from exc
-    except DeploymentFailedError as exc:
-        console.print(f"\n[red]Error:[/red] {exc}")
-        raise typer.Exit(code=1) from exc
-
-    # 11. Print URL
-    url = ext.endpoints.external if ext.endpoints else None
-    console.print(f"\n  [green]\u2713[/green] Rollout complete")
-    console.print()
-    console.print(f"[bold]{info.name}[/bold] is running at:")
-    if url:
-        console.print(f"  [blue]{url}[/blue]")
-    else:
-        console.print(f"  [dim](no external URL reported — check kz-ext status)[/dim]")
-
-    # Restore SSL env var
-    if old_verify_ssl is None:
-        os.environ.pop("KAMIWAZA_VERIFY_SSL", None)
-    else:
-        os.environ["KAMIWAZA_VERIFY_SSL"] = old_verify_ssl
+        # 11. Print URL
+        url = ext.endpoints.external if ext.endpoints else None
+        console.print(f"\n  [green]\u2713[/green] Rollout complete")
+        console.print()
+        console.print(f"[bold]{info.name}[/bold] is running at:")
+        if url:
+            console.print(f"  [blue]{url}[/blue]")
+        else:
+            console.print(f"  [dim](no external URL reported — check kz-ext status)[/dim]")
+    finally:
+        if old_verify_ssl is None:
+            os.environ.pop("KAMIWAZA_VERIFY_SSL", None)
+        else:
+            os.environ["KAMIWAZA_VERIFY_SSL"] = old_verify_ssl

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -47,6 +47,31 @@ def _detect_kind_registry() -> Optional[str]:
     return None
 
 
+def _extract_user_id(access_token: str) -> str:
+    """Extract a stable user identifier (``sub`` claim) from a JWT.
+
+    Falls back to hashing the token if decoding fails.
+    """
+    import base64
+    import json as _json
+
+    try:
+        # JWT is header.payload.signature — decode the payload
+        payload_b64 = access_token.split(".")[1]
+        # Add padding if needed
+        padding = 4 - len(payload_b64) % 4
+        if padding != 4:
+            payload_b64 += "=" * padding
+        payload = _json.loads(base64.urlsafe_b64decode(payload_b64))
+        sub = payload.get("sub")
+        if sub:
+            return sub
+    except Exception:
+        pass
+    # Fallback: hash the token itself
+    return access_token
+
+
 def run_dev_remote(
     *,
     no_build: bool = False,
@@ -190,7 +215,7 @@ def run_dev_remote(
 
     # 8. Build API payload
     payload_builder = PayloadBuilder()
-    dev_name = PayloadBuilder.make_dev_name(info.name, user_id=token.access_token)
+    dev_name = PayloadBuilder.make_dev_name(info.name, user_id=_extract_user_id(token.access_token))
     payload = payload_builder.build(
         metadata=info.metadata,
         transformed_compose=transformed,
@@ -200,6 +225,7 @@ def run_dev_remote(
 
     # 9. Deploy: create or replace
     console.print(f"Deploying to {connection.url}...")
+    old_verify_ssl = os.environ.get("KAMIWAZA_VERIFY_SSL")
     if not connection.verify_ssl:
         os.environ["KAMIWAZA_VERIFY_SSL"] = "false"
     client = KamiwazaClient(
@@ -218,20 +244,29 @@ def run_dev_remote(
                 client.extensions.delete_extension(dev_name)
             except Exception as del_exc:
                 console.print(f"  [dim]Delete failed: {del_exc}[/dim]")
-            # Wait for deletion to complete
+            # Wait for deletion, then retry create with backoff
             import time
-            for _ in range(10):
-                time.sleep(1)
+            ext = None
+            for attempt in range(15):
+                time.sleep(2)
                 try:
                     client.extensions.get_extension(dev_name)
+                    # Still exists — keep waiting
+                    continue
                 except Exception:
-                    break  # Extension is gone
-            try:
-                ext = client.extensions.create_extension(payload)
-                console.print("  [green]\u2713[/green] Extension replaced")
-            except APIError as create_exc:
-                console.print(f"[red]Error:[/red] Deploy failed: {create_exc}")
-                raise typer.Exit(code=1) from create_exc
+                    pass  # Deleted
+                try:
+                    ext = client.extensions.create_extension(payload)
+                    console.print("  [green]\u2713[/green] Extension replaced")
+                    break
+                except APIError as retry_exc:
+                    if retry_exc.status_code == 409 and attempt < 14:
+                        continue  # Finalizer still running, retry
+                    console.print(f"[red]Error:[/red] Deploy failed: {retry_exc}")
+                    raise typer.Exit(code=1) from retry_exc
+            if ext is None:
+                console.print("[red]Error:[/red] Timed out waiting for old deployment to be removed")
+                raise typer.Exit(code=1)
         else:
             console.print(f"[red]Error:[/red] Deploy failed: {exc}")
             raise typer.Exit(code=1) from exc
@@ -263,3 +298,9 @@ def run_dev_remote(
         console.print(f"  [blue]{url}[/blue]")
     else:
         console.print(f"  [dim](no external URL reported — check kz-ext status)[/dim]")
+
+    # Restore SSL env var
+    if old_verify_ssl is None:
+        os.environ.pop("KAMIWAZA_VERIFY_SSL", None)
+    else:
+        os.environ["KAMIWAZA_VERIFY_SSL"] = old_verify_ssl

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -1,0 +1,180 @@
+"""In-memory Docker Compose transformation for deployment."""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any, Dict, List, Optional
+
+
+# Default resource limits by service pattern
+_RESOURCE_DEFAULTS: List[tuple[re.Pattern, Dict[str, str]]] = [
+    (re.compile(r"postgres|mysql|mariadb", re.I), {"cpus": "0.5", "memory": "512M"}),
+    (re.compile(r"redis|valkey", re.I), {"cpus": "0.25", "memory": "256M"}),
+    (re.compile(r"frontend|nginx|caddy", re.I), {"cpus": "0.5", "memory": "512M"}),
+]
+_DEFAULT_LIMITS = {"cpus": "1.0", "memory": "1G"}
+
+
+class ComposeTransformer:
+    """Transform a local-dev compose dict into a deployment-ready dict.
+
+    All operations are pure (no I/O).  The caller provides the parsed
+    compose dict and receives a new dict suitable for building a
+    ``CreateExtension`` payload.
+    """
+
+    def transform(
+        self,
+        compose_data: Dict[str, Any],
+        extension_name: str,
+        revision_tag: str,
+        registry: str,
+    ) -> Dict[str, Any]:
+        """Return a deployment-ready copy of *compose_data*.
+
+        Transformations applied per-service:
+        1. Strip host port bindings
+        2. Strip bind mounts (keep named volumes)
+        3. Remove ``build`` contexts
+        4. Add / update ``image`` fields with *registry*/*revision_tag*
+        5. Add resource limits if missing
+        6. Remove ``extra_hosts``, ``container_name``, ``networks`` keys
+        """
+        out = copy.deepcopy(compose_data)
+
+        for svc_name, svc in (out.get("services") or {}).items():
+            out["services"][svc_name] = self.transform_service(
+                svc,
+                svc_name,
+                extension_name,
+                revision_tag,
+                registry,
+            )
+
+        # Remove top-level networks (platform manages networking)
+        out.pop("networks", None)
+
+        return out
+
+    def transform_service(
+        self,
+        service: Dict[str, Any],
+        service_name: str,
+        extension_name: str,
+        revision_tag: str,
+        registry: str,
+    ) -> Dict[str, Any]:
+        svc = copy.deepcopy(service)
+
+        # 1. Strip host port bindings
+        if "ports" in svc:
+            svc["ports"] = _strip_host_ports(svc["ports"])
+
+        # 2. Strip bind mounts, keep named volumes
+        if "volumes" in svc:
+            svc["volumes"] = _strip_bind_mounts(svc["volumes"])
+            if not svc["volumes"]:
+                del svc["volumes"]
+
+        # 3 & 4. Remove build context, ensure image field
+        had_build = "build" in svc
+        svc.pop("build", None)
+
+        if had_build and "image" not in svc:
+            svc["image"] = f"{registry}/{extension_name}-{service_name}:{revision_tag}"
+        elif had_build and "image" in svc:
+            # Update tag on the existing image field
+            svc["image"] = _update_tag(svc["image"], revision_tag)
+        elif "image" in svc and not _is_external_image(svc["image"], extension_name):
+            svc["image"] = _update_tag(svc["image"], revision_tag)
+        # External images (postgres, redis, etc.) are left unchanged.
+
+        # 5. Add resource limits if missing
+        _ensure_resource_limits(svc)
+
+        # 6. Remove deployment-incompatible keys
+        svc.pop("extra_hosts", None)
+        svc.pop("container_name", None)
+        svc.pop("networks", None)
+
+        return svc
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _strip_host_ports(ports: List[Any]) -> List[str]:
+    """``"3000:3000"`` -> ``"3000"``; ``"8080:3000/tcp"`` -> ``"3000/tcp"``."""
+    result = []
+    for port in ports:
+        s = str(port)
+        if ":" in s:
+            # Take the part after the last colon (container port + optional protocol)
+            container_part = s.rsplit(":", 1)[1]
+            result.append(container_part)
+        else:
+            result.append(s)
+    return result
+
+
+def _strip_bind_mounts(volumes: List[Any]) -> List[str]:
+    """Keep named volumes, remove bind mounts (``./``, ``../``, absolute paths)."""
+    kept = []
+    for vol in volumes:
+        if isinstance(vol, dict):
+            # Long-form volume — check type
+            if vol.get("type") == "volume":
+                kept.append(vol)
+            # bind / tmpfs types are stripped
+            continue
+        s = str(vol)
+        if s.startswith("/") or s.startswith("./") or s.startswith("../"):
+            continue
+        if ":" in s:
+            host_part = s.split(":", 1)[0]
+            if host_part.startswith("/") or host_part.startswith("./") or host_part.startswith("../"):
+                continue
+        kept.append(s)
+    return kept
+
+
+def _update_tag(image: str, new_tag: str) -> str:
+    """Replace the tag portion of an image reference."""
+    last_slash = image.rfind("/")
+    last_colon = image.rfind(":")
+    if last_colon > last_slash:
+        return image[:last_colon] + ":" + new_tag
+    return image + ":" + new_tag
+
+
+def _is_external_image(image: str, extension_name: str) -> bool:
+    """Return True for images that are NOT part of this extension (e.g., postgres)."""
+    lower = image.lower()
+    # Common external images
+    if any(ext in lower for ext in ("postgres", "mysql", "mariadb", "redis", "valkey",
+                                     "mongo", "rabbitmq", "elasticsearch", "milvus",
+                                     "nginx", "memcached", "minio")):
+        return True
+    # If image doesn't contain the extension name, treat as external
+    if extension_name.lower() not in lower:
+        return True
+    return False
+
+
+def _ensure_resource_limits(svc: Dict[str, Any]) -> None:
+    """Add default resource limits if not already specified."""
+    deploy = svc.setdefault("deploy", {})
+    resources = deploy.setdefault("resources", {})
+    if "limits" in resources:
+        return
+
+    # Determine defaults from image name or service content
+    hint = svc.get("image", "")
+    for pattern, limits in _RESOURCE_DEFAULTS:
+        if pattern.search(hint):
+            resources["limits"] = dict(limits)
+            return
+    resources["limits"] = dict(_DEFAULT_LIMITS)

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -84,8 +84,8 @@ class ComposeTransformer:
         if had_build and "image" not in svc:
             svc["image"] = f"{registry}/{extension_name}-{service_name}:{revision_tag}"
         elif had_build and "image" in svc:
-            # Update tag on the existing image field
-            svc["image"] = _update_tag(svc["image"], revision_tag)
+            # Use consistent registry/extension-service:tag format (matches image builder)
+            svc["image"] = f"{registry}/{extension_name}-{service_name}:{revision_tag}"
         elif "image" in svc and not _is_external_image(svc["image"], extension_name):
             svc["image"] = _update_tag(svc["image"], revision_tag)
         # External images (postgres, redis, etc.) are left unchanged.
@@ -143,6 +143,9 @@ def _strip_bind_mounts(volumes: List[Any]) -> List[str]:
 
 def _update_tag(image: str, new_tag: str) -> str:
     """Replace the tag portion of an image reference."""
+    # Don't rewrite digest references
+    if "@sha256:" in image:
+        return image
     last_slash = image.rfind("/")
     last_colon = image.rfind(":")
     if last_colon > last_slash:

--- a/kamiwaza_extensions/deployment_poller.py
+++ b/kamiwaza_extensions/deployment_poller.py
@@ -111,9 +111,12 @@ class DeploymentPoller:
             total = len(statuses)
             summary = f"{ready_count}/{total} ready"
             return ready_count == total, summary
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            # kubectl not available; fall back to API-only check
-            return True, "ready (kubectl unavailable)"
+        except FileNotFoundError:
+            # kubectl not installed — warn and skip pod-readiness gate
+            console.print("  [yellow]Warning:[/yellow] kubectl not found, cannot verify pod readiness")
+            return True, "skipped (no kubectl)"
+        except subprocess.TimeoutExpired:
+            return False, "checking... (kubectl timeout)"
 
     @staticmethod
     def _extract_failure_message(ext: Extension) -> str:

--- a/kamiwaza_extensions/deployment_poller.py
+++ b/kamiwaza_extensions/deployment_poller.py
@@ -1,0 +1,85 @@
+"""Poll extension deployment status until ready or timeout."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from rich.console import Console
+
+from kamiwaza_sdk import KamiwazaClient
+from kamiwaza_sdk.schemas.extensions import Extension
+
+console = Console(stderr=True)
+
+
+class DeploymentTimeoutError(RuntimeError):
+    """Extension did not reach Running state within the timeout."""
+
+    pass
+
+
+class DeploymentFailedError(RuntimeError):
+    """Extension reached a Failed state."""
+
+    pass
+
+
+class DeploymentPoller:
+    """Poll ``GET /extensions/{name}`` until the extension is running."""
+
+    def wait_for_ready(
+        self,
+        client: KamiwazaClient,
+        extension_name: str,
+        timeout: int = 120,
+        poll_interval: int = 3,
+    ) -> Extension:
+        """Block until the extension reaches *Running* phase.
+
+        Args:
+            client: Authenticated SDK client.
+            extension_name: CR name of the extension.
+            timeout: Max seconds to wait.
+            poll_interval: Seconds between polls.
+
+        Returns:
+            The extension in Running state.
+
+        Raises:
+            DeploymentTimeoutError: Timeout exceeded.
+            DeploymentFailedError: Extension reached Failed phase.
+        """
+        deadline = time.monotonic() + timeout
+        last_phase: Optional[str] = None
+
+        while time.monotonic() < deadline:
+            ext = client.extensions.get_extension(extension_name)
+            phase = ext.phase or "Unknown"
+
+            if phase != last_phase:
+                console.print(f"  [dim]Status: {phase}[/dim]")
+                last_phase = phase
+
+            if phase == "Running":
+                return ext
+
+            if phase == "Failed":
+                msg = self._extract_failure_message(ext)
+                raise DeploymentFailedError(
+                    f"Extension deployment failed: {msg}"
+                )
+
+            time.sleep(poll_interval)
+
+        raise DeploymentTimeoutError(
+            f"Extension did not reach Running state within {timeout}s "
+            f"(last phase: {last_phase})"
+        )
+
+    @staticmethod
+    def _extract_failure_message(ext: Extension) -> str:
+        for svc in ext.services:
+            if svc.message:
+                return svc.message
+        return "no details available"

--- a/kamiwaza_extensions/deployment_poller.py
+++ b/kamiwaza_extensions/deployment_poller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import time
 from typing import Optional
 
@@ -35,7 +36,7 @@ class DeploymentPoller:
         timeout: int = 120,
         poll_interval: int = 3,
     ) -> Extension:
-        """Block until the extension reaches *Running* phase.
+        """Block until the extension reaches *Running* phase and pods are ready.
 
         Args:
             client: Authenticated SDK client.
@@ -52,6 +53,7 @@ class DeploymentPoller:
         """
         deadline = time.monotonic() + timeout
         last_phase: Optional[str] = None
+        last_ready: Optional[str] = None
 
         while time.monotonic() < deadline:
             ext = client.extensions.get_extension(extension_name)
@@ -61,14 +63,20 @@ class DeploymentPoller:
                 console.print(f"  [dim]Status: {phase}[/dim]")
                 last_phase = phase
 
-            if phase == "Running":
-                return ext
-
             if phase == "Failed":
                 msg = self._extract_failure_message(ext)
                 raise DeploymentFailedError(
                     f"Extension deployment failed: {msg}"
                 )
+
+            if phase == "Running":
+                # Verify pods are actually ready via kubectl
+                ready, summary = self._check_pods_ready(extension_name)
+                if summary != last_ready:
+                    console.print(f"  [dim]Pods: {summary}[/dim]")
+                    last_ready = summary
+                if ready:
+                    return ext
 
             time.sleep(poll_interval)
 
@@ -76,6 +84,36 @@ class DeploymentPoller:
             f"Extension did not reach Running state within {timeout}s "
             f"(last phase: {last_phase})"
         )
+
+    @staticmethod
+    def _check_pods_ready(extension_name: str) -> tuple[bool, str]:
+        """Check if all pods for the extension are ready via kubectl."""
+        try:
+            result = subprocess.run(
+                [
+                    "kubectl", "get", "pods",
+                    "-n", "kamiwaza-extensions",
+                    "-l", f"extensions.kamiwaza.io/deployment-id={extension_name}",
+                    "-o", "jsonpath={range .items[*]}{.status.containerStatuses[0].ready}{' '}{end}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                return False, "checking..."
+
+            statuses = result.stdout.strip().split()
+            if not statuses:
+                return False, "no pods yet"
+
+            ready_count = sum(1 for s in statuses if s == "true")
+            total = len(statuses)
+            summary = f"{ready_count}/{total} ready"
+            return ready_count == total, summary
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            # kubectl not available; fall back to API-only check
+            return True, "ready (kubectl unavailable)"
 
     @staticmethod
     def _extract_failure_message(ext: Extension) -> str:

--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -1,8 +1,7 @@
-"""DevLocalRunner — extension detection, env overlay, Docker Compose lifecycle."""
+"""DevLocalRunner — env overlay, Docker Compose lifecycle for local dev."""
 
 from __future__ import annotations
 
-import json
 import os
 import signal
 import subprocess
@@ -13,7 +12,7 @@ from typing import Dict, List, Optional
 from rich.console import Console
 
 from kamiwaza_extensions.connections import ConnectionInfo, ConnectionManager
-from kamiwaza_extensions.constants import COMPOSE_FILENAMES
+from kamiwaza_extensions.extension_detector import ExtensionDetector
 
 console = Console(stderr=True)
 
@@ -23,82 +22,42 @@ class DevLocalRunner:
 
     def __init__(self, config_dir: Optional[Path] = None) -> None:
         self._conn_mgr = ConnectionManager(config_dir=config_dir)
+        self._detector = ExtensionDetector()
 
     def run(self, *, detach: bool = False) -> int:
-        # 1. Find extension
-        ext_dir = self._find_extension()
+        # 1. Detect extension (shared logic)
+        info = self._detector.detect()
 
-        # 2. Read extension name from kamiwaza.json
-        ext_name = self._read_extension_name(ext_dir)
+        # 2. Ensure compose file exists
+        if info.compose_path is None:
+            raise FileNotFoundError(
+                f"No compose file found in {info.path}. "
+                "Expected docker-compose.yml or compose.yml."
+            )
 
-        # 3. Find compose file
-        compose_file = self._find_compose_file(ext_dir)
-
-        # 4. Detect compose command
+        # 3. Detect compose command
         compose_cmd = detect_compose_command()
 
-        # 5. Build env overlay
+        # 4. Build env overlay
         connection = self._conn_mgr.get_active_connection()
         env = os.environ.copy()
         if connection:
-            overlay = build_env_overlay(connection, ext_name)
+            overlay = build_env_overlay(connection, info.name)
             env.update(overlay)
             console.print(f"[dim]Using connection:[/dim] {connection.name} ({connection.url})")
             console.print(f"[dim]KAMIWAZA_USE_AUTH=false (local dev mode)[/dim]")
         else:
             console.print("[yellow]No Kamiwaza connection configured — running in standalone mode[/yellow]")
 
-        # 6. Build command
-        cmd = compose_cmd + ["-f", str(compose_file), "up", "--build"]
+        # 5. Build command
+        cmd = compose_cmd + ["-f", str(info.compose_path), "up", "--build"]
         if detach:
             cmd.append("-d")
 
         console.print(f"[dim]Running:[/dim] {' '.join(cmd)}")
 
-        # 7. Run subprocess with signal forwarding
-        return self._run_subprocess(cmd, env=env, cwd=str(ext_dir))
-
-    # ------------------------------------------------------------------
-    # Extension detection
-    # ------------------------------------------------------------------
-
-    def _find_extension(self) -> Path:
-        cwd = Path.cwd()
-
-        # Check root
-        if (cwd / "kamiwaza.json").exists():
-            return cwd
-
-        # Check one level deep
-        found = [d.parent for d in cwd.glob("*/kamiwaza.json")]
-        if len(found) == 1:
-            return found[0]
-        if len(found) > 1:
-            dirs = ", ".join(str(d.name) for d in found)
-            raise FileNotFoundError(
-                f"Multiple kamiwaza.json found: {dirs}. Run from inside a specific extension directory."
-            )
-
-        raise FileNotFoundError(
-            "No kamiwaza.json found. Run this in an extension directory or use `kz-ext create`."
-        )
-
-    def _read_extension_name(self, ext_dir: Path) -> str:
-        try:
-            with (ext_dir / "kamiwaza.json").open("r") as f:
-                data = json.load(f)
-            return data.get("name", ext_dir.name)
-        except (json.JSONDecodeError, FileNotFoundError):
-            return ext_dir.name
-
-    def _find_compose_file(self, ext_dir: Path) -> Path:
-        for name in COMPOSE_FILENAMES:
-            candidate = ext_dir / name
-            if candidate.exists():
-                return candidate
-        raise FileNotFoundError(
-            f"No compose file found in {ext_dir}. Expected one of: {', '.join(COMPOSE_FILENAMES)}"
-        )
+        # 6. Run subprocess with signal forwarding
+        return self._run_subprocess(cmd, env=env, cwd=str(info.path))
 
     # ------------------------------------------------------------------
     # Subprocess management

--- a/kamiwaza_extensions/extension_detector.py
+++ b/kamiwaza_extensions/extension_detector.py
@@ -106,6 +106,9 @@ class ExtensionDetector:
                 try:
                     data = yaml.safe_load(candidate.read_text())
                     return candidate, data
-                except yaml.YAMLError:
+                except yaml.YAMLError as exc:
+                    from rich.console import Console
+                    console = Console(stderr=True)
+                    console.print(f"[yellow]Warning:[/yellow] Failed to parse {candidate}: {exc}")
                     return candidate, None
         return None, None

--- a/kamiwaza_extensions/extension_detector.py
+++ b/kamiwaza_extensions/extension_detector.py
@@ -1,0 +1,111 @@
+"""Shared extension auto-detection and metadata loading."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import yaml
+
+from kamiwaza_extensions.constants import COMPOSE_FILENAMES
+
+
+@dataclass
+class ExtensionInfo:
+    """Detected extension metadata."""
+
+    path: Path
+    name: str
+    version: str
+    metadata: Dict[str, Any]
+    compose_path: Optional[Path] = None
+    compose_data: Optional[Dict[str, Any]] = field(default=None, repr=False)
+
+
+class ExtensionNotFoundError(FileNotFoundError):
+    """No kamiwaza.json found in expected locations."""
+
+    pass
+
+
+class MultipleExtensionsError(FileNotFoundError):
+    """Ambiguous — multiple kamiwaza.json found one level deep."""
+
+    pass
+
+
+class ExtensionDetector:
+    """Find extension root directory and load metadata + compose data."""
+
+    def detect(self, start_dir: Optional[Path] = None) -> ExtensionInfo:
+        """Find the extension and load its metadata.
+
+        Search order:
+        1. ``start_dir`` (default: cwd) for ``kamiwaza.json``
+        2. One level deep (``*/kamiwaza.json``)
+
+        Returns an ``ExtensionInfo`` with metadata and, if present, compose
+        data loaded from the first matching compose filename.
+        """
+        root = start_dir or Path.cwd()
+        ext_dir = self._find_root(root)
+        metadata = self._load_metadata(ext_dir)
+        compose_path, compose_data = self._load_compose(ext_dir)
+        return ExtensionInfo(
+            path=ext_dir,
+            name=metadata.get("name", ext_dir.name),
+            version=metadata.get("version", "0.0.0"),
+            metadata=metadata,
+            compose_path=compose_path,
+            compose_data=compose_data,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _find_root(self, start: Path) -> Path:
+        if (start / "kamiwaza.json").exists():
+            return start
+
+        found = sorted(
+            (d.parent for d in start.glob("*/kamiwaza.json")),
+            key=lambda p: p.name,
+        )
+        if len(found) == 1:
+            return found[0]
+        if len(found) > 1:
+            dirs = ", ".join(str(d.name) for d in found)
+            raise MultipleExtensionsError(
+                f"Multiple kamiwaza.json found: {dirs}. "
+                "Run from inside a specific extension directory."
+            )
+
+        raise ExtensionNotFoundError(
+            "No kamiwaza.json found. "
+            "Run this in an extension directory or use `kz-ext create`."
+        )
+
+    def _load_metadata(self, ext_dir: Path) -> Dict[str, Any]:
+        path = ext_dir / "kamiwaza.json"
+        try:
+            return json.loads(path.read_text())
+        except (json.JSONDecodeError, FileNotFoundError) as exc:
+            raise ExtensionNotFoundError(
+                f"Cannot read kamiwaza.json in {ext_dir}: {exc}"
+            ) from exc
+
+    def _load_compose(
+        self, ext_dir: Path
+    ) -> tuple[Optional[Path], Optional[Dict[str, Any]]]:
+        for name in COMPOSE_FILENAMES:
+            candidate = ext_dir / name
+            if candidate.exists():
+                try:
+                    data = yaml.safe_load(candidate.read_text())
+                    return candidate, data
+                except yaml.YAMLError:
+                    return candidate, None
+        return None, None

--- a/kamiwaza_extensions/image_builder.py
+++ b/kamiwaza_extensions/image_builder.py
@@ -84,7 +84,7 @@ class ImageBuilder:
             if Path(df).is_absolute():
                 dockerfile = Path(df)
             else:
-                dockerfile = extension_dir / df
+                dockerfile = context / df
         else:
             context = extension_dir
             dockerfile = extension_dir / "Dockerfile"

--- a/kamiwaza_extensions/image_builder.py
+++ b/kamiwaza_extensions/image_builder.py
@@ -107,9 +107,9 @@ class ImageBuilder:
         ]
         try:
             if verbose:
-                subprocess.run(cmd, check=True)
+                subprocess.run(cmd, check=True, timeout=3600)
             else:
-                result = subprocess.run(cmd, capture_output=True, text=True)
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=3600)
                 if result.returncode != 0:
                     # Show last 20 lines of output on failure
                     lines = (result.stdout + result.stderr).strip().splitlines()

--- a/kamiwaza_extensions/image_builder.py
+++ b/kamiwaza_extensions/image_builder.py
@@ -100,6 +100,7 @@ class ImageBuilder:
     ) -> None:
         cmd = [
             "docker", "build",
+            "--load",
             "-t", image_ref,
             "-f", str(dockerfile),
             str(context),

--- a/kamiwaza_extensions/image_builder.py
+++ b/kamiwaza_extensions/image_builder.py
@@ -1,0 +1,122 @@
+"""Docker image build subprocess management."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from rich.console import Console
+
+console = Console(stderr=True)
+
+
+class ImageBuildError(RuntimeError):
+    """A Docker build failed."""
+
+    pass
+
+
+class ImageBuilder:
+    """Build Docker images for extension services."""
+
+    def build(
+        self,
+        extension_dir: Path,
+        compose_data: Dict[str, Any],
+        extension_name: str,
+        revision_tag: str,
+        registry: str,
+        service_filter: Optional[str] = None,
+        verbose: bool = False,
+    ) -> List[str]:
+        """Build images and return the list of image references.
+
+        Args:
+            extension_dir: Root directory of the extension.
+            compose_data: *Original* (untransformed) compose dict.
+            extension_name: Extension name from kamiwaza.json.
+            revision_tag: Tag for built images.
+            registry: Registry prefix (e.g. ``registry.kamiwaza.test``).
+            service_filter: Build only this service (``--service`` flag).
+            verbose: Stream full build output.
+
+        Returns:
+            List of image references that were built.
+        """
+        services = compose_data.get("services") or {}
+        built: List[str] = []
+
+        for svc_name, svc in services.items():
+            if service_filter and svc_name != service_filter:
+                continue
+            if "build" not in svc:
+                continue
+
+            image_ref = f"{registry}/{extension_name}-{svc_name}:{revision_tag}"
+            dockerfile, context = self._resolve_build_config(svc["build"], extension_dir)
+
+            console.print(f"  Building [bold]{svc_name}[/bold]...")
+            self._docker_build(image_ref, dockerfile, context, verbose=verbose)
+            built.append(image_ref)
+            console.print(f"  [green]\u2713[/green] {svc_name}  ({image_ref})")
+
+        if service_filter and not built:
+            raise ImageBuildError(
+                f"Service '{service_filter}' not found or has no build context."
+            )
+
+        return built
+
+    @staticmethod
+    def _resolve_build_config(
+        build_spec: Any, extension_dir: Path
+    ) -> tuple[Path, Path]:
+        """Return ``(dockerfile_path, context_dir)`` from a compose ``build:`` value."""
+        if isinstance(build_spec, str):
+            context = extension_dir / build_spec
+            dockerfile = context / "Dockerfile"
+        elif isinstance(build_spec, dict):
+            ctx = build_spec.get("context", ".")
+            context = extension_dir / ctx
+            df = build_spec.get("dockerfile", "Dockerfile")
+            if Path(df).is_absolute():
+                dockerfile = Path(df)
+            else:
+                dockerfile = extension_dir / df
+        else:
+            context = extension_dir
+            dockerfile = extension_dir / "Dockerfile"
+        return dockerfile, context
+
+    @staticmethod
+    def _docker_build(
+        image_ref: str,
+        dockerfile: Path,
+        context: Path,
+        *,
+        verbose: bool = False,
+    ) -> None:
+        cmd = [
+            "docker", "build",
+            "-t", image_ref,
+            "-f", str(dockerfile),
+            str(context),
+        ]
+        try:
+            if verbose:
+                subprocess.run(cmd, check=True)
+            else:
+                result = subprocess.run(cmd, capture_output=True, text=True)
+                if result.returncode != 0:
+                    # Show last 20 lines of output on failure
+                    lines = (result.stdout + result.stderr).strip().splitlines()
+                    tail = "\n".join(lines[-20:])
+                    raise ImageBuildError(
+                        f"Docker build failed for {image_ref}:\n{tail}"
+                    )
+        except FileNotFoundError:
+            raise ImageBuildError(
+                "Docker not found. Install Docker Desktop or ensure 'docker' is on PATH."
+            )

--- a/kamiwaza_extensions/image_pusher.py
+++ b/kamiwaza_extensions/image_pusher.py
@@ -1,0 +1,81 @@
+"""Docker image push subprocess management."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import List, Optional
+
+from rich.console import Console
+
+console = Console(stderr=True)
+
+
+class ImagePushError(RuntimeError):
+    """A Docker push failed."""
+
+    pass
+
+
+class ImagePusher:
+    """Push Docker images to a container registry."""
+
+    def push(
+        self,
+        image_refs: List[str],
+        registry: str,
+        token: Optional[str] = None,
+        verbose: bool = False,
+    ) -> None:
+        """Push all images to the registry.
+
+        If *token* is provided, authenticates with the registry first
+        via ``docker login`` (password passed on stdin, not CLI args).
+        """
+        if token:
+            self.login_registry(registry, token)
+
+        for ref in image_refs:
+            short = ref.rsplit("/", 1)[-1] if "/" in ref else ref
+            console.print(f"  Pushing [bold]{short}[/bold]...")
+            self._docker_push(ref, verbose=verbose)
+            console.print(f"  [green]\u2713[/green] {short}")
+
+    @staticmethod
+    def login_registry(registry: str, token: str) -> None:
+        """Authenticate with the container registry using a PAT via stdin."""
+        try:
+            proc = subprocess.run(
+                ["docker", "login", registry, "-u", "token", "--password-stdin"],
+                input=token,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if proc.returncode != 0:
+                raise ImagePushError(
+                    f"Registry login failed for {registry}: {proc.stderr.strip()}"
+                )
+        except FileNotFoundError:
+            raise ImagePushError(
+                "Docker not found. Install Docker Desktop or ensure 'docker' is on PATH."
+            )
+
+    @staticmethod
+    def _docker_push(image_ref: str, *, verbose: bool = False) -> None:
+        try:
+            if verbose:
+                subprocess.run(["docker", "push", image_ref], check=True)
+            else:
+                result = subprocess.run(
+                    ["docker", "push", image_ref],
+                    capture_output=True,
+                    text=True,
+                )
+                if result.returncode != 0:
+                    raise ImagePushError(
+                        f"Push failed for {image_ref}: {result.stderr.strip()}"
+                    )
+        except FileNotFoundError:
+            raise ImagePushError(
+                "Docker not found. Install Docker Desktop or ensure 'docker' is on PATH."
+            )

--- a/kamiwaza_extensions/image_pusher.py
+++ b/kamiwaza_extensions/image_pusher.py
@@ -81,12 +81,13 @@ class ImagePusher:
             cmd.insert(2, "--tls-verify=false")
         try:
             if verbose:
-                subprocess.run(cmd, check=True)
+                subprocess.run(cmd, check=True, timeout=600)
             else:
                 result = subprocess.run(
                     cmd,
                     capture_output=True,
                     text=True,
+                    timeout=600,
                 )
                 if result.returncode != 0:
                     raise ImagePushError(

--- a/kamiwaza_extensions/image_pusher.py
+++ b/kamiwaza_extensions/image_pusher.py
@@ -1,7 +1,8 @@
-"""Docker image push subprocess management."""
+"""Docker/Podman image push subprocess management."""
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from typing import List, Optional
 
@@ -16,6 +17,11 @@ class ImagePushError(RuntimeError):
     pass
 
 
+def _has_podman() -> bool:
+    """Return True if the ``podman`` CLI is available on PATH."""
+    return shutil.which("podman") is not None
+
+
 class ImagePusher:
     """Push Docker images to a container registry."""
 
@@ -24,28 +30,35 @@ class ImagePusher:
         image_refs: List[str],
         registry: str,
         token: Optional[str] = None,
+        insecure: bool = False,
         verbose: bool = False,
     ) -> None:
         """Push all images to the registry.
 
-        If *token* is provided, authenticates with the registry first
-        via ``docker login`` (password passed on stdin, not CLI args).
+        If *token* is provided, authenticates with the registry first.
+        When *insecure* is True and Podman is available, ``--tls-verify=false``
+        is passed to bypass self-signed certificate errors.
         """
+        use_podman = insecure and _has_podman()
         if token:
-            self.login_registry(registry, token)
+            self._login_registry(registry, token, use_podman=use_podman)
 
         for ref in image_refs:
             short = ref.rsplit("/", 1)[-1] if "/" in ref else ref
             console.print(f"  Pushing [bold]{short}[/bold]...")
-            self._docker_push(ref, verbose=verbose)
+            self._push(ref, use_podman=use_podman, verbose=verbose)
             console.print(f"  [green]\u2713[/green] {short}")
 
     @staticmethod
-    def login_registry(registry: str, token: str) -> None:
+    def _login_registry(registry: str, token: str, *, use_podman: bool = False) -> None:
         """Authenticate with the container registry using a PAT via stdin."""
+        cli = "podman" if use_podman else "docker"
+        cmd = [cli, "login", registry, "-u", "token", "--password-stdin"]
+        if use_podman:
+            cmd.insert(2, "--tls-verify=false")
         try:
             proc = subprocess.run(
-                ["docker", "login", registry, "-u", "token", "--password-stdin"],
+                cmd,
                 input=token,
                 capture_output=True,
                 text=True,
@@ -57,17 +70,21 @@ class ImagePusher:
                 )
         except FileNotFoundError:
             raise ImagePushError(
-                "Docker not found. Install Docker Desktop or ensure 'docker' is on PATH."
+                f"{cli} not found. Install Docker/Podman or ensure '{cli}' is on PATH."
             )
 
     @staticmethod
-    def _docker_push(image_ref: str, *, verbose: bool = False) -> None:
+    def _push(image_ref: str, *, use_podman: bool = False, verbose: bool = False) -> None:
+        cli = "podman" if use_podman else "docker"
+        cmd = [cli, "push", image_ref]
+        if use_podman:
+            cmd.insert(2, "--tls-verify=false")
         try:
             if verbose:
-                subprocess.run(["docker", "push", image_ref], check=True)
+                subprocess.run(cmd, check=True)
             else:
                 result = subprocess.run(
-                    ["docker", "push", image_ref],
+                    cmd,
                     capture_output=True,
                     text=True,
                 )
@@ -77,5 +94,5 @@ class ImagePusher:
                     )
         except FileNotFoundError:
             raise ImagePushError(
-                "Docker not found. Install Docker Desktop or ensure 'docker' is on PATH."
+                f"{cli} not found. Install Docker/Podman or ensure '{cli}' is on PATH."
             )

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -118,17 +118,21 @@ class PayloadBuilder:
             if is_primary and app_path:
                 env.append({"name": "KAMIWAZA_APP_PATH", "value": app_path})
 
-            specs.append(
-                ExtensionServiceSpec(
-                    name=svc_name,
-                    image=svc.get("image", ""),
-                    primary=is_primary,
-                    ports=ports,
-                    env=env if env else None,
-                    replicas=1,
-                    resources=resources,
-                )
+            health_check = self._default_health_check(svc_name, ports, is_primary)
+
+            spec_kwargs: Dict[str, Any] = dict(
+                name=svc_name,
+                image=svc.get("image", ""),
+                primary=is_primary,
+                ports=ports,
+                env=env if env else None,
+                replicas=1,
+                resources=resources,
             )
+            if health_check:
+                spec_kwargs["healthCheck"] = health_check
+
+            specs.append(ExtensionServiceSpec(**spec_kwargs))
 
         return specs
 
@@ -170,6 +174,42 @@ class PayloadBuilder:
                     entry["value"] = str(v)
                 result.append(entry)
         return result
+
+    @staticmethod
+    def _default_health_check(
+        svc_name: str, ports: List[ExtensionPort], is_primary: bool,
+    ) -> Optional[Dict[str, Any]]:
+        """Generate a default health check based on service type."""
+        if not ports:
+            return None
+        port = ports[0].container_port
+
+        if is_primary or svc_name == "frontend":
+            # Frontend: exec curl with basePath support
+            return {
+                "exec": {
+                    "command": [
+                        "/bin/sh", "-c",
+                        f'curl -fsS -o /dev/null "http://localhost:{port}'
+                        '${NEXT_PUBLIC_APP_BASE_PATH:-${KAMIWAZA_APP_PATH:-/}}"',
+                    ],
+                },
+                "initialDelaySeconds": 10,
+                "periodSeconds": 5,
+                "failureThreshold": 24,
+                "startPeriod": 10,
+                "timeoutSeconds": 5,
+            }
+        else:
+            # Backend: HTTP GET /health
+            return {
+                "httpGet": {"path": "/health", "port": port},
+                "initialDelaySeconds": 10,
+                "periodSeconds": 10,
+                "failureThreshold": 3,
+                "startPeriod": 5,
+                "timeoutSeconds": 5,
+            }
 
     @staticmethod
     def _parse_resources(svc: Dict[str, Any]) -> Optional[ResourceSpec]:

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -185,12 +185,12 @@ class PayloadBuilder:
         port = ports[0].container_port
 
         if is_primary or svc_name == "frontend":
-            # Frontend: exec curl with basePath support
+            # Frontend: exec wget with basePath support (Alpine lacks curl)
             return {
                 "exec": {
                     "command": [
                         "/bin/sh", "-c",
-                        f'curl -fsS -o /dev/null "http://localhost:{port}'
+                        f'wget -qO /dev/null "http://localhost:{port}'
                         '${NEXT_PUBLIC_APP_BASE_PATH:-${KAMIWAZA_APP_PATH:-/}}"',
                     ],
                 },

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -99,20 +99,26 @@ class PayloadBuilder:
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
         specs: List[ExtensionServiceSpec] = []
-        primary_assigned = False
+
+        # Determine primary service: prefer "frontend", fall back to first with ports
+        primary_name = None
+        for svc_name, svc in services_dict.items():
+            ports = self._parse_ports(svc.get("ports", []))
+            if svc_name == "frontend" and ports:
+                primary_name = svc_name
+                break
+        if primary_name is None:
+            for svc_name, svc in services_dict.items():
+                if self._parse_ports(svc.get("ports", [])):
+                    primary_name = svc_name
+                    break
 
         for svc_name, svc in services_dict.items():
             ports = self._parse_ports(svc.get("ports", []))
             env = self._parse_env(svc.get("environment", []))
             resources = self._parse_resources(svc)
 
-            is_primary = False
-            if not primary_assigned and ports:
-                is_primary = True
-                primary_assigned = True
-            if svc_name == "frontend" and not primary_assigned:
-                is_primary = True
-                primary_assigned = True
+            is_primary = (svc_name == primary_name)
 
             # Inject platform env vars for primary service
             if is_primary and app_path:

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -1,0 +1,161 @@
+"""Map transformed compose + metadata to CreateExtension SDK model."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, List, Optional
+
+from kamiwaza_sdk.schemas.extensions import (
+    CreateExtension,
+    ExtensionPort,
+    ExtensionServiceSpec,
+    KamiwazaIntegrationSpec,
+    NetworkingSpec,
+    ResourceSpec,
+    SecuritySpec,
+)
+
+from kamiwaza_extensions.connections import ConnectionInfo
+
+
+class PayloadBuilder:
+    """Build a ``CreateExtension`` request from extension metadata and
+    a transformed compose dict."""
+
+    def build(
+        self,
+        metadata: Dict[str, Any],
+        transformed_compose: Dict[str, Any],
+        connection: ConnectionInfo,
+        dev_name: str,
+    ) -> CreateExtension:
+        services = self._build_services(transformed_compose)
+        ext_type = self._resolve_type(metadata)
+
+        return CreateExtension(
+            name=dev_name,
+            type=ext_type,
+            version=metadata.get("version", "0.0.0"),
+            services=services,
+            kamiwaza=KamiwazaIntegrationSpec(
+                api_url=connection.url,
+                public_api_url=connection.url.removesuffix("/api"),
+                use_auth="true",
+            ),
+            networking=NetworkingSpec(ingress_enabled=True),
+            security=SecuritySpec(
+                risk_tier=metadata.get("risk_tier", 1),
+                source_type=metadata.get("source_type", "kamiwaza"),
+                verified=metadata.get("verified", False),
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Dev naming
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def make_dev_name(extension_name: str, user_id: Optional[str] = None) -> str:
+        """Generate a unique dev deployment name.
+
+        Format: ``{name}-dev-{hash6}`` where *hash6* is derived from the
+        user ID (or ``"local"`` when no user context).
+        """
+        seed = user_id or "local"
+        h = hashlib.sha256(seed.encode()).hexdigest()[:6]
+        return f"{extension_name}-dev-{h}"
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_services(
+        self, transformed: Dict[str, Any]
+    ) -> List[ExtensionServiceSpec]:
+        services_dict = transformed.get("services") or {}
+        specs: List[ExtensionServiceSpec] = []
+        primary_assigned = False
+
+        for svc_name, svc in services_dict.items():
+            ports = self._parse_ports(svc.get("ports", []))
+            env = self._parse_env(svc.get("environment", []))
+            resources = self._parse_resources(svc)
+
+            is_primary = False
+            if not primary_assigned and ports:
+                # First service with ports, or named "frontend"
+                is_primary = True
+                primary_assigned = True
+            if svc_name == "frontend" and not primary_assigned:
+                is_primary = True
+                primary_assigned = True
+
+            specs.append(
+                ExtensionServiceSpec(
+                    name=svc_name,
+                    image=svc.get("image", ""),
+                    primary=is_primary,
+                    ports=ports,
+                    env=env if env else None,
+                    replicas=1,
+                    resources=resources,
+                )
+            )
+
+        return specs
+
+    @staticmethod
+    def _parse_ports(ports: List[Any]) -> List[ExtensionPort]:
+        result = []
+        for p in ports:
+            s = str(p)
+            # Strip protocol suffix if present
+            proto = "TCP"
+            if "/" in s:
+                s, proto_str = s.rsplit("/", 1)
+                proto = proto_str.upper() if proto_str.upper() in ("TCP", "UDP") else "TCP"
+            try:
+                result.append(ExtensionPort(container_port=int(s), protocol=proto))
+            except (ValueError, TypeError):
+                continue
+        return result
+
+    @staticmethod
+    def _parse_env(env: Any) -> List[Dict[str, Any]]:
+        """Convert compose env formats to K8s env format."""
+        result = []
+        if isinstance(env, list):
+            for item in env:
+                if isinstance(item, str):
+                    if "=" in item:
+                        key, _, val = item.partition("=")
+                        result.append({"name": key, "value": val})
+                    else:
+                        result.append({"name": item})
+                elif isinstance(item, dict):
+                    for k, v in item.items():
+                        result.append({"name": str(k), "value": str(v)})
+        elif isinstance(env, dict):
+            for k, v in env.items():
+                entry: Dict[str, Any] = {"name": str(k)}
+                if v is not None:
+                    entry["value"] = str(v)
+                result.append(entry)
+        return result
+
+    @staticmethod
+    def _parse_resources(svc: Dict[str, Any]) -> Optional[ResourceSpec]:
+        deploy = svc.get("deploy", {})
+        res = deploy.get("resources", {})
+        limits = res.get("limits")
+        requests = res.get("requests") or res.get("reservations")
+        if limits or requests:
+            return ResourceSpec(limits=limits, requests=requests)
+        return None
+
+    @staticmethod
+    def _resolve_type(metadata: Dict[str, Any]) -> str:
+        t = metadata.get("template_type") or metadata.get("type", "app")
+        if t not in ("app", "tool", "service"):
+            return "app"
+        return t

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -18,6 +18,26 @@ from kamiwaza_sdk.schemas.extensions import (
 from kamiwaza_extensions.connections import ConnectionInfo
 
 
+def _compose_resources_to_k8s(resources: Dict[str, str]) -> Dict[str, str]:
+    """Translate Docker Compose resource keys to Kubernetes format.
+
+    - ``cpus`` → ``cpu`` (e.g. ``"0.5"`` → ``"500m"``)
+    - ``memory`` passed through as-is (``"512M"`` is valid in both)
+    """
+    out: Dict[str, str] = {}
+    for key, val in resources.items():
+        if key == "cpus":
+            # Convert decimal CPU to millicpu
+            try:
+                millicpu = int(float(val) * 1000)
+                out["cpu"] = f"{millicpu}m"
+            except (ValueError, TypeError):
+                out["cpu"] = val
+        else:
+            out[key] = val
+    return out
+
+
 class PayloadBuilder:
     """Build a ``CreateExtension`` request from extension metadata and
     a transformed compose dict."""
@@ -150,7 +170,10 @@ class PayloadBuilder:
         limits = res.get("limits")
         requests = res.get("requests") or res.get("reservations")
         if limits or requests:
-            return ResourceSpec(limits=limits, requests=requests)
+            return ResourceSpec(
+                limits=_compose_resources_to_k8s(limits) if limits else None,
+                requests=_compose_resources_to_k8s(requests) if requests else None,
+            )
         return None
 
     @staticmethod

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -194,10 +194,10 @@ class PayloadBuilder:
                         '${NEXT_PUBLIC_APP_BASE_PATH:-${KAMIWAZA_APP_PATH:-/}}"',
                     ],
                 },
-                "initialDelaySeconds": 10,
-                "periodSeconds": 5,
-                "failureThreshold": 24,
-                "startPeriod": 10,
+                "initialDelaySeconds": 30,
+                "periodSeconds": 10,
+                "failureThreshold": 30,
+                "startPeriod": 300,
                 "timeoutSeconds": 5,
             }
         else:

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -49,8 +49,9 @@ class PayloadBuilder:
         connection: ConnectionInfo,
         dev_name: str,
     ) -> CreateExtension:
-        services = self._build_services(transformed_compose)
         ext_type = self._resolve_type(metadata)
+        app_path = f"/runtime/apps/{dev_name}" if ext_type == "app" else f"/runtime/{ext_type}s/{dev_name}"
+        services = self._build_services(transformed_compose, app_path=app_path)
         origin = connection.url.removesuffix("/api")
         tls_reject = "0" if not connection.verify_ssl else "1"
 
@@ -94,7 +95,7 @@ class PayloadBuilder:
     # ------------------------------------------------------------------
 
     def _build_services(
-        self, transformed: Dict[str, Any]
+        self, transformed: Dict[str, Any], app_path: str = "",
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
         specs: List[ExtensionServiceSpec] = []
@@ -107,12 +108,15 @@ class PayloadBuilder:
 
             is_primary = False
             if not primary_assigned and ports:
-                # First service with ports, or named "frontend"
                 is_primary = True
                 primary_assigned = True
             if svc_name == "frontend" and not primary_assigned:
                 is_primary = True
                 primary_assigned = True
+
+            # Inject platform env vars for primary service
+            if is_primary and app_path:
+                env.append({"name": "KAMIWAZA_APP_PATH", "value": app_path})
 
             specs.append(
                 ExtensionServiceSpec(

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -51,6 +51,8 @@ class PayloadBuilder:
     ) -> CreateExtension:
         services = self._build_services(transformed_compose)
         ext_type = self._resolve_type(metadata)
+        origin = connection.url.removesuffix("/api")
+        tls_reject = "0" if not connection.verify_ssl else "1"
 
         return CreateExtension(
             name=dev_name,
@@ -59,8 +61,10 @@ class PayloadBuilder:
             services=services,
             kamiwaza=KamiwazaIntegrationSpec(
                 api_url=connection.url,
-                public_api_url=connection.url.removesuffix("/api"),
+                public_api_url=connection.url,
+                origin=origin,
                 use_auth="true",
+                tls_reject_unauthorized=tls_reject,
             ),
             networking=NetworkingSpec(ingress_enabled=True),
             security=SecuritySpec(
@@ -135,7 +139,7 @@ class PayloadBuilder:
                 s, proto_str = s.rsplit("/", 1)
                 proto = proto_str.upper() if proto_str.upper() in ("TCP", "UDP") else "TCP"
             try:
-                result.append(ExtensionPort(container_port=int(s), protocol=proto))
+                result.append(ExtensionPort(container_port=int(s), protocol=proto, name="http"))
             except (ValueError, TypeError):
                 continue
         return result

--- a/kamiwaza_extensions/revision_tagger.py
+++ b/kamiwaza_extensions/revision_tagger.py
@@ -1,0 +1,85 @@
+"""Dev revision tag generation from git state + timestamp."""
+
+from __future__ import annotations
+
+import subprocess
+import time
+from typing import Optional, Tuple
+
+
+class RevisionTagger:
+    """Generate unique Docker image tags for dev builds.
+
+    Tag format:
+    - Clean repo:  ``{version}-dev+{sha7}.{epoch}``
+    - Dirty repo:  ``{version}-dev+dirty.{epoch}``
+    - No git:      ``{version}-dev+nogit.{epoch}``
+    - Custom:      whatever the caller passes via *custom*
+    """
+
+    def generate_tag(
+        self,
+        version: str,
+        custom: Optional[str] = None,
+        *,
+        _now: Optional[int] = None,
+    ) -> str:
+        """Return a unique dev revision tag.
+
+        Args:
+            version: Base version from kamiwaza.json (e.g. ``"1.0.0"``).
+            custom: If provided, returned as-is (``--revision`` flag).
+            _now: Override epoch for deterministic tests.
+        """
+        if custom:
+            return custom
+
+        ts = _now if _now is not None else int(time.time())
+        sha, dirty = self.get_git_info()
+
+        if sha is None:
+            slug = "nogit"
+        elif dirty:
+            slug = "dirty"
+        else:
+            slug = sha
+
+        return f"{version}-dev+{slug}.{ts}"
+
+    @staticmethod
+    def get_git_info() -> Tuple[Optional[str], bool]:
+        """Return ``(short_sha | None, is_dirty)``.
+
+        Returns ``(None, False)`` when the working directory is not inside a
+        git repository or git is not installed.
+        """
+        try:
+            sha = (
+                subprocess.run(
+                    ["git", "rev-parse", "--short", "HEAD"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=5,
+                )
+                .stdout.strip()
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+            return None, False
+
+        try:
+            status = (
+                subprocess.run(
+                    ["git", "status", "--porcelain"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                    timeout=5,
+                )
+                .stdout.strip()
+            )
+            dirty = bool(status)
+        except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+            dirty = False
+
+        return sha, dirty

--- a/kamiwaza_extensions/revision_tagger.py
+++ b/kamiwaza_extensions/revision_tagger.py
@@ -10,10 +10,10 @@ from typing import Optional, Tuple
 class RevisionTagger:
     """Generate unique Docker image tags for dev builds.
 
-    Tag format:
-    - Clean repo:  ``{version}-dev+{sha7}.{epoch}``
-    - Dirty repo:  ``{version}-dev+dirty.{epoch}``
-    - No git:      ``{version}-dev+nogit.{epoch}``
+    Tag format (``+`` replaced with ``-`` for OCI compatibility):
+    - Clean repo:  ``{version}-dev-{sha7}.{epoch}``
+    - Dirty repo:  ``{version}-dev-dirty.{epoch}``
+    - No git:      ``{version}-dev-nogit.{epoch}``
     - Custom:      whatever the caller passes via *custom*
     """
 
@@ -44,7 +44,7 @@ class RevisionTagger:
         else:
             slug = sha
 
-        return f"{version}-dev+{slug}.{ts}"
+        return f"{version}-dev-{slug}.{ts}"
 
     @staticmethod
     def get_git_info() -> Tuple[Optional[str], bool]:

--- a/kamiwaza_extensions/templates/app/backend/Dockerfile
+++ b/kamiwaza_extensions/templates/app/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-slim
 
-RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser
+RUN groupadd -r -g 1001 appuser && useradd -r -u 1001 -g appuser -d /app appuser
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 RUN chown -R appuser:appuser /app
 
-USER appuser
+USER 1001
 
 EXPOSE 8000
 

--- a/kamiwaza_extensions/templates/app/backend/Dockerfile
+++ b/kamiwaza_extensions/templates/app/backend/Dockerfile
@@ -1,11 +1,16 @@
 FROM python:3.10-slim
 
+RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser
+
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+RUN chown -R appuser:appuser /app
+
+USER appuser
 
 EXPOSE 8000
 

--- a/kamiwaza_extensions/templates/app/frontend/Dockerfile
+++ b/kamiwaza_extensions/templates/app/frontend/Dockerfile
@@ -9,10 +9,14 @@ RUN npm install
 
 COPY . .
 RUN npm run build || true
-RUN chown -R appuser:appuser /app
+RUN mkdir -p /tmp/app && chown -R appuser:appuser /app /tmp/app
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 USER 1001
 
 EXPOSE 3000
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["npm", "run", "start"]

--- a/kamiwaza_extensions/templates/app/frontend/Dockerfile
+++ b/kamiwaza_extensions/templates/app/frontend/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine AS base
 
-RUN addgroup -S appuser && adduser -S appuser -G appuser
+RUN addgroup -S -g 1001 appuser && adduser -S -u 1001 -G appuser appuser
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ RUN npm install
 COPY . .
 RUN chown -R appuser:appuser /app
 
-USER appuser
+USER 1001
 
 EXPOSE 3000
 

--- a/kamiwaza_extensions/templates/app/frontend/Dockerfile
+++ b/kamiwaza_extensions/templates/app/frontend/Dockerfile
@@ -8,10 +8,11 @@ COPY package.json package-lock.json* ./
 RUN npm install
 
 COPY . .
+RUN npm run build || true
 RUN chown -R appuser:appuser /app
 
 USER 1001
 
 EXPOSE 3000
 
-CMD ["npm", "run", "dev"]
+CMD ["npm", "run", "start"]

--- a/kamiwaza_extensions/templates/app/frontend/Dockerfile
+++ b/kamiwaza_extensions/templates/app/frontend/Dockerfile
@@ -1,11 +1,16 @@
 FROM node:20-alpine AS base
 
+RUN addgroup -S appuser && adduser -S appuser -G appuser
+
 WORKDIR /app
 
 COPY package.json package-lock.json* ./
 RUN npm install
 
 COPY . .
+RUN chown -R appuser:appuser /app
+
+USER appuser
 
 EXPOSE 3000
 

--- a/kamiwaza_extensions/templates/app/frontend/docker-entrypoint.sh
+++ b/kamiwaza_extensions/templates/app/frontend/docker-entrypoint.sh
@@ -6,8 +6,9 @@ export NEXT_TELEMETRY_DISABLED=1
 # If running under a path prefix, rebuild with basePath
 if [ -n "$KAMIWAZA_APP_PATH" ]; then
     echo "Building Next.js for base path: $KAMIWAZA_APP_PATH"
-    cd /tmp/app
+    mkdir -p /tmp/app
     cp -r /app/. /tmp/app/
+    cd /tmp/app
     npm run build
     exec npm run start
 fi

--- a/kamiwaza_extensions/templates/app/frontend/docker-entrypoint.sh
+++ b/kamiwaza_extensions/templates/app/frontend/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+export NEXT_TELEMETRY_DISABLED=1
+
+# If running under a path prefix, rebuild with basePath
+if [ -n "$KAMIWAZA_APP_PATH" ]; then
+    echo "Building Next.js for base path: $KAMIWAZA_APP_PATH"
+    cd /tmp/app
+    cp -r /app/. /tmp/app/
+    npm run build
+    exec npm run start
+fi
+
+cd /app
+exec "$@"

--- a/kamiwaza_extensions/templates/app/frontend/next.config.js
+++ b/kamiwaza_extensions/templates/app/frontend/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
+const basePath = process.env.KAMIWAZA_APP_PATH || "";
+
 const nextConfig = {
     output: "standalone",
+    basePath: basePath || undefined,
+    assetPrefix: basePath || undefined,
 };
 
 module.exports = nextConfig;

--- a/kamiwaza_extensions/templates/service/Dockerfile
+++ b/kamiwaza_extensions/templates/service/Dockerfile
@@ -1,13 +1,13 @@
 FROM python:3.10-slim
 
-RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser
+RUN groupadd -r -g 1001 appuser && useradd -r -u 1001 -g appuser -d /app appuser
 
 WORKDIR /app
 
 COPY . .
 RUN chown -R appuser:appuser /app
 
-USER appuser
+USER 1001
 
 EXPOSE 8000
 

--- a/kamiwaza_extensions/templates/service/Dockerfile
+++ b/kamiwaza_extensions/templates/service/Dockerfile
@@ -1,8 +1,13 @@
 FROM python:3.10-slim
 
+RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser
+
 WORKDIR /app
 
 COPY . .
+RUN chown -R appuser:appuser /app
+
+USER appuser
 
 EXPOSE 8000
 

--- a/kamiwaza_extensions/templates/tool/Dockerfile
+++ b/kamiwaza_extensions/templates/tool/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-slim
 
-RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser
+RUN groupadd -r -g 1001 appuser && useradd -r -u 1001 -g appuser -d /app appuser
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 RUN chown -R appuser:appuser /app
 
-USER appuser
+USER 1001
 
 EXPOSE 8000
 

--- a/kamiwaza_extensions/templates/tool/Dockerfile
+++ b/kamiwaza_extensions/templates/tool/Dockerfile
@@ -1,11 +1,16 @@
 FROM python:3.10-slim
 
+RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser
+
 WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+RUN chown -R appuser:appuser /app
+
+USER appuser
 
 EXPOSE 8000
 

--- a/kamiwaza_sdk/schemas/extensions.py
+++ b/kamiwaza_sdk/schemas/extensions.py
@@ -84,8 +84,8 @@ class CreateExtension(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     name: str = Field(..., description="Extension name (K8s DNS label)")
-    type: Literal["app", "tool"] = Field(
-        ..., description="Extension type: 'app' or 'tool'"
+    type: Literal["app", "tool", "service"] = Field(
+        ..., description="Extension type: 'app', 'tool', or 'service'"
     )
     version: str = Field(..., description="Extension version (semver)")
     services: List[ExtensionServiceSpec] = Field(..., min_length=1)

--- a/kamiwaza_sdk/schemas/extensions.py
+++ b/kamiwaza_sdk/schemas/extensions.py
@@ -57,6 +57,7 @@ class KamiwazaIntegrationSpec(BaseModel):
     public_api_url: Optional[str] = None
     origin: Optional[str] = None
     use_auth: str = Field(default="true")
+    tls_reject_unauthorized: Optional[str] = None
 
 
 class NetworkingSpec(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "kamiwaza-sdk"
 version = "0.11.0"
 description = "Python client library for the Kamiwaza AI Platform"
 readme = "README.md"
-license = "MIT"
+license = {text = "MIT"}
 requires-python = ">=3.10"
 authors = [
     { name = "Kamiwaza Team", email = "eng@kamiwaza.ai" },

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -1,0 +1,212 @@
+"""Tests for ComposeTransformer."""
+
+import pytest
+
+from kamiwaza_extensions.compose_transformer import ComposeTransformer
+
+
+@pytest.fixture
+def transformer():
+    return ComposeTransformer()
+
+
+@pytest.fixture
+def multi_service_compose():
+    """A realistic multi-service compose dict."""
+    return {
+        "services": {
+            "frontend": {
+                "build": {"context": ".", "dockerfile": "frontend/Dockerfile"},
+                "ports": ["3000:3000"],
+                "environment": ["NEXT_PUBLIC_API_URL=http://backend:8000"],
+                "networks": ["default"],
+            },
+            "backend": {
+                "build": "./backend",
+                "ports": ["8000:8000"],
+                "volumes": [
+                    "./data:/app/data",
+                    "backend_data:/app/persist",
+                ],
+                "environment": {
+                    "OPENAI_BASE_URL": "${KAMIWAZA_ENDPOINT:-http://host.docker.internal:8080}",
+                },
+                "extra_hosts": ["host.docker.internal:host-gateway"],
+                "container_name": "my-backend",
+            },
+            "db": {
+                "image": "postgres:15",
+                "ports": ["5432:5432"],
+                "volumes": ["pgdata:/var/lib/postgresql/data"],
+                "environment": {"POSTGRES_PASSWORD": "secret"},
+            },
+        },
+        "volumes": {
+            "backend_data": None,
+            "pgdata": None,
+        },
+        "networks": {
+            "default": None,
+        },
+    }
+
+
+class TestStripHostPorts:
+    def test_strips_host_port(self, transformer):
+        compose = {"services": {"web": {"ports": ["3000:3000"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["web"]["ports"] == ["3000"]
+
+    def test_strips_with_protocol(self, transformer):
+        compose = {"services": {"web": {"ports": ["8080:3000/tcp"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["web"]["ports"] == ["3000/tcp"]
+
+    def test_container_only_port_unchanged(self, transformer):
+        compose = {"services": {"web": {"ports": ["8000"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["web"]["ports"] == ["8000"]
+
+
+class TestStripBindMounts:
+    def test_strips_relative_bind_mount(self, transformer):
+        compose = {"services": {"web": {"volumes": ["./data:/app/data", "named:/app/persist"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["web"]["volumes"] == ["named:/app/persist"]
+
+    def test_strips_absolute_bind_mount(self, transformer):
+        compose = {"services": {"web": {"volumes": ["/host/path:/container"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert "volumes" not in result["services"]["web"]
+
+    def test_keeps_named_volumes(self, transformer):
+        compose = {"services": {"web": {"volumes": ["data:/app/data"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["web"]["volumes"] == ["data:/app/data"]
+
+
+class TestBuildContextRemoval:
+    def test_removes_build_adds_image(self, transformer):
+        compose = {"services": {"api": {"build": "./backend"}}}
+        result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test")
+        svc = result["services"]["api"]
+        assert "build" not in svc
+        assert svc["image"] == "registry.test/my-app-api:1.0.0-dev"
+
+    def test_updates_existing_image_tag(self, transformer):
+        compose = {
+            "services": {
+                "api": {
+                    "build": "./backend",
+                    "image": "kamiwazaai/my-app-api:old-tag",
+                }
+            }
+        }
+        result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test")
+        assert result["services"]["api"]["image"] == "kamiwazaai/my-app-api:1.0.0-dev"
+
+    def test_dict_build_config(self, transformer):
+        compose = {
+            "services": {
+                "web": {
+                    "build": {"context": ".", "dockerfile": "frontend/Dockerfile"}
+                }
+            }
+        }
+        result = transformer.transform(compose, "my-app", "v1", "reg")
+        assert "build" not in result["services"]["web"]
+        assert result["services"]["web"]["image"] == "reg/my-app-web:v1"
+
+
+class TestExternalImages:
+    def test_postgres_preserved(self, transformer):
+        compose = {"services": {"db": {"image": "postgres:15"}}}
+        result = transformer.transform(compose, "my-app", "v1", "reg")
+        assert result["services"]["db"]["image"] == "postgres:15"
+
+    def test_redis_preserved(self, transformer):
+        compose = {"services": {"cache": {"image": "redis:7-alpine"}}}
+        result = transformer.transform(compose, "my-app", "v1", "reg")
+        assert result["services"]["cache"]["image"] == "redis:7-alpine"
+
+
+class TestResourceLimits:
+    def test_adds_default_limits(self, transformer):
+        compose = {"services": {"api": {"image": "my-app/api:1"}}}
+        result = transformer.transform(compose, "my-app", "v1", "reg")
+        limits = result["services"]["api"]["deploy"]["resources"]["limits"]
+        assert limits["cpus"] == "1.0"
+        assert limits["memory"] == "1G"
+
+    def test_preserves_existing_limits(self, transformer):
+        compose = {
+            "services": {
+                "api": {
+                    "image": "my-app/api:1",
+                    "deploy": {"resources": {"limits": {"cpus": "2.0", "memory": "4G"}}},
+                }
+            }
+        }
+        result = transformer.transform(compose, "my-app", "v1", "reg")
+        limits = result["services"]["api"]["deploy"]["resources"]["limits"]
+        assert limits["cpus"] == "2.0"
+
+    def test_postgres_gets_smaller_limits(self, transformer):
+        compose = {"services": {"db": {"image": "postgres:15"}}}
+        result = transformer.transform(compose, "my-app", "v1", "reg")
+        limits = result["services"]["db"]["deploy"]["resources"]["limits"]
+        assert limits["cpus"] == "0.5"
+        assert limits["memory"] == "512M"
+
+
+class TestCleanup:
+    def test_removes_extra_hosts(self, transformer):
+        compose = {"services": {"api": {"extra_hosts": ["host.docker.internal:host-gateway"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert "extra_hosts" not in result["services"]["api"]
+
+    def test_removes_container_name(self, transformer):
+        compose = {"services": {"api": {"container_name": "my-api"}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert "container_name" not in result["services"]["api"]
+
+    def test_removes_networks(self, transformer):
+        compose = {"services": {"api": {"networks": ["default"]}}, "networks": {"default": None}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert "networks" not in result["services"]["api"]
+        assert "networks" not in result
+
+
+class TestFullTransform:
+    def test_multi_service(self, transformer, multi_service_compose):
+        result = transformer.transform(
+            multi_service_compose, "my-app", "1.0.0-dev+abc.123", "registry.test"
+        )
+        # Frontend
+        fe = result["services"]["frontend"]
+        assert "build" not in fe
+        assert fe["image"] == "registry.test/my-app-frontend:1.0.0-dev+abc.123"
+        assert fe["ports"] == ["3000"]
+        assert "networks" not in fe
+
+        # Backend
+        be = result["services"]["backend"]
+        assert "build" not in be
+        assert "extra_hosts" not in be
+        assert "container_name" not in be
+        assert be["volumes"] == ["backend_data:/app/persist"]  # bind mount stripped
+
+        # DB (external)
+        db = result["services"]["db"]
+        assert db["image"] == "postgres:15"
+
+        # Top-level
+        assert "networks" not in result
+        assert "volumes" in result  # named volumes preserved
+
+    def test_does_not_mutate_input(self, transformer):
+        compose = {"services": {"api": {"build": ".", "ports": ["8000:8000"]}}}
+        original_ports = list(compose["services"]["api"]["ports"])
+        transformer.transform(compose, "test", "v1", "reg")
+        assert compose["services"]["api"]["ports"] == original_ports
+        assert "build" in compose["services"]["api"]

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -103,7 +103,8 @@ class TestBuildContextRemoval:
             }
         }
         result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test")
-        assert result["services"]["api"]["image"] == "kamiwazaai/my-app-api:1.0.0-dev"
+        # When service has both build and image, use consistent registry format (matches image builder)
+        assert result["services"]["api"]["image"] == "registry.test/my-app-api:1.0.0-dev"
 
     def test_dict_build_config(self, transformer):
         compose = {

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -180,12 +180,12 @@ class TestCleanup:
 class TestFullTransform:
     def test_multi_service(self, transformer, multi_service_compose):
         result = transformer.transform(
-            multi_service_compose, "my-app", "1.0.0-dev+abc.123", "registry.test"
+            multi_service_compose, "my-app", "1.0.0-dev-abc.123", "registry.test"
         )
         # Frontend
         fe = result["services"]["frontend"]
         assert "build" not in fe
-        assert fe["image"] == "registry.test/my-app-frontend:1.0.0-dev+abc.123"
+        assert fe["image"] == "registry.test/my-app-frontend:1.0.0-dev-abc.123"
         assert fe["ports"] == ["3000"]
         assert "networks" not in fe
 

--- a/tests/unit/extensions/test_deployment_poller.py
+++ b/tests/unit/extensions/test_deployment_poller.py
@@ -1,0 +1,84 @@
+"""Tests for DeploymentPoller."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kamiwaza_sdk.schemas.extensions import (
+    Extension,
+    ExtensionEndpoints,
+    ExtensionServiceStatus,
+)
+
+from kamiwaza_extensions.deployment_poller import (
+    DeploymentFailedError,
+    DeploymentPoller,
+    DeploymentTimeoutError,
+)
+
+
+@pytest.fixture
+def poller():
+    return DeploymentPoller()
+
+
+def _make_ext(phase: str, url: str = None, message: str = None) -> Extension:
+    endpoints = ExtensionEndpoints(external=url) if url else None
+    services = []
+    if message:
+        services = [ExtensionServiceStatus(name="backend", message=message)]
+    return Extension(
+        name="test-dev-abc",
+        type="app",
+        version="1.0.0",
+        phase=phase,
+        endpoints=endpoints,
+        services=services,
+    )
+
+
+class TestWaitForReady:
+    @patch("kamiwaza_extensions.deployment_poller.time.sleep")
+    def test_returns_on_running(self, mock_sleep, poller):
+        client = MagicMock()
+        client.extensions.get_extension.return_value = _make_ext(
+            "Running", url="https://cluster.test/app"
+        )
+
+        result = poller.wait_for_ready(client, "test-dev-abc", timeout=10)
+        assert result.phase == "Running"
+        assert result.endpoints.external == "https://cluster.test/app"
+
+    @patch("kamiwaza_extensions.deployment_poller.time.sleep")
+    def test_polls_through_provisioning(self, mock_sleep, poller):
+        client = MagicMock()
+        client.extensions.get_extension.side_effect = [
+            _make_ext("Pending"),
+            _make_ext("Provisioning"),
+            _make_ext("Running", url="https://cluster.test/app"),
+        ]
+
+        result = poller.wait_for_ready(client, "test-dev-abc", timeout=30)
+        assert result.phase == "Running"
+        assert client.extensions.get_extension.call_count == 3
+
+    @patch("kamiwaza_extensions.deployment_poller.time.sleep")
+    def test_raises_on_failed(self, mock_sleep, poller):
+        client = MagicMock()
+        client.extensions.get_extension.return_value = _make_ext(
+            "Failed", message="ImagePullBackOff"
+        )
+
+        with pytest.raises(DeploymentFailedError, match="ImagePullBackOff"):
+            poller.wait_for_ready(client, "test", timeout=10)
+
+    @patch("kamiwaza_extensions.deployment_poller.time.monotonic")
+    @patch("kamiwaza_extensions.deployment_poller.time.sleep")
+    def test_raises_on_timeout(self, mock_sleep, mock_monotonic, poller):
+        # Simulate time passing beyond deadline
+        mock_monotonic.side_effect = [0, 0, 200]  # start, first check, past deadline
+        client = MagicMock()
+        client.extensions.get_extension.return_value = _make_ext("Provisioning")
+
+        with pytest.raises(DeploymentTimeoutError, match="Provisioning"):
+            poller.wait_for_ready(client, "test", timeout=120)

--- a/tests/unit/extensions/test_deployment_poller.py
+++ b/tests/unit/extensions/test_deployment_poller.py
@@ -38,8 +38,9 @@ def _make_ext(phase: str, url: str = None, message: str = None) -> Extension:
 
 
 class TestWaitForReady:
+    @patch.object(DeploymentPoller, "_check_pods_ready", return_value=(True, "2/2 ready"))
     @patch("kamiwaza_extensions.deployment_poller.time.sleep")
-    def test_returns_on_running(self, mock_sleep, poller):
+    def test_returns_on_running(self, mock_sleep, mock_pods, poller):
         client = MagicMock()
         client.extensions.get_extension.return_value = _make_ext(
             "Running", url="https://cluster.test/app"
@@ -49,8 +50,9 @@ class TestWaitForReady:
         assert result.phase == "Running"
         assert result.endpoints.external == "https://cluster.test/app"
 
+    @patch.object(DeploymentPoller, "_check_pods_ready", return_value=(True, "2/2 ready"))
     @patch("kamiwaza_extensions.deployment_poller.time.sleep")
-    def test_polls_through_provisioning(self, mock_sleep, poller):
+    def test_polls_through_provisioning(self, mock_sleep, mock_pods, poller):
         client = MagicMock()
         client.extensions.get_extension.side_effect = [
             _make_ext("Pending"),
@@ -81,4 +83,15 @@ class TestWaitForReady:
         client.extensions.get_extension.return_value = _make_ext("Provisioning")
 
         with pytest.raises(DeploymentTimeoutError, match="Provisioning"):
+            poller.wait_for_ready(client, "test", timeout=120)
+
+    @patch.object(DeploymentPoller, "_check_pods_ready", return_value=(False, "1/2 ready"))
+    @patch("kamiwaza_extensions.deployment_poller.time.monotonic")
+    @patch("kamiwaza_extensions.deployment_poller.time.sleep")
+    def test_waits_for_pods_ready(self, mock_sleep, mock_monotonic, mock_pods, poller):
+        mock_monotonic.side_effect = [0, 0, 0, 200]
+        client = MagicMock()
+        client.extensions.get_extension.return_value = _make_ext("Running")
+
+        with pytest.raises(DeploymentTimeoutError):
             poller.wait_for_ready(client, "test", timeout=120)

--- a/tests/unit/extensions/test_dev_local.py
+++ b/tests/unit/extensions/test_dev_local.py
@@ -1,47 +1,15 @@
-"""Tests for DevLocalRunner."""
+"""Tests for DevLocalRunner.
 
-import json
+Extension detection and compose file discovery tests moved to
+test_extension_detector.py (shared ExtensionDetector module).
+"""
+
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 from kamiwaza_extensions.connections import ConnectionInfo
-from kamiwaza_extensions.dev_local import DevLocalRunner, build_env_overlay, detect_compose_command
-
-
-@pytest.mark.unit
-class TestExtensionDetection:
-    def test_finds_extension_at_root(self, tmp_path, monkeypatch):
-        (tmp_path / "kamiwaza.json").write_text(json.dumps({"name": "my-app"}))
-        monkeypatch.chdir(tmp_path)
-        runner = DevLocalRunner(config_dir=tmp_path / ".kamiwaza")
-        ext_dir = runner._find_extension()
-        assert ext_dir == tmp_path
-
-    def test_finds_extension_one_level_deep(self, tmp_path, monkeypatch):
-        sub = tmp_path / "my-app"
-        sub.mkdir()
-        (sub / "kamiwaza.json").write_text(json.dumps({"name": "my-app"}))
-        monkeypatch.chdir(tmp_path)
-        runner = DevLocalRunner(config_dir=tmp_path / ".kamiwaza")
-        ext_dir = runner._find_extension()
-        assert ext_dir == sub
-
-    def test_errors_when_no_extension_found(self, tmp_path, monkeypatch):
-        monkeypatch.chdir(tmp_path)
-        runner = DevLocalRunner(config_dir=tmp_path / ".kamiwaza")
-        with pytest.raises(FileNotFoundError, match="No kamiwaza.json"):
-            runner._find_extension()
-
-    def test_errors_when_multiple_extensions(self, tmp_path, monkeypatch):
-        for name in ("app-a", "app-b"):
-            d = tmp_path / name
-            d.mkdir()
-            (d / "kamiwaza.json").write_text(json.dumps({"name": name}))
-        monkeypatch.chdir(tmp_path)
-        runner = DevLocalRunner(config_dir=tmp_path / ".kamiwaza")
-        with pytest.raises(FileNotFoundError, match="Multiple"):
-            runner._find_extension()
+from kamiwaza_extensions.dev_local import build_env_overlay, detect_compose_command
 
 
 @pytest.mark.unit
@@ -92,21 +60,5 @@ class TestComposeDetection:
                 detect_compose_command()
 
 
-@pytest.mark.unit
-class TestComposeFileDetection:
-    def test_finds_docker_compose_yml(self, tmp_path):
-        (tmp_path / "docker-compose.yml").write_text("version: '3'")
-        runner = DevLocalRunner(config_dir=tmp_path / ".kamiwaza")
-        result = runner._find_compose_file(tmp_path)
-        assert result.name == "docker-compose.yml"
 
-    def test_finds_compose_yaml(self, tmp_path):
-        (tmp_path / "compose.yaml").write_text("version: '3'")
-        runner = DevLocalRunner(config_dir=tmp_path / ".kamiwaza")
-        result = runner._find_compose_file(tmp_path)
-        assert result.name == "compose.yaml"
-
-    def test_errors_when_no_compose_file(self, tmp_path):
-        runner = DevLocalRunner(config_dir=tmp_path / ".kamiwaza")
-        with pytest.raises(FileNotFoundError, match="No compose file"):
-            runner._find_compose_file(tmp_path)
+# Compose file detection tests are in test_extension_detector.py

--- a/tests/unit/extensions/test_extension_detector.py
+++ b/tests/unit/extensions/test_extension_detector.py
@@ -1,0 +1,103 @@
+"""Tests for ExtensionDetector."""
+
+import json
+
+import pytest
+import yaml
+
+from kamiwaza_extensions.extension_detector import (
+    ExtensionDetector,
+    ExtensionInfo,
+    ExtensionNotFoundError,
+    MultipleExtensionsError,
+)
+
+
+@pytest.fixture
+def detector():
+    return ExtensionDetector()
+
+
+@pytest.fixture
+def ext_dir(tmp_path):
+    """Create a minimal extension directory."""
+    meta = {"name": "my-app", "version": "1.0.0", "source_type": "kamiwaza"}
+    (tmp_path / "kamiwaza.json").write_text(json.dumps(meta))
+    compose = {"services": {"backend": {"build": "./backend", "ports": ["8000"]}}}
+    (tmp_path / "docker-compose.yml").write_text(yaml.dump(compose))
+    return tmp_path
+
+
+class TestFindRoot:
+    def test_root_level(self, detector, ext_dir):
+        info = detector.detect(ext_dir)
+        assert info.path == ext_dir
+        assert info.name == "my-app"
+        assert info.version == "1.0.0"
+
+    def test_one_level_deep(self, detector, tmp_path):
+        sub = tmp_path / "my-ext"
+        sub.mkdir()
+        meta = {"name": "nested-ext", "version": "2.0.0"}
+        (sub / "kamiwaza.json").write_text(json.dumps(meta))
+        (sub / "docker-compose.yml").write_text("services: {}")
+
+        info = detector.detect(tmp_path)
+        assert info.path == sub
+        assert info.name == "nested-ext"
+
+    def test_multiple_extensions_error(self, detector, tmp_path):
+        for name in ("ext-a", "ext-b"):
+            d = tmp_path / name
+            d.mkdir()
+            (d / "kamiwaza.json").write_text(json.dumps({"name": name}))
+
+        with pytest.raises(MultipleExtensionsError, match="Multiple kamiwaza.json"):
+            detector.detect(tmp_path)
+
+    def test_no_extension_found(self, detector, tmp_path):
+        with pytest.raises(ExtensionNotFoundError, match="No kamiwaza.json"):
+            detector.detect(tmp_path)
+
+
+class TestMetadataLoading:
+    def test_name_fallback_to_dir(self, detector, tmp_path):
+        (tmp_path / "kamiwaza.json").write_text(json.dumps({"version": "1.0.0"}))
+        info = detector.detect(tmp_path)
+        assert info.name == tmp_path.name
+
+    def test_version_fallback(self, detector, tmp_path):
+        (tmp_path / "kamiwaza.json").write_text(json.dumps({"name": "x"}))
+        info = detector.detect(tmp_path)
+        assert info.version == "0.0.0"
+
+    def test_corrupt_json(self, detector, tmp_path):
+        (tmp_path / "kamiwaza.json").write_text("{invalid json")
+        with pytest.raises(ExtensionNotFoundError, match="Cannot read"):
+            detector.detect(tmp_path)
+
+
+class TestComposeLoading:
+    def test_compose_loaded(self, detector, ext_dir):
+        info = detector.detect(ext_dir)
+        assert info.compose_path == ext_dir / "docker-compose.yml"
+        assert "services" in info.compose_data
+
+    def test_no_compose(self, detector, tmp_path):
+        (tmp_path / "kamiwaza.json").write_text(json.dumps({"name": "x"}))
+        info = detector.detect(tmp_path)
+        assert info.compose_path is None
+        assert info.compose_data is None
+
+    def test_compose_yaml_variant(self, detector, tmp_path):
+        (tmp_path / "kamiwaza.json").write_text(json.dumps({"name": "x"}))
+        (tmp_path / "compose.yml").write_text("services:\n  web:\n    image: nginx")
+        info = detector.detect(tmp_path)
+        assert info.compose_path == tmp_path / "compose.yml"
+
+    def test_prefers_docker_compose_yml(self, detector, tmp_path):
+        (tmp_path / "kamiwaza.json").write_text(json.dumps({"name": "x"}))
+        (tmp_path / "docker-compose.yml").write_text("services: {a: {}}")
+        (tmp_path / "compose.yml").write_text("services: {b: {}}")
+        info = detector.detect(tmp_path)
+        assert info.compose_path.name == "docker-compose.yml"

--- a/tests/unit/extensions/test_image_builder.py
+++ b/tests/unit/extensions/test_image_builder.py
@@ -40,12 +40,12 @@ class TestBuild:
             extension_dir=tmp_path,
             compose_data=compose_with_build,
             extension_name="my-app",
-            revision_tag="1.0.0-dev+abc.123",
+            revision_tag="1.0.0-dev-abc.123",
             registry="registry.test",
         )
         assert len(refs) == 2  # backend + frontend (not db)
-        assert "registry.test/my-app-backend:1.0.0-dev+abc.123" in refs
-        assert "registry.test/my-app-frontend:1.0.0-dev+abc.123" in refs
+        assert "registry.test/my-app-backend:1.0.0-dev-abc.123" in refs
+        assert "registry.test/my-app-frontend:1.0.0-dev-abc.123" in refs
 
     @patch("kamiwaza_extensions.image_builder.subprocess.run")
     def test_service_filter(self, mock_run, builder, compose_with_build, tmp_path):

--- a/tests/unit/extensions/test_image_builder.py
+++ b/tests/unit/extensions/test_image_builder.py
@@ -99,3 +99,11 @@ class TestResolveBuildConfig:
         )
         assert ctx == tmp_path
         assert df == tmp_path / "backend" / "Dockerfile"
+
+    def test_dict_build_dockerfile_relative_to_context(self, builder, tmp_path):
+        """When context is a subdirectory, dockerfile resolves relative to it."""
+        df, ctx = builder._resolve_build_config(
+            {"context": "./frontend", "dockerfile": "Dockerfile"}, tmp_path
+        )
+        assert ctx == tmp_path / "frontend"
+        assert df == tmp_path / "frontend" / "Dockerfile"

--- a/tests/unit/extensions/test_image_builder.py
+++ b/tests/unit/extensions/test_image_builder.py
@@ -1,0 +1,101 @@
+"""Tests for ImageBuilder."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kamiwaza_extensions.image_builder import ImageBuilder, ImageBuildError
+
+
+@pytest.fixture
+def builder():
+    return ImageBuilder()
+
+
+@pytest.fixture
+def compose_with_build():
+    return {
+        "services": {
+            "backend": {
+                "build": {"context": ".", "dockerfile": "backend/Dockerfile"},
+                "ports": ["8000"],
+            },
+            "frontend": {
+                "build": "./frontend",
+                "ports": ["3000"],
+            },
+            "db": {
+                "image": "postgres:15",
+            },
+        },
+    }
+
+
+class TestBuild:
+    @patch("kamiwaza_extensions.image_builder.subprocess.run")
+    def test_builds_services_with_build_context(self, mock_run, builder, compose_with_build, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        refs = builder.build(
+            extension_dir=tmp_path,
+            compose_data=compose_with_build,
+            extension_name="my-app",
+            revision_tag="1.0.0-dev+abc.123",
+            registry="registry.test",
+        )
+        assert len(refs) == 2  # backend + frontend (not db)
+        assert "registry.test/my-app-backend:1.0.0-dev+abc.123" in refs
+        assert "registry.test/my-app-frontend:1.0.0-dev+abc.123" in refs
+
+    @patch("kamiwaza_extensions.image_builder.subprocess.run")
+    def test_service_filter(self, mock_run, builder, compose_with_build, tmp_path):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        refs = builder.build(
+            extension_dir=tmp_path,
+            compose_data=compose_with_build,
+            extension_name="my-app",
+            revision_tag="v1",
+            registry="reg",
+            service_filter="backend",
+        )
+        assert len(refs) == 1
+        assert "my-app-backend" in refs[0]
+
+    def test_service_filter_not_found(self, builder, compose_with_build, tmp_path):
+        with pytest.raises(ImageBuildError, match="not found"):
+            builder.build(
+                extension_dir=tmp_path,
+                compose_data=compose_with_build,
+                extension_name="my-app",
+                revision_tag="v1",
+                registry="reg",
+                service_filter="nonexistent",
+            )
+
+    @patch("kamiwaza_extensions.image_builder.subprocess.run")
+    def test_skips_services_without_build(self, mock_run, builder, tmp_path):
+        compose = {"services": {"db": {"image": "postgres:15"}}}
+        mock_run.return_value = MagicMock(returncode=0)
+        refs = builder.build(tmp_path, compose, "test", "v1", "reg")
+        assert refs == []
+
+    @patch("kamiwaza_extensions.image_builder.subprocess.run")
+    def test_build_failure_raises(self, mock_run, builder, tmp_path):
+        mock_run.return_value = MagicMock(returncode=1, stdout="error output", stderr="")
+        compose = {"services": {"api": {"build": "."}}}
+        with pytest.raises(ImageBuildError, match="build failed"):
+            builder.build(tmp_path, compose, "test", "v1", "reg")
+
+
+class TestResolveBuildConfig:
+    def test_string_build(self, builder, tmp_path):
+        df, ctx = builder._resolve_build_config("./backend", tmp_path)
+        assert ctx == tmp_path / "backend"
+        assert df == tmp_path / "backend" / "Dockerfile"
+
+    def test_dict_build(self, builder, tmp_path):
+        df, ctx = builder._resolve_build_config(
+            {"context": ".", "dockerfile": "backend/Dockerfile"}, tmp_path
+        )
+        assert ctx == tmp_path
+        assert df == tmp_path / "backend" / "Dockerfile"

--- a/tests/unit/extensions/test_image_pusher.py
+++ b/tests/unit/extensions/test_image_pusher.py
@@ -1,0 +1,86 @@
+"""Tests for ImagePusher."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kamiwaza_extensions.image_pusher import ImagePusher, ImagePushError
+
+
+@pytest.fixture
+def pusher():
+    return ImagePusher()
+
+
+class TestLoginRegistry:
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_docker_login(self, mock_run, pusher):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        pusher._login_registry("reg.test", "my-token")
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "docker"
+        assert "--tls-verify=false" not in cmd
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_podman_login_insecure(self, mock_run, pusher):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        pusher._login_registry("reg.test", "my-token", use_podman=True)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "podman"
+        assert "--tls-verify=false" in cmd
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_login_failure_raises(self, mock_run, pusher):
+        mock_run.return_value = MagicMock(returncode=1, stderr="auth failed")
+        with pytest.raises(ImagePushError, match="login failed"):
+            pusher._login_registry("reg.test", "bad-token")
+
+
+class TestPush:
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_docker_push(self, mock_run, pusher):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        pusher._push("reg.test/app:v1")
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "docker"
+        assert "--tls-verify=false" not in cmd
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_podman_push_insecure(self, mock_run, pusher):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        pusher._push("reg.test/app:v1", use_podman=True)
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "podman"
+        assert "--tls-verify=false" in cmd
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_push_failure_raises(self, mock_run, pusher):
+        mock_run.return_value = MagicMock(returncode=1, stderr="denied")
+        with pytest.raises(ImagePushError, match="Push failed"):
+            pusher._push("reg.test/app:v1")
+
+
+class TestPushOrchestration:
+    @patch("kamiwaza_extensions.image_pusher._has_podman", return_value=True)
+    @patch.object(ImagePusher, "_login_registry")
+    @patch.object(ImagePusher, "_push")
+    def test_insecure_uses_podman(self, mock_push, mock_login, _mock_hp, pusher):
+        pusher.push(["reg/app:v1"], registry="reg", token="tok", insecure=True)
+        mock_login.assert_called_once_with("reg", "tok", use_podman=True)
+        mock_push.assert_called_once_with("reg/app:v1", use_podman=True, verbose=False)
+
+    @patch("kamiwaza_extensions.image_pusher._has_podman", return_value=False)
+    @patch.object(ImagePusher, "_login_registry")
+    @patch.object(ImagePusher, "_push")
+    def test_insecure_no_podman_falls_back_to_docker(self, mock_push, mock_login, _mock_hp, pusher):
+        pusher.push(["reg/app:v1"], registry="reg", token="tok", insecure=True)
+        mock_login.assert_called_once_with("reg", "tok", use_podman=False)
+        mock_push.assert_called_once_with("reg/app:v1", use_podman=False, verbose=False)
+
+    @patch("kamiwaza_extensions.image_pusher._has_podman", return_value=True)
+    @patch.object(ImagePusher, "_login_registry")
+    @patch.object(ImagePusher, "_push")
+    def test_secure_uses_docker(self, mock_push, mock_login, _mock_hp, pusher):
+        pusher.push(["reg/app:v1"], registry="reg", token="tok", insecure=False)
+        mock_login.assert_called_once_with("reg", "tok", use_podman=False)
+        mock_push.assert_called_once_with("reg/app:v1", use_podman=False, verbose=False)

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -123,6 +123,23 @@ class TestDevNaming:
         assert "dev-" in name
 
 
+class TestResourceParsing:
+    def test_cpus_converted_to_millicpu(self, builder):
+        svc = {"deploy": {"resources": {"limits": {"cpus": "0.5", "memory": "512M"}}}}
+        res = builder._parse_resources(svc)
+        assert res.limits["cpu"] == "500m"
+        assert "cpus" not in res.limits
+        assert res.limits["memory"] == "512M"
+
+    def test_whole_cpu_converted(self, builder):
+        svc = {"deploy": {"resources": {"limits": {"cpus": "2.0", "memory": "1G"}}}}
+        res = builder._parse_resources(svc)
+        assert res.limits["cpu"] == "2000m"
+
+    def test_no_resources_returns_none(self, builder):
+        assert builder._parse_resources({}) is None
+
+
 class TestResolveType:
     def test_default_app(self, builder):
         assert builder._resolve_type({}) == "app"

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -1,0 +1,134 @@
+"""Tests for PayloadBuilder."""
+
+import pytest
+
+from kamiwaza_extensions.connections import ConnectionInfo
+from kamiwaza_extensions.payload_builder import PayloadBuilder
+
+
+@pytest.fixture
+def builder():
+    return PayloadBuilder()
+
+
+@pytest.fixture
+def connection():
+    return ConnectionInfo(
+        name="test",
+        url="https://cluster.kamiwaza.test/api",
+        active=True,
+        created_at=0.0,
+    )
+
+
+@pytest.fixture
+def metadata():
+    return {
+        "name": "my-app",
+        "version": "1.0.0",
+        "source_type": "kamiwaza",
+        "risk_tier": 1,
+        "verified": False,
+    }
+
+
+@pytest.fixture
+def transformed_compose():
+    return {
+        "services": {
+            "frontend": {
+                "image": "registry.test/my-app-frontend:1.0.0-dev",
+                "ports": ["3000"],
+                "environment": ["NEXT_PUBLIC_API_URL=http://backend:8000"],
+                "deploy": {"resources": {"limits": {"cpus": "0.5", "memory": "512M"}}},
+            },
+            "backend": {
+                "image": "registry.test/my-app-backend:1.0.0-dev",
+                "ports": ["8000"],
+                "environment": {
+                    "OPENAI_BASE_URL": "http://host.docker.internal:8080",
+                },
+                "deploy": {"resources": {"limits": {"cpus": "1.0", "memory": "1G"}}},
+            },
+        },
+    }
+
+
+class TestBuild:
+    def test_produces_valid_payload(self, builder, metadata, transformed_compose, connection):
+        payload = builder.build(metadata, transformed_compose, connection, "my-app-dev-abc123")
+        assert payload.name == "my-app-dev-abc123"
+        assert payload.type == "app"
+        assert payload.version == "1.0.0"
+        assert len(payload.services) == 2
+
+    def test_primary_service_assigned(self, builder, metadata, transformed_compose, connection):
+        payload = builder.build(metadata, transformed_compose, connection, "test")
+        primaries = [s for s in payload.services if s.primary]
+        assert len(primaries) == 1
+        assert primaries[0].name == "frontend"
+
+    def test_ports_parsed(self, builder, metadata, transformed_compose, connection):
+        payload = builder.build(metadata, transformed_compose, connection, "test")
+        fe = next(s for s in payload.services if s.name == "frontend")
+        assert len(fe.ports) == 1
+        assert fe.ports[0].container_port == 3000
+
+    def test_kamiwaza_integration(self, builder, metadata, transformed_compose, connection):
+        payload = builder.build(metadata, transformed_compose, connection, "test")
+        assert payload.kamiwaza.api_url == "https://cluster.kamiwaza.test/api"
+        assert payload.kamiwaza.use_auth == "true"
+
+    def test_security_from_metadata(self, builder, metadata, transformed_compose, connection):
+        payload = builder.build(metadata, transformed_compose, connection, "test")
+        assert payload.security.risk_tier == 1
+
+
+class TestEnvParsing:
+    def test_list_format(self, builder):
+        result = builder._parse_env(["KEY=value", "BARE_KEY"])
+        assert result == [
+            {"name": "KEY", "value": "value"},
+            {"name": "BARE_KEY"},
+        ]
+
+    def test_dict_format(self, builder):
+        result = builder._parse_env({"KEY": "value", "NULL_KEY": None})
+        assert {"name": "KEY", "value": "value"} in result
+        assert {"name": "NULL_KEY"} in result
+
+    def test_empty(self, builder):
+        assert builder._parse_env([]) == []
+        assert builder._parse_env({}) == []
+
+
+class TestDevNaming:
+    def test_format(self):
+        name = PayloadBuilder.make_dev_name("my-app", user_id="user-123")
+        assert name.startswith("my-app-dev-")
+        assert len(name.split("-")[-1]) == 6  # 6 char hash
+
+    def test_deterministic(self):
+        a = PayloadBuilder.make_dev_name("my-app", user_id="user-123")
+        b = PayloadBuilder.make_dev_name("my-app", user_id="user-123")
+        assert a == b
+
+    def test_different_users_different_names(self):
+        a = PayloadBuilder.make_dev_name("my-app", user_id="user-a")
+        b = PayloadBuilder.make_dev_name("my-app", user_id="user-b")
+        assert a != b
+
+    def test_no_user_uses_local(self):
+        name = PayloadBuilder.make_dev_name("my-app")
+        assert "dev-" in name
+
+
+class TestResolveType:
+    def test_default_app(self, builder):
+        assert builder._resolve_type({}) == "app"
+
+    def test_template_type_takes_precedence(self, builder):
+        assert builder._resolve_type({"template_type": "tool", "type": "app"}) == "tool"
+
+    def test_service_type(self, builder):
+        assert builder._resolve_type({"template_type": "service"}) == "service"

--- a/tests/unit/extensions/test_revision_tagger.py
+++ b/tests/unit/extensions/test_revision_tagger.py
@@ -22,21 +22,21 @@ class TestGenerateTag:
             RevisionTagger, "get_git_info", return_value=("abc1234", False)
         ):
             tag = tagger.generate_tag("1.0.0", _now=1711900800)
-        assert tag == "1.0.0-dev+abc1234.1711900800"
+        assert tag == "1.0.0-dev-abc1234.1711900800"
 
     def test_dirty_repo_format(self, tagger):
         with patch.object(
             RevisionTagger, "get_git_info", return_value=("abc1234", True)
         ):
             tag = tagger.generate_tag("1.0.0", _now=1711900800)
-        assert tag == "1.0.0-dev+dirty.1711900800"
+        assert tag == "1.0.0-dev-dirty.1711900800"
 
     def test_no_git_format(self, tagger):
         with patch.object(
             RevisionTagger, "get_git_info", return_value=(None, False)
         ):
             tag = tagger.generate_tag("2.3.1", _now=1711900800)
-        assert tag == "2.3.1-dev+nogit.1711900800"
+        assert tag == "2.3.1-dev-nogit.1711900800"
 
     def test_tag_is_docker_compatible(self, tagger):
         """Docker tags: [a-zA-Z0-9_.-]+, max 128 chars."""
@@ -44,7 +44,7 @@ class TestGenerateTag:
             RevisionTagger, "get_git_info", return_value=("abc1234", False)
         ):
             tag = tagger.generate_tag("1.0.0", _now=1711900800)
-        assert re.match(r"^[a-zA-Z0-9_.+-]+$", tag)
+        assert re.match(r"^[a-zA-Z0-9_.-]+$", tag)
         assert len(tag) <= 128
 
     def test_different_timestamps_produce_different_tags(self, tagger):
@@ -61,7 +61,7 @@ class TestGenerateTag:
         ):
             tag = tagger.generate_tag("1.0.0")
         # Should contain a recent epoch — just verify format
-        assert re.match(r"^1\.0\.0-dev\+abc1234\.\d{10}$", tag)
+        assert re.match(r"^1\.0\.0-dev-abc1234\.\d{10}$", tag)
 
 
 class TestGetGitInfo:

--- a/tests/unit/extensions/test_revision_tagger.py
+++ b/tests/unit/extensions/test_revision_tagger.py
@@ -1,0 +1,81 @@
+"""Tests for RevisionTagger."""
+
+import re
+from unittest.mock import patch
+
+import pytest
+
+from kamiwaza_extensions.revision_tagger import RevisionTagger
+
+
+@pytest.fixture
+def tagger():
+    return RevisionTagger()
+
+
+class TestGenerateTag:
+    def test_custom_tag_returned_as_is(self, tagger):
+        assert tagger.generate_tag("1.0.0", custom="my-experiment") == "my-experiment"
+
+    def test_clean_repo_format(self, tagger):
+        with patch.object(
+            RevisionTagger, "get_git_info", return_value=("abc1234", False)
+        ):
+            tag = tagger.generate_tag("1.0.0", _now=1711900800)
+        assert tag == "1.0.0-dev+abc1234.1711900800"
+
+    def test_dirty_repo_format(self, tagger):
+        with patch.object(
+            RevisionTagger, "get_git_info", return_value=("abc1234", True)
+        ):
+            tag = tagger.generate_tag("1.0.0", _now=1711900800)
+        assert tag == "1.0.0-dev+dirty.1711900800"
+
+    def test_no_git_format(self, tagger):
+        with patch.object(
+            RevisionTagger, "get_git_info", return_value=(None, False)
+        ):
+            tag = tagger.generate_tag("2.3.1", _now=1711900800)
+        assert tag == "2.3.1-dev+nogit.1711900800"
+
+    def test_tag_is_docker_compatible(self, tagger):
+        """Docker tags: [a-zA-Z0-9_.-]+, max 128 chars."""
+        with patch.object(
+            RevisionTagger, "get_git_info", return_value=("abc1234", False)
+        ):
+            tag = tagger.generate_tag("1.0.0", _now=1711900800)
+        assert re.match(r"^[a-zA-Z0-9_.+-]+$", tag)
+        assert len(tag) <= 128
+
+    def test_different_timestamps_produce_different_tags(self, tagger):
+        with patch.object(
+            RevisionTagger, "get_git_info", return_value=("abc1234", False)
+        ):
+            t1 = tagger.generate_tag("1.0.0", _now=1000)
+            t2 = tagger.generate_tag("1.0.0", _now=1001)
+        assert t1 != t2
+
+    def test_uses_real_time_by_default(self, tagger):
+        with patch.object(
+            RevisionTagger, "get_git_info", return_value=("abc1234", False)
+        ):
+            tag = tagger.generate_tag("1.0.0")
+        # Should contain a recent epoch — just verify format
+        assert re.match(r"^1\.0\.0-dev\+abc1234\.\d{10}$", tag)
+
+
+class TestGetGitInfo:
+    def test_returns_sha_and_clean(self, tagger):
+        """Smoke test — depends on this repo being a git repo."""
+        sha, dirty = tagger.get_git_info()
+        # We're running inside kamiwaza-sdk which is a git repo
+        if sha is not None:
+            assert len(sha) >= 7
+            assert isinstance(dirty, bool)
+
+    def test_no_git_returns_none(self, tagger):
+        with patch("kamiwaza_extensions.revision_tagger.subprocess.run") as mock:
+            mock.side_effect = FileNotFoundError("git not found")
+            sha, dirty = tagger.get_git_info()
+        assert sha is None
+        assert dirty is False


### PR DESCRIPTION
## Summary
- Implements the **dev inner loop** for remote extension deployment (`kz-ext dev`)
- Extracts extension detection into shared `ExtensionDetector` module (used by both local and remote flows)
- Adds image build, registry push, compose transformation, revision tagging, payload building, and deployment polling stages
- CLI: `kz-ext dev` runs full remote pipeline; `kz-ext dev local` unchanged from Phase 1

### New modules
| Module | Purpose |
|--------|---------|
| `extension_detector.py` | Shared kamiwaza.json + compose file discovery |
| `image_builder.py` | Docker image build orchestration |
| `image_pusher.py` | Registry push with retry |
| `compose_transformer.py` | Rewrite compose for cluster (strip ports, rewrite images) |
| `revision_tagger.py` | Git-based dev revision tags |
| `payload_builder.py` | Build CreateExtension API payload |
| `deployment_poller.py` | Poll deployment rollout status |
| `commands/dev.py` | Remote deploy pipeline orchestrator |

### Changes to existing files
- `cli.py` — Added `kz-ext dev` callback for remote deploy; dev help text updated
- `dev_local.py` — Refactored to use shared `ExtensionDetector`; removed duplicated detection logic
- `test_dev_local.py` — Detection tests moved to `test_extension_detector.py`

## Test plan
- [x] All 160 extension unit tests passing (`uv run pytest tests/unit/extensions/ -v`)
- [ ] Manual: `kz-ext dev` against a staging cluster with a sample extension
- [ ] Manual: `kz-ext dev --no-build --no-push` skips build/push stages
- [ ] Manual: `kz-ext dev local` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)