### PR TITLE
[codex] Fix extension app local dev startup flow

### DIFF
--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -230,20 +230,23 @@ def build_typescript_lib(spec: SdkOverrideSpec) -> bool:
 # ------------------------------------------------------------------
 
 
-_PYTHON_LIB_COPY = (
-    'SITE=$(python -c "import kamiwaza_extensions_lib as m, os;'
-    ' print(os.path.dirname(m.__file__))")'
-    ' && SITE_PARENT=$(dirname "$SITE")'
-    ' && rm -rf "$SITE"'
-    ' && mkdir -p "$SITE_PARENT"'
-    ' && cp -r /sdk/kamiwaza_extensions_lib "$SITE_PARENT/"'
-)
+_PYTHON_LIB_COPY = 'export PYTHONPATH="/sdk${PYTHONPATH:+:$PYTHONPATH}"'
 
 _TS_LIB_INSTALL = (
     "TARBALL=$(cd /sdk/kamiwaza-ai-extensions-lib"
     " && npm pack --ignore-scripts --pack-destination /tmp 2>/dev/null | tail -1)"
     ' && cd /app && npm install --ignore-scripts "/tmp/$TARBALL"'
 )
+
+
+def _escape_compose_shell_vars(command: str) -> str:
+    """Escape shell variable syntax so Docker Compose preserves it.
+
+    Compose interpolates ``$VAR`` and ``${VAR}`` when it parses YAML. Local
+    SDK override commands intentionally rely on those variables being expanded
+    later inside the container shell, so they must be emitted as ``$$...``.
+    """
+    return command.replace("$", "$$")
 
 
 def detect_service_type(
@@ -392,7 +395,7 @@ def generate_compose_override(
             )
             svc_override["entrypoint"] = ["/bin/sh", "-c"]
             svc_override["command"] = [
-                _PYTHON_LIB_COPY + f" && exec {exec_cmd}"
+                _escape_compose_shell_vars(_PYTHON_LIB_COPY) + f" && exec {exec_cmd}"
             ]
 
         elif svc_type == "frontend" and spec.typescript:
@@ -407,7 +410,7 @@ def generate_compose_override(
             )
             svc_override["entrypoint"] = ["/bin/sh", "-c"]
             svc_override["command"] = [
-                _TS_LIB_INSTALL + f" && exec {exec_cmd}"
+                _escape_compose_shell_vars(_TS_LIB_INSTALL) + f" && exec {exec_cmd}"
             ]
 
         if svc_override:

--- a/kamiwaza_extensions/templates/app/frontend/start.mjs
+++ b/kamiwaza_extensions/templates/app/frontend/start.mjs
@@ -1,4 +1,4 @@
-import { cp, mkdir, readdir, rm, symlink } from "node:fs/promises";
+import { access, cp, mkdir, readdir, rm, symlink } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
 import { spawn } from "node:child_process";
@@ -6,6 +6,13 @@ import { spawn } from "node:child_process";
 const APP_DIR = "/app";
 const RUNTIME_DIR = "/tmp/app-runtime";
 const NEXT_CLI = path.join(APP_DIR, "node_modules/next/dist/bin/next");
+const NEXT_STATIC_DIR = path.join(RUNTIME_DIR, ".next", "static");
+const PUBLIC_DIR = path.join(RUNTIME_DIR, "public");
+const STANDALONE_DIR = path.join(RUNTIME_DIR, ".next", "standalone");
+const STANDALONE_NEXT_DIR = path.join(STANDALONE_DIR, ".next");
+const STANDALONE_STATIC_DIR = path.join(STANDALONE_NEXT_DIR, "static");
+const STANDALONE_PUBLIC_DIR = path.join(STANDALONE_DIR, "public");
+const STANDALONE_SERVER = path.join(STANDALONE_DIR, "server.js");
 const SIGNAL_EXIT_CODES = {
   SIGINT: 130,
   SIGTERM: 143,
@@ -25,6 +32,15 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
 
 function isExpandedValue(s) {
   return s && !s.includes("${");
+}
+
+async function pathExists(target) {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function resolveBasePath() {
@@ -59,6 +75,10 @@ function runNext(command, cwd, env) {
     args.push("--hostname", "0.0.0.0", "--port", process.env.PORT || "3000");
   }
 
+  return runNodeArgs(args, cwd, env);
+}
+
+function runNodeArgs(args, cwd, env) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, args, {
       cwd,
@@ -86,6 +106,17 @@ function runNext(command, cwd, env) {
   });
 }
 
+async function prepareStandaloneRuntime() {
+  if (await pathExists(NEXT_STATIC_DIR)) {
+    await mkdir(STANDALONE_NEXT_DIR, { recursive: true });
+    await cp(NEXT_STATIC_DIR, STANDALONE_STATIC_DIR, { recursive: true, force: true });
+  }
+
+  if (await pathExists(PUBLIC_DIR)) {
+    await cp(PUBLIC_DIR, STANDALONE_PUBLIC_DIR, { recursive: true, force: true });
+  }
+}
+
 async function main() {
   const basePath = resolveBasePath();
   const env = {
@@ -107,7 +138,21 @@ async function main() {
     process.exit(buildExitCode);
   }
 
-  const startExitCode = await runNext("start", RUNTIME_DIR, env);
+  let startExitCode;
+  if (await pathExists(STANDALONE_SERVER)) {
+    await prepareStandaloneRuntime();
+    startExitCode = await runNodeArgs(
+      [STANDALONE_SERVER],
+      STANDALONE_DIR,
+      {
+        ...env,
+        HOSTNAME: process.env.HOSTNAME || "0.0.0.0",
+        PORT: process.env.PORT || "3000",
+      },
+    );
+  } else {
+    startExitCode = await runNext("start", RUNTIME_DIR, env);
+  }
   process.exit(startExitCode);
 }
 

--- a/tests/unit/extensions/test_scaffolder.py
+++ b/tests/unit/extensions/test_scaffolder.py
@@ -107,6 +107,17 @@ class TestScaffolder:
         assert "test-app" in main_py
         assert "{{name}}" not in main_py
 
+    def test_app_template_uses_standalone_frontend_runtime(self, tmp_path, monkeypatch, scaffolder):
+        d = self._empty_dir(tmp_path)
+        monkeypatch.chdir(d)
+        with patch("subprocess.run"):
+            scaffolder.create(type_="app", name="test-app")
+
+        start_mjs = (d / "frontend" / "start.mjs").read_text()
+        assert "const STANDALONE_SERVER = path.join(STANDALONE_DIR, \"server.js\");" in start_mjs
+        assert "await prepareStandaloneRuntime();" in start_mjs
+        assert "startExitCode = await runNodeArgs(" in start_mjs
+
     def test_git_init_called(self, tmp_path, monkeypatch, scaffolder):
         d = self._empty_dir(tmp_path)
         monkeypatch.chdir(d)

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -296,7 +296,7 @@ class TestGenerateComposeOverride:
         services = override["services"]
 
         # Backend reads CMD from Dockerfile
-        assert "kamiwaza_extensions_lib" in services["backend"]["command"][0]
+        assert 'export PYTHONPATH="/sdk$${PYTHONPATH:+:$$PYTHONPATH}"' in services["backend"]["command"][0]
         assert "exec uvicorn app.main:app --host 0.0.0.0" in services["backend"]["command"][0]
 
         # Frontend reads ENTRYPOINT from Dockerfile
@@ -366,7 +366,7 @@ class TestGenerateComposeOverride:
         }
         override = generate_compose_override(spec, compose)
         services = override["services"]
-        assert "kamiwaza_extensions_lib" in services["backend"]["command"][0]
+        assert 'export PYTHONPATH="/sdk$${PYTHONPATH:+:$$PYTHONPATH}"' in services["backend"]["command"][0]
         assert "frontend" not in services
 
     def test_typescript_only(self, tmp_path):
@@ -383,7 +383,7 @@ class TestGenerateComposeOverride:
         assert "npm pack" in services["frontend"]["command"][0]
         assert "backend" not in services
 
-    def test_python_override_replaces_existing_package(self, tmp_path):
+    def test_python_override_prefers_local_sdk_via_pythonpath(self, tmp_path):
         spec = self._make_spec(tmp_path, typescript=False)
         compose = {
             "services": {
@@ -393,8 +393,20 @@ class TestGenerateComposeOverride:
 
         override = generate_compose_override(spec, compose)
         command = override["services"]["backend"]["command"][0]
-        assert 'rm -rf "$SITE"' in command
-        assert 'cp -r /sdk/kamiwaza_extensions_lib "$SITE_PARENT/"' in command
+        assert 'export PYTHONPATH="/sdk$${PYTHONPATH:+:$$PYTHONPATH}"' in command
+
+    def test_typescript_override_escapes_tarball_for_compose(self, tmp_path):
+        spec = self._make_spec(tmp_path, python=False)
+        compose = {
+            "services": {
+                "frontend": {"build": "./frontend", "ports": ["3000:3000"]},
+            }
+        }
+
+        override = generate_compose_override(spec, compose)
+        command = override["services"]["frontend"]["command"][0]
+        assert "TARBALL=$$(cd /sdk/kamiwaza-ai-extensions-lib" in command
+        assert 'npm install --ignore-scripts "/tmp/$$TARBALL"' in command
 
     def test_volume_mount_is_readonly(self, tmp_path):
         spec = self._make_spec(tmp_path)


### PR DESCRIPTION
## Summary
- fix local SDK compose overrides so shell variables survive Docker Compose interpolation
- switch Python local-dev overrides to prefer `/sdk` via `PYTHONPATH` instead of mutating root-owned `site-packages`
- update the app extension frontend template to start Next.js standalone output correctly for future `kz-ext create --type app` scaffolds

## Root Cause
The local SDK override generator emitted shell commands containing `$SITE`, `$SITE_PARENT`, and `$TARBALL` directly into the compose override. Docker Compose expanded those on the host before the container shell ran them, which collapsed the runtime commands and broke startup. After that was fixed, the backend override still tried to replace an installed package inside root-owned `site-packages` while the container ran as an unprivileged user.

Separately, the generated app template built with `output: "standalone"` but still launched with `next start`, which produces a runtime warning.

## Impact
- `kz-ext dev local --sdk-repo ...` now brings up scaffolded app extensions cleanly with local Python and TypeScript SDK overrides
- future `kz-ext create --type app` projects inherit the standalone frontend runtime behavior automatically
- tests now cover both the compose override escaping and the scaffolded frontend launcher behavior

## Validation
- `pytest /Users/jonathan/repos/kamiwaza-sdk/tests/unit/extensions/test_sdk_override.py -q`
- `pytest /Users/jonathan/repos/kamiwaza-sdk/tests/unit/extensions/test_scaffolder.py -q`
- `node --check /Users/jonathan/repos/kamiwaza-sdk/kamiwaza_extensions/templates/app/frontend/start.mjs`
- `kz-ext dev local --sdk-repo /Users/jonathan/repos/kamiwaza-sdk`
