### PR TITLE
[codex] Fix standalone app template bind host for probes

### DIFF
--- a/kamiwaza_extensions/templates/app/frontend/start.mjs
+++ b/kamiwaza_extensions/templates/app/frontend/start.mjs
@@ -146,7 +146,7 @@ async function main() {
       STANDALONE_DIR,
       {
         ...env,
-        HOSTNAME: process.env.HOSTNAME || "0.0.0.0",
+        HOSTNAME: "0.0.0.0",
         PORT: process.env.PORT || "3000",
       },
     );

--- a/tests/unit/extensions/test_scaffolder.py
+++ b/tests/unit/extensions/test_scaffolder.py
@@ -117,6 +117,7 @@ class TestScaffolder:
         assert "const STANDALONE_SERVER = path.join(STANDALONE_DIR, \"server.js\");" in start_mjs
         assert "await prepareStandaloneRuntime();" in start_mjs
         assert "startExitCode = await runNodeArgs(" in start_mjs
+        assert 'HOSTNAME: "0.0.0.0"' in start_mjs
 
     def test_git_init_called(self, tmp_path, monkeypatch, scaffolder):
         d = self._empty_dir(tmp_path)


### PR DESCRIPTION
## Summary
- bind the scaffolded app template's standalone Next.js server to `0.0.0.0`
- extend the scaffolder test to assert the generated runtime launcher keeps that bind host

## Root Cause
The scaffolded frontend runtime launcher reused the ambient `HOSTNAME` environment variable when starting Next.js standalone output. In Kubernetes, `HOSTNAME` is already populated with the pod name, so the server bound to the pod hostname/IP instead of loopback or all interfaces.

Kamiwaza's frontend health probes execute inside the container and check `127.0.0.1:3000${KAMIWAZA_APP_PATH}`. That meant the app logs showed `Ready`, but the probe still got `ECONNREFUSED`, leaving deployments stuck in `Provisioning`.

## Impact
- app extensions created with `kz-ext create --type app` now bind the standalone frontend server in a probe-friendly way
- remote `kz-ext dev` deploys no longer stall in `Provisioning` when the frontend is otherwise healthy

## Validation
- `pytest /Users/jonathan/repos/kamiwaza-sdk/tests/unit/extensions/test_scaffolder.py -q`
- remote deploy verification via `kz-ext dev --sdk-repo /Users/jonathan/repos/kamiwaza-sdk`, followed by `kz-ext status` showing `Phase: Running`
