### PR TITLE
[codex] Handle invalid app session token 401s

### DIFF
--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -157,7 +157,8 @@ class KamiwazaClient:
         path: str,
         response: requests.Response,
     ) -> bool:
-        if not path.startswith(cls._APP_SESSION_ENDPOINT_PREFIX):
+        app_session_prefix = cls._APP_SESSION_ENDPOINT_PREFIX
+        if path != app_session_prefix and not path.startswith(f"{app_session_prefix}/"):
             return False
         detail = cls._response_detail(response)
         return (

--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -185,17 +185,20 @@ class KamiwazaClient:
                         f"Unauthenticated request failed for {endpoint}: {response.text}"
                     )
                 logger.warning(f"Received 401 Unauthorized. Response: {response.text}")
-                if self.authenticator:
-                    if not did_refresh:
-                        did_refresh = True
-                        self.authenticator.refresh_token(self.session)
-                        continue
+                
+                # If the backend is rejecting an app-level session token, do not refresh the core SDK token
+                if "Invalid session token" not in response.text:
+                    if self.authenticator:
+                        if not did_refresh:
+                            did_refresh = True
+                            self.authenticator.refresh_token(self.session)
+                            continue
+                        raise AuthenticationError(
+                            "Authentication failed after token refresh."
+                        )
                     raise AuthenticationError(
-                        "Authentication failed after token refresh."
+                        "Authentication failed. No authenticator provided."
                     )
-                raise AuthenticationError(
-                    "Authentication failed. No authenticator provided."
-                )
 
             if response.status_code >= 400:
                 content_type = response.headers.get("content-type", "")

--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -40,6 +40,8 @@ class KamiwazaClient:
     _RECENT_DATASET_TTL_SECONDS = 30.0
     _RECENT_DATASET_MAX = 1024
     _APP_SESSION_ENDPOINT_PREFIX = "apps/sessions"
+    # Keep this pinned to the backend's current session-auth detail string until
+    # the API exposes a structured error code for app-session 401 responses.
     _APP_SESSION_INVALID_TOKEN_DETAIL = "Invalid session token"
 
     # Retry window for PUT-after-create/update schema operations.
@@ -231,6 +233,7 @@ class KamiwazaClient:
                     raise AuthenticationError(
                         "Authentication failed. No authenticator provided."
                     )
+                # Fall through so app-session 401s raise APIError(401) below.
 
             if response.status_code >= 400:
                 content_type = response.headers.get("content-type", "")

--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -39,6 +39,8 @@ logger = logging.getLogger(__name__)
 class KamiwazaClient:
     _RECENT_DATASET_TTL_SECONDS = 30.0
     _RECENT_DATASET_MAX = 1024
+    _APP_SESSION_ENDPOINT_PREFIX = "apps/sessions"
+    _APP_SESSION_INVALID_TOKEN_DETAIL = "Invalid session token"
 
     # Retry window for PUT-after-create/update schema operations.
     # Total sleep time sums to 5.0s.
@@ -134,6 +136,35 @@ class KamiwazaClient:
             return False
         return True
 
+    @staticmethod
+    def _response_detail(response: requests.Response) -> Optional[str]:
+        try:
+            payload = response.json()
+        except ValueError:
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+
+        detail = payload.get("detail")
+        if not isinstance(detail, str):
+            return None
+        return detail.strip()
+
+    @classmethod
+    def _is_app_session_invalid_token_response(
+        cls,
+        path: str,
+        response: requests.Response,
+    ) -> bool:
+        if not path.startswith(cls._APP_SESSION_ENDPOINT_PREFIX):
+            return False
+        detail = cls._response_detail(response)
+        return (
+            isinstance(detail, str)
+            and detail.casefold() == cls._APP_SESSION_INVALID_TOKEN_DETAIL.casefold()
+        )
+
     def _request(
         self,
         method: str,
@@ -185,9 +216,9 @@ class KamiwazaClient:
                         f"Unauthenticated request failed for {endpoint}: {response.text}"
                     )
                 logger.warning(f"Received 401 Unauthorized. Response: {response.text}")
-                
+
                 # If the backend is rejecting an app-level session token, do not refresh the core SDK token
-                if "Invalid session token" not in response.text:
+                if not self._is_app_session_invalid_token_response(path, response):
                     if self.authenticator:
                         if not did_refresh:
                             did_refresh = True

--- a/tests/integration/test_apps_live.py
+++ b/tests/integration/test_apps_live.py
@@ -115,11 +115,11 @@ def test_apps_deploy_and_deployment_error_paths(live_kamiwaza_client) -> None:
     session_payload = {"session_token": f"sdk-session-{uuid4().hex}"}
     with pytest.raises(APIError) as exc:
         client.post("/apps/sessions/heartbeat", json=session_payload)
-    assert exc.value.status_code == 404
+    assert exc.value.status_code == 401
 
     with pytest.raises(APIError) as exc:
         client.post("/apps/sessions/end", json={**session_payload, "reason": "sdk-test"})
-    assert exc.value.status_code == 404
+    assert exc.value.status_code == 401
 
     deployments = client.get("/apps/deployments")
     assert isinstance(deployments, list)

--- a/tests/unit/test_client_request_error_mapping.py
+++ b/tests/unit/test_client_request_error_mapping.py
@@ -102,8 +102,8 @@ def test_401_invalid_session_token_does_not_refresh_sdk_auth(
 ) -> None:
     response = _StubResponse(
         status_code=401,
-        text='{"detail":"Invalid session token"}',
-        json_data={"detail": "Invalid session token"},
+        text='{"detail":"invalid SESSION token"}',
+        json_data={"detail": "invalid SESSION token"},
     )
     authenticator = _StubAuthenticator()
     client = KamiwazaClient(
@@ -118,3 +118,34 @@ def test_401_invalid_session_token_does_not_refresh_sdk_auth(
     assert exc_info.value.status_code == 401
     assert authenticator.authenticate_calls == 1
     assert authenticator.refresh_calls == 0
+
+
+def test_401_invalid_session_token_outside_app_sessions_refreshes_sdk_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = iter(
+        [
+            _StubResponse(
+                status_code=401,
+                text='{"detail":"Invalid session token"}',
+                json_data={"detail": "Invalid session token"},
+            ),
+            _StubResponse(
+                status_code=200,
+                text='{"ok":true}',
+                json_data={"ok": True},
+            ),
+        ]
+    )
+    authenticator = _StubAuthenticator()
+    client = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=authenticator,
+    )
+    monkeypatch.setattr(client.session, "request", lambda *_args, **_kwargs: next(responses))
+
+    result = client.get("/cluster/status")
+
+    assert result == {"ok": True}
+    assert authenticator.authenticate_calls == 1
+    assert authenticator.refresh_calls == 1

--- a/tests/unit/test_client_request_error_mapping.py
+++ b/tests/unit/test_client_request_error_mapping.py
@@ -102,6 +102,29 @@ def test_401_invalid_session_token_does_not_refresh_sdk_auth(
 ) -> None:
     response = _StubResponse(
         status_code=401,
+        text='{"detail":"Invalid session token"}',
+        json_data={"detail": "Invalid session token"},
+    )
+    authenticator = _StubAuthenticator()
+    client = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=authenticator,
+    )
+    monkeypatch.setattr(client.session, "request", lambda *_args, **_kwargs: response)
+
+    with pytest.raises(APIError) as exc_info:
+        client.post("/apps/sessions/heartbeat", json={"session_token": "sdk-session"})
+
+    assert exc_info.value.status_code == 401
+    assert authenticator.authenticate_calls == 1
+    assert authenticator.refresh_calls == 0
+
+
+def test_401_invalid_session_token_match_is_case_insensitive_for_app_sessions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _StubResponse(
+        status_code=401,
         text='{"detail":"invalid SESSION token"}',
         json_data={"detail": "invalid SESSION token"},
     )
@@ -151,7 +174,38 @@ def test_401_invalid_session_token_outside_app_sessions_refreshes_sdk_auth(
     assert authenticator.refresh_calls == 1
 
 
-def test_401_invalid_session_token_for_non_session_prefix_refreshes_sdk_auth(
+def test_401_non_matching_detail_for_app_sessions_refreshes_sdk_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = iter(
+        [
+            _StubResponse(
+                status_code=401,
+                text='{"detail":"Core token expired"}',
+                json_data={"detail": "Core token expired"},
+            ),
+            _StubResponse(
+                status_code=200,
+                text='{"ok":true}',
+                json_data={"ok": True},
+            ),
+        ]
+    )
+    authenticator = _StubAuthenticator()
+    client = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=authenticator,
+    )
+    monkeypatch.setattr(client.session, "request", lambda *_args, **_kwargs: next(responses))
+
+    result = client.post("/apps/sessions/heartbeat", json={"session_token": "sdk-session"})
+
+    assert result == {"ok": True}
+    assert authenticator.authenticate_calls == 1
+    assert authenticator.refresh_calls == 1
+
+
+def test_401_invalid_session_token_for_apps_sessions_lookalike_prefix_refreshes_sdk_auth(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     responses = iter(

--- a/tests/unit/test_client_request_error_mapping.py
+++ b/tests/unit/test_client_request_error_mapping.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from kamiwaza_sdk.authentication import Authenticator
 from kamiwaza_sdk.client import KamiwazaClient
 from kamiwaza_sdk.exceptions import APIError, VectorDBUnavailableError
 
@@ -27,6 +28,19 @@ class _StubResponse:
         if self._json_data is None:
             raise ValueError("No JSON payload")
         return self._json_data
+
+
+class _StubAuthenticator(Authenticator):
+    def __init__(self) -> None:
+        self.authenticate_calls = 0
+        self.refresh_calls = 0
+
+    def authenticate(self, session) -> None:
+        self.authenticate_calls += 1
+        session.headers.update({"Authorization": "Bearer sdk-token"})
+
+    def refresh_token(self, session) -> None:
+        self.refresh_calls += 1
 
 
 def _make_client_with_response(
@@ -81,3 +95,26 @@ def test_501_non_vectordb_path_raises_api_error(monkeypatch: pytest.MonkeyPatch)
 
     assert not isinstance(exc_info.value, VectorDBUnavailableError)
     assert exc_info.value.status_code == 501
+
+
+def test_401_invalid_session_token_does_not_refresh_sdk_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = _StubResponse(
+        status_code=401,
+        text='{"detail":"Invalid session token"}',
+        json_data={"detail": "Invalid session token"},
+    )
+    authenticator = _StubAuthenticator()
+    client = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=authenticator,
+    )
+    monkeypatch.setattr(client.session, "request", lambda *_args, **_kwargs: response)
+
+    with pytest.raises(APIError) as exc_info:
+        client.post("/apps/sessions/heartbeat", json={"session_token": "sdk-session"})
+
+    assert exc_info.value.status_code == 401
+    assert authenticator.authenticate_calls == 1
+    assert authenticator.refresh_calls == 0

--- a/tests/unit/test_client_request_error_mapping.py
+++ b/tests/unit/test_client_request_error_mapping.py
@@ -149,3 +149,34 @@ def test_401_invalid_session_token_outside_app_sessions_refreshes_sdk_auth(
     assert result == {"ok": True}
     assert authenticator.authenticate_calls == 1
     assert authenticator.refresh_calls == 1
+
+
+def test_401_invalid_session_token_for_non_session_prefix_refreshes_sdk_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = iter(
+        [
+            _StubResponse(
+                status_code=401,
+                text='{"detail":"Invalid session token"}',
+                json_data={"detail": "Invalid session token"},
+            ),
+            _StubResponse(
+                status_code=200,
+                text='{"ok":true}',
+                json_data={"ok": True},
+            ),
+        ]
+    )
+    authenticator = _StubAuthenticator()
+    client = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=authenticator,
+    )
+    monkeypatch.setattr(client.session, "request", lambda *_args, **_kwargs: next(responses))
+
+    result = client.get("/apps/sessions-invalid/heartbeat")
+
+    assert result == {"ok": True}
+    assert authenticator.authenticate_calls == 1
+    assert authenticator.refresh_calls == 1


### PR DESCRIPTION
## Summary
Prevent the SDK from refreshing its core auth token when an app session endpoint rejects an app-level `session_token`, and align the live app-session assertions with the backend's current `401` response.

## Type
- [ ] Feature - New functionality
- [x] Bug Fix - Corrects existing behavior
- [ ] Refactor - Code improvement without behavior change
- [ ] Documentation - Docs only
- [ ] Test - Test coverage improvement
- [ ] Chore - Dependencies, config, CI/CD

## Change Flags
- [ ] API change - Endpoints added, modified, or removed
- [ ] Configuration change - New or modified config parameters
- [ ] Requirements change - Dependencies added, updated, or removed
- [ ] Schema change - Database or Pydantic model changes

## Breaking Changes
- [x] None - Fully backward compatible
- [ ] API contract - Existing clients may need updates
- [ ] Database schema - Migration required before/after deploy
- [ ] Configuration format - Existing config files need updating
- [ ] Internal interface - Other services/modules need coordinated updates

## Motivation
App session endpoints use their own `session_token` semantics. When the backend returns `401 Invalid session token`, the SDK should surface that app-session failure instead of treating it like expired core SDK auth and refreshing the main access token.

## Source
- [ ] Issue/Ticket: N/A
- [ ] Spec/Design Doc: N/A
- [x] Conversation/Discussion: publish the SDK fix for invalid app session token handling
- [ ] Self-identified: N/A

## Alternatives Considered
Refreshing the SDK auth token on every `401` was already the default path, but it obscures the real failure mode for app session APIs and can trigger an unnecessary refresh for a token type the SDK authenticator does not own.

## Changes Made
- skip SDK auth refresh when the backend responds with `Invalid session token` for app-session requests
- keep returning the backend `401` as an `APIError` so callers see the actual app-session failure
- update the live app-session integration test to expect `401` instead of `404`
- add unit coverage to verify the invalid-session-token path does not call `refresh_token`

## Technical Notes
This change keys off the backend's current `Invalid session token` response text so the existing refresh-on-401 behavior is preserved for other authentication failures.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No tests needed - explain below

## Verification
| Environment | Steps Performed | Result |
|-------------|-----------------|--------|
| Local | `uv run pytest tests/unit/test_client_request_error_mapping.py -q` | Pass |

## Test Coverage
Covers the request-error path where an authenticated SDK client calls an app session endpoint and receives `401 {"detail":"Invalid session token"}`. The live integration assertions were also updated to match the backend's current status code for invalid session tokens.

## Review Focus
Check that the `401` handling remains correct for normal SDK authentication failures while bypassing refresh only for app-session token rejections.

## Deployment Notes
N/A

## Checklist
- [x] Self-reviewed the code
- [x] Tests pass locally
- [ ] Verified on live system (see Verification above)
- [ ] Documentation updated (if applicable)

## Vibe Check
N/A