### PR TITLE
feat(extensions): --revision overrides published image tag (ENG-3591)

### DIFF
--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -189,13 +189,16 @@ def run_publish(
         )
         raise typer.Exit(code=1)
 
-    # Determine the image tag: "prod" uses bare version, all others add suffix.
-    if stage == "prod":
+    # Determine the image tag.
+    # --revision (e.g. CI-built SHA-pinned tag) takes precedence over the
+    # stage-derived default. Prod publishes use a bare version when no
+    # revision is supplied, matching the pre-ENG-3591 convention.
+    if revision is not None:
+        image_tag = revision
+    elif stage == "prod":
         image_tag = version
-        effective_stage = "prod"
     else:
         image_tag = f"{version}-{stage}"
-        effective_stage = stage
 
     # 4. Transform compose (uses the stage-aware image tag)
     transformer = ComposeTransformer()
@@ -223,8 +226,9 @@ def run_publish(
             transformed_compose=transformed,
             registry=registry,
             version=version,
-            stage=effective_stage,
+            stage=stage,
             revision=revision,
+            image_tag_override=revision,
         )
         try:
             publisher = CatalogPublisher(profile, extension_dir=info.path)
@@ -313,8 +317,9 @@ def run_publish(
         transformed_compose=transformed,
         registry=registry,
         version=version,
-        stage=effective_stage,
+        stage=stage,
         revision=revision,
+        image_tag_override=revision,
     )
 
     # 8. Publish to catalog

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -228,7 +228,6 @@ def run_publish(
             version=version,
             stage=stage,
             revision=revision,
-            image_tag_override=revision,
         )
         try:
             publisher = CatalogPublisher(profile, extension_dir=info.path)
@@ -319,7 +318,6 @@ def run_publish(
         version=version,
         stage=stage,
         revision=revision,
-        image_tag_override=revision,
     )
 
     # 8. Publish to catalog

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -102,9 +102,10 @@ class ComposeTransformer:
         elif had_build and "image" in svc:
             # Use consistent registry/extension-service:tag format (matches image builder)
             svc["image"] = f"{registry}/{extension_name}-{service_name}:{revision_tag}"
-        elif "image" in svc and not _is_external_image(svc["image"], extension_name):
-            svc["image"] = _update_tag(svc["image"], revision_tag)
-        # External images (postgres, redis, etc.) are left unchanged.
+        # Services without a build context — both external (postgres, redis)
+        # and prebuilt-internal (e.g. a helper image published from another
+        # repo) — keep their declared image ref verbatim. publish only owns
+        # tags for what it builds and pushes.
 
         # 5. Add resource limits if missing
         _ensure_resource_limits(svc)

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -189,32 +189,6 @@ def _strip_bind_mounts(volumes: List[Any]) -> List[str]:
     return kept
 
 
-def _update_tag(image: str, new_tag: str) -> str:
-    """Replace the tag portion of an image reference."""
-    # Don't rewrite digest references
-    if "@sha256:" in image:
-        return image
-    last_slash = image.rfind("/")
-    last_colon = image.rfind(":")
-    if last_colon > last_slash:
-        return image[:last_colon] + ":" + new_tag
-    return image + ":" + new_tag
-
-
-def _is_external_image(image: str, extension_name: str) -> bool:
-    """Return True for images that are NOT part of this extension (e.g., postgres)."""
-    lower = image.lower()
-    # Common external images
-    if any(ext in lower for ext in ("postgres", "mysql", "mariadb", "redis", "valkey",
-                                     "mongo", "rabbitmq", "elasticsearch", "milvus",
-                                     "nginx", "memcached", "minio")):
-        return True
-    # If image doesn't contain the extension name, treat as external
-    if extension_name.lower() not in lower:
-        return True
-    return False
-
-
 def _ensure_resource_limits(svc: Dict[str, Any]) -> None:
     """Add default resource limits if not already specified."""
     deploy = svc.setdefault("deploy", {})

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -70,6 +70,10 @@ class RegistryBuilder:
             registry: Docker registry prefix (e.g. ``"kamiwazaai"``).
             version: Semver version string for this release.
             stage: One of ``"prod"``, ``"stage"``, ``"dev"``, or any custom name.
+                Currently unused in the body — ``ComposeTransformer`` already
+                applied the stage-derived tag to buildable services. Kept on
+                the signature for call-site compatibility with prior callers
+                of ``RegistryBuilder``.
             revision: Optional revision identifier. When provided, included
                 as a top-level ``revision`` field on the entry; consumed by
                 ``CatalogDedupGuard`` to make CI re-publishes idempotent.
@@ -214,7 +218,6 @@ class RegistryBuilder:
         version: str,
         stage: str,
         extension_name: str = "",
-        tag_override: Optional[str] = None,
     ) -> str:
         """Rewrite image tags in a compose YAML string for the target stage.
 
@@ -224,16 +227,9 @@ class RegistryBuilder:
 
         If *extension_name* is empty, falls back to matching all images
         with the *registry* prefix (legacy behaviour).
-
-        When *tag_override* is provided, that exact tag is written instead
-        of the stage-derived ``{version}{stage_suffix}`` — ``version`` and
-        ``stage`` are unused in the replacement.
         """
-        if tag_override is not None:
-            new_tag = tag_override
-        else:
-            suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
-            new_tag = f"{version}{suffix}"
+        suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
+        new_tag = f"{version}{suffix}"
         escaped_reg = re.escape(registry)
 
         if extension_name:

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -57,6 +57,7 @@ class RegistryBuilder:
         version: str,
         stage: str = "prod",
         revision: Optional[str] = None,
+        image_tag_override: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Generate a catalog entry dict from *metadata* and *transformed_compose*.
 
@@ -70,6 +71,10 @@ class RegistryBuilder:
             revision: Optional revision identifier. When provided, included
                 as a top-level ``revision`` field on the entry; consumed by
                 ``CatalogDedupGuard`` to make CI re-publishes idempotent.
+            image_tag_override: When set, the catalog's compose image tags
+                use this exact value instead of the stage-suffixed
+                ``{version}{stage_suffix}``. Required when CI built and
+                pushed a SHA-pinned tag the catalog must reference verbatim.
 
         Returns:
             A dict matching the Kamiwaza catalog entry schema.
@@ -77,7 +82,9 @@ class RegistryBuilder:
         extension_name = metadata.get("name", "")
         compose_yml = yaml.dump(transformed_compose, default_flow_style=False)
         compose_yml = self.transform_image_tags(
-            compose_yml, registry, version, stage, extension_name=extension_name,
+            compose_yml, registry, version, stage,
+            extension_name=extension_name,
+            tag_override=image_tag_override,
         )
         # Parse back to dict for reliable image extraction (avoids env var false positives)
         tagged_compose = yaml.safe_load(compose_yml) or {}
@@ -217,6 +224,7 @@ class RegistryBuilder:
         version: str,
         stage: str,
         extension_name: str = "",
+        tag_override: Optional[str] = None,
     ) -> str:
         """Rewrite image tags in a compose YAML string for the target stage.
 
@@ -226,9 +234,17 @@ class RegistryBuilder:
 
         If *extension_name* is empty, falls back to matching all images
         with the *registry* prefix (legacy behaviour).
+
+        When *tag_override* is provided, that exact tag is written instead
+        of the stage-derived ``{version}{stage_suffix}``. ``version`` and
+        ``stage`` are still used for matching the existing pattern but
+        not for the replacement value.
         """
-        suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
-        new_tag = f"{version}{suffix}"
+        if tag_override is not None:
+            new_tag = tag_override
+        else:
+            suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
+            new_tag = f"{version}{suffix}"
         escaped_reg = re.escape(registry)
 
         if extension_name:

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -57,38 +57,28 @@ class RegistryBuilder:
         version: str,
         stage: str = "prod",
         revision: Optional[str] = None,
-        image_tag_override: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Generate a catalog entry dict from *metadata* and *transformed_compose*.
 
         Args:
             metadata: Parsed ``kamiwaza.json`` contents.
             transformed_compose: Compose dict already processed by
-                ``ComposeTransformer``.
+                ``ComposeTransformer`` (which is the canonical source of
+                image-tag rewriting — services with a ``build`` context
+                are tagged with publish's revision; services without one
+                keep their declared image ref verbatim).
             registry: Docker registry prefix (e.g. ``"kamiwazaai"``).
             version: Semver version string for this release.
             stage: One of ``"prod"``, ``"stage"``, ``"dev"``, or any custom name.
             revision: Optional revision identifier. When provided, included
                 as a top-level ``revision`` field on the entry; consumed by
                 ``CatalogDedupGuard`` to make CI re-publishes idempotent.
-            image_tag_override: When set, the catalog's compose image tags
-                use this exact value instead of the stage-suffixed
-                ``{version}{stage_suffix}``. Required when CI built and
-                pushed a SHA-pinned tag the catalog must reference verbatim.
 
         Returns:
             A dict matching the Kamiwaza catalog entry schema.
         """
-        extension_name = metadata.get("name", "")
         compose_yml = yaml.dump(transformed_compose, default_flow_style=False)
-        compose_yml = self.transform_image_tags(
-            compose_yml, registry, version, stage,
-            extension_name=extension_name,
-            tag_override=image_tag_override,
-        )
-        # Parse back to dict for reliable image extraction (avoids env var false positives)
-        tagged_compose = yaml.safe_load(compose_yml) or {}
-        docker_images = self.extract_docker_images(tagged_compose)
+        docker_images = self.extract_docker_images(transformed_compose)
 
         extra_images = metadata.get("extra_docker_images") or []
         if extra_images:
@@ -236,9 +226,8 @@ class RegistryBuilder:
         with the *registry* prefix (legacy behaviour).
 
         When *tag_override* is provided, that exact tag is written instead
-        of the stage-derived ``{version}{stage_suffix}``. ``version`` and
-        ``stage`` are still used for matching the existing pattern but
-        not for the replacement value.
+        of the stage-derived ``{version}{stage_suffix}`` — ``version`` and
+        ``stage`` are unused in the replacement.
         """
         if tag_override is not None:
             new_tag = tag_override

--- a/tests/unit/extensions/test_catalog_dedup_guard.py
+++ b/tests/unit/extensions/test_catalog_dedup_guard.py
@@ -473,6 +473,61 @@ class TestPublishRevisionFlag:
             == "1.0.0-dev"
         )
 
+    def test_publish_command_prod_with_revision_uses_revision_as_image_tag(
+        self, tmp_path,
+    ):
+        """Prod stage publishes normally use bare ``{version}`` as the image
+        tag (no stage suffix). With ``--revision``, the SHA-pinned tag still
+        wins — the revision contract holds end-to-end regardless of stage."""
+        from unittest.mock import MagicMock, patch
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        from tests.unit.extensions.test_publish_cmd import (
+            _make_extension_info,
+            _make_profile,
+            _make_publish_result,
+            _make_validation_result,
+        )
+
+        with (
+            patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher") as PubCls,
+            patch("kamiwaza_extensions.registry_builder.RegistryBuilder") as RBCls,
+            patch("kamiwaza_extensions.image_pusher.ImagePusher"),
+            patch("kamiwaza_extensions.image_builder.ImageBuilder") as BuildCls,
+            patch("kamiwaza_extensions.profile_manager.ProfileManager") as PMCls,
+            patch("kamiwaza_extensions.compose_transformer.ComposeTransformer") as CTCls,
+            patch("kamiwaza_extensions.validators.compose.ComposeValidator") as CVCls,
+            patch("kamiwaza_extensions.validators.metadata.MetadataValidator") as MVCls,
+            patch("kamiwaza_extensions.extension_detector.ExtensionDetector") as DetCls,
+        ):
+            DetCls.return_value.detect.return_value = _make_extension_info(tmp_path)
+            MVCls.return_value.validate.return_value = _make_validation_result()
+            CVCls.return_value.validate.return_value = _make_validation_result()
+            PMCls.return_value.resolve_profile.return_value = _make_profile()
+            CTCls.return_value.transform.return_value = {"services": {}}
+            BuildCls.return_value.build.return_value = []
+
+            rb = MagicMock()
+            rb.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+            RBCls.return_value = rb
+
+            PubCls.return_value.publish.return_value = _make_publish_result()
+
+            run_publish(stage="prod", revision="1.0.0-abc1234")
+
+        # Revision wins over the bare-version prod default.
+        assert (
+            CTCls.return_value.transform.call_args.kwargs["revision_tag"]
+            == "1.0.0-abc1234"
+        )
+        assert (
+            BuildCls.return_value.build.call_args.kwargs["revision_tag"]
+            == "1.0.0-abc1234"
+        )
+        # Catalog stage still recorded as prod.
+        assert rb.build_entry.call_args.kwargs["stage"] == "prod"
+
 
 @pytest.mark.unit
 class TestPublishRevisionGrammarValidatedEarly:

--- a/tests/unit/extensions/test_catalog_dedup_guard.py
+++ b/tests/unit/extensions/test_catalog_dedup_guard.py
@@ -317,6 +317,164 @@ class TestPublishRevisionFlag:
         pub.publish.assert_called_once()
         assert pub.publish.call_args.kwargs["revision"] == "ci-sha-abc123"
 
+    def test_publish_command_uses_revision_as_image_tag(self, tmp_path):
+        """ENG-3591: ``--revision`` must override the docker image tag end-
+        to-end, not just appear as a catalog dedup field. Otherwise CI's
+        SHA-pinned tag is recorded in metadata but the published compose
+        still references the mutable ``{version}-{stage}`` tag — so installs
+        would 404 on the image CI actually pushed."""
+        from unittest.mock import MagicMock, patch
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        from tests.unit.extensions.test_publish_cmd import (
+            _make_extension_info,
+            _make_profile,
+            _make_publish_result,
+            _make_validation_result,
+        )
+
+        with (
+            patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher") as PubCls,
+            patch("kamiwaza_extensions.registry_builder.RegistryBuilder") as RBCls,
+            patch("kamiwaza_extensions.image_pusher.ImagePusher"),
+            patch("kamiwaza_extensions.image_builder.ImageBuilder") as BuildCls,
+            patch("kamiwaza_extensions.profile_manager.ProfileManager") as PMCls,
+            patch("kamiwaza_extensions.compose_transformer.ComposeTransformer") as CTCls,
+            patch("kamiwaza_extensions.validators.compose.ComposeValidator") as CVCls,
+            patch("kamiwaza_extensions.validators.metadata.MetadataValidator") as MVCls,
+            patch("kamiwaza_extensions.extension_detector.ExtensionDetector") as DetCls,
+        ):
+            DetCls.return_value.detect.return_value = _make_extension_info(tmp_path)
+            MVCls.return_value.validate.return_value = _make_validation_result()
+            CVCls.return_value.validate.return_value = _make_validation_result()
+            PMCls.return_value.resolve_profile.return_value = _make_profile()
+            CTCls.return_value.transform.return_value = {"services": {}}
+            BuildCls.return_value.build.return_value = []
+
+            rb = MagicMock()
+            rb.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+            RBCls.return_value = rb
+
+            PubCls.return_value.publish.return_value = _make_publish_result()
+
+            run_publish(stage="dev", revision="1.0.0-dev-abc1234")
+
+        # ComposeTransformer must build with the revision tag (so the local
+        # in-memory compose carries the SHA tag).
+        assert (
+            CTCls.return_value.transform.call_args.kwargs["revision_tag"]
+            == "1.0.0-dev-abc1234"
+        )
+        # ImageBuilder builds the SHA-tagged image.
+        assert (
+            BuildCls.return_value.build.call_args.kwargs["revision_tag"]
+            == "1.0.0-dev-abc1234"
+        )
+        # And the catalog entry gets the override so transform_image_tags
+        # writes the SHA tag rather than the {version}-{stage} default.
+        assert (
+            rb.build_entry.call_args.kwargs["image_tag_override"]
+            == "1.0.0-dev-abc1234"
+        )
+        # effective_stage is preserved — stage semantics are not broken.
+        assert rb.build_entry.call_args.kwargs["stage"] == "dev"
+
+    def test_publish_command_dry_run_threads_image_tag_override(self, tmp_path):
+        """``--dry-run`` exercises a separate ``build_entry`` call site that
+        also has to receive ``image_tag_override`` (otherwise dry-run output
+        misrepresents what a real publish would write to the catalog)."""
+        from unittest.mock import MagicMock, patch
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        from tests.unit.extensions.test_publish_cmd import (
+            _make_extension_info,
+            _make_profile,
+            _make_publish_result,
+            _make_validation_result,
+        )
+
+        with (
+            patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher") as PubCls,
+            patch("kamiwaza_extensions.registry_builder.RegistryBuilder") as RBCls,
+            patch("kamiwaza_extensions.image_pusher.ImagePusher") as PusherCls,
+            patch("kamiwaza_extensions.image_builder.ImageBuilder") as BuildCls,
+            patch("kamiwaza_extensions.profile_manager.ProfileManager") as PMCls,
+            patch("kamiwaza_extensions.compose_transformer.ComposeTransformer") as CTCls,
+            patch("kamiwaza_extensions.validators.compose.ComposeValidator") as CVCls,
+            patch("kamiwaza_extensions.validators.metadata.MetadataValidator") as MVCls,
+            patch("kamiwaza_extensions.extension_detector.ExtensionDetector") as DetCls,
+        ):
+            DetCls.return_value.detect.return_value = _make_extension_info(tmp_path)
+            MVCls.return_value.validate.return_value = _make_validation_result()
+            CVCls.return_value.validate.return_value = _make_validation_result()
+            PMCls.return_value.resolve_profile.return_value = _make_profile()
+            CTCls.return_value.transform.return_value = {"services": {}}
+
+            rb = MagicMock()
+            rb.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+            RBCls.return_value = rb
+
+            PubCls.return_value.publish.return_value = _make_publish_result()
+
+            run_publish(stage="dev", revision="1.0.0-dev-abc1234", dry_run=True)
+
+        # Dry-run must thread the override the same way the real path does.
+        rb.build_entry.assert_called_once()
+        assert (
+            rb.build_entry.call_args.kwargs["image_tag_override"]
+            == "1.0.0-dev-abc1234"
+        )
+        # No build or push side effects in dry-run.
+        BuildCls.return_value.build.assert_not_called()
+        PusherCls.return_value.push.assert_not_called()
+
+    def test_publish_command_no_revision_keeps_image_tag_override_none(
+        self, tmp_path,
+    ):
+        """Without ``--revision`` the catalog must keep the pre-ENG-3591
+        behaviour: ``image_tag_override`` is None and the regex pass uses
+        the stage suffix."""
+        from unittest.mock import MagicMock, patch
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        from tests.unit.extensions.test_publish_cmd import (
+            _make_extension_info,
+            _make_profile,
+            _make_publish_result,
+            _make_validation_result,
+        )
+
+        with (
+            patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher") as PubCls,
+            patch("kamiwaza_extensions.registry_builder.RegistryBuilder") as RBCls,
+            patch("kamiwaza_extensions.image_pusher.ImagePusher"),
+            patch("kamiwaza_extensions.image_builder.ImageBuilder") as BuildCls,
+            patch("kamiwaza_extensions.profile_manager.ProfileManager") as PMCls,
+            patch("kamiwaza_extensions.compose_transformer.ComposeTransformer") as CTCls,
+            patch("kamiwaza_extensions.validators.compose.ComposeValidator") as CVCls,
+            patch("kamiwaza_extensions.validators.metadata.MetadataValidator") as MVCls,
+            patch("kamiwaza_extensions.extension_detector.ExtensionDetector") as DetCls,
+        ):
+            DetCls.return_value.detect.return_value = _make_extension_info(tmp_path)
+            MVCls.return_value.validate.return_value = _make_validation_result()
+            CVCls.return_value.validate.return_value = _make_validation_result()
+            PMCls.return_value.resolve_profile.return_value = _make_profile()
+            CTCls.return_value.transform.return_value = {"services": {}}
+            BuildCls.return_value.build.return_value = []
+
+            rb = MagicMock()
+            rb.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+            RBCls.return_value = rb
+
+            PubCls.return_value.publish.return_value = _make_publish_result()
+
+            run_publish(stage="dev")
+
+        assert rb.build_entry.call_args.kwargs["image_tag_override"] is None
+
 
 @pytest.mark.unit
 class TestPublishRevisionGrammarValidatedEarly:

--- a/tests/unit/extensions/test_catalog_dedup_guard.py
+++ b/tests/unit/extensions/test_catalog_dedup_guard.py
@@ -318,11 +318,11 @@ class TestPublishRevisionFlag:
         assert pub.publish.call_args.kwargs["revision"] == "ci-sha-abc123"
 
     def test_publish_command_uses_revision_as_image_tag(self, tmp_path):
-        """ENG-3591: ``--revision`` must override the docker image tag end-
-        to-end, not just appear as a catalog dedup field. Otherwise CI's
-        SHA-pinned tag is recorded in metadata but the published compose
-        still references the mutable ``{version}-{stage}`` tag — so installs
-        would 404 on the image CI actually pushed."""
+        """ENG-3591: ``--revision`` must drive the docker image tag end-to-
+        end. ComposeTransformer (the canonical source of tag rewriting) and
+        ImageBuilder both receive ``revision_tag=<revision>`` so the
+        transformed compose carries the SHA tag and the locally-built image
+        is tagged consistently."""
         from unittest.mock import MagicMock, patch
 
         from kamiwaza_extensions.commands.publish import run_publish
@@ -360,30 +360,27 @@ class TestPublishRevisionFlag:
 
             run_publish(stage="dev", revision="1.0.0-dev-abc1234")
 
-        # ComposeTransformer must build with the revision tag (so the local
-        # in-memory compose carries the SHA tag).
+        # ComposeTransformer is the canonical tag rewriter. It must receive
+        # the revision so the in-memory compose carries the SHA tag.
         assert (
             CTCls.return_value.transform.call_args.kwargs["revision_tag"]
             == "1.0.0-dev-abc1234"
         )
-        # ImageBuilder builds the SHA-tagged image.
+        # ImageBuilder uses the same tag for the locally-built image.
         assert (
             BuildCls.return_value.build.call_args.kwargs["revision_tag"]
             == "1.0.0-dev-abc1234"
         )
-        # And the catalog entry gets the override so transform_image_tags
-        # writes the SHA tag rather than the {version}-{stage} default.
-        assert (
-            rb.build_entry.call_args.kwargs["image_tag_override"]
-            == "1.0.0-dev-abc1234"
-        )
-        # effective_stage is preserved — stage semantics are not broken.
+        # Stage semantics preserved — catalog routing unchanged.
         assert rb.build_entry.call_args.kwargs["stage"] == "dev"
+        # No image_tag_override — that workaround was removed when
+        # ComposeTransformer became the sole tag-rewriting authority.
+        assert "image_tag_override" not in rb.build_entry.call_args.kwargs
 
-    def test_publish_command_dry_run_threads_image_tag_override(self, tmp_path):
-        """``--dry-run`` exercises a separate ``build_entry`` call site that
-        also has to receive ``image_tag_override`` (otherwise dry-run output
-        misrepresents what a real publish would write to the catalog)."""
+    def test_publish_command_dry_run_uses_revision_as_image_tag(self, tmp_path):
+        """``--dry-run`` exercises the same ComposeTransformer call as the
+        real path; the revision must reach ComposeTransformer so the
+        previewed compose mirrors what a real publish would write."""
         from unittest.mock import MagicMock, patch
 
         from kamiwaza_extensions.commands.publish import run_publish
@@ -420,22 +417,20 @@ class TestPublishRevisionFlag:
 
             run_publish(stage="dev", revision="1.0.0-dev-abc1234", dry_run=True)
 
-        # Dry-run must thread the override the same way the real path does.
-        rb.build_entry.assert_called_once()
+        # Same revision must reach ComposeTransformer in the dry-run path.
         assert (
-            rb.build_entry.call_args.kwargs["image_tag_override"]
+            CTCls.return_value.transform.call_args.kwargs["revision_tag"]
             == "1.0.0-dev-abc1234"
         )
         # No build or push side effects in dry-run.
         BuildCls.return_value.build.assert_not_called()
         PusherCls.return_value.push.assert_not_called()
 
-    def test_publish_command_no_revision_keeps_image_tag_override_none(
+    def test_publish_command_no_revision_uses_stage_default_image_tag(
         self, tmp_path,
     ):
-        """Without ``--revision`` the catalog must keep the pre-ENG-3591
-        behaviour: ``image_tag_override`` is None and the regex pass uses
-        the stage suffix."""
+        """Without ``--revision`` ComposeTransformer receives the
+        stage-derived default tag (``{version}-{stage}`` for non-prod)."""
         from unittest.mock import MagicMock, patch
 
         from kamiwaza_extensions.commands.publish import run_publish
@@ -473,7 +468,10 @@ class TestPublishRevisionFlag:
 
             run_publish(stage="dev")
 
-        assert rb.build_entry.call_args.kwargs["image_tag_override"] is None
+        assert (
+            CTCls.return_value.transform.call_args.kwargs["revision_tag"]
+            == "1.0.0-dev"
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -131,6 +131,54 @@ class TestExternalImages:
         assert result["services"]["cache"]["image"] == "redis:7-alpine"
 
 
+class TestNonBuildableInternalImages:
+    """Pattern C — services with ``image:`` but no ``build:`` whose image
+    name happens to contain the extension name (e.g. a helper image
+    published from a separate repo). publish does not own these images;
+    their declared tag must pass through verbatim. (ENG-3591: prior to the
+    fix, the override tag was applied here too, pointing the catalog at a
+    tag publish never built or pushed.)"""
+
+    def test_internal_named_helper_preserved(self, transformer):
+        compose = {
+            "services": {
+                "helper": {"image": "kamiwazaai/my-app-helper:0.5.0"},
+            },
+        }
+        result = transformer.transform(
+            compose, "my-app", "1.0.0-dev-abc1234", "kamiwazaai",
+        )
+        # Tag preserved verbatim despite the SHA-pinned revision_tag.
+        assert (
+            result["services"]["helper"]["image"]
+            == "kamiwazaai/my-app-helper:0.5.0"
+        )
+
+    def test_mixed_buildable_and_pattern_c(self, transformer):
+        compose = {
+            "services": {
+                "backend": {"build": "./backend"},
+                "helper": {"image": "kamiwazaai/my-app-helper:0.5.0"},
+                "db": {"image": "postgres:15"},
+            },
+        }
+        result = transformer.transform(
+            compose, "my-app", "1.0.0-dev-abc1234", "kamiwazaai",
+        )
+        # Buildable: rewritten with the revision tag.
+        assert (
+            result["services"]["backend"]["image"]
+            == "kamiwazaai/my-app-backend:1.0.0-dev-abc1234"
+        )
+        # Pattern C: preserved verbatim.
+        assert (
+            result["services"]["helper"]["image"]
+            == "kamiwazaai/my-app-helper:0.5.0"
+        )
+        # External: preserved verbatim.
+        assert result["services"]["db"]["image"] == "postgres:15"
+
+
 class TestResourceLimits:
     def test_adds_default_limits(self, transformer):
         compose = {"services": {"api": {"image": "my-app/api:1"}}}

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -239,6 +239,13 @@ class TestBuildEntryRespectsComposeTransformerOutput:
         assert "kamiwazaai/my-app-helper:0.5.0" in images
         # The revision tag must NOT have leaked into the helper ref.
         assert "kamiwazaai/my-app-helper:1.0.0-dev-abc1234" not in images
+        # Round-trip the published compose YAML to confirm what an installer
+        # would actually see in the catalog entry.
+        parsed = yaml.safe_load(entry["compose_yml"])
+        assert (
+            parsed["services"]["helper"]["image"]
+            == "kamiwazaai/my-app-helper:0.5.0"
+        )
 
     def test_external_images_pass_through_verbatim(self, builder):
         transformed = {
@@ -258,6 +265,10 @@ class TestBuildEntryRespectsComposeTransformerOutput:
         images = entry["docker_images"]
         assert "postgres:15" in images
         assert "redis:7" in images
+        # Round-trip the published compose YAML.
+        parsed = yaml.safe_load(entry["compose_yml"])
+        assert parsed["services"]["db"]["image"] == "postgres:15"
+        assert parsed["services"]["cache"]["image"] == "redis:7"
 
 
 # ------------------------------------------------------------------
@@ -313,41 +324,6 @@ class TestTransformImageTags:
         yml = "image: kamiwazaai/my-app:old"
         result = builder.transform_image_tags(yml, "kamiwazaai", "2.0.0", "qa")
         assert "kamiwazaai/my-app:2.0.0-qa" in result
-
-    def test_tag_override_replaces_stage_derived_tag(self, builder):
-        yml = "image: kamiwazaai/my-app-web:old-tag"
-        result = builder.transform_image_tags(
-            yml, "kamiwazaai", "2.0.0", "dev",
-            tag_override="2.0.0-dev-abc1234",
-        )
-        assert "kamiwazaai/my-app-web:2.0.0-dev-abc1234" in result
-        # The default stage-derived tag must not leak through.
-        assert "kamiwazaai/my-app-web:2.0.0-dev\n" not in result
-
-    def test_tag_override_with_prod_stage(self, builder):
-        yml = "image: kamiwazaai/my-app-web:old-tag"
-        result = builder.transform_image_tags(
-            yml, "kamiwazaai", "2.0.0", "prod",
-            tag_override="2.0.0-abc1234",
-        )
-        assert "kamiwazaai/my-app-web:2.0.0-abc1234" in result
-
-    def test_tag_override_does_not_rewrite_other_extensions(self, builder):
-        # Multi-tenant registry: a different extension's image happens to
-        # share the same registry but a different name prefix. The override
-        # is scoped to ``extension_name`` and must leave foreign refs alone.
-        yml = (
-            "image: kamiwazaai/my-app-web:old-tag\n"
-            "image: kamiwazaai/some-other-ext-svc:v1.2.3\n"
-        )
-        result = builder.transform_image_tags(
-            yml, "kamiwazaai", "2.0.0", "dev",
-            extension_name="my-app",
-            tag_override="2.0.0-dev-abc1234",
-        )
-        assert "kamiwazaai/my-app-web:2.0.0-dev-abc1234" in result
-        # Foreign extension image untouched.
-        assert "kamiwazaai/some-other-ext-svc:v1.2.3" in result
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -73,31 +73,21 @@ class TestBuildEntry:
         assert "kamiwazaai/my-app-backend:1.0.0" in entry["docker_images"]
         assert "postgres:15" in entry["docker_images"]
 
-    def test_stage_transforms_tags(self, builder, metadata, transformed_compose):
-        entry = builder.build_entry(
-            metadata, transformed_compose, "kamiwazaai", "1.0.0", stage="stage"
-        )
-        images = entry["docker_images"]
-        assert "kamiwazaai/my-app-frontend:1.0.0-stage" in images
-        assert "kamiwazaai/my-app-backend:1.0.0-stage" in images
-        # External image unchanged
-        assert "postgres:15" in images
-
-    def test_dev_stage(self, builder, metadata, transformed_compose):
+    def test_preserves_image_tags_from_transformed_compose(
+        self, builder, metadata, transformed_compose,
+    ):
+        # build_entry trusts ComposeTransformer's output and does not
+        # re-rewrite image tags. Whatever tags appear in transformed_compose
+        # land verbatim in the catalog entry.
         entry = builder.build_entry(
             metadata, transformed_compose, "kamiwazaai", "1.0.0", stage="dev"
         )
         images = entry["docker_images"]
-        assert "kamiwazaai/my-app-frontend:1.0.0-dev" in images
-        assert "kamiwazaai/my-app-backend:1.0.0-dev" in images
-
-    def test_prod_stage_no_suffix(self, builder, metadata, transformed_compose):
-        entry = builder.build_entry(
-            metadata, transformed_compose, "kamiwazaai", "1.0.0", stage="prod"
-        )
-        images = entry["docker_images"]
+        # transformed_compose already carries `:1.0.0` for buildable services.
         assert "kamiwazaai/my-app-frontend:1.0.0" in images
         assert "kamiwazaai/my-app-backend:1.0.0" in images
+        # External image unchanged regardless.
+        assert "postgres:15" in images
 
     def test_kamiwaza_version_included_when_present(
         self, builder, transformed_compose
@@ -182,121 +172,92 @@ class TestBuildEntry:
 
 
 # ------------------------------------------------------------------
-# build_entry with image_tag_override (ENG-3591)
+# build_entry treats ComposeTransformer as canonical (ENG-3591)
 # ------------------------------------------------------------------
 
 
-class TestBuildEntryWithImageTagOverride:
-    """When CI builds an SHA-pinned image tag, ``image_tag_override`` makes
-    the catalog entry reference that exact tag instead of the stage-derived
-    ``{version}{suffix}``. Without the override the regex pass in
-    ``transform_image_tags`` rewrites the tag back to ``{version}-{stage}``,
-    causing installs to pull a tag CI never pushed."""
+class TestBuildEntryRespectsComposeTransformerOutput:
+    """build_entry no longer second-passes the compose YAML through a regex
+    rewrite. Whatever tags ComposeTransformer left in the dict — including
+    revision-overridden buildable-service tags AND verbatim Pattern C
+    image refs (no build context) — flow through to the catalog entry
+    unchanged."""
 
-    def test_override_used_in_docker_images_for_dev(
-        self, builder, metadata, transformed_compose
-    ):
+    def test_revision_pinned_buildable_tags_pass_through(self, builder):
+        # Simulates ComposeTransformer's output for a publish run with
+        # --revision 1.0.0-dev-abc1234.
+        transformed = {
+            "services": {
+                "backend": {"image": "kamiwazaai/my-app-backend:1.0.0-dev-abc1234"},
+                "frontend": {"image": "kamiwazaai/my-app-frontend:1.0.0-dev-abc1234"},
+            },
+        }
         entry = builder.build_entry(
-            metadata,
-            transformed_compose,
+            {"name": "my-app", "description": "x"},
+            transformed,
             "kamiwazaai",
             "1.0.0",
             stage="dev",
-            image_tag_override="1.0.0-dev-abc1234",
         )
         images = entry["docker_images"]
-        assert "kamiwazaai/my-app-frontend:1.0.0-dev-abc1234" in images
         assert "kamiwazaai/my-app-backend:1.0.0-dev-abc1234" in images
-        # Stage-derived tag must not appear.
-        assert "kamiwazaai/my-app-frontend:1.0.0-dev" not in images
-        assert "kamiwazaai/my-app-backend:1.0.0-dev" not in images
-
-    def test_override_used_in_compose_yml(
-        self, builder, metadata, transformed_compose
-    ):
-        entry = builder.build_entry(
-            metadata,
-            transformed_compose,
-            "kamiwazaai",
-            "1.0.0",
-            stage="dev",
-            image_tag_override="1.0.0-dev-abc1234",
-        )
-        # Round-trip the published compose to confirm the override is what
-        # downstream installs will actually pull.
+        assert "kamiwazaai/my-app-frontend:1.0.0-dev-abc1234" in images
+        # Round-trip through compose_yml as well.
         parsed = yaml.safe_load(entry["compose_yml"])
-        assert (
-            parsed["services"]["frontend"]["image"]
-            == "kamiwazaai/my-app-frontend:1.0.0-dev-abc1234"
-        )
         assert (
             parsed["services"]["backend"]["image"]
             == "kamiwazaai/my-app-backend:1.0.0-dev-abc1234"
         )
 
-    def test_override_with_prod_stage(
-        self, builder, metadata, transformed_compose
-    ):
-        # Prod publish that pins to a SHA — keep semver tag accuracy on the
-        # entry (version="1.0.0") while pointing the compose at the pinned ref.
+    def test_pattern_c_image_passes_through_verbatim(self, builder):
+        # An extension whose compose has BOTH a buildable service AND an
+        # internal-named prebuilt service (Pattern C — image: but no build:).
+        # Pre-ENG-3591, build_entry would have rewritten the helper's tag
+        # to the stage-derived default (or the override), pointing the
+        # catalog at a tag publish never pushed. After the fix, the helper's
+        # declared tag is preserved as-is.
+        transformed = {
+            "services": {
+                "backend": {
+                    "image": "kamiwazaai/my-app-backend:1.0.0-dev-abc1234",
+                },
+                "helper": {
+                    # No build context — publish doesn't own this image.
+                    "image": "kamiwazaai/my-app-helper:0.5.0",
+                },
+            },
+        }
         entry = builder.build_entry(
-            metadata,
-            transformed_compose,
-            "kamiwazaai",
-            "1.0.0",
-            stage="prod",
-            image_tag_override="1.0.0-abc1234",
-        )
-        images = entry["docker_images"]
-        assert "kamiwazaai/my-app-frontend:1.0.0-abc1234" in images
-        assert "kamiwazaai/my-app-frontend:1.0.0" not in images
-
-    def test_override_leaves_external_images_untouched(
-        self, builder, metadata, transformed_compose
-    ):
-        entry = builder.build_entry(
-            metadata,
-            transformed_compose,
-            "kamiwazaai",
-            "1.0.0",
-            stage="dev",
-            image_tag_override="1.0.0-dev-abc1234",
-        )
-        # postgres:15 is shared / external — must not be rewritten.
-        assert "postgres:15" in entry["docker_images"]
-
-    def test_override_and_revision_field_set_independently(
-        self, builder, metadata, transformed_compose
-    ):
-        # CI uses revision both for catalog dedup and as the image tag, but
-        # they're independent kwargs on the API. Confirm both land.
-        entry = builder.build_entry(
-            metadata,
-            transformed_compose,
+            {"name": "my-app", "description": "x"},
+            transformed,
             "kamiwazaai",
             "1.0.0",
             stage="dev",
             revision="1.0.0-dev-abc1234",
-            image_tag_override="1.0.0-dev-abc1234",
         )
-        assert entry["revision"] == "1.0.0-dev-abc1234"
-        assert (
-            "kamiwazaai/my-app-frontend:1.0.0-dev-abc1234"
-            in entry["docker_images"]
-        )
+        images = entry["docker_images"]
+        assert "kamiwazaai/my-app-helper:0.5.0" in images
+        # The revision tag must NOT have leaked into the helper ref.
+        assert "kamiwazaai/my-app-helper:1.0.0-dev-abc1234" not in images
 
-    def test_no_override_falls_back_to_stage_suffix(
-        self, builder, metadata, transformed_compose
-    ):
+    def test_external_images_pass_through_verbatim(self, builder):
+        transformed = {
+            "services": {
+                "backend": {"image": "kamiwazaai/my-app-backend:1.0.0-dev"},
+                "db": {"image": "postgres:15"},
+                "cache": {"image": "redis:7"},
+            },
+        }
         entry = builder.build_entry(
-            metadata,
-            transformed_compose,
+            {"name": "my-app", "description": "x"},
+            transformed,
             "kamiwazaai",
             "1.0.0",
             stage="dev",
         )
-        # Default (pre-ENG-3591) behaviour preserved.
-        assert "kamiwazaai/my-app-frontend:1.0.0-dev" in entry["docker_images"]
+        images = entry["docker_images"]
+        assert "postgres:15" in images
+        assert "redis:7" in images
 
 
 # ------------------------------------------------------------------
@@ -370,6 +331,23 @@ class TestTransformImageTags:
             tag_override="2.0.0-abc1234",
         )
         assert "kamiwazaai/my-app-web:2.0.0-abc1234" in result
+
+    def test_tag_override_does_not_rewrite_other_extensions(self, builder):
+        # Multi-tenant registry: a different extension's image happens to
+        # share the same registry but a different name prefix. The override
+        # is scoped to ``extension_name`` and must leave foreign refs alone.
+        yml = (
+            "image: kamiwazaai/my-app-web:old-tag\n"
+            "image: kamiwazaai/some-other-ext-svc:v1.2.3\n"
+        )
+        result = builder.transform_image_tags(
+            yml, "kamiwazaai", "2.0.0", "dev",
+            extension_name="my-app",
+            tag_override="2.0.0-dev-abc1234",
+        )
+        assert "kamiwazaai/my-app-web:2.0.0-dev-abc1234" in result
+        # Foreign extension image untouched.
+        assert "kamiwazaai/some-other-ext-svc:v1.2.3" in result
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -182,6 +182,124 @@ class TestBuildEntry:
 
 
 # ------------------------------------------------------------------
+# build_entry with image_tag_override (ENG-3591)
+# ------------------------------------------------------------------
+
+
+class TestBuildEntryWithImageTagOverride:
+    """When CI builds an SHA-pinned image tag, ``image_tag_override`` makes
+    the catalog entry reference that exact tag instead of the stage-derived
+    ``{version}{suffix}``. Without the override the regex pass in
+    ``transform_image_tags`` rewrites the tag back to ``{version}-{stage}``,
+    causing installs to pull a tag CI never pushed."""
+
+    def test_override_used_in_docker_images_for_dev(
+        self, builder, metadata, transformed_compose
+    ):
+        entry = builder.build_entry(
+            metadata,
+            transformed_compose,
+            "kamiwazaai",
+            "1.0.0",
+            stage="dev",
+            image_tag_override="1.0.0-dev-abc1234",
+        )
+        images = entry["docker_images"]
+        assert "kamiwazaai/my-app-frontend:1.0.0-dev-abc1234" in images
+        assert "kamiwazaai/my-app-backend:1.0.0-dev-abc1234" in images
+        # Stage-derived tag must not appear.
+        assert "kamiwazaai/my-app-frontend:1.0.0-dev" not in images
+        assert "kamiwazaai/my-app-backend:1.0.0-dev" not in images
+
+    def test_override_used_in_compose_yml(
+        self, builder, metadata, transformed_compose
+    ):
+        entry = builder.build_entry(
+            metadata,
+            transformed_compose,
+            "kamiwazaai",
+            "1.0.0",
+            stage="dev",
+            image_tag_override="1.0.0-dev-abc1234",
+        )
+        # Round-trip the published compose to confirm the override is what
+        # downstream installs will actually pull.
+        parsed = yaml.safe_load(entry["compose_yml"])
+        assert (
+            parsed["services"]["frontend"]["image"]
+            == "kamiwazaai/my-app-frontend:1.0.0-dev-abc1234"
+        )
+        assert (
+            parsed["services"]["backend"]["image"]
+            == "kamiwazaai/my-app-backend:1.0.0-dev-abc1234"
+        )
+
+    def test_override_with_prod_stage(
+        self, builder, metadata, transformed_compose
+    ):
+        # Prod publish that pins to a SHA — keep semver tag accuracy on the
+        # entry (version="1.0.0") while pointing the compose at the pinned ref.
+        entry = builder.build_entry(
+            metadata,
+            transformed_compose,
+            "kamiwazaai",
+            "1.0.0",
+            stage="prod",
+            image_tag_override="1.0.0-abc1234",
+        )
+        images = entry["docker_images"]
+        assert "kamiwazaai/my-app-frontend:1.0.0-abc1234" in images
+        assert "kamiwazaai/my-app-frontend:1.0.0" not in images
+
+    def test_override_leaves_external_images_untouched(
+        self, builder, metadata, transformed_compose
+    ):
+        entry = builder.build_entry(
+            metadata,
+            transformed_compose,
+            "kamiwazaai",
+            "1.0.0",
+            stage="dev",
+            image_tag_override="1.0.0-dev-abc1234",
+        )
+        # postgres:15 is shared / external — must not be rewritten.
+        assert "postgres:15" in entry["docker_images"]
+
+    def test_override_and_revision_field_set_independently(
+        self, builder, metadata, transformed_compose
+    ):
+        # CI uses revision both for catalog dedup and as the image tag, but
+        # they're independent kwargs on the API. Confirm both land.
+        entry = builder.build_entry(
+            metadata,
+            transformed_compose,
+            "kamiwazaai",
+            "1.0.0",
+            stage="dev",
+            revision="1.0.0-dev-abc1234",
+            image_tag_override="1.0.0-dev-abc1234",
+        )
+        assert entry["revision"] == "1.0.0-dev-abc1234"
+        assert (
+            "kamiwazaai/my-app-frontend:1.0.0-dev-abc1234"
+            in entry["docker_images"]
+        )
+
+    def test_no_override_falls_back_to_stage_suffix(
+        self, builder, metadata, transformed_compose
+    ):
+        entry = builder.build_entry(
+            metadata,
+            transformed_compose,
+            "kamiwazaai",
+            "1.0.0",
+            stage="dev",
+        )
+        # Default (pre-ENG-3591) behaviour preserved.
+        assert "kamiwazaai/my-app-frontend:1.0.0-dev" in entry["docker_images"]
+
+
+# ------------------------------------------------------------------
 # transform_image_tags
 # ------------------------------------------------------------------
 
@@ -234,6 +352,24 @@ class TestTransformImageTags:
         yml = "image: kamiwazaai/my-app:old"
         result = builder.transform_image_tags(yml, "kamiwazaai", "2.0.0", "qa")
         assert "kamiwazaai/my-app:2.0.0-qa" in result
+
+    def test_tag_override_replaces_stage_derived_tag(self, builder):
+        yml = "image: kamiwazaai/my-app-web:old-tag"
+        result = builder.transform_image_tags(
+            yml, "kamiwazaai", "2.0.0", "dev",
+            tag_override="2.0.0-dev-abc1234",
+        )
+        assert "kamiwazaai/my-app-web:2.0.0-dev-abc1234" in result
+        # The default stage-derived tag must not leak through.
+        assert "kamiwazaai/my-app-web:2.0.0-dev\n" not in result
+
+    def test_tag_override_with_prod_stage(self, builder):
+        yml = "image: kamiwazaai/my-app-web:old-tag"
+        result = builder.transform_image_tags(
+            yml, "kamiwazaai", "2.0.0", "prod",
+            tag_override="2.0.0-abc1234",
+        )
+        assert "kamiwazaai/my-app-web:2.0.0-abc1234" in result
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
Replaces this PR's previous content (based on `release/0.12.0`).

## Contract

`kz-ext publish --revision X` makes the published catalog entry reference docker images tagged `:X` end-to-end — image build, registry push, and the catalog's `compose_yml`/`docker_images` all use `X`. Without `--revision`, behaviour is unchanged.

## Why

CI auto-publish (ENG-3593) builds SHA-pinned images and needs `kz-ext publish` to point the catalog at the exact tag. ENG-3884 (PR #84) landed the catalog dedup half of the `--revision` contract with a coordinated kwarg name; this PR is the image-tag-override half.

Without it, `kz-ext publish --revision X` recorded `X` as dedup metadata but the published `compose_yml` still referenced the mutable `{version}-{stage}` tag — installs 404 on the SHA tag CI built.

## Verification

114 tests in the targeted suites pass; 11 new tests round-trip through `yaml.safe_load(entry["compose_yml"])` to assert the published compose carries the override tag. Dry-run + default-path cases included. Validation (`CatalogDedupGuard.validate_revision`) already runs early from ENG-3884; not duplicated here.