### PR TITLE
Improve kz-ext convert for generic and static apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ kz-ext publish --stage prod
 |---------|-------------|
 | `kz-ext login [url]` | Authenticate with a Kamiwaza instance (default: `https://kamiwaza.test/api`). Supports `--api-key`, `--name`, `--list`, `--use`, `--no-verify-ssl`. |
 | `kz-ext create --type <type> --name <name>` | Scaffold a new extension in the current (empty) directory. Types: `app` (Next.js + FastAPI), `tool` (FastMCP), `service` (minimal). |
-| `kz-ext validate [path]` | Validate `kamiwaza.json` and `docker-compose.yml`. Use `--json` for machine-readable output. |
+| `kz-ext validate [path]` | Validate `kamiwaza.json`, `docker-compose.yml`, and clear platform-runtime incompatibilities such as privileged ports or root-only web containers. Use `--json` for machine-readable output. |
 | `kz-ext dev local` | Run the extension locally via Docker Compose with Kamiwaza env vars injected. Auto-detects port conflicts and remaps to available ports. Supports `--sdk-repo`, `--detach`. |
 | `kz-ext dev` | Build, push, and deploy to a Kamiwaza cluster. Uses zero-downtime PATCH updates for existing extensions. Supports `--no-build`, `--no-push`, `--service`, `--revision`, `--sdk-repo`. |
 | `kz-ext status` | Show deployment status: phase, per-service readiness, URL, and recent K8s events. Supports `--name`. |
@@ -207,7 +207,7 @@ Publish profiles support multiple environments (dev/staging/prod) and CI via env
 kz-ext convert /path/to/existing-app
 ```
 
-Uses an AI agent to analyze existing Dockerfiles, compose files, and source code, then generates `kamiwaza.json` and wires in SDK integration (health endpoints, auth middleware, runtime libraries). All changes are git-tracked — review with `git diff`.
+Uses an AI agent to analyze existing Dockerfiles, compose files, and source code, then generates `kamiwaza.json` and wires in SDK integration (health endpoints, auth middleware, runtime libraries). The conversion flow now validates generated output against the Kamiwaza runtime contract as well, including non-root execution, unprivileged HTTP ports, and read-only-root-filesystem-friendly web wrappers. All changes are git-tracked — review with `git diff`.
 
 Optionally uses `OPENAI_API_KEY` (or `ANTHROPIC_API_KEY`) for AI-powered conversion. Falls back to basic `kamiwaza.json` generation without an API key. Set `OPENAI_BASE_URL` to use any OpenAI-compatible provider (Kamiwaza, vLLM, Ollama, etc.). Set `KZ_PUBLISH_DOCKER_TOKEN` or `DOCKER_TOKEN` for registry auth during publish.
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Publish profiles support multiple environments (dev/staging/prod) and CI via env
 kz-ext convert /path/to/existing-app
 ```
 
-Uses an AI agent to analyze existing Dockerfiles, compose files, and source code, then generates `kamiwaza.json` and wires in SDK integration (health endpoints, auth middleware, runtime libraries). The conversion flow now validates generated output against the Kamiwaza runtime contract as well, including non-root execution, unprivileged HTTP ports, and read-only-root-filesystem-friendly web wrappers. All changes are git-tracked — review with `git diff`.
+Uses an AI agent to analyze existing Dockerfiles, compose files, and size-capped source context, then generates `kamiwaza.json` and wires in SDK integration (health endpoints, auth middleware, runtime libraries). Common secret-bearing files such as `.env`, credential JSON files, and private key files are excluded from that context. The conversion flow now validates generated output against the Kamiwaza runtime contract as well, including non-root execution, unprivileged HTTP ports, and read-only-root-filesystem-friendly web wrappers. All changes are git-tracked — review with `git diff`.
 
 Optionally uses `OPENAI_API_KEY` (or `ANTHROPIC_API_KEY`) for AI-powered conversion. Falls back to basic `kamiwaza.json` generation without an API key. Set `OPENAI_BASE_URL` to use any OpenAI-compatible provider (Kamiwaza, vLLM, Ollama, etc.). Set `KZ_PUBLISH_DOCKER_TOKEN` or `DOCKER_TOKEN` for registry auth during publish.
 

--- a/kamiwaza_extensions/app_analyzer.py
+++ b/kamiwaza_extensions/app_analyzer.py
@@ -12,7 +12,18 @@ import yaml
 
 from kamiwaza_extensions import __version__
 
-_SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv"}
+_SKIP_DIRS = {
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".next",
+    "build",
+    "dist",
+    "target",
+    "coverage",
+}
 _MANIFEST_FILES = {
     "package.json",
     "requirements.txt",
@@ -28,6 +39,9 @@ _MANIFEST_FILES = {
     "README.md",
     "nginx.conf",
     "Caddyfile",
+    "go.mod",
+    "Cargo.toml",
+    "Gemfile",
 }
 _ENTRYPOINT_NAMES = {
     "main.py",
@@ -55,6 +69,26 @@ _CONTEXT_SUFFIXES = (
 )
 _MAX_REPO_TREE_ENTRIES = 40
 _MAX_CONTEXT_FILES = 80
+_MAX_CONTEXT_FILE_SIZE = 10000
+_SENSITIVE_FILE_NAMES = {
+    ".env",
+    ".npmrc",
+    ".pypirc",
+    "credentials.json",
+    "credential.json",
+    "secret.json",
+    "secrets.json",
+    "id_rsa",
+    "id_ed25519",
+}
+_SENSITIVE_FILE_SUFFIXES = (
+    ".key",
+    ".pem",
+    ".p12",
+    ".pfx",
+    ".der",
+)
+_SENSITIVE_NAME_TOKENS = ("secret", "credential")
 
 
 def _walk_files(root: Path, extensions: tuple[str, ...] | None = None) -> Generator[Path, None, None]:
@@ -459,8 +493,8 @@ class AppAnalyzer:
                 content = path.read_text(encoding="utf-8")
                 rel = str(path.relative_to(result.app_dir))
                 # Limit file size to avoid blowing up the LLM context
-                if len(content) > 10000:
-                    content = content[:10000] + "\n... (truncated)"
+                if len(content) > _MAX_CONTEXT_FILE_SIZE:
+                    content = content[:_MAX_CONTEXT_FILE_SIZE] + "\n... (truncated)"
                 result.file_contents[rel] = content
             except (OSError, UnicodeDecodeError):
                 pass
@@ -500,6 +534,17 @@ def _is_entrypoint(path: Path) -> bool:
 
 
 def _is_context_file(path: Path) -> bool:
+    if _is_sensitive_context_file(path):
+        return False
     if _is_dockerfile(path) or _is_manifest(path) or _is_entrypoint(path):
         return True
     return path.suffix.lower() in _CONTEXT_SUFFIXES
+
+
+def _is_sensitive_context_file(path: Path) -> bool:
+    name = path.name.lower()
+    if name in _SENSITIVE_FILE_NAMES or name.startswith(".env."):
+        return True
+    if path.suffix.lower() in _SENSITIVE_FILE_SUFFIXES:
+        return True
+    return any(token in name for token in _SENSITIVE_NAME_TOKENS)

--- a/kamiwaza_extensions/app_analyzer.py
+++ b/kamiwaza_extensions/app_analyzer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 import re
 from dataclasses import dataclass, field
@@ -14,6 +13,48 @@ import yaml
 from kamiwaza_extensions import __version__
 
 _SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv"}
+_MANIFEST_FILES = {
+    "package.json",
+    "requirements.txt",
+    "pyproject.toml",
+    "Pipfile",
+    "Pipfile.lock",
+    "poetry.lock",
+    "uv.lock",
+    "vite.config.js",
+    "vite.config.ts",
+    "webpack.config.js",
+    "webpack.config.ts",
+    "README.md",
+    "nginx.conf",
+    "Caddyfile",
+}
+_ENTRYPOINT_NAMES = {
+    "main.py",
+    "app.py",
+    "server.py",
+    "index.html",
+    "index.js",
+    "index.ts",
+    "main.js",
+    "main.ts",
+}
+_CONTEXT_SUFFIXES = (
+    ".py",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".html",
+    ".css",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".md",
+    ".conf",
+)
+_MAX_REPO_TREE_ENTRIES = 40
+_MAX_CONTEXT_FILES = 80
 
 
 def _walk_files(root: Path, extensions: tuple[str, ...] | None = None) -> Generator[Path, None, None]:
@@ -65,12 +106,17 @@ class AnalysisResult:
 
     # File contents (for LLM context)
     file_contents: Dict[str, str] = field(default_factory=dict)
+    repo_tree: List[str] = field(default_factory=list)
+    detected_manifests: List[str] = field(default_factory=list)
+    candidate_entrypoints: List[str] = field(default_factory=list)
+    runtime_hints: List[str] = field(default_factory=list)
 
     # Description
     description: str = ""
 
     # Inferred type
     extension_type: str = "app"
+    conversion_mode: str = "structured"
 
 
 class AppAnalyzer:
@@ -94,7 +140,9 @@ class AppAnalyzer:
         self._detect_health_endpoint(result)
         self._infer_description(result)
         self._infer_type(result)
+        self._gather_repo_inventory(result)
         self._gather_file_contents(result)
+        self._infer_conversion_mode(result)
 
         return result
 
@@ -179,7 +227,9 @@ class AppAnalyzer:
             return
 
         # Fallback: find Dockerfiles in subdirectories
-        for dockerfile in sorted(_walk_files(result.app_dir, ("Dockerfile",))):
+        for dockerfile in sorted(
+            path for path in _walk_files(result.app_dir) if _is_dockerfile(path)
+        ):
             parent = dockerfile.parent
             svc_name = parent.name if parent != result.app_dir else "app"
             base_image, language = self._detect_language(dockerfile)
@@ -322,6 +372,58 @@ class AppAnalyzer:
                         pass
             result.extension_type = "app"
 
+    def _gather_repo_inventory(self, result: AnalysisResult) -> None:
+        """Collect lightweight repo structure hints for generic conversion."""
+        entries = []
+        for entry in sorted(result.app_dir.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
+            label = f"{entry.name}/" if entry.is_dir() else entry.name
+            entries.append(label)
+            if len(entries) >= _MAX_REPO_TREE_ENTRIES:
+                break
+        result.repo_tree = entries
+
+        manifests: List[str] = []
+        entrypoints: List[str] = []
+        runtime_hints: set[str] = set()
+
+        for path in _walk_files(result.app_dir):
+            rel = str(path.relative_to(result.app_dir))
+            name = path.name
+
+            if _is_manifest(path):
+                manifests.append(rel)
+            if _is_entrypoint(path):
+                entrypoints.append(rel)
+
+            suffix = path.suffix.lower()
+            if suffix == ".html":
+                runtime_hints.add("static-html")
+            elif suffix in (".js", ".jsx", ".ts", ".tsx"):
+                runtime_hints.add("javascript-or-typescript")
+            elif suffix == ".py":
+                runtime_hints.add("python")
+
+            if name == "package.json":
+                runtime_hints.add("node-package")
+            elif name in {"requirements.txt", "pyproject.toml", "Pipfile"}:
+                runtime_hints.add("python-package")
+            elif name == "nginx.conf":
+                runtime_hints.add("nginx")
+            elif name == "Caddyfile":
+                runtime_hints.add("caddy")
+            elif _is_dockerfile(path):
+                runtime_hints.add("dockerized")
+
+        for svc in result.services:
+            if svc.language:
+                runtime_hints.add(f"{svc.language}-service")
+            if svc.base_image and any(token in svc.base_image for token in ("nginx", "caddy", "httpd")):
+                runtime_hints.add("static-web-server")
+
+        result.detected_manifests = manifests[:_MAX_CONTEXT_FILES]
+        result.candidate_entrypoints = entrypoints[:_MAX_CONTEXT_FILES]
+        result.runtime_hints = sorted(runtime_hints)
+
     def _gather_file_contents(self, result: AnalysisResult) -> None:
         """Read key files to provide as context for the LLM agent."""
         targets = []
@@ -335,21 +437,11 @@ class AppAnalyzer:
             if svc.dockerfile:
                 targets.append(svc.dockerfile)
 
-        # Key source files (main.py, app.py, server.py, index.ts, etc.)
-        for pattern in [
-            "*/main.py", "*/app.py", "*/server.py", "main.py", "app.py",
-            "*/src/app/layout.tsx", "*/src/app/layout.jsx",
-            "*/src/app/page.tsx", "*/src/index.ts", "*/src/index.js",
-        ]:
-            for f in result.app_dir.glob(pattern):
-                if ".git" not in f.parts and "node_modules" not in f.parts:
-                    targets.append(f)
-
-        # Dependency files
-        for pattern in ["*/requirements.txt", "requirements.txt", "*/package.json"]:
-            for f in result.app_dir.glob(pattern):
-                if ".git" not in f.parts and "node_modules" not in f.parts:
-                    targets.append(f)
+        for path in _walk_files(result.app_dir):
+            if _is_context_file(path):
+                targets.append(path)
+            if len(targets) >= _MAX_CONTEXT_FILES:
+                break
 
         # README
         readme = result.app_dir / "README.md"
@@ -373,6 +465,15 @@ class AppAnalyzer:
             except (OSError, UnicodeDecodeError):
                 pass
 
+    def _infer_conversion_mode(self, result: AnalysisResult) -> None:
+        if result.compose_path or result.services:
+            result.conversion_mode = "structured"
+            return
+        if result.file_contents or result.detected_manifests or result.candidate_entrypoints:
+            result.conversion_mode = "generic"
+            return
+        result.conversion_mode = "generic"
+
     @staticmethod
     def _sanitize_name(name: str) -> str:
         """Sanitize directory name for use as extension name."""
@@ -381,3 +482,24 @@ class AppAnalyzer:
         name = re.sub(r"-+", "-", name)
         name = name.strip("-")
         return name or "my-extension"
+
+
+def _is_dockerfile(path: Path) -> bool:
+    return path.name == "Dockerfile" or path.name.startswith("Dockerfile.")
+
+
+def _is_manifest(path: Path) -> bool:
+    return path.name in _MANIFEST_FILES
+
+
+def _is_entrypoint(path: Path) -> bool:
+    if path.name in _ENTRYPOINT_NAMES:
+        return True
+    rel = path.as_posix()
+    return rel.endswith("/src/index.ts") or rel.endswith("/src/index.js") or rel.endswith("/src/main.ts") or rel.endswith("/src/main.js")
+
+
+def _is_context_file(path: Path) -> bool:
+    if _is_dockerfile(path) or _is_manifest(path) or _is_entrypoint(path):
+        return True
+    return path.suffix.lower() in _CONTEXT_SUFFIXES

--- a/kamiwaza_extensions/app_analyzer.py
+++ b/kamiwaza_extensions/app_analyzer.py
@@ -72,6 +72,7 @@ _MAX_CONTEXT_FILES = 80
 _MAX_CONTEXT_FILE_SIZE = 10000
 _SENSITIVE_FILE_NAMES = {
     ".env",
+    ".envrc",
     ".npmrc",
     ".pypirc",
     "credentials.json",

--- a/kamiwaza_extensions/app_analyzer.py
+++ b/kamiwaza_extensions/app_analyzer.py
@@ -88,7 +88,7 @@ _SENSITIVE_FILE_SUFFIXES = (
     ".pfx",
     ".der",
 )
-_SENSITIVE_NAME_TOKENS = ("secret", "credential")
+_SENSITIVE_STEMS = {"secret", "secrets", "credential", "credentials"}
 
 
 def _walk_files(root: Path, extensions: tuple[str, ...] | None = None) -> Generator[Path, None, None]:
@@ -547,4 +547,4 @@ def _is_sensitive_context_file(path: Path) -> bool:
         return True
     if path.suffix.lower() in _SENSITIVE_FILE_SUFFIXES:
         return True
-    return any(token in name for token in _SENSITIVE_NAME_TOKENS)
+    return path.stem.lower() in _SENSITIVE_STEMS

--- a/kamiwaza_extensions/app_analyzer.py
+++ b/kamiwaza_extensions/app_analyzer.py
@@ -410,6 +410,10 @@ class AppAnalyzer:
         """Collect lightweight repo structure hints for generic conversion."""
         entries = []
         for entry in sorted(result.app_dir.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower())):
+            if entry.name in _SKIP_DIRS:
+                continue
+            if entry.is_file() and _is_sensitive_context_file(entry):
+                continue
             label = f"{entry.name}/" if entry.is_dir() else entry.name
             entries.append(label)
             if len(entries) >= _MAX_REPO_TREE_ENTRIES:
@@ -421,6 +425,8 @@ class AppAnalyzer:
         runtime_hints: set[str] = set()
 
         for path in _walk_files(result.app_dir):
+            if _is_sensitive_context_file(path):
+                continue
             rel = str(path.relative_to(result.app_dir))
             name = path.name
 

--- a/kamiwaza_extensions/commands/convert.py
+++ b/kamiwaza_extensions/commands/convert.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Optional
 
 import typer
 from rich.console import Console
@@ -36,6 +34,8 @@ def run_convert(
 
     # Print analysis summary
     console.print(f"    Type:              [bold]{analysis.extension_type}[/bold]")
+    mode_label = "generic AI fallback" if analysis.conversion_mode == "generic" else "structured"
+    console.print(f"    Mode:              [bold]{mode_label}[/bold]")
     if analysis.services:
         svc_names = ", ".join(s.name for s in analysis.services)
         console.print(f"    Services:          {svc_names}")
@@ -75,26 +75,12 @@ def run_convert(
 
     console.print()
 
-    # 2. Generate kamiwaza.json (always — even in dry-run)
-    kamiwaza_json_path = app_dir / "kamiwaza.json"
-    kamiwaza_data = analyzer.generate_kamiwaza_json(analysis)
-
-    if kamiwaza_json_path.exists():
-        console.print("    [yellow]\u26a0[/yellow] kamiwaza.json already exists — skipping generation")
-    elif dry_run:
-        console.print("    [dim]Would create kamiwaza.json[/dim]")
-    else:
-        kamiwaza_json_path.write_text(
-            json.dumps(kamiwaza_data, indent=4) + "\n", encoding="utf-8"
-        )
-        console.print("    [green]\u2713[/green] Created kamiwaza.json")
-
-    # 3. Run AI agent for file modifications
+    # 2. Run AI agent for file modifications
     console.print()
     plan = run_agent(analysis, dry_run=dry_run)
 
-    # 4. Print results
-    if plan.modifications:
+    # 3. Print results
+    if plan.success and plan.modifications:
         console.print()
         if dry_run:
             console.print("  [bold]Would modify:[/bold]")
@@ -102,7 +88,6 @@ def run_convert(
             console.print("  [bold]Files modified:[/bold]")
 
         for mod in plan.modifications:
-            target = app_dir / mod.path
             if mod.action == "create":
                 icon = "[green]\u2713[/green]" if not dry_run else "[dim]\u2713[/dim]"
                 action = "created" if not dry_run else "would create"
@@ -111,6 +96,12 @@ def run_convert(
                 action = "modified" if not dry_run else "would modify"
             desc = f" ({mod.description})" if mod.description else ""
             console.print(f"    {icon} {mod.path} — {action}{desc}")
+
+    if plan.errors:
+        console.print()
+        console.print("  [bold red]Conversion failed:[/bold red]")
+        for err in plan.errors:
+            console.print(f"    [red]\u2717[/red] {err}")
 
     if plan.manual_items:
         console.print()
@@ -122,7 +113,10 @@ def run_convert(
         console.print()
         console.print(f"  [dim]{plan.summary}[/dim]")
 
-    # 5. Next steps
+    if not plan.success:
+        raise typer.Exit(code=1)
+
+    # 4. Next steps
     console.print()
     console.print("  [bold]Next steps:[/bold]")
     console.print("    git diff                    # Review all changes")

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -49,7 +49,7 @@ def _detect_kind_registry() -> Optional[str]:
 
 
 
-def _delete_and_recreate(client, dev_name, payload, console) -> "Extension":
+def _delete_and_recreate(client, dev_name, payload, console):
     """Legacy fallback: delete the old extension and re-create it.
 
     Used when the platform does not support PATCH.
@@ -225,7 +225,9 @@ def run_dev_remote(
                         )
 
                 print_override_diagnostics(override_spec)
-                build_overrides = generate_build_overrides(override_spec, info.compose_data)
+                build_overrides = generate_build_overrides(
+                    override_spec, info.compose_data, extension_dir=info.path,
+                )
         console.print()
 
     # 6. Build images
@@ -373,10 +375,10 @@ def run_dev_remote(
 
         # 11. Print URL
         url = ext.endpoints.external if ext.endpoints else None
-        console.print(f"\n  [green]\u2713[/green] Rollout complete")
+        console.print("\n  [green]\u2713[/green] Rollout complete")
         console.print()
         console.print(f"[bold]{info.name}[/bold] is running at:")
         if url:
             console.print(f"  [blue]{url}[/blue]")
         else:
-            console.print(f"  [dim](no external URL reported — check kz-ext status)[/dim]")
+            console.print("  [dim](no external URL reported — check kz-ext status)[/dim]")

--- a/kamiwaza_extensions/commands/validate.py
+++ b/kamiwaza_extensions/commands/validate.py
@@ -16,6 +16,7 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
     """Validate extension metadata and compose files."""
     from kamiwaza_extensions.validators.metadata import MetadataValidator
     from kamiwaza_extensions.validators.compose import ComposeValidator
+    from kamiwaza_extensions.validators.platform_runtime import PlatformRuntimeValidator
 
     ext_dir = Path(path) if path else Path.cwd()
 
@@ -33,10 +34,14 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
 
     # Run compose validation
     compose_validator = ComposeValidator()
+    runtime_validator = PlatformRuntimeValidator()
     compose_file = _find_compose_file(ext_dir)
     compose_result = None
+    runtime_result = None
     if compose_file:
         compose_result = compose_validator.validate(compose_file, ext_dir)
+        if compose_result.passed:
+            runtime_result = runtime_validator.validate(compose_file, ext_dir)
     else:
         meta_result.warnings.append("No docker-compose file found — kz-ext dev local will not work")
 
@@ -46,6 +51,9 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
     if compose_result:
         all_errors.extend(compose_result.errors)
         all_warnings.extend(compose_result.warnings)
+    if runtime_result:
+        all_errors.extend(runtime_result.errors)
+        all_warnings.extend(runtime_result.warnings)
 
     passed = len(all_errors) == 0
 

--- a/kamiwaza_extensions/convert_agent.py
+++ b/kamiwaza_extensions/convert_agent.py
@@ -1,26 +1,34 @@
 """AI-agent-powered conversion for kz-ext convert.
 
-Uses Claude API to intelligently modify existing apps for Kamiwaza
-extension compatibility. Falls back to basic kamiwaza.json generation
-when the LLM is unavailable.
+The conversion flow is intentionally AI-led. Deterministic logic is limited to:
+- collecting broader repo context
+- staging proposed changes in a temporary workspace
+- validating the staged output
+- asking the model to repair validation failures before applying changes
 """
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import re
+import shutil
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from rich.console import Console
 
-from kamiwaza_extensions.app_analyzer import AnalysisResult
+from kamiwaza_extensions.app_analyzer import AnalysisResult, AppAnalyzer
+from kamiwaza_extensions.constants import COMPOSE_FILENAMES
 
 console = Console(stderr=True)
 
 # Max total content size sent to LLM (characters)
 _MAX_CONTEXT_SIZE = 50000
+_MAX_REPAIR_ATTEMPTS = 2
+_STAGING_SKIP_DIRS = (".git", "node_modules", "__pycache__", ".venv", "venv")
 
 
 @dataclass
@@ -34,55 +42,65 @@ class FileModification:
 
 
 @dataclass
+class ConversionStrategy:
+    """High-level approach chosen by the LLM before file generation."""
+
+    extension_type: str = "app"
+    conversion_mode: str = "preserve_existing_runtime"
+    primary_service: str = "app"
+    required_files: List[str] = field(default_factory=list)
+    runtime_summary: str = ""
+    manual_items: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ValidationSummary:
+    """Validation result for staged conversion output."""
+
+    passed: bool = False
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+
+@dataclass
 class ConversionPlan:
     """The agent's plan for converting an app."""
 
     modifications: List[FileModification] = field(default_factory=list)
     manual_items: List[str] = field(default_factory=list)
     summary: str = ""
+    success: bool = True
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    mode: str = "structured"
+    strategy: Optional[ConversionStrategy] = None
 
 
 def build_prompt(analysis: AnalysisResult) -> str:
-    """Build the structured prompt for the conversion agent."""
-    files_section = ""
-    total_chars = 0
-    total_files = len(analysis.file_contents)
-    included_files = 0
-    for rel_path, content in sorted(analysis.file_contents.items()):
-        entry = f"\n### {rel_path}\n```\n{content}\n```\n"
-        if total_chars + len(entry) > _MAX_CONTEXT_SIZE:
-            break
-        files_section += entry
-        total_chars += len(entry)
-        included_files += 1
+    """Backward-compatible entrypoint for prompt inspection tests."""
+    return build_strategy_prompt(analysis)
 
-    omitted = total_files - included_files
-    if omitted > 0:
-        files_section += f"\n*Note: {omitted} file(s) omitted due to context size limits.*\n"
 
-    services_section = ""
-    for svc in analysis.services:
-        services_section += f"- **{svc.name}**: language={svc.language or 'unknown'}, ports={svc.ports}, dockerfile={'yes' if svc.dockerfile else 'no'}\n"
+def build_strategy_prompt(analysis: AnalysisResult) -> str:
+    """Build the first-pass prompt that asks for a conversion strategy."""
+    services_section = _render_services(analysis)
+    compat_section = _render_compatibility_issues(analysis)
+    files_section = _render_context_files(analysis)
+    inventory_section = _render_repo_inventory(analysis)
 
-    compat_section = ""
-    if analysis.has_host_ports:
-        compat_section += f"- Host port bindings (auto-stripped during deploy): {', '.join(analysis.has_host_ports)}\n"
-    if analysis.has_bind_mounts:
-        compat_section += f"- Bind mounts (auto-stripped during deploy): {', '.join(analysis.has_bind_mounts)}\n"
-    if analysis.missing_resource_limits:
-        compat_section += f"- Missing resource limits: {', '.join(analysis.missing_resource_limits)}\n"
-    if not analysis.has_health_endpoint:
-        compat_section += "- No health endpoint detected\n"
-    if not analysis.has_python_runtime_lib:
-        compat_section += "- Python runtime library (kamiwaza-extensions-lib) not installed\n"
-    if not analysis.has_ts_runtime_lib:
-        compat_section += "- TypeScript runtime library (@kamiwaza-ai/extensions-lib) not installed\n"
+    return f"""You are planning a best-effort conversion of an existing application into a Kamiwaza extension.
 
-    return f"""You are converting an existing containerized application into a Kamiwaza extension.
+## Goal
+Produce a valid Kamiwaza extension repository while preserving the existing application/runtime shape when possible.
 
-## Application: {analysis.app_name}
-Type: {analysis.extension_type}
+## Application
+Name: {analysis.app_name}
+Current extension type guess: {analysis.extension_type}
+Current conversion mode hint: {analysis.conversion_mode}
 Description: {analysis.description or 'No description'}
+
+## Repo Inventory
+{inventory_section}
 
 ## Services
 {services_section}
@@ -93,102 +111,124 @@ Description: {analysis.description or 'No description'}
 ## Current Files
 {files_section}
 
-## Kamiwaza Extension Requirements
+## Kamiwaza Conversion Rules
+- Prefer preserving the detected runtime/server and containerization when it already exists.
+- If the repo is not containerized, generate the thinnest viable containerization and docker-compose setup.
+- Always target a valid repo with `kamiwaza.json`, a compose file, resource limits, and `CONVERT_NOTES.md`.
+- Use `type=app` unless there is strong evidence the repo is an MCP/tool or generic background service.
+- Python backend runtime library: `kamiwaza-extensions-lib` is appropriate when there is an actual Python application backend.
+- TypeScript runtime library: `@kamiwaza-ai/extensions-lib` is appropriate for real Node/Next frontends.
+- Pure static HTML/CSS/JS sites do not need Kamiwaza runtime libraries; they do need a container, compose, resource limits, and a healthable HTTP path.
+- Keep user source intact. Prefer additive wrappers/config over rewrites.
 
-### Python Backend Integration (kamiwaza-extensions-lib)
-Add to requirements.txt:
-```
-kamiwaza-extensions-lib>=0.1.0
-```
-
-Add to FastAPI main.py:
-```python
-from kamiwaza_extensions_lib import create_session_router, require_auth, Identity
-from fastapi import Depends
-
-# Add session endpoints (required for frontend auth)
-app.include_router(create_session_router())
-
-# Add health endpoint if missing
-@app.get("/health")
-async def health():
-    return {{"status": "ok"}}
-
-# Example protected endpoint:
-# @app.get("/api/protected")
-# async def protected(identity: Identity = Depends(require_auth)):
-#     return {{"user": identity.email}}
-```
-
-### TypeScript Frontend Integration (@kamiwaza-ai/extensions-lib)
-Add to package.json dependencies:
-```
-"@kamiwaza-ai/extensions-lib": "^0.2.0"
-```
-
-Update the root layout to wrap with SessionProvider and AuthGuard:
-```tsx
-import {{ SessionProvider, AuthGuard }} from '@kamiwaza-ai/extensions-lib/client';
-
-export default function RootLayout({{ children }}: {{ children: React.ReactNode }}) {{
-    return (
-        <html lang="en">
-            <body>
-                <SessionProvider>
-                    <AuthGuard>
-                        {{children}}
-                    </AuthGuard>
-                </SessionProvider>
-            </body>
-        </html>
-    );
-}}
-```
-
-### Docker Compose Resource Limits
-Add deploy.resources.limits to each service:
-```yaml
-services:
-  backend:
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: "1G"
-```
-
-## Instructions
-
-Analyze the application and produce modifications to make it a Kamiwaza extension. Output ONLY a JSON object with this structure:
-
+Return ONLY JSON with this shape:
 ```json
 {{
-    "modifications": [
-        {{
-            "path": "relative/path/to/file",
-            "action": "create" | "modify",
-            "content": "full file content",
-            "description": "what was changed"
-        }}
-    ],
-    "manual_items": [
-        "Description of something that needs manual attention"
-    ],
-    "summary": "Brief summary of all changes"
+  "extension_type": "app|tool|service",
+  "conversion_mode": "preserve_existing_runtime|add_minimal_wrapper|containerize_repo_root|multi_service",
+  "primary_service": "service-name",
+  "required_files": ["path/to/file"],
+  "runtime_summary": "short summary of the runtime/layout you detected",
+  "manual_items": ["manual follow-up if truly unavoidable"]
 }}
 ```
+"""
 
-Rules:
-1. For "modify" actions, output the COMPLETE new file content (not a diff).
-2. For "create" actions, output the full file content.
-3. Only modify files that need changes. Don't touch files that are already correct.
-4. Add kamiwaza-extensions-lib to Python backends. Add @kamiwaza-ai/extensions-lib to Node.js frontends.
-5. Add a health endpoint if one doesn't exist.
-6. Add create_session_router() to FastAPI apps.
-7. Add resource limits to docker-compose.yml services that are missing them.
-8. Wrap frontend layouts with SessionProvider + AuthGuard if not already wrapped.
-9. Keep existing functionality intact — add SDK integration, don't remove existing code.
-10. If you're unsure about a change, add it to manual_items instead.
+
+def build_modification_prompt(
+    analysis: AnalysisResult,
+    strategy: ConversionStrategy,
+    metadata_seed: Dict[str, Any],
+    *,
+    validation: Optional[ValidationSummary] = None,
+    previous_plan: Optional[ConversionPlan] = None,
+) -> str:
+    """Build the prompt that asks the LLM for concrete file changes."""
+    files_section = _render_context_files(analysis)
+    inventory_section = _render_repo_inventory(analysis)
+    services_section = _render_services(analysis)
+    compat_section = _render_compatibility_issues(analysis)
+
+    validation_section = ""
+    if validation is not None:
+        error_lines = "\n".join(f"- {err}" for err in validation.errors) or "- None"
+        warning_lines = "\n".join(f"- {warn}" for warn in validation.warnings) or "- None"
+        validation_section = f"""
+## Validation Feedback From Previous Attempt
+Errors:
+{error_lines}
+
+Warnings:
+{warning_lines}
+"""
+
+    previous_plan_section = ""
+    if previous_plan is not None and previous_plan.modifications:
+        previous_plan_section = f"""
+## Previous Proposed Modifications
+```json
+{json.dumps(_plan_to_dict(previous_plan), indent=2)}
+```
+"""
+
+    return f"""You are converting an existing application into a valid Kamiwaza extension repository.
+
+## Application
+Name: {analysis.app_name}
+Detected conversion mode: {analysis.conversion_mode}
+
+## Strategy
+```json
+{json.dumps(_strategy_to_dict(strategy), indent=2)}
+```
+
+## Metadata Seed
+```json
+{json.dumps(metadata_seed, indent=2)}
+```
+
+## Repo Inventory
+{inventory_section}
+
+## Services
+{services_section}
+
+## Compatibility Issues
+{compat_section or 'None detected'}
+
+## Current Files
+{files_section}
+{validation_section}
+{previous_plan_section}
+
+## Conversion Requirements
+- Preserve the app/runtime shape when possible.
+- Create or update `kamiwaza.json`.
+- Create or update a compose file so `kz-ext validate` will not fail and `kz-ext dev local` has a clear path.
+- Ensure each compose service defines `deploy.resources.limits`.
+- Ensure the primary HTTP service has a healthable HTTP path at `/health`.
+- Generate `CONVERT_NOTES.md` summarizing what changed and any remaining manual follow-ups.
+- Only add Kamiwaza runtime libraries when they fit the actual stack.
+- Avoid deleting user source files unless a generated wrapper/config file supersedes them.
+- Keep the output small and practical: wrappers/config/dockerization are fine; full framework rewrites are not.
+
+Return ONLY JSON with this shape:
+```json
+{{
+  "modifications": [
+    {{
+      "path": "relative/path/to/file",
+      "action": "create" | "modify" | "append",
+      "content": "full file content",
+      "description": "what changed and why"
+    }}
+  ],
+  "manual_items": [
+    "manual follow-up if still required"
+  ],
+  "summary": "brief summary"
+}}
+```
 """
 
 
@@ -211,9 +251,7 @@ def call_llm(prompt: str) -> Optional[str]:
     # --- OpenAI-compatible (priority — covers OpenAI, Kamiwaza, vLLM, Ollama, etc.) ---
     openai_key = os.environ.get("OPENAI_API_KEY")
     if openai_key:
-        try:
-            import openai as _openai  # noqa: F811
-        except ImportError:
+        if importlib.util.find_spec("openai") is None:
             console.print(
                 "[dim]OPENAI_API_KEY is set but openai package is not installed. "
                 "Install with: pip install openai[/dim]"
@@ -227,14 +265,11 @@ def call_llm(prompt: str) -> Optional[str]:
             )
             if result is not None:
                 return result
-            # OpenAI call failed — fall through to Anthropic
 
     # --- Anthropic (fallback) ---
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY")
     if anthropic_key:
-        try:
-            import anthropic
-        except ImportError:
+        if importlib.util.find_spec("anthropic") is None:
             console.print(
                 "[dim]ANTHROPIC_API_KEY is set but anthropic package is not installed. "
                 "Install with: pip install kamiwaza-sdk[convert][/dim]"
@@ -301,22 +336,35 @@ def _call_openai_compatible(
         return None
 
 
+def parse_strategy_response(response_text: str) -> Optional[ConversionStrategy]:
+    """Parse the strategy response from the LLM."""
+    data = _parse_json_payload(response_text)
+    if not isinstance(data, dict):
+        return None
+
+    extension_type = str(data.get("extension_type", "app"))
+    if extension_type not in {"app", "tool", "service"}:
+        extension_type = "app"
+
+    return ConversionStrategy(
+        extension_type=extension_type,
+        conversion_mode=str(data.get("conversion_mode", "preserve_existing_runtime")),
+        primary_service=str(data.get("primary_service", "app")),
+        required_files=[str(item) for item in data.get("required_files", []) if item],
+        runtime_summary=str(data.get("runtime_summary", "")),
+        manual_items=[str(item) for item in data.get("manual_items", []) if item],
+    )
+
+
 def parse_response(response_text: str) -> ConversionPlan:
     """Parse the LLM response into a ConversionPlan."""
-    # Extract JSON from the response (may be wrapped in markdown code block)
-    json_match = re.search(r"```(?:json)?\s*\n(.*?)\n```", response_text, re.DOTALL)
-    if json_match:
-        json_str = json_match.group(1)
-    else:
-        # Try parsing the whole response as JSON
-        json_str = response_text.strip()
-
-    try:
-        data = json.loads(json_str)
-    except json.JSONDecodeError:
+    data = _parse_json_payload(response_text)
+    if not isinstance(data, dict):
         return ConversionPlan(
+            success=False,
             manual_items=["LLM response could not be parsed. Review the app manually."],
             summary="Conversion plan could not be generated automatically.",
+            errors=["LLM response could not be parsed."],
         )
 
     try:
@@ -333,13 +381,15 @@ def parse_response(response_text: str) -> ConversionPlan:
 
         return ConversionPlan(
             modifications=modifications,
-            manual_items=data.get("manual_items", []),
-            summary=data.get("summary", ""),
+            manual_items=[str(item) for item in data.get("manual_items", []) if item],
+            summary=str(data.get("summary", "")),
         )
     except (TypeError, AttributeError, KeyError):
         return ConversionPlan(
+            success=False,
             manual_items=["LLM returned unexpected response shape. Review the app manually."],
             summary="Conversion plan could not be generated automatically.",
+            errors=["LLM returned unexpected response shape."],
         )
 
 
@@ -349,7 +399,6 @@ def apply_plan(plan: ConversionPlan, app_dir: Path, dry_run: bool = False) -> Li
     Returns list of applied change descriptions.
     """
     applied = []
-    # Resolve once to avoid TOCTOU with symlinks changing between iterations
     resolved_app_dir = app_dir.resolve()
     for mod in plan.modifications:
         if not mod.path or not mod.content:
@@ -363,7 +412,6 @@ def apply_plan(plan: ConversionPlan, app_dir: Path, dry_run: bool = False) -> Li
             continue
 
         target = (resolved_app_dir / mod.path).resolve()
-        # Security: reject paths that escape the app directory
         if not target.is_relative_to(resolved_app_dir):
             console.print(
                 f"[yellow]Warning:[/yellow] Skipping '{mod.path}' — path escapes app directory"
@@ -392,34 +440,320 @@ def apply_plan(plan: ConversionPlan, app_dir: Path, dry_run: bool = False) -> Li
 
 
 def run_agent(analysis: AnalysisResult, dry_run: bool = False) -> ConversionPlan:
-    """Run the full conversion agent: build prompt → call LLM → parse → apply.
-
-    Returns the ConversionPlan (applied or not depending on dry_run).
-    """
-    prompt = build_prompt(analysis)
+    """Run the full conversion agent with staged validation and repair."""
     console.print(
         "  [dim]Note: source code will be sent to an external LLM provider for analysis.[/dim]"
     )
+    console.print(f"  [dim]Conversion mode: {analysis.conversion_mode}[/dim]")
     console.print("  [dim]Calling AI agent...[/dim]")
-    response = call_llm(prompt)
 
-    if response is None:
+    strategy_text = call_llm(build_strategy_prompt(analysis))
+    if strategy_text is None:
         return ConversionPlan(
-            summary="LLM unavailable — basic conversion only.",
+            success=False,
+            mode=analysis.conversion_mode,
+            summary="LLM unavailable — convert cannot produce a validated extension automatically.",
             manual_items=[
                 "Set ANTHROPIC_API_KEY or OPENAI_API_KEY for full AI-powered conversion.",
                 "For other providers, set OPENAI_API_KEY + OPENAI_BASE_URL (any OpenAI-compatible API).",
-                "Manually add kamiwaza-extensions-lib to your Python backend.",
-                "Manually add @kamiwaza-ai/extensions-lib to your frontend.",
-                "Add a health endpoint at GET /health.",
-                "Add resource limits to docker-compose.yml.",
             ],
+            errors=["LLM unavailable."],
         )
 
-    plan = parse_response(response)
-    applied = apply_plan(plan, analysis.app_dir, dry_run=dry_run)
+    strategy = parse_strategy_response(strategy_text)
+    if strategy is None:
+        return ConversionPlan(
+            success=False,
+            mode=analysis.conversion_mode,
+            summary="The conversion strategy could not be parsed automatically.",
+            manual_items=["Review the repo manually and re-run convert after tightening the app shape."],
+            errors=["Conversion strategy could not be parsed."],
+        )
 
-    if dry_run:
-        plan.summary = f"[Dry run] Would apply {len(applied)} modifications. " + (plan.summary or "")
+    metadata_seed = _default_metadata(analysis, strategy)
+    previous_plan: Optional[ConversionPlan] = None
+    last_validation = ValidationSummary(passed=False, errors=["No validated plan produced."])
 
-    return plan
+    for attempt in range(_MAX_REPAIR_ATTEMPTS + 1):
+        validation = last_validation if attempt > 0 else None
+        prompt = build_modification_prompt(
+            analysis,
+            strategy,
+            metadata_seed,
+            validation=validation,
+            previous_plan=previous_plan,
+        )
+        response = call_llm(prompt)
+        if response is None:
+            return ConversionPlan(
+                success=False,
+                mode=analysis.conversion_mode,
+                strategy=strategy,
+                summary="LLM became unavailable before a validated conversion could be produced.",
+                manual_items=_merge_manual_items(
+                    strategy.manual_items,
+                    ["Re-run convert once LLM access is available again."],
+                ),
+                errors=["LLM unavailable during modification generation."],
+            )
+
+        plan = parse_response(response)
+        plan.mode = analysis.conversion_mode
+        plan.strategy = strategy
+        plan.manual_items = _merge_manual_items(strategy.manual_items, plan.manual_items)
+        if not plan.success:
+            return plan
+
+        _ensure_supporting_files(plan, analysis, metadata_seed, strategy)
+        last_validation = _validate_plan_in_staging(plan, analysis.app_dir)
+        if last_validation.passed:
+            plan.success = True
+            plan.warnings = last_validation.warnings
+            apply_plan(plan, analysis.app_dir, dry_run=dry_run)
+            if dry_run:
+                plan.summary = f"[Dry run] Validated {len(plan.modifications)} proposed modifications. {plan.summary}".strip()
+            return plan
+
+        previous_plan = plan
+
+    return ConversionPlan(
+        modifications=previous_plan.modifications if previous_plan else [],
+        manual_items=_merge_manual_items(
+            strategy.manual_items,
+            ["Automatic conversion could not satisfy validation after repair attempts."],
+        ),
+        summary="Conversion could not be validated automatically.",
+        success=False,
+        errors=last_validation.errors,
+        warnings=last_validation.warnings,
+        mode=analysis.conversion_mode,
+        strategy=strategy,
+    )
+
+
+def _parse_json_payload(response_text: str) -> Any:
+    json_match = re.search(r"```(?:json)?\s*\n(.*?)\n```", response_text, re.DOTALL)
+    json_str = json_match.group(1) if json_match else response_text.strip()
+    try:
+        return json.loads(json_str)
+    except json.JSONDecodeError:
+        return None
+
+
+def _render_services(analysis: AnalysisResult) -> str:
+    if not analysis.services:
+        return "- No services detected yet"
+    return "\n".join(
+        f"- **{svc.name}**: language={svc.language or 'unknown'}, ports={svc.ports}, dockerfile={'yes' if svc.dockerfile else 'no'}"
+        for svc in analysis.services
+    )
+
+
+def _render_compatibility_issues(analysis: AnalysisResult) -> str:
+    compat_lines = []
+    if analysis.has_host_ports:
+        compat_lines.append(
+            f"- Host port bindings (auto-stripped during deploy): {', '.join(analysis.has_host_ports)}"
+        )
+    if analysis.has_bind_mounts:
+        compat_lines.append(
+            f"- Bind mounts (auto-stripped during deploy): {', '.join(analysis.has_bind_mounts)}"
+        )
+    if analysis.missing_resource_limits:
+        compat_lines.append(
+            f"- Missing resource limits: {', '.join(analysis.missing_resource_limits)}"
+        )
+    if not analysis.has_health_endpoint:
+        compat_lines.append("- No health endpoint detected")
+    if not analysis.has_python_runtime_lib:
+        compat_lines.append("- Python runtime library (kamiwaza-extensions-lib) not installed")
+    if not analysis.has_ts_runtime_lib:
+        compat_lines.append("- TypeScript runtime library (@kamiwaza-ai/extensions-lib) not installed")
+    return "\n".join(compat_lines)
+
+
+def _render_repo_inventory(analysis: AnalysisResult) -> str:
+    sections = []
+    if analysis.repo_tree:
+        sections.append("Top level:\n" + "\n".join(f"- {entry}" for entry in analysis.repo_tree))
+    if analysis.detected_manifests:
+        sections.append(
+            "Detected manifests:\n" + "\n".join(f"- {entry}" for entry in analysis.detected_manifests[:20])
+        )
+    if analysis.candidate_entrypoints:
+        sections.append(
+            "Candidate entrypoints:\n" + "\n".join(f"- {entry}" for entry in analysis.candidate_entrypoints[:20])
+        )
+    if analysis.runtime_hints:
+        sections.append("Runtime hints:\n" + "\n".join(f"- {entry}" for entry in analysis.runtime_hints))
+    return "\n\n".join(sections) or "- No notable repo inventory discovered"
+
+
+def _render_context_files(analysis: AnalysisResult) -> str:
+    files_section = ""
+    total_chars = 0
+    total_files = len(analysis.file_contents)
+    included_files = 0
+    for rel_path, content in sorted(analysis.file_contents.items()):
+        entry = f"\n### {rel_path}\n```\n{content}\n```\n"
+        if total_chars + len(entry) > _MAX_CONTEXT_SIZE:
+            break
+        files_section += entry
+        total_chars += len(entry)
+        included_files += 1
+
+    omitted = total_files - included_files
+    if omitted > 0:
+        files_section += f"\n*Note: {omitted} file(s) omitted due to context size limits.*\n"
+    return files_section or "\n*(No file contents gathered.)*\n"
+
+
+def _default_metadata(analysis: AnalysisResult, strategy: ConversionStrategy) -> Dict[str, Any]:
+    analyzer = AppAnalyzer()
+    metadata = analyzer.generate_kamiwaza_json(analysis)
+    metadata["type"] = strategy.extension_type
+    return metadata
+
+
+def _ensure_supporting_files(
+    plan: ConversionPlan,
+    analysis: AnalysisResult,
+    metadata_seed: Dict[str, Any],
+    strategy: ConversionStrategy,
+) -> None:
+    by_path = {mod.path: mod for mod in plan.modifications}
+
+    if "kamiwaza.json" not in by_path and not (analysis.app_dir / "kamiwaza.json").exists():
+        plan.modifications.insert(
+            0,
+            FileModification(
+                path="kamiwaza.json",
+                action="create",
+                content=json.dumps(metadata_seed, indent=4) + "\n",
+                description="generated extension metadata scaffold",
+            ),
+        )
+
+    if "CONVERT_NOTES.md" not in by_path:
+        notes_path = analysis.app_dir / "CONVERT_NOTES.md"
+        plan.modifications.append(
+            FileModification(
+                path="CONVERT_NOTES.md",
+                action="modify" if notes_path.exists() else "create",
+                content=_build_convert_notes(plan, strategy),
+                description="summarized conversion decisions and follow-ups",
+            )
+        )
+
+
+def _build_convert_notes(plan: ConversionPlan, strategy: ConversionStrategy) -> str:
+    lines = [
+        "# Convert Notes",
+        "",
+        "## Summary",
+        plan.summary or "Best-effort Kamiwaza conversion generated by `kz-ext convert`.",
+        "",
+        "## Strategy",
+        f"- Extension type: {strategy.extension_type}",
+        f"- Conversion mode: {strategy.conversion_mode}",
+        f"- Primary service: {strategy.primary_service}",
+    ]
+    if strategy.runtime_summary:
+        lines.append(f"- Runtime summary: {strategy.runtime_summary}")
+
+    items = _merge_manual_items(strategy.manual_items, plan.manual_items)
+    if items:
+        lines.extend(["", "## Manual Follow-ups"])
+        lines.extend(f"- {item}" for item in items)
+    else:
+        lines.extend(["", "## Manual Follow-ups", "- None noted by the AI conversion pass."])
+
+    return "\n".join(lines) + "\n"
+
+
+def _validate_plan_in_staging(plan: ConversionPlan, app_dir: Path) -> ValidationSummary:
+    from kamiwaza_extensions.validators.compose import ComposeValidator
+    from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+    with tempfile.TemporaryDirectory(prefix="kz-ext-convert-") as tmp_dir:
+        staged_root = Path(tmp_dir) / app_dir.name
+        shutil.copytree(
+            app_dir,
+            staged_root,
+            ignore=shutil.ignore_patterns(*_STAGING_SKIP_DIRS),
+            dirs_exist_ok=True,
+        )
+        apply_plan(plan, staged_root, dry_run=False)
+
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        metadata_path = staged_root / "kamiwaza.json"
+        if not metadata_path.exists():
+            errors.append("No kamiwaza.json found after conversion.")
+        else:
+            meta_result = MetadataValidator().validate(metadata_path)
+            errors.extend(meta_result.errors)
+            warnings.extend(meta_result.warnings)
+
+        compose_path = _find_compose_file(staged_root)
+        if compose_path is None:
+            errors.append("No docker-compose file found after conversion.")
+        else:
+            compose_result = ComposeValidator().validate(compose_path, staged_root)
+            errors.extend(compose_result.errors)
+            warnings.extend(compose_result.warnings)
+            for warning in compose_result.warnings:
+                if "no resource limits defined" in warning.lower():
+                    errors.append(f"Blocking conversion warning: {warning}")
+
+        if not (staged_root / "CONVERT_NOTES.md").exists():
+            errors.append("CONVERT_NOTES.md was not generated.")
+
+        return ValidationSummary(passed=len(errors) == 0, errors=errors, warnings=warnings)
+
+
+def _find_compose_file(ext_dir: Path) -> Optional[Path]:
+    for name in COMPOSE_FILENAMES:
+        candidate = ext_dir / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _plan_to_dict(plan: ConversionPlan) -> Dict[str, Any]:
+    return {
+        "modifications": [
+            {
+                "path": mod.path,
+                "action": mod.action,
+                "content": mod.content,
+                "description": mod.description,
+            }
+            for mod in plan.modifications
+        ],
+        "manual_items": plan.manual_items,
+        "summary": plan.summary,
+    }
+
+
+def _strategy_to_dict(strategy: ConversionStrategy) -> Dict[str, Any]:
+    return {
+        "extension_type": strategy.extension_type,
+        "conversion_mode": strategy.conversion_mode,
+        "primary_service": strategy.primary_service,
+        "required_files": strategy.required_files,
+        "runtime_summary": strategy.runtime_summary,
+        "manual_items": strategy.manual_items,
+    }
+
+
+def _merge_manual_items(*groups: List[str]) -> List[str]:
+    seen = set()
+    merged: List[str] = []
+    for group in groups:
+        for item in group:
+            if item and item not in seen:
+                seen.add(item)
+                merged.append(item)
+    return merged

--- a/kamiwaza_extensions/convert_agent.py
+++ b/kamiwaza_extensions/convert_agent.py
@@ -624,6 +624,9 @@ def _render_context_files(analysis: AnalysisResult) -> str:
 def _default_metadata(analysis: AnalysisResult, strategy: ConversionStrategy) -> Dict[str, Any]:
     analyzer = AppAnalyzer()
     metadata = analyzer.generate_kamiwaza_json(analysis)
+    existing_metadata = _load_existing_kamiwaza_json(analysis.app_dir / "kamiwaza.json")
+    if existing_metadata:
+        metadata.update(existing_metadata)
     metadata["type"] = strategy.extension_type
     return metadata
 
@@ -655,9 +658,18 @@ def _apply_basic_fallback(analysis: AnalysisResult, *, dry_run: bool) -> Convers
 
 
 def _preserve_existing_kamiwaza_json(plan: ConversionPlan, analysis: AnalysisResult) -> None:
-    """Do not overwrite an existing manifest during conversion."""
+    """Preserve an existing valid manifest, but allow repairs for invalid ones."""
     metadata_path = analysis.app_dir / "kamiwaza.json"
     if not metadata_path.exists():
+        return
+    if not _is_valid_existing_kamiwaza_json(metadata_path):
+        if any(mod.path == "kamiwaza.json" for mod in plan.modifications):
+            plan.manual_items = _merge_manual_items(
+                plan.manual_items,
+                [
+                    "Existing kamiwaza.json is invalid; keeping AI-proposed metadata repairs so conversion can pass validation.",
+                ],
+            )
         return
 
     kept: List[FileModification] = []
@@ -676,6 +688,22 @@ def _preserve_existing_kamiwaza_json(plan: ConversionPlan, analysis: AnalysisRes
                 "kamiwaza.json already exists; preserving the existing manifest and skipping AI-proposed metadata changes.",
             ],
         )
+
+
+def _load_existing_kamiwaza_json(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+
+    return data if isinstance(data, dict) else None
+
+
+def _is_valid_existing_kamiwaza_json(path: Path) -> bool:
+    from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+    return MetadataValidator().validate(path).passed
 
 
 def _ensure_supporting_files(

--- a/kamiwaza_extensions/convert_agent.py
+++ b/kamiwaza_extensions/convert_agent.py
@@ -28,7 +28,19 @@ console = Console(stderr=True)
 # Max total content size sent to LLM (characters)
 _MAX_CONTEXT_SIZE = 50000
 _MAX_REPAIR_ATTEMPTS = 2
-_STAGING_SKIP_DIRS = (".git", "node_modules", "__pycache__", ".venv", "venv")
+_MAX_PREVIOUS_MODIFICATIONS = 20
+_STAGING_SKIP_DIRS = (
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".next",
+    "build",
+    "dist",
+    "target",
+    "coverage",
+)
 
 
 @dataclass
@@ -171,7 +183,7 @@ Warnings:
         previous_plan_section = f"""
 ## Previous Proposed Modifications
 ```json
-{json.dumps(_plan_to_dict(previous_plan), indent=2)}
+{json.dumps(_summarize_previous_plan(previous_plan), indent=2)}
 ```
 """
 
@@ -450,23 +462,15 @@ def apply_plan(plan: ConversionPlan, app_dir: Path, dry_run: bool = False) -> Li
 def run_agent(analysis: AnalysisResult, dry_run: bool = False) -> ConversionPlan:
     """Run the full conversion agent with staged validation and repair."""
     console.print(
-        "  [dim]Note: source code will be sent to an external LLM provider for analysis.[/dim]"
+        "  [dim]Note: size-capped source context will be sent to an external LLM provider for analysis; "
+        "common secret-bearing files such as .env, credentials, and key files are excluded.[/dim]"
     )
     console.print(f"  [dim]Conversion mode: {analysis.conversion_mode}[/dim]")
     console.print("  [dim]Calling AI agent...[/dim]")
 
     strategy_text = call_llm(build_strategy_prompt(analysis))
     if strategy_text is None:
-        return ConversionPlan(
-            success=False,
-            mode=analysis.conversion_mode,
-            summary="LLM unavailable — convert cannot produce a validated extension automatically.",
-            manual_items=[
-                "Set ANTHROPIC_API_KEY or OPENAI_API_KEY for full AI-powered conversion.",
-                "For other providers, set OPENAI_API_KEY + OPENAI_BASE_URL (any OpenAI-compatible API).",
-            ],
-            errors=["LLM unavailable."],
-        )
+        return _apply_basic_fallback(analysis, dry_run=dry_run)
 
     strategy = parse_strategy_response(strategy_text)
     if strategy is None:
@@ -512,6 +516,7 @@ def run_agent(analysis: AnalysisResult, dry_run: bool = False) -> ConversionPlan
         if not plan.success:
             return plan
 
+        _preserve_existing_kamiwaza_json(plan, analysis)
         _ensure_supporting_files(plan, analysis, metadata_seed, strategy)
         last_validation = _validate_plan_in_staging(plan, analysis.app_dir)
         if last_validation.passed:
@@ -623,6 +628,56 @@ def _default_metadata(analysis: AnalysisResult, strategy: ConversionStrategy) ->
     return metadata
 
 
+def _apply_basic_fallback(analysis: AnalysisResult, *, dry_run: bool) -> ConversionPlan:
+    """Apply the documented non-LLM fallback scaffold."""
+    strategy = ConversionStrategy(
+        extension_type=analysis.extension_type,
+        conversion_mode=analysis.conversion_mode,
+        primary_service=analysis.services[0].name if analysis.services else "app",
+        runtime_summary=analysis.description or "Basic metadata-only fallback",
+    )
+    metadata_seed = _default_metadata(analysis, strategy)
+    plan = ConversionPlan(
+        mode=analysis.conversion_mode,
+        strategy=strategy,
+        summary="LLM unavailable — created a basic Kamiwaza scaffold only.",
+        manual_items=[
+            "Set ANTHROPIC_API_KEY or OPENAI_API_KEY for full AI-powered conversion.",
+            "For other providers, set OPENAI_API_KEY + OPENAI_BASE_URL (any OpenAI-compatible API).",
+            "Review kamiwaza.json, then rerun convert with an LLM to attempt compose and runtime integration.",
+        ],
+    )
+    _ensure_supporting_files(plan, analysis, metadata_seed, strategy)
+    apply_plan(plan, analysis.app_dir, dry_run=dry_run)
+    if dry_run:
+        plan.summary = f"[Dry run] {plan.summary}"
+    return plan
+
+
+def _preserve_existing_kamiwaza_json(plan: ConversionPlan, analysis: AnalysisResult) -> None:
+    """Do not overwrite an existing manifest during conversion."""
+    metadata_path = analysis.app_dir / "kamiwaza.json"
+    if not metadata_path.exists():
+        return
+
+    kept: List[FileModification] = []
+    skipped_metadata_change = False
+    for mod in plan.modifications:
+        if mod.path == "kamiwaza.json":
+            skipped_metadata_change = True
+            continue
+        kept.append(mod)
+
+    if skipped_metadata_change:
+        plan.modifications = kept
+        plan.manual_items = _merge_manual_items(
+            plan.manual_items,
+            [
+                "kamiwaza.json already exists; preserving the existing manifest and skipping AI-proposed metadata changes.",
+            ],
+        )
+
+
 def _ensure_supporting_files(
     plan: ConversionPlan,
     analysis: AnalysisResult,
@@ -680,7 +735,10 @@ def _build_convert_notes(plan: ConversionPlan, strategy: ConversionStrategy) -> 
 
 
 def _validate_plan_in_staging(plan: ConversionPlan, app_dir: Path) -> ValidationSummary:
-    from kamiwaza_extensions.validators.compose import ComposeValidator
+    from kamiwaza_extensions.validators.compose import (
+        ComposeValidator,
+        is_missing_resource_limits_warning,
+    )
     from kamiwaza_extensions.validators.metadata import MetadataValidator
     from kamiwaza_extensions.validators.platform_runtime import PlatformRuntimeValidator
 
@@ -713,7 +771,7 @@ def _validate_plan_in_staging(plan: ConversionPlan, app_dir: Path) -> Validation
             errors.extend(compose_result.errors)
             warnings.extend(compose_result.warnings)
             for warning in compose_result.warnings:
-                if "no resource limits defined" in warning.lower():
+                if is_missing_resource_limits_warning(warning):
                     errors.append(f"Blocking conversion warning: {warning}")
             if compose_result.passed:
                 runtime_result = PlatformRuntimeValidator().validate(compose_path, staged_root)
@@ -748,6 +806,28 @@ def _plan_to_dict(plan: ConversionPlan) -> Dict[str, Any]:
         "manual_items": plan.manual_items,
         "summary": plan.summary,
     }
+
+
+def _summarize_previous_plan(plan: ConversionPlan) -> Dict[str, Any]:
+    summarized_mods = []
+    for mod in plan.modifications[:_MAX_PREVIOUS_MODIFICATIONS]:
+        summarized_mods.append(
+            {
+                "path": mod.path,
+                "action": mod.action,
+                "description": mod.description,
+                "content_chars": len(mod.content or ""),
+            }
+        )
+    omitted = max(0, len(plan.modifications) - len(summarized_mods))
+    summary: Dict[str, Any] = {
+        "modifications": summarized_mods,
+        "manual_items": plan.manual_items,
+        "summary": plan.summary,
+    }
+    if omitted:
+        summary["omitted_modifications"] = omitted
+    return summary
 
 
 def _strategy_to_dict(strategy: ConversionStrategy) -> Dict[str, Any]:

--- a/kamiwaza_extensions/convert_agent.py
+++ b/kamiwaza_extensions/convert_agent.py
@@ -792,22 +792,6 @@ def _find_compose_file(ext_dir: Path) -> Optional[Path]:
     return None
 
 
-def _plan_to_dict(plan: ConversionPlan) -> Dict[str, Any]:
-    return {
-        "modifications": [
-            {
-                "path": mod.path,
-                "action": mod.action,
-                "content": mod.content,
-                "description": mod.description,
-            }
-            for mod in plan.modifications
-        ],
-        "manual_items": plan.manual_items,
-        "summary": plan.summary,
-    }
-
-
 def _summarize_previous_plan(plan: ConversionPlan) -> Dict[str, Any]:
     summarized_mods = []
     for mod in plan.modifications[:_MAX_PREVIOUS_MODIFICATIONS]:

--- a/kamiwaza_extensions/convert_agent.py
+++ b/kamiwaza_extensions/convert_agent.py
@@ -116,9 +116,13 @@ Description: {analysis.description or 'No description'}
 - If the repo is not containerized, generate the thinnest viable containerization and docker-compose setup.
 - Always target a valid repo with `kamiwaza.json`, a compose file, resource limits, and `CONVERT_NOTES.md`.
 - Use `type=app` unless there is strong evidence the repo is an MCP/tool or generic background service.
+- Kamiwaza deploys extension containers as non-root and expects compatibility with a read-only root filesystem.
+- Primary HTTP services should listen on an unprivileged in-container port; prefer `8080` unless the repo clearly requires something else.
+- Static/web-server wrappers must use writable runtime paths under `/tmp` when the server needs temp, cache, or pid files.
 - Python backend runtime library: `kamiwaza-extensions-lib` is appropriate when there is an actual Python application backend.
 - TypeScript runtime library: `@kamiwaza-ai/extensions-lib` is appropriate for real Node/Next frontends.
 - Pure static HTML/CSS/JS sites do not need Kamiwaza runtime libraries; they do need a container, compose, resource limits, and a healthable HTTP path.
+- If the detected runtime is a poor fit for these constraints, a minimal runtime swap is allowed if it preserves app behavior better than patching a broken root-only setup.
 - Keep user source intact. Prefer additive wrappers/config over rewrites.
 
 Return ONLY JSON with this shape:
@@ -207,10 +211,14 @@ Detected conversion mode: {analysis.conversion_mode}
 - Create or update a compose file so `kz-ext validate` will not fail and `kz-ext dev local` has a clear path.
 - Ensure each compose service defines `deploy.resources.limits`.
 - Ensure the primary HTTP service has a healthable HTTP path at `/health`.
+- Generated services must be compatible with Kamiwaza's non-root, read-only-root-filesystem runtime contract.
+- Prefer an unprivileged in-container HTTP port such as `8080`.
+- For nginx/static web servers, configure writable temp/pid paths under `/tmp` when needed.
 - Generate `CONVERT_NOTES.md` summarizing what changed and any remaining manual follow-ups.
 - Only add Kamiwaza runtime libraries when they fit the actual stack.
 - Avoid deleting user source files unless a generated wrapper/config file supersedes them.
 - Keep the output small and practical: wrappers/config/dockerization are fine; full framework rewrites are not.
+- Safe minimal runtime swaps are allowed when they materially improve deploy success on Kamiwaza.
 
 Return ONLY JSON with this shape:
 ```json
@@ -674,6 +682,7 @@ def _build_convert_notes(plan: ConversionPlan, strategy: ConversionStrategy) -> 
 def _validate_plan_in_staging(plan: ConversionPlan, app_dir: Path) -> ValidationSummary:
     from kamiwaza_extensions.validators.compose import ComposeValidator
     from kamiwaza_extensions.validators.metadata import MetadataValidator
+    from kamiwaza_extensions.validators.platform_runtime import PlatformRuntimeValidator
 
     with tempfile.TemporaryDirectory(prefix="kz-ext-convert-") as tmp_dir:
         staged_root = Path(tmp_dir) / app_dir.name
@@ -706,6 +715,10 @@ def _validate_plan_in_staging(plan: ConversionPlan, app_dir: Path) -> Validation
             for warning in compose_result.warnings:
                 if "no resource limits defined" in warning.lower():
                     errors.append(f"Blocking conversion warning: {warning}")
+            if compose_result.passed:
+                runtime_result = PlatformRuntimeValidator().validate(compose_path, staged_root)
+                errors.extend(runtime_result.errors)
+                warnings.extend(runtime_result.warnings)
 
         if not (staged_root / "CONVERT_NOTES.md").exists():
             errors.append("CONVERT_NOTES.md was not generated.")

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -217,9 +217,11 @@ class PayloadBuilder:
                 "timeoutSeconds": 5,
             }
         else:
-            # Backend: HTTP GET /health
+            # Generic frontends usually serve "/" even when they lack a
+            # dedicated /health endpoint; backend-style services still use /health.
+            path = "/" if svc_name == "frontend" else "/health"
             return {
-                "httpGet": {"path": "/health", "port": port},
+                "httpGet": {"path": path, "port": port},
                 "initialDelaySeconds": 10,
                 "periodSeconds": 10,
                 "failureThreshold": 3,

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -281,4 +281,18 @@ def _should_use_node_frontend_probe(svc_name: str, svc: Dict[str, Any]) -> bool:
         if "node" in text or "next" in text:
             return True
 
+    image = str(svc.get("image", "")).lower()
+    if any(token in image for token in ("nginx", "caddy", "httpd", "apache", "static")):
+        return False
+
+    ports = svc.get("ports", [])
+    for port in ports:
+        port_str = str(port).split("/", 1)[0]
+        try:
+            container_port = int(port_str.rsplit(":", 1)[-1])
+        except ValueError:
+            continue
+        if container_port in {3000, 3001, 4173, 5173}:
+            return True
+
     return False

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -129,7 +129,7 @@ class PayloadBuilder:
             if not verify_ssl:
                 env.append({"name": "KAMIWAZA_VERIFY_SSL", "value": "false"})
 
-            health_check = self._default_health_check(svc_name, ports)
+            health_check = self._default_health_check(svc_name, svc, ports)
 
             spec_kwargs: Dict[str, Any] = dict(
                 name=svc_name,
@@ -188,14 +188,14 @@ class PayloadBuilder:
 
     @staticmethod
     def _default_health_check(
-        svc_name: str, ports: List[ExtensionPort],
+        svc_name: str, svc: Dict[str, Any], ports: List[ExtensionPort],
     ) -> Optional[Dict[str, Any]]:
         """Generate a default health check based on service type."""
         if not ports:
             return None
         port = ports[0].container_port
 
-        if svc_name == "frontend":
+        if _should_use_node_frontend_probe(svc_name, svc):
             # Frontend: use node to resolve basePath env vars reliably
             # (shell-based wget probes fail with nested ${} on Alpine)
             probe_script = (
@@ -246,3 +246,39 @@ class PayloadBuilder:
         if t not in ("app", "tool", "service"):
             return "app"
         return t
+
+
+def _should_use_node_frontend_probe(svc_name: str, svc: Dict[str, Any]) -> bool:
+    """Use the Node-based probe only for likely Node/Next frontends.
+
+    Generic/static web services may still be called "frontend", so avoid
+    forcing a Node probe unless the compose service carries Node-like hints.
+    """
+    if svc_name != "frontend":
+        return False
+
+    env = svc.get("environment", {})
+    env_keys: List[str] = []
+    if isinstance(env, dict):
+        env_keys = [str(key) for key in env.keys()]
+    elif isinstance(env, list):
+        for item in env:
+            if isinstance(item, str):
+                key, _, _ = item.partition("=")
+                env_keys.append(key or item)
+            elif isinstance(item, dict):
+                env_keys.extend(str(key) for key in item.keys())
+
+    if any(key == "BACKEND_URL" or key.startswith("NEXT_PUBLIC_") for key in env_keys):
+        return True
+
+    for key in ("command", "entrypoint"):
+        value = svc.get(key)
+        if isinstance(value, list):
+            text = " ".join(str(part) for part in value).lower()
+        else:
+            text = str(value).lower()
+        if "node" in text or "next" in text:
+            return True
+
+    return False

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -311,6 +311,47 @@ def detect_service_runtime(
     return detect_service_type(svc_name, svc_config)
 
 
+def _detect_build_service_runtime(
+    svc_name: str,
+    svc_config: dict,
+    *,
+    extension_dir: Optional[Path] = None,
+) -> str:
+    """Classify a service for build-time SDK overlay insertion.
+
+    Multi-stage frontends often compile in a Node/Bun stage and ship from a
+    static final image such as nginx. Those should still receive the
+    TypeScript overlay during ``kz-ext dev --sdk-repo`` because the local SDK
+    must be installed before the frontend bundle is built.
+    """
+    dockerfile = None
+    if extension_dir is not None and "build" in svc_config:
+        dockerfile = _resolve_dockerfile(svc_config["build"], extension_dir)
+
+    stage_bases = _read_dockerfile_stage_bases(dockerfile)
+    if not stage_bases:
+        return detect_service_runtime(
+            svc_name, svc_config, extension_dir=extension_dir,
+        )
+
+    final_base = _image_basename(stage_bases[-1])
+    if "python" in final_base:
+        return "backend"
+    if "node" in final_base or "bun" in final_base:
+        return "frontend"
+    if any(token in final_base for token in ("nginx", "caddy", "httpd", "apache")):
+        if any(
+            "node" in _image_basename(base) or "bun" in _image_basename(base)
+            for base in stage_bases[:-1]
+        ):
+            return "frontend"
+        return "static"
+
+    return detect_service_runtime(
+        svc_name, svc_config, extension_dir=extension_dir,
+    )
+
+
 def _resolve_dockerfile(build_spec: Any, extension_dir: Path) -> Optional[Path]:
     """Resolve the Dockerfile path from a compose build spec."""
     if isinstance(build_spec, str):
@@ -369,18 +410,25 @@ def _read_dockerfile_startup(dockerfile: Path) -> Optional[DockerStartup]:
 
 def _read_final_base_image(dockerfile: Optional[Path]) -> Optional[str]:
     """Return the final FROM image name from a Dockerfile, if readable."""
+    stage_bases = _read_dockerfile_stage_bases(dockerfile)
+    if not stage_bases:
+        return None
+    return stage_bases[-1]
+
+
+def _read_dockerfile_stage_bases(dockerfile: Optional[Path]) -> List[str]:
+    """Return effective base images for each Dockerfile stage."""
     from kamiwaza_extensions.validators.platform_runtime import parse_from_instruction
 
     if not dockerfile or not dockerfile.is_file():
-        return None
+        return []
 
     try:
         content = dockerfile.read_text()
     except OSError:
-        return None
+        return []
 
     stages: List[tuple[str, Optional[str]]] = []
-    alias_map: dict[str, str] = {}
     for line in content.splitlines():
         stripped = line.strip()
         if stripped.upper().startswith("FROM "):
@@ -388,18 +436,31 @@ def _read_final_base_image(dockerfile: Optional[Path]) -> Optional[str]:
             if base_ref:
                 base = base_ref.lower()
                 stages.append((base, alias.lower() if alias else None))
-                if alias:
-                    alias_map[alias.lower()] = base
 
     if not stages:
-        return None
+        return []
 
-    final_image = stages[-1][0]
-    seen: set[str] = set()
-    while final_image in alias_map and final_image not in seen:
-        seen.add(final_image)
-        final_image = alias_map[final_image]
-    return final_image
+    alias_map = {
+        alias: index for index, (_base, alias) in enumerate(stages) if alias
+    }
+
+    def resolve_stage_base(index: int, seen: Optional[set[str]] = None) -> str:
+        base_ref = stages[index][0]
+        key = base_ref.lower()
+        alias_idx = alias_map.get(key)
+        seen = seen or set()
+        if alias_idx is None or key in seen:
+            return base_ref
+        seen.add(key)
+        return resolve_stage_base(alias_idx, seen)
+
+    return [resolve_stage_base(index) for index in range(len(stages))]
+
+
+def _image_basename(image_ref: str) -> str:
+    ref = image_ref.split("@", 1)[0]
+    name = ref.rsplit("/", 1)[-1]
+    return name.split(":", 1)[0].lower()
 
 
 def _startup_argv(
@@ -552,7 +613,7 @@ def generate_build_overrides(
         if "build" not in svc_config:
             continue
 
-        svc_type = detect_service_runtime(
+        svc_type = _detect_build_service_runtime(
             svc_name, svc_config, extension_dir=extension_dir,
         )
 

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -369,6 +369,8 @@ def _read_dockerfile_startup(dockerfile: Path) -> Optional[DockerStartup]:
 
 def _read_final_base_image(dockerfile: Optional[Path]) -> Optional[str]:
     """Return the final FROM image name from a Dockerfile, if readable."""
+    from kamiwaza_extensions.validators.platform_runtime import _parse_from_instruction
+
     if not dockerfile or not dockerfile.is_file():
         return None
 
@@ -381,9 +383,9 @@ def _read_final_base_image(dockerfile: Optional[Path]) -> Optional[str]:
     for line in content.splitlines():
         stripped = line.strip()
         if stripped.upper().startswith("FROM "):
-            parts = stripped.split()
-            if len(parts) >= 2:
-                last_image = parts[1].lower()
+            base_ref, _alias = _parse_from_instruction(stripped)
+            if base_ref:
+                last_image = base_ref.lower()
     return last_image
 
 

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -369,7 +369,7 @@ def _read_dockerfile_startup(dockerfile: Path) -> Optional[DockerStartup]:
 
 def _read_final_base_image(dockerfile: Optional[Path]) -> Optional[str]:
     """Return the final FROM image name from a Dockerfile, if readable."""
-    from kamiwaza_extensions.validators.platform_runtime import _parse_from_instruction
+    from kamiwaza_extensions.validators.platform_runtime import parse_from_instruction
 
     if not dockerfile or not dockerfile.is_file():
         return None
@@ -379,14 +379,27 @@ def _read_final_base_image(dockerfile: Optional[Path]) -> Optional[str]:
     except OSError:
         return None
 
-    last_image = None
+    stages: List[tuple[str, Optional[str]]] = []
+    alias_map: dict[str, str] = {}
     for line in content.splitlines():
         stripped = line.strip()
         if stripped.upper().startswith("FROM "):
-            base_ref, _alias = _parse_from_instruction(stripped)
+            base_ref, alias = parse_from_instruction(stripped)
             if base_ref:
-                last_image = base_ref.lower()
-    return last_image
+                base = base_ref.lower()
+                stages.append((base, alias.lower() if alias else None))
+                if alias:
+                    alias_map[alias.lower()] = base
+
+    if not stages:
+        return None
+
+    final_image = stages[-1][0]
+    seen: set[str] = set()
+    while final_image in alias_map and final_image not in seen:
+        seen.add(final_image)
+        final_image = alias_map[final_image]
+    return final_image
 
 
 def _startup_argv(

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -278,6 +278,39 @@ def detect_service_type(
     return "backend"
 
 
+def detect_service_runtime(
+    svc_name: str,
+    svc_config: dict,
+    *,
+    extension_dir: Optional[Path] = None,
+) -> str:
+    """Classify a service runtime for SDK override purposes.
+
+    Returns one of:
+    - ``frontend`` for likely Node/Next-style services
+    - ``backend`` for likely Python/backend services
+    - ``static`` for generic web servers such as nginx/caddy/httpd
+
+    When the Dockerfile is available, prefer its final base image over naming
+    heuristics so converted static apps do not get a Python SDK overlay.
+    """
+    dockerfile = None
+    if extension_dir is not None and "build" in svc_config:
+        dockerfile = _resolve_dockerfile(svc_config["build"], extension_dir)
+
+    base_image = _read_final_base_image(dockerfile) if dockerfile else None
+    if base_image:
+        base = base_image.split(":")[0].rsplit("/", 1)[-1]
+        if "python" in base:
+            return "backend"
+        if "node" in base or "bun" in base:
+            return "frontend"
+        if any(token in base for token in ("nginx", "caddy", "httpd", "apache")):
+            return "static"
+
+    return detect_service_type(svc_name, svc_config)
+
+
 def _resolve_dockerfile(build_spec: Any, extension_dir: Path) -> Optional[Path]:
     """Resolve the Dockerfile path from a compose build spec."""
     if isinstance(build_spec, str):
@@ -334,6 +367,26 @@ def _read_dockerfile_startup(dockerfile: Path) -> Optional[DockerStartup]:
     return startup
 
 
+def _read_final_base_image(dockerfile: Optional[Path]) -> Optional[str]:
+    """Return the final FROM image name from a Dockerfile, if readable."""
+    if not dockerfile or not dockerfile.is_file():
+        return None
+
+    try:
+        content = dockerfile.read_text()
+    except OSError:
+        return None
+
+    last_image = None
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.upper().startswith("FROM "):
+            parts = stripped.split()
+            if len(parts) >= 2:
+                last_image = parts[1].lower()
+    return last_image
+
+
 def _startup_argv(
     startup: Optional[DockerStartup],
     fallback: List[str],
@@ -373,7 +426,9 @@ def generate_compose_override(
         if "build" not in svc_config:
             continue
 
-        svc_type = detect_service_type(svc_name, svc_config)
+        svc_type = detect_service_runtime(
+            svc_name, svc_config, extension_dir=extension_dir,
+        )
         svc_override: dict = {}
 
         # Read the original startup command from the Dockerfile
@@ -466,6 +521,7 @@ _TS_BUILD_PATTERNS = re.compile(
 def generate_build_overrides(
     spec: SdkOverrideSpec,
     compose_data: dict,
+    extension_dir: Optional[Path] = None,
 ) -> List[BuildOverride]:
     """Generate build overrides to bake local SDK source into images.
 
@@ -481,7 +537,9 @@ def generate_build_overrides(
         if "build" not in svc_config:
             continue
 
-        svc_type = detect_service_type(svc_name, svc_config)
+        svc_type = detect_service_runtime(
+            svc_name, svc_config, extension_dir=extension_dir,
+        )
 
         if svc_type == "backend" and spec.python:
             overrides.append(BuildOverride(

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import List
 
 import yaml
 
 from kamiwaza_extensions.validators.result import ValidationResult
+
+MISSING_RESOURCE_LIMITS_TEXT = "no resource limits defined"
+
+
+def is_missing_resource_limits_warning(message: str) -> bool:
+    """Return True when *message* is the compose missing-limits warning."""
+    return MISSING_RESOURCE_LIMITS_TEXT in message.lower()
 
 
 class ComposeValidator:
@@ -57,9 +64,9 @@ class ComposeValidator:
             if isinstance(deploy, dict):
                 resources = deploy.get("resources", {})
                 if not resources or not isinstance(resources, dict) or not resources.get("limits"):
-                    warnings.append(f"Service '{svc_name}': no resource limits defined")
+                    warnings.append(f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}")
             else:
-                warnings.append(f"Service '{svc_name}': no resource limits defined")
+                warnings.append(f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}")
 
             # Explicit container_name
             if "container_name" in svc_config:

--- a/kamiwaza_extensions/validators/platform_runtime.py
+++ b/kamiwaza_extensions/validators/platform_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shlex
@@ -20,6 +21,7 @@ _NGINX_CONF_LISTEN_RE = re.compile(
     r"(?mi)^\s*listen\s+(?:(?:\[[^\]]+\]|[^\s;:]+):)?(?P<port>\d+)\b"
 )
 _TMP_PATH_RE = re.compile(r"(?<!\S)/tmp(?:/|\b)")
+_HEREDOC_RE = re.compile(r"<<(?P<strip>-?)(?P<quote>['\"]?)(?P<marker>[A-Za-z_][A-Za-z0-9_]*)\2")
 _CONFIG_SKIP_DIRS = {
     ".git",
     "node_modules",
@@ -91,7 +93,13 @@ class PlatformRuntimeValidator:
             if not dockerfile_path.exists():
                 continue
 
-            dockerfile_text = dockerfile_path.read_text(encoding="utf-8")
+            try:
+                dockerfile_text = dockerfile_path.read_text(encoding="utf-8")
+            except OSError:
+                warnings.append(
+                    f"Service '{svc_name}': Dockerfile could not be read for runtime validation"
+                )
+                continue
             stages = _parse_dockerfile_stages(dockerfile_text)
             if not stages:
                 continue
@@ -100,7 +108,7 @@ class PlatformRuntimeValidator:
             base_image = _resolve_effective_base_image(stages, final_stage)
             effective_user = _resolve_effective_user(stages, final_stage)
             final_text = _resolve_stage_text(stages, final_stage)
-            nginx_texts = _load_nginx_config_texts(build_context) if build_context else []
+            nginx_texts = _load_nginx_config_texts(build_context, final_text) if build_context else []
 
             for port in _parse_exposed_ports(final_text):
                 if port < 1024:
@@ -129,7 +137,7 @@ class PlatformRuntimeValidator:
                             "prefer 8080+"
                         )
 
-            if _is_rootful_httpd_image(base_image) and not _is_non_root_user(effective_user):
+            if _is_rootful_httpd_image(base_image) and not _has_non_root_runtime_user(base_image, effective_user):
                 errors.append(
                     f"Service '{svc_name}': HTTP server image does not switch to a non-root user"
                 )
@@ -225,8 +233,11 @@ def _parse_dockerfile_stages(text: str) -> List[_DockerStage]:
 def _logical_dockerfile_lines(text: str) -> List[str]:
     logical_lines: List[str] = []
     current = ""
+    lines = text.splitlines()
+    idx = 0
 
-    for raw_line in text.splitlines():
+    while idx < len(lines):
+        raw_line = lines[idx]
         line = raw_line.rstrip()
         if current:
             current += " " + line.lstrip()
@@ -235,15 +246,35 @@ def _logical_dockerfile_lines(text: str) -> List[str]:
 
         if current.endswith("\\"):
             current = current[:-1]
+            idx += 1
             continue
 
         logical_lines.append(current)
+        heredoc_markers = _extract_heredoc_markers(current)
         current = ""
+        idx += 1
+
+        if heredoc_markers:
+            marker_index = 0
+            while idx < len(lines) and marker_index < len(heredoc_markers):
+                candidate = lines[idx].rstrip()
+                marker, strip_tabs = heredoc_markers[marker_index]
+                compare = candidate.lstrip("\t") if strip_tabs else candidate
+                if compare == marker:
+                    marker_index += 1
+                idx += 1
 
     if current:
         logical_lines.append(current)
 
     return logical_lines
+
+
+def _extract_heredoc_markers(line: str) -> List[Tuple[str, bool]]:
+    markers: List[Tuple[str, bool]] = []
+    for match in _HEREDOC_RE.finditer(line):
+        markers.append((match.group("marker"), match.group("strip") == "-"))
+    return markers
 
 
 def parse_from_instruction(line: str) -> tuple[Optional[str], Optional[str]]:
@@ -345,26 +376,117 @@ def _parse_exposed_ports(text: str) -> List[int]:
     return ports
 
 
-def _load_nginx_config_texts(build_context: Path) -> List[str]:
+def _load_nginx_config_texts(build_context: Path, final_text: str) -> List[str]:
     if not build_context.exists():
         return []
 
     texts: List[str] = []
-    for dirpath, dirnames, filenames in os.walk(build_context):
+    for path in sorted(_find_nginx_config_paths(build_context, final_text)):
+        try:
+            texts.append(path.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+    return texts
+
+
+def _find_nginx_config_paths(build_context: Path, final_text: str) -> set[Path]:
+    paths: set[Path] = set()
+    for line in final_text.splitlines():
+        stripped = line.strip()
+        if not stripped.upper().startswith(("COPY ", "ADD ")):
+            continue
+        paths.update(_extract_nginx_config_sources(build_context, stripped))
+    return paths
+
+
+def _extract_nginx_config_sources(build_context: Path, instruction: str) -> set[Path]:
+    command, _, remainder = instruction.partition(" ")
+    if command.upper() not in {"COPY", "ADD"} or not remainder.strip():
+        return set()
+
+    rest = remainder.strip()
+    from_stage = False
+    while rest.startswith("--"):
+        flag, _, next_rest = rest.partition(" ")
+        if not next_rest:
+            return set()
+        if flag.startswith("--from"):
+            from_stage = True
+        rest = next_rest.lstrip()
+
+    if from_stage:
+        return set()
+
+    sources, dest = _parse_copy_arguments(rest)
+    if not sources or not _is_nginx_config_destination(dest):
+        return set()
+
+    resolved: set[Path] = set()
+    for source in sources:
+        resolved.update(_resolve_copy_source_paths(build_context, source))
+    return resolved
+
+
+def _parse_copy_arguments(text: str) -> Tuple[List[str], str]:
+    stripped = text.strip()
+    if stripped.startswith("["):
+        try:
+            items = json.loads(stripped)
+        except json.JSONDecodeError:
+            return [], ""
+        if not isinstance(items, list) or len(items) < 2:
+            return [], ""
+        values = [str(item) for item in items]
+        return values[:-1], values[-1]
+
+    try:
+        tokens = shlex.split(stripped, comments=False, posix=True)
+    except ValueError:
+        tokens = stripped.split()
+    if len(tokens) < 2:
+        return [], ""
+    return tokens[:-1], tokens[-1]
+
+
+def _is_nginx_config_destination(dest: str) -> bool:
+    lower = dest.lower()
+    return (
+        lower.startswith("/etc/nginx/")
+        or "/nginx/conf.d/" in lower
+        or ("/nginx/conf/" in lower and lower.endswith(".conf"))
+        or lower.endswith("/nginx.conf")
+    )
+
+
+def _resolve_copy_source_paths(build_context: Path, source: str) -> set[Path]:
+    if not source or source == ".":
+        return set()
+
+    candidates: set[Path] = set()
+    if any(token in source for token in "*?["):
+        for match in build_context.glob(source):
+            candidates.update(_collect_config_paths(match))
+        return candidates
+
+    candidate = _resolve_relative_to_ext_dir(build_context, source)
+    if candidate is None:
+        return set()
+    return _collect_config_paths(candidate)
+
+
+def _collect_config_paths(path: Path) -> set[Path]:
+    if path.is_file():
+        return {path}
+    if not path.is_dir():
+        return set()
+
+    paths: set[Path] = set()
+    for dirpath, dirnames, filenames in os.walk(path):
         dirnames[:] = [d for d in dirnames if d not in _CONFIG_SKIP_DIRS]
         for filename in filenames:
-            if not filename.endswith(".conf"):
-                continue
-            path = Path(dirpath) / filename
-            rel = path.relative_to(build_context)
-            rel_str = str(rel).lower()
-            if (
-                rel.name == "default.conf"
-                or "nginx" in rel_str
-                or "conf.d" in rel.parts
-            ):
-                texts.append(path.read_text(encoding="utf-8"))
-    return texts
+            if filename.endswith(".conf") or filename == "nginx.conf":
+                paths.add(Path(dirpath) / filename)
+    return paths
 
 
 def _parse_nginx_listen_ports(final_text: str, config_texts: Iterable[str]) -> List[int]:

--- a/kamiwaza_extensions/validators/platform_runtime.py
+++ b/kamiwaza_extensions/validators/platform_runtime.py
@@ -6,7 +6,7 @@ import re
 import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 import yaml
 
@@ -60,8 +60,15 @@ class PlatformRuntimeValidator:
                         "Kamiwaza deploys extensions as non-root, prefer 8080+"
                     )
 
-            dockerfile_path = _resolve_dockerfile_path(svc_config, ext_dir)
-            if dockerfile_path is None or not dockerfile_path.exists():
+            dockerfile_path, build_context, build_path_escaped = _resolve_build_paths(svc_config, ext_dir)
+            if build_path_escaped:
+                warnings.append(
+                    f"Service '{svc_name}': build path escapes the extension directory and was not inspected"
+                )
+                continue
+            if dockerfile_path is None:
+                continue
+            if not dockerfile_path.exists():
                 continue
 
             dockerfile_text = dockerfile_path.read_text(encoding="utf-8")
@@ -73,7 +80,7 @@ class PlatformRuntimeValidator:
             base_image = _resolve_effective_base_image(stages, final_stage)
             effective_user = _resolve_effective_user(stages, final_stage)
             final_text = _resolve_stage_text(stages, final_stage)
-            build_context = dockerfile_path.parent
+            nginx_texts = _load_nginx_config_texts(build_context) if build_context else []
 
             for port in _parse_exposed_ports(final_text):
                 if port < 1024:
@@ -82,13 +89,12 @@ class PlatformRuntimeValidator:
                         "Kamiwaza deploys extensions as non-root"
                     )
 
-            if _is_rootful_nginx_image(base_image):
-                if not _is_non_root_user(effective_user):
+            if _is_nginx_image(base_image):
+                if not _has_non_root_runtime_user(base_image, effective_user):
                     errors.append(
                         f"Service '{svc_name}': nginx-based Dockerfile does not switch to a non-root user"
                     )
 
-                nginx_texts = _load_nginx_config_texts(build_context)
                 combined_text = "\n".join([final_text, *nginx_texts])
                 if not _TMP_PATH_RE.search(combined_text):
                     errors.append(
@@ -136,15 +142,32 @@ def _parse_service_ports(svc_config: Dict[str, Any]) -> List[int]:
     return parsed
 
 
-def _resolve_dockerfile_path(svc_config: Dict[str, Any], ext_dir: Path) -> Optional[Path]:
+def _resolve_build_paths(
+    svc_config: Dict[str, Any], ext_dir: Path
+) -> Tuple[Optional[Path], Optional[Path], bool]:
     build = svc_config.get("build")
     if isinstance(build, dict):
         context = build.get("context", ".")
         dockerfile = build.get("dockerfile", "Dockerfile")
-        return ext_dir / context / dockerfile
+        build_context = _resolve_relative_to_ext_dir(ext_dir, context)
+        if build_context is None:
+            return None, None, True
+        dockerfile_path = _resolve_relative_to_ext_dir(build_context, dockerfile)
+        return dockerfile_path, build_context, dockerfile_path is None
     if isinstance(build, str):
-        return ext_dir / build / "Dockerfile"
-    return None
+        build_context = _resolve_relative_to_ext_dir(ext_dir, build)
+        if build_context is None:
+            return None, None, True
+        dockerfile_path = _resolve_relative_to_ext_dir(build_context, "Dockerfile")
+        return dockerfile_path, build_context, dockerfile_path is None
+    return None, None, False
+
+
+def _resolve_relative_to_ext_dir(root: Path, relative_path: Any) -> Optional[Path]:
+    candidate = (root / str(relative_path)).resolve()
+    if not candidate.is_relative_to(root.resolve()):
+        return None
+    return candidate
 
 
 def _parse_dockerfile_stages(text: str) -> List[_DockerStage]:
@@ -186,7 +209,7 @@ def _logical_dockerfile_lines(text: str) -> List[str]:
     for raw_line in text.splitlines():
         line = raw_line.rstrip()
         if current:
-            current += line.lstrip()
+            current += " " + line.lstrip()
         else:
             current = line
 
@@ -339,9 +362,19 @@ def _is_non_root_user(user: Optional[str]) -> bool:
     return True
 
 
-def _is_rootful_nginx_image(base_image: str) -> bool:
+def _is_nginx_image(base_image: str) -> bool:
+    return "nginx" in base_image.lower()
+
+
+def _has_non_root_runtime_user(base_image: str, user: Optional[str]) -> bool:
+    if user is not None:
+        return _is_non_root_user(user)
+    return _default_image_user_is_non_root(base_image)
+
+
+def _default_image_user_is_non_root(base_image: str) -> bool:
     lower = base_image.lower()
-    return "nginx" in lower and "unprivileged" not in lower
+    return "unprivileged" in lower or "nonroot" in lower or "non-root" in lower
 
 
 def _is_rootful_httpd_image(base_image: str) -> bool:

--- a/kamiwaza_extensions/validators/platform_runtime.py
+++ b/kamiwaza_extensions/validators/platform_runtime.py
@@ -15,7 +15,9 @@ from kamiwaza_extensions.validators.result import ValidationResult
 _INLINE_NGINX_LISTEN_RE = re.compile(
     r"(?i)(?:^|\s)(?:echo|printf)\s+['\"][^'\"]*?\blisten\s+(?P<port>\d+)\b"
 )
-_NGINX_CONF_LISTEN_RE = re.compile(r"(?mi)^\s*listen\s+(?:\[::\]:)?(?P<port>\d+)\b")
+_NGINX_CONF_LISTEN_RE = re.compile(
+    r"(?mi)^\s*listen\s+(?:(?:\[[^\]]+\]|[^\s;:]+):)?(?P<port>\d+)\b"
+)
 _TMP_PATH_RE = re.compile(r"(?<!\S)/tmp(?:/|\b)")
 
 
@@ -226,7 +228,7 @@ def _logical_dockerfile_lines(text: str) -> List[str]:
     return logical_lines
 
 
-def _parse_from_instruction(line: str) -> tuple[Optional[str], Optional[str]]:
+def parse_from_instruction(line: str) -> tuple[Optional[str], Optional[str]]:
     try:
         tokens = shlex.split(line, comments=False, posix=True)
     except ValueError:
@@ -251,6 +253,11 @@ def _parse_from_instruction(line: str) -> tuple[Optional[str], Optional[str]]:
         idx += 1
 
     return base_ref, alias
+
+
+def _parse_from_instruction(line: str) -> tuple[Optional[str], Optional[str]]:
+    """Backward-compatible wrapper for internal callers/tests."""
+    return parse_from_instruction(line)
 
 
 def _resolve_effective_base_image(stages: List[_DockerStage], index: int, seen: Optional[set[str]] = None) -> str:

--- a/kamiwaza_extensions/validators/platform_runtime.py
+++ b/kamiwaza_extensions/validators/platform_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import shlex
 from dataclasses import dataclass, field
@@ -19,6 +20,18 @@ _NGINX_CONF_LISTEN_RE = re.compile(
     r"(?mi)^\s*listen\s+(?:(?:\[[^\]]+\]|[^\s;:]+):)?(?P<port>\d+)\b"
 )
 _TMP_PATH_RE = re.compile(r"(?<!\S)/tmp(?:/|\b)")
+_CONFIG_SKIP_DIRS = {
+    ".git",
+    "node_modules",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".next",
+    "build",
+    "dist",
+    "target",
+    "coverage",
+}
 
 
 @dataclass
@@ -69,6 +82,11 @@ class PlatformRuntimeValidator:
                 )
                 continue
             if dockerfile_path is None:
+                image_errors, image_warnings = _validate_image_only_service(
+                    svc_name, str(svc_config.get("image") or ""),
+                )
+                errors.extend(image_errors)
+                warnings.extend(image_warnings)
                 continue
             if not dockerfile_path.exists():
                 continue
@@ -332,15 +350,20 @@ def _load_nginx_config_texts(build_context: Path) -> List[str]:
         return []
 
     texts: List[str] = []
-    for path in build_context.rglob("*.conf"):
-        rel = path.relative_to(build_context)
-        rel_str = str(rel).lower()
-        if (
-            rel.name == "default.conf"
-            or "nginx" in rel_str
-            or "conf.d" in rel.parts
-        ):
-            texts.append(path.read_text(encoding="utf-8"))
+    for dirpath, dirnames, filenames in os.walk(build_context):
+        dirnames[:] = [d for d in dirnames if d not in _CONFIG_SKIP_DIRS]
+        for filename in filenames:
+            if not filename.endswith(".conf"):
+                continue
+            path = Path(dirpath) / filename
+            rel = path.relative_to(build_context)
+            rel_str = str(rel).lower()
+            if (
+                rel.name == "default.conf"
+                or "nginx" in rel_str
+                or "conf.d" in rel.parts
+            ):
+                texts.append(path.read_text(encoding="utf-8"))
     return texts
 
 
@@ -370,7 +393,8 @@ def _is_non_root_user(user: Optional[str]) -> bool:
 
 
 def _is_nginx_image(base_image: str) -> bool:
-    return "nginx" in base_image.lower()
+    base = _image_basename(base_image)
+    return base == "nginx" or base.startswith("nginx-")
 
 
 def _has_non_root_runtime_user(base_image: str, user: Optional[str]) -> bool:
@@ -385,8 +409,48 @@ def _default_image_user_is_non_root(base_image: str) -> bool:
 
 
 def _is_rootful_httpd_image(base_image: str) -> bool:
-    lower = base_image.lower()
-    return "httpd" in lower or "apache" in lower
+    base = _image_basename(base_image)
+    return (
+        base == "httpd"
+        or base.startswith("httpd-")
+        or base == "apache"
+        or base.startswith("apache-")
+    )
+
+
+def _validate_image_only_service(
+    svc_name: str,
+    image_ref: str,
+) -> Tuple[List[str], List[str]]:
+    if not image_ref:
+        return [], []
+
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    if _is_nginx_image(image_ref):
+        if not _has_non_root_runtime_user(image_ref, user=None):
+            errors.append(
+                f"Service '{svc_name}': image-only nginx service '{image_ref}' is likely rootful; "
+                "use an unprivileged image or provide a Dockerfile that switches users"
+            )
+        warnings.append(
+            f"Service '{svc_name}': image-only nginx service '{image_ref}' could not be inspected "
+            "for listen ports or writable /tmp runtime paths"
+        )
+    elif _is_rootful_httpd_image(image_ref) and not _has_non_root_runtime_user(image_ref, user=None):
+        errors.append(
+            f"Service '{svc_name}': image-only HTTP server image '{image_ref}' is likely rootful; "
+            "use a non-root image or provide a Dockerfile that switches users"
+        )
+
+    return errors, warnings
+
+
+def _image_basename(image_ref: str) -> str:
+    ref = image_ref.split("@", 1)[0]
+    name = ref.rsplit("/", 1)[-1]
+    return name.split(":", 1)[0].lower()
 
 
 def _dedupe(items: List[str]) -> List[str]:

--- a/kamiwaza_extensions/validators/platform_runtime.py
+++ b/kamiwaza_extensions/validators/platform_runtime.py
@@ -1,0 +1,359 @@
+"""Validation for Kamiwaza platform runtime compatibility."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import yaml
+
+from kamiwaza_extensions.validators.result import ValidationResult
+
+_INLINE_NGINX_LISTEN_RE = re.compile(
+    r"(?i)(?:^|\s)(?:echo|printf)\s+['\"][^'\"]*?\blisten\s+(?P<port>\d+)\b"
+)
+_NGINX_CONF_LISTEN_RE = re.compile(r"(?mi)^\s*listen\s+(?:\[::\]:)?(?P<port>\d+)\b")
+_TMP_PATH_RE = re.compile(r"(?<!\S)/tmp(?:/|\b)")
+
+
+@dataclass
+class _DockerStage:
+    base_ref: str
+    alias: Optional[str] = None
+    user: Optional[str] = None
+    instructions: List[str] = field(default_factory=list)
+
+
+class PlatformRuntimeValidator:
+    """Validates that an extension is likely to run under Kamiwaza."""
+
+    def validate(self, compose_path: Path, ext_dir: Path) -> ValidationResult:
+        errors: List[str] = []
+        warnings: List[str] = []
+
+        try:
+            with compose_path.open("r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as exc:
+            return ValidationResult(passed=False, errors=[f"Invalid YAML: {exc}"])
+        except FileNotFoundError:
+            return ValidationResult(passed=False, errors=[f"File not found: {compose_path}"])
+
+        if not isinstance(data, dict):
+            return ValidationResult(passed=False, errors=["Compose file must be a YAML mapping"])
+
+        services = data.get("services", {})
+        if not isinstance(services, dict) or not services:
+            return ValidationResult(passed=True)
+
+        for svc_name, svc_config in services.items():
+            if not isinstance(svc_config, dict):
+                continue
+
+            for port in _parse_service_ports(svc_config):
+                if port < 1024:
+                    errors.append(
+                        f"Service '{svc_name}': container port {port} is privileged; "
+                        "Kamiwaza deploys extensions as non-root, prefer 8080+"
+                    )
+
+            dockerfile_path = _resolve_dockerfile_path(svc_config, ext_dir)
+            if dockerfile_path is None or not dockerfile_path.exists():
+                continue
+
+            dockerfile_text = dockerfile_path.read_text(encoding="utf-8")
+            stages = _parse_dockerfile_stages(dockerfile_text)
+            if not stages:
+                continue
+
+            final_stage = len(stages) - 1
+            base_image = _resolve_effective_base_image(stages, final_stage)
+            effective_user = _resolve_effective_user(stages, final_stage)
+            final_text = _resolve_stage_text(stages, final_stage)
+            build_context = dockerfile_path.parent
+
+            for port in _parse_exposed_ports(final_text):
+                if port < 1024:
+                    errors.append(
+                        f"Service '{svc_name}': Dockerfile exposes privileged port {port}; "
+                        "Kamiwaza deploys extensions as non-root"
+                    )
+
+            if _is_rootful_nginx_image(base_image):
+                if not _is_non_root_user(effective_user):
+                    errors.append(
+                        f"Service '{svc_name}': nginx-based Dockerfile does not switch to a non-root user"
+                    )
+
+                nginx_texts = _load_nginx_config_texts(build_context)
+                combined_text = "\n".join([final_text, *nginx_texts])
+                if not _TMP_PATH_RE.search(combined_text):
+                    errors.append(
+                        f"Service '{svc_name}': nginx runtime does not declare writable /tmp paths "
+                        "required for readOnlyRootFilesystem"
+                    )
+
+                for port in _parse_nginx_listen_ports(final_text, nginx_texts):
+                    if port < 1024:
+                        errors.append(
+                            f"Service '{svc_name}': nginx configuration listens on privileged port {port}; "
+                            "prefer 8080+"
+                        )
+
+            if _is_rootful_httpd_image(base_image) and not _is_non_root_user(effective_user):
+                errors.append(
+                    f"Service '{svc_name}': HTTP server image does not switch to a non-root user"
+                )
+
+        return ValidationResult(
+            passed=len(errors) == 0,
+            errors=_dedupe(errors),
+            warnings=_dedupe(warnings),
+        )
+
+
+def _parse_service_ports(svc_config: Dict[str, Any]) -> List[int]:
+    ports = svc_config.get("ports", [])
+    parsed: List[int] = []
+    for port in ports:
+        if isinstance(port, dict):
+            target = port.get("target") or port.get("container_port")
+            try:
+                parsed.append(int(str(target)))
+            except (TypeError, ValueError):
+                continue
+            continue
+
+        port_str = str(port)
+        if "/" in port_str:
+            port_str = port_str.split("/", 1)[0]
+        match = re.search(r"(\d+)(?:-\d+)?$", port_str)
+        if match:
+            parsed.append(int(match.group(1)))
+    return parsed
+
+
+def _resolve_dockerfile_path(svc_config: Dict[str, Any], ext_dir: Path) -> Optional[Path]:
+    build = svc_config.get("build")
+    if isinstance(build, dict):
+        context = build.get("context", ".")
+        dockerfile = build.get("dockerfile", "Dockerfile")
+        return ext_dir / context / dockerfile
+    if isinstance(build, str):
+        return ext_dir / build / "Dockerfile"
+    return None
+
+
+def _parse_dockerfile_stages(text: str) -> List[_DockerStage]:
+    stages: List[_DockerStage] = []
+    current: Optional[_DockerStage] = None
+
+    for line in _logical_dockerfile_lines(text):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if stripped.upper().startswith("FROM "):
+            base_ref, alias = _parse_from_instruction(stripped)
+            if not base_ref:
+                continue
+            current = _DockerStage(base_ref=base_ref, alias=alias)
+            stages.append(current)
+            continue
+
+        if current is None:
+            continue
+
+        current.instructions.append(stripped)
+        if stripped.upper().startswith("USER "):
+            user = stripped[5:].strip()
+            try:
+                user_tokens = shlex.split(user, comments=False, posix=True)
+            except ValueError:
+                user_tokens = user.split()
+            current.user = user_tokens[0] if user_tokens else user
+
+    return stages
+
+
+def _logical_dockerfile_lines(text: str) -> List[str]:
+    logical_lines: List[str] = []
+    current = ""
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if current:
+            current += line.lstrip()
+        else:
+            current = line
+
+        if current.endswith("\\"):
+            current = current[:-1]
+            continue
+
+        logical_lines.append(current)
+        current = ""
+
+    if current:
+        logical_lines.append(current)
+
+    return logical_lines
+
+
+def _parse_from_instruction(line: str) -> tuple[Optional[str], Optional[str]]:
+    try:
+        tokens = shlex.split(line, comments=False, posix=True)
+    except ValueError:
+        tokens = line.split()
+
+    base_ref: Optional[str] = None
+    alias: Optional[str] = None
+    idx = 1
+    while idx < len(tokens):
+        token = tokens[idx]
+        if token.startswith("--"):
+            idx += 1
+            continue
+        base_ref = token
+        idx += 1
+        break
+
+    while idx < len(tokens) - 1:
+        if tokens[idx].upper() == "AS":
+            alias = tokens[idx + 1]
+            break
+        idx += 1
+
+    return base_ref, alias
+
+
+def _resolve_effective_base_image(stages: List[_DockerStage], index: int, seen: Optional[set[str]] = None) -> str:
+    alias_map = {
+        stage.alias.lower(): idx for idx, stage in enumerate(stages) if stage.alias
+    }
+    seen = seen or set()
+    base_ref = stages[index].base_ref
+    key = base_ref.lower()
+    alias_idx = alias_map.get(key)
+    if alias_idx is None or key in seen:
+        return base_ref
+    seen.add(key)
+    return _resolve_effective_base_image(stages, alias_idx, seen)
+
+
+def _resolve_effective_user(stages: List[_DockerStage], index: int, seen: Optional[set[str]] = None) -> Optional[str]:
+    alias_map = {
+        stage.alias.lower(): idx for idx, stage in enumerate(stages) if stage.alias
+    }
+    stage = stages[index]
+    if stage.user is not None:
+        return stage.user
+
+    seen = seen or set()
+    key = stage.base_ref.lower()
+    alias_idx = alias_map.get(key)
+    if alias_idx is None or key in seen:
+        return None
+    seen.add(key)
+    return _resolve_effective_user(stages, alias_idx, seen)
+
+
+def _resolve_stage_text(stages: List[_DockerStage], index: int, seen: Optional[set[str]] = None) -> str:
+    alias_map = {
+        stage.alias.lower(): idx for idx, stage in enumerate(stages) if stage.alias
+    }
+    stage = stages[index]
+    parts: List[str] = []
+    seen = seen or set()
+    key = stage.base_ref.lower()
+    alias_idx = alias_map.get(key)
+    if alias_idx is not None and key not in seen:
+        seen.add(key)
+        parts.append(_resolve_stage_text(stages, alias_idx, seen))
+    parts.append("\n".join(stage.instructions))
+    return "\n".join(part for part in parts if part)
+
+
+def _parse_exposed_ports(text: str) -> List[int]:
+    ports: List[int] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.upper().startswith("EXPOSE "):
+            continue
+        remainder = stripped[7:].strip()
+        try:
+            tokens = shlex.split(remainder, comments=False, posix=True)
+        except ValueError:
+            tokens = remainder.split()
+        for token in tokens:
+            port_token = token.split("/", 1)[0]
+            try:
+                ports.append(int(port_token))
+            except ValueError:
+                continue
+    return ports
+
+
+def _load_nginx_config_texts(build_context: Path) -> List[str]:
+    if not build_context.exists():
+        return []
+
+    texts: List[str] = []
+    for path in build_context.rglob("*.conf"):
+        rel = path.relative_to(build_context)
+        rel_str = str(rel).lower()
+        if (
+            rel.name == "default.conf"
+            or "nginx" in rel_str
+            or "conf.d" in rel.parts
+        ):
+            texts.append(path.read_text(encoding="utf-8"))
+    return texts
+
+
+def _parse_nginx_listen_ports(final_text: str, config_texts: Iterable[str]) -> List[int]:
+    ports: List[int] = []
+    for match in _INLINE_NGINX_LISTEN_RE.finditer(final_text):
+        ports.append(int(match.group("port")))
+    for text in config_texts:
+        for match in _NGINX_CONF_LISTEN_RE.finditer(text):
+            ports.append(int(match.group("port")))
+    return ports
+
+
+def _is_non_root_user(user: Optional[str]) -> bool:
+    if not user:
+        return False
+    normalized = user.strip().lower()
+    if normalized == "root":
+        return False
+
+    primary = normalized.split(":", 1)[0]
+    if primary.isdigit():
+        return int(primary) != 0
+    if primary == "root":
+        return False
+    return True
+
+
+def _is_rootful_nginx_image(base_image: str) -> bool:
+    lower = base_image.lower()
+    return "nginx" in lower and "unprivileged" not in lower
+
+
+def _is_rootful_httpd_image(base_image: str) -> bool:
+    lower = base_image.lower()
+    return "httpd" in lower or "apache" in lower
+
+
+def _dedupe(items: List[str]) -> List[str]:
+    seen = set()
+    deduped: List[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            deduped.append(item)
+    return deduped

--- a/tests/unit/extensions/test_app_analyzer.py
+++ b/tests/unit/extensions/test_app_analyzer.py
@@ -1,7 +1,6 @@
 """Unit tests for AppAnalyzer."""
 
 import json
-import textwrap
 
 import pytest
 import yaml
@@ -158,6 +157,34 @@ class TestAnalyze:
         result = AppAnalyzer().analyze(tmp_path)
         assert result.compose_path is None
         assert result.compose_data is None
+
+    def test_collects_html_context_for_generic_repo(self, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AppAnalyzer
+
+        (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
+        (tmp_path / "styles.css").write_text("body { color: red; }")
+
+        result = AppAnalyzer().analyze(tmp_path)
+
+        assert result.conversion_mode == "generic"
+        assert "index.html" in result.file_contents
+        assert "static-html" in result.runtime_hints
+        assert "index.html" in result.candidate_entrypoints
+
+    def test_collects_root_package_json_for_generic_repo(self, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AppAnalyzer
+
+        pkg = {"name": "demo", "scripts": {"start": "vite"}}
+        (tmp_path / "package.json").write_text(json.dumps(pkg))
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "main.ts").write_text("console.log('hi');")
+
+        result = AppAnalyzer().analyze(tmp_path)
+
+        assert result.conversion_mode == "generic"
+        assert "package.json" in result.file_contents
+        assert "package.json" in result.detected_manifests
+        assert "node-package" in result.runtime_hints
 
 
 class TestGenerateKamiwazaJson:

--- a/tests/unit/extensions/test_app_analyzer.py
+++ b/tests/unit/extensions/test_app_analyzer.py
@@ -186,6 +186,28 @@ class TestAnalyze:
         assert "package.json" in result.detected_manifests
         assert "node-package" in result.runtime_hints
 
+    def test_excludes_common_secret_bearing_files_from_context(self, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AppAnalyzer
+
+        (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
+        (tmp_path / ".env").write_text("API_KEY=secret\n")
+        (tmp_path / "credentials.json").write_text("{\"token\": \"secret\"}\n")
+
+        result = AppAnalyzer().analyze(tmp_path)
+
+        assert "index.html" in result.file_contents
+        assert ".env" not in result.file_contents
+        assert "credentials.json" not in result.file_contents
+
+    def test_detects_additional_language_manifests(self, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AppAnalyzer
+
+        (tmp_path / "go.mod").write_text("module demo\n")
+
+        result = AppAnalyzer().analyze(tmp_path)
+
+        assert "go.mod" in result.detected_manifests
+
 
 class TestGenerateKamiwazaJson:
     def test_basic_generation(self, tmp_path):

--- a/tests/unit/extensions/test_app_analyzer.py
+++ b/tests/unit/extensions/test_app_analyzer.py
@@ -199,6 +199,21 @@ class TestAnalyze:
         assert ".env" not in result.file_contents
         assert "credentials.json" not in result.file_contents
 
+    def test_excludes_common_secret_bearing_files_from_repo_inventory(self, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AppAnalyzer
+
+        (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
+        (tmp_path / ".env").write_text("API_KEY=secret\n")
+        (tmp_path / "credentials.json").write_text("{\"token\": \"secret\"}\n")
+        (tmp_path / "id_rsa").write_text("private-key\n")
+
+        result = AppAnalyzer().analyze(tmp_path)
+
+        assert "index.html" in result.repo_tree
+        assert ".env" not in result.repo_tree
+        assert "credentials.json" not in result.repo_tree
+        assert "id_rsa" not in result.repo_tree
+
     def test_keeps_legit_source_with_secret_like_names(self, tmp_path):
         from kamiwaza_extensions.app_analyzer import AppAnalyzer
 

--- a/tests/unit/extensions/test_app_analyzer.py
+++ b/tests/unit/extensions/test_app_analyzer.py
@@ -199,6 +199,19 @@ class TestAnalyze:
         assert ".env" not in result.file_contents
         assert "credentials.json" not in result.file_contents
 
+    def test_keeps_legit_source_with_secret_like_names(self, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AppAnalyzer
+
+        (tmp_path / "secret_manager.py").write_text("def load_secret(): pass\n")
+        (tmp_path / "credential_store.py").write_text("def load_credentials(): pass\n")
+        (tmp_path / "secrets_test.py").write_text("def test_secret(): pass\n")
+
+        result = AppAnalyzer().analyze(tmp_path)
+
+        assert "secret_manager.py" in result.file_contents
+        assert "credential_store.py" in result.file_contents
+        assert "secrets_test.py" in result.file_contents
+
     def test_detects_additional_language_manifests(self, tmp_path):
         from kamiwaza_extensions.app_analyzer import AppAnalyzer
 

--- a/tests/unit/extensions/test_app_analyzer.py
+++ b/tests/unit/extensions/test_app_analyzer.py
@@ -191,12 +191,14 @@ class TestAnalyze:
 
         (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
         (tmp_path / ".env").write_text("API_KEY=secret\n")
+        (tmp_path / ".envrc").write_text("export API_KEY=secret\n")
         (tmp_path / "credentials.json").write_text("{\"token\": \"secret\"}\n")
 
         result = AppAnalyzer().analyze(tmp_path)
 
         assert "index.html" in result.file_contents
         assert ".env" not in result.file_contents
+        assert ".envrc" not in result.file_contents
         assert "credentials.json" not in result.file_contents
 
     def test_excludes_common_secret_bearing_files_from_repo_inventory(self, tmp_path):
@@ -204,6 +206,7 @@ class TestAnalyze:
 
         (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
         (tmp_path / ".env").write_text("API_KEY=secret\n")
+        (tmp_path / ".envrc").write_text("export API_KEY=secret\n")
         (tmp_path / "credentials.json").write_text("{\"token\": \"secret\"}\n")
         (tmp_path / "id_rsa").write_text("private-key\n")
 
@@ -211,6 +214,7 @@ class TestAnalyze:
 
         assert "index.html" in result.repo_tree
         assert ".env" not in result.repo_tree
+        assert ".envrc" not in result.repo_tree
         assert "credentials.json" not in result.repo_tree
         assert "id_rsa" not in result.repo_tree
 

--- a/tests/unit/extensions/test_convert_agent.py
+++ b/tests/unit/extensions/test_convert_agent.py
@@ -301,6 +301,95 @@ class TestRunAgent:
         assert persisted["version"] == "9.9.9"
         assert any("preserving the existing manifest" in item for item in plan.manual_items)
 
+    def test_invalid_existing_kamiwaza_json_can_be_repaired(self, monkeypatch, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AnalysisResult
+        from kamiwaza_extensions.convert_agent import run_agent
+
+        existing = {
+            "name": "demo",
+            "version": "not-semver",
+            "source_type": "user_repo",
+            "visibility": "private",
+            "description": "broken",
+            "risk_tier": 1,
+            "verified": False,
+        }
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(existing) + "\n")
+        (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
+        analysis = AnalysisResult(
+            app_dir=tmp_path,
+            app_name="demo",
+            extension_type="app",
+            conversion_mode="generic",
+            file_contents={"index.html": "<html><body>Hello</body></html>"},
+            candidate_entrypoints=["index.html"],
+            runtime_hints=["static-html"],
+        )
+
+        responses = iter([
+            json.dumps({
+                "extension_type": "app",
+                "conversion_mode": "add_minimal_wrapper",
+                "primary_service": "web",
+                "required_files": ["docker-compose.yml", "CONVERT_NOTES.md", "kamiwaza.json"],
+                "runtime_summary": "Static HTML site served by nginx",
+                "manual_items": [],
+            }),
+            json.dumps({
+                "modifications": [
+                    {
+                        "path": "kamiwaza.json",
+                        "action": "modify",
+                        "content": json.dumps({
+                            "name": "demo",
+                            "version": "0.1.0",
+                            "type": "app",
+                            "source_type": "user_repo",
+                            "visibility": "private",
+                            "description": "repaired manifest",
+                            "risk_tier": 1,
+                            "verified": False,
+                            "kz_ext_version": ">=0.12.0,<1.0.0",
+                        }, indent=4)
+                        + "\n",
+                        "description": "Repair invalid manifest",
+                    },
+                    {
+                        "path": "docker-compose.yml",
+                        "action": "create",
+                        "content": (
+                            "services:\n"
+                            "  web:\n"
+                            "    image: nginxinc/nginx-unprivileged:stable-alpine\n"
+                            "    ports:\n"
+                            "      - \"8080:8080\"\n"
+                            "    deploy:\n"
+                            "      resources:\n"
+                            "        limits:\n"
+                            "          cpus: \"1.0\"\n"
+                            "          memory: \"1G\"\n"
+                        ),
+                        "description": "Use an unprivileged static web runtime",
+                    },
+                ],
+                "manual_items": [],
+                "summary": "Repair existing manifest and add runtime wrapper",
+            }),
+        ])
+
+        monkeypatch.setattr(
+            "kamiwaza_extensions.convert_agent.call_llm",
+            lambda prompt: next(responses, None),
+        )
+
+        plan = run_agent(analysis, dry_run=False)
+
+        assert plan.success is True
+        persisted = json.loads((tmp_path / "kamiwaza.json").read_text())
+        assert persisted["version"] == "0.1.0"
+        assert persisted["description"] == "repaired manifest"
+        assert any("keeping AI-proposed metadata repairs" in item for item in plan.manual_items)
+
     def test_validation_repair_loop_applies_fixed_plan(self, monkeypatch, tmp_path):
         from kamiwaza_extensions.app_analyzer import AnalysisResult
         from kamiwaza_extensions.convert_agent import run_agent

--- a/tests/unit/extensions/test_convert_agent.py
+++ b/tests/unit/extensions/test_convert_agent.py
@@ -204,7 +204,7 @@ class TestApplyPlan:
 
 
 class TestRunAgent:
-    def test_fallback_without_llm(self, monkeypatch):
+    def test_fallback_without_llm_creates_basic_scaffold(self, monkeypatch, tmp_path):
         from kamiwaza_extensions.app_analyzer import AnalysisResult
         from kamiwaza_extensions.convert_agent import run_agent
 
@@ -212,13 +212,94 @@ class TestRunAgent:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
         result = AnalysisResult(
-            app_dir=Path("/tmp/test"),
+            app_dir=tmp_path,
             app_name="test",
         )
         plan = run_agent(result)
-        assert plan.success is False
-        assert "unavailable" in plan.summary.lower()
+        assert plan.success is True
+        assert "basic" in plan.summary.lower()
         assert len(plan.manual_items) > 0
+        assert (tmp_path / "kamiwaza.json").exists()
+        assert (tmp_path / "CONVERT_NOTES.md").exists()
+
+    def test_existing_kamiwaza_json_is_not_overwritten(self, monkeypatch, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AnalysisResult
+        from kamiwaza_extensions.convert_agent import run_agent
+
+        existing = {
+            "name": "custom-name",
+            "version": "9.9.9",
+            "source_type": "user_repo",
+            "visibility": "private",
+            "description": "custom",
+            "risk_tier": 1,
+            "verified": False,
+            "kz_ext_version": ">=0.1.0,<1.0.0",
+        }
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(existing) + "\n")
+        (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
+        analysis = AnalysisResult(
+            app_dir=tmp_path,
+            app_name="demo",
+            extension_type="app",
+            conversion_mode="generic",
+            file_contents={"index.html": "<html><body>Hello</body></html>"},
+            candidate_entrypoints=["index.html"],
+            runtime_hints=["static-html"],
+        )
+
+        responses = iter([
+            json.dumps({
+                "extension_type": "app",
+                "conversion_mode": "add_minimal_wrapper",
+                "primary_service": "web",
+                "required_files": ["docker-compose.yml", "CONVERT_NOTES.md"],
+                "runtime_summary": "Static HTML site served by nginx",
+                "manual_items": [],
+            }),
+            json.dumps({
+                "modifications": [
+                    {
+                        "path": "kamiwaza.json",
+                        "action": "modify",
+                        "content": json.dumps({"name": "llm-name", "version": "0.1.0"}),
+                        "description": "Overwrite manifest",
+                    },
+                    {
+                        "path": "docker-compose.yml",
+                        "action": "create",
+                        "content": (
+                            "services:\n"
+                            "  web:\n"
+                            "    image: nginxinc/nginx-unprivileged:stable-alpine\n"
+                            "    ports:\n"
+                            "      - \"8080:8080\"\n"
+                            "    deploy:\n"
+                            "      resources:\n"
+                            "        limits:\n"
+                            "          cpus: \"1.0\"\n"
+                            "          memory: \"1G\"\n"
+                        ),
+                        "description": "Compose only",
+                    },
+                ],
+                "manual_items": [],
+                "summary": "Attempted overwrite",
+            }),
+        ])
+
+        monkeypatch.setattr(
+            "kamiwaza_extensions.convert_agent.call_llm",
+            lambda prompt: next(responses, None),
+        )
+
+        plan = run_agent(analysis, dry_run=False)
+
+        assert plan.success is True
+        persisted = json.loads((tmp_path / "kamiwaza.json").read_text())
+        assert persisted["name"] == "custom-name"
+        assert persisted["version"] == "9.9.9"
+        assert any("preserving the existing manifest" in item for item in plan.manual_items)
 
     def test_validation_repair_loop_applies_fixed_plan(self, monkeypatch, tmp_path):
         from kamiwaza_extensions.app_analyzer import AnalysisResult

--- a/tests/unit/extensions/test_convert_agent.py
+++ b/tests/unit/extensions/test_convert_agent.py
@@ -1,6 +1,7 @@
 """Unit tests for the convert agent."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -11,7 +12,6 @@ class TestBuildPrompt:
     def test_includes_app_name(self):
         from kamiwaza_extensions.app_analyzer import AnalysisResult, ServiceInfo
         from kamiwaza_extensions.convert_agent import build_prompt
-        from pathlib import Path
 
         result = AnalysisResult(
             app_dir=Path("/tmp/myapp"),
@@ -25,20 +25,20 @@ class TestBuildPrompt:
         assert "python" in prompt
         assert "kamiwaza-extensions-lib" in prompt
 
-    def test_includes_compatibility_issues(self):
+    def test_includes_repo_inventory_hints(self):
         from kamiwaza_extensions.app_analyzer import AnalysisResult
         from kamiwaza_extensions.convert_agent import build_prompt
-        from pathlib import Path
 
         result = AnalysisResult(
             app_dir=Path("/tmp/myapp"),
             app_name="myapp",
-            has_host_ports=["backend: 8000:8000"],
-            missing_resource_limits=["backend"],
+            repo_tree=["index.html", "assets/", "package.json"],
+            candidate_entrypoints=["index.html"],
+            runtime_hints=["static-html", "node-package"],
         )
         prompt = build_prompt(result)
-        assert "8000:8000" in prompt
-        assert "Missing resource limits" in prompt
+        assert "index.html" in prompt
+        assert "static-html" in prompt
 
 
 class TestParseResponse:
@@ -63,6 +63,7 @@ class TestParseResponse:
         assert plan.modifications[0].action == "modify"
         assert len(plan.manual_items) == 1
         assert plan.summary == "Added SDK integration"
+        assert plan.success is True
 
     def test_parse_json_in_code_block(self):
         from kamiwaza_extensions.convert_agent import parse_response
@@ -70,18 +71,20 @@ class TestParseResponse:
         response = '```json\n{"modifications": [], "manual_items": [], "summary": "ok"}\n```'
         plan = parse_response(response)
         assert plan.summary == "ok"
+        assert plan.success is True
 
     def test_parse_invalid_json(self):
         from kamiwaza_extensions.convert_agent import parse_response
 
         plan = parse_response("this is not json")
+        assert plan.success is False
         assert len(plan.manual_items) > 0
         assert "could not be parsed" in plan.summary.lower() or "could not be parsed" in plan.manual_items[0].lower()
 
 
 class TestApplyPlan:
     def test_create_file(self, tmp_path):
-        from kamiwaza_extensions.convert_agent import apply_plan, ConversionPlan, FileModification
+        from kamiwaza_extensions.convert_agent import ConversionPlan, FileModification, apply_plan
 
         plan = ConversionPlan(
             modifications=[
@@ -99,7 +102,7 @@ class TestApplyPlan:
         assert json.loads((tmp_path / "kamiwaza.json").read_text()) == {"name": "test"}
 
     def test_modify_file(self, tmp_path):
-        from kamiwaza_extensions.convert_agent import apply_plan, ConversionPlan, FileModification
+        from kamiwaza_extensions.convert_agent import ConversionPlan, FileModification, apply_plan
 
         (tmp_path / "requirements.txt").write_text("fastapi\n")
         plan = ConversionPlan(
@@ -116,7 +119,7 @@ class TestApplyPlan:
         assert "kamiwaza-extensions-lib" in (tmp_path / "requirements.txt").read_text()
 
     def test_append_to_file(self, tmp_path):
-        from kamiwaza_extensions.convert_agent import apply_plan, ConversionPlan, FileModification
+        from kamiwaza_extensions.convert_agent import ConversionPlan, FileModification, apply_plan
 
         (tmp_path / "main.py").write_text("# existing\n")
         plan = ConversionPlan(
@@ -128,13 +131,13 @@ class TestApplyPlan:
                 )
             ]
         )
-        applied = apply_plan(plan, tmp_path)
+        apply_plan(plan, tmp_path)
         content = (tmp_path / "main.py").read_text()
         assert "existing" in content
         assert "new stuff" in content
 
     def test_dry_run_does_not_write(self, tmp_path):
-        from kamiwaza_extensions.convert_agent import apply_plan, ConversionPlan, FileModification
+        from kamiwaza_extensions.convert_agent import ConversionPlan, FileModification, apply_plan
 
         plan = ConversionPlan(
             modifications=[
@@ -147,7 +150,7 @@ class TestApplyPlan:
         assert not (tmp_path / "new_file.py").exists()
 
     def test_creates_parent_dirs(self, tmp_path):
-        from kamiwaza_extensions.convert_agent import apply_plan, ConversionPlan, FileModification
+        from kamiwaza_extensions.convert_agent import ConversionPlan, FileModification, apply_plan
 
         plan = ConversionPlan(
             modifications=[
@@ -158,7 +161,7 @@ class TestApplyPlan:
         assert (tmp_path / "deep" / "nested" / "file.py").exists()
 
     def test_skips_empty_content(self, tmp_path):
-        from kamiwaza_extensions.convert_agent import apply_plan, ConversionPlan, FileModification
+        from kamiwaza_extensions.convert_agent import ConversionPlan, FileModification, apply_plan
 
         plan = ConversionPlan(
             modifications=[FileModification(path="", action="create", content="")]
@@ -167,8 +170,7 @@ class TestApplyPlan:
         assert len(applied) == 0
 
     def test_rejects_path_traversal(self, tmp_path):
-        """Paths that escape app_dir via '..' must be rejected."""
-        from kamiwaza_extensions.convert_agent import apply_plan, ConversionPlan, FileModification
+        from kamiwaza_extensions.convert_agent import ConversionPlan, FileModification, apply_plan
 
         plan = ConversionPlan(
             modifications=[
@@ -184,8 +186,7 @@ class TestApplyPlan:
         assert not (tmp_path.parent / "etc" / "evil.conf").exists()
 
     def test_rejects_absolute_path(self, tmp_path):
-        """Absolute paths must be rejected."""
-        from kamiwaza_extensions.convert_agent import apply_plan, ConversionPlan, FileModification
+        from kamiwaza_extensions.convert_agent import ConversionPlan, FileModification, apply_plan
 
         plan = ConversionPlan(
             modifications=[
@@ -202,18 +203,167 @@ class TestApplyPlan:
 
 class TestRunAgent:
     def test_fallback_without_llm(self, monkeypatch):
-        """When anthropic is not available, returns fallback plan."""
         from kamiwaza_extensions.app_analyzer import AnalysisResult
         from kamiwaza_extensions.convert_agent import run_agent
-        from pathlib import Path
 
-        # Ensure no API key
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
         result = AnalysisResult(
             app_dir=Path("/tmp/test"),
             app_name="test",
         )
         plan = run_agent(result)
-        assert "unavailable" in plan.summary.lower() or "basic" in plan.summary.lower()
+        assert plan.success is False
+        assert "unavailable" in plan.summary.lower()
         assert len(plan.manual_items) > 0
+
+    def test_validation_repair_loop_applies_fixed_plan(self, monkeypatch, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AnalysisResult
+        from kamiwaza_extensions.convert_agent import run_agent
+
+        (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
+        analysis = AnalysisResult(
+            app_dir=tmp_path,
+            app_name="demo",
+            extension_type="app",
+            conversion_mode="generic",
+            file_contents={"index.html": "<html><body>Hello</body></html>"},
+            candidate_entrypoints=["index.html"],
+            runtime_hints=["static-html"],
+        )
+
+        responses = iter([
+            json.dumps({
+                "extension_type": "app",
+                "conversion_mode": "add_minimal_wrapper",
+                "primary_service": "web",
+                "required_files": ["Dockerfile", "docker-compose.yml", "kamiwaza.json", "CONVERT_NOTES.md"],
+                "runtime_summary": "Static HTML site served by nginx",
+                "manual_items": [],
+            }),
+            json.dumps({
+                "modifications": [
+                    {
+                        "path": "Dockerfile",
+                        "action": "create",
+                        "content": "FROM nginx:alpine\nCOPY index.html /usr/share/nginx/html/index.html\nRUN printf 'ok' > /usr/share/nginx/html/health\nEXPOSE 8080\n",
+                        "description": "Serve the static site",
+                    },
+                    {
+                        "path": "docker-compose.yml",
+                        "action": "create",
+                        "content": (
+                            "services:\n"
+                            "  web:\n"
+                            "    build: .\n"
+                            "    ports:\n"
+                            "      - \"8080:8080\"\n"
+                        ),
+                        "description": "Initial compose without limits to trigger repair",
+                    },
+                ],
+                "manual_items": [],
+                "summary": "Created initial static-site conversion",
+            }),
+            json.dumps({
+                "modifications": [
+                    {
+                        "path": "Dockerfile",
+                        "action": "create",
+                        "content": (
+                            "FROM nginx:alpine\n"
+                            "COPY index.html /usr/share/nginx/html/index.html\n"
+                            "RUN printf 'ok' > /usr/share/nginx/html/health\n"
+                            "RUN sed -i 's/listen       80;/listen       8080;/' /etc/nginx/conf.d/default.conf\n"
+                            "EXPOSE 8080\n"
+                        ),
+                        "description": "Serve the static site on port 8080",
+                    },
+                    {
+                        "path": "docker-compose.yml",
+                        "action": "create",
+                        "content": (
+                            "services:\n"
+                            "  web:\n"
+                            "    build: .\n"
+                            "    ports:\n"
+                            "      - \"8080:8080\"\n"
+                            "    deploy:\n"
+                            "      resources:\n"
+                            "        limits:\n"
+                            "          cpus: \"1.0\"\n"
+                            "          memory: \"1G\"\n"
+                        ),
+                        "description": "Compose with resource limits",
+                    },
+                ],
+                "manual_items": [],
+                "summary": "Created validated static-site conversion",
+            }),
+        ])
+
+        monkeypatch.setattr(
+            "kamiwaza_extensions.convert_agent.call_llm",
+            lambda prompt: next(responses, None),
+        )
+
+        plan = run_agent(analysis, dry_run=False)
+
+        assert plan.success is True
+        assert (tmp_path / "kamiwaza.json").exists()
+        assert (tmp_path / "docker-compose.yml").exists()
+        assert (tmp_path / "Dockerfile").exists()
+        assert (tmp_path / "CONVERT_NOTES.md").exists()
+        assert "limits" in (tmp_path / "docker-compose.yml").read_text()
+
+    def test_failed_validation_returns_errors_without_writing(self, monkeypatch, tmp_path):
+        from kamiwaza_extensions.app_analyzer import AnalysisResult
+        from kamiwaza_extensions.convert_agent import run_agent
+
+        (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
+        analysis = AnalysisResult(
+            app_dir=tmp_path,
+            app_name="demo",
+            extension_type="app",
+            conversion_mode="generic",
+            file_contents={"index.html": "<html><body>Hello</body></html>"},
+        )
+
+        responses = iter([
+            json.dumps({
+                "extension_type": "app",
+                "conversion_mode": "containerize_repo_root",
+                "primary_service": "web",
+                "required_files": ["docker-compose.yml"],
+                "runtime_summary": "Static HTML site",
+                "manual_items": [],
+            }),
+            json.dumps({
+                "modifications": [],
+                "manual_items": [],
+                "summary": "No-op response",
+            }),
+            json.dumps({
+                "modifications": [],
+                "manual_items": [],
+                "summary": "No-op response",
+            }),
+            json.dumps({
+                "modifications": [],
+                "manual_items": [],
+                "summary": "No-op response",
+            }),
+        ])
+
+        monkeypatch.setattr(
+            "kamiwaza_extensions.convert_agent.call_llm",
+            lambda prompt: next(responses, None),
+        )
+
+        plan = run_agent(analysis, dry_run=False)
+
+        assert plan.success is False
+        assert plan.errors
+        assert not (tmp_path / "kamiwaza.json").exists()
+        assert not (tmp_path / "CONVERT_NOTES.md").exists()

--- a/tests/unit/extensions/test_convert_agent.py
+++ b/tests/unit/extensions/test_convert_agent.py
@@ -39,6 +39,8 @@ class TestBuildPrompt:
         prompt = build_prompt(result)
         assert "index.html" in prompt
         assert "static-html" in prompt
+        assert "non-root" in prompt.lower()
+        assert "8080" in prompt
 
 
 class TestParseResponse:
@@ -247,8 +249,13 @@ class TestRunAgent:
                     {
                         "path": "Dockerfile",
                         "action": "create",
-                        "content": "FROM nginx:alpine\nCOPY index.html /usr/share/nginx/html/index.html\nRUN printf 'ok' > /usr/share/nginx/html/health\nEXPOSE 8080\n",
-                        "description": "Serve the static site",
+                        "content": (
+                            "FROM nginx:alpine\n"
+                            "COPY index.html /usr/share/nginx/html/index.html\n"
+                            "RUN printf 'ok' > /usr/share/nginx/html/health\n"
+                            "EXPOSE 80\n"
+                        ),
+                        "description": "Initial rootful nginx wrapper",
                     },
                     {
                         "path": "docker-compose.yml",
@@ -258,9 +265,14 @@ class TestRunAgent:
                             "  web:\n"
                             "    build: .\n"
                             "    ports:\n"
-                            "      - \"8080:8080\"\n"
+                            "      - \"8080:80\"\n"
+                            "    deploy:\n"
+                            "      resources:\n"
+                            "        limits:\n"
+                            "          cpus: \"1.0\"\n"
+                            "          memory: \"1G\"\n"
                         ),
-                        "description": "Initial compose without limits to trigger repair",
+                        "description": "Initial compose that should fail platform validation",
                     },
                 ],
                 "manual_items": [],
@@ -272,13 +284,37 @@ class TestRunAgent:
                         "path": "Dockerfile",
                         "action": "create",
                         "content": (
-                            "FROM nginx:alpine\n"
+                            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
                             "COPY index.html /usr/share/nginx/html/index.html\n"
-                            "RUN printf 'ok' > /usr/share/nginx/html/health\n"
-                            "RUN sed -i 's/listen       80;/listen       8080;/' /etc/nginx/conf.d/default.conf\n"
+                            "COPY nginx.conf /etc/nginx/conf.d/default.conf\n"
                             "EXPOSE 8080\n"
                         ),
-                        "description": "Serve the static site on port 8080",
+                        "description": "Serve the static site with a non-root nginx runtime",
+                    },
+                    {
+                        "path": "nginx.conf",
+                        "action": "create",
+                        "content": (
+                            "server {\n"
+                            "    listen 8080;\n"
+                            "    server_name localhost;\n"
+                            "    root /usr/share/nginx/html;\n"
+                            "    index index.html;\n"
+                            "    location = /health {\n"
+                            "        access_log off;\n"
+                            "        return 200 'ok';\n"
+                            "    }\n"
+                            "    location / {\n"
+                            "        try_files $uri $uri/ /index.html;\n"
+                            "    }\n"
+                            "    client_body_temp_path /tmp/client_temp;\n"
+                            "    proxy_temp_path /tmp/proxy_temp;\n"
+                            "    fastcgi_temp_path /tmp/fastcgi_temp;\n"
+                            "    uwsgi_temp_path /tmp/uwsgi_temp;\n"
+                            "    scgi_temp_path /tmp/scgi_temp;\n"
+                            "}\n"
+                        ),
+                        "description": "Configure nginx for port 8080 and writable temp paths",
                     },
                     {
                         "path": "docker-compose.yml",
@@ -314,8 +350,11 @@ class TestRunAgent:
         assert (tmp_path / "kamiwaza.json").exists()
         assert (tmp_path / "docker-compose.yml").exists()
         assert (tmp_path / "Dockerfile").exists()
+        assert (tmp_path / "nginx.conf").exists()
         assert (tmp_path / "CONVERT_NOTES.md").exists()
         assert "limits" in (tmp_path / "docker-compose.yml").read_text()
+        assert "nginxinc/nginx-unprivileged" in (tmp_path / "Dockerfile").read_text()
+        assert "listen 8080;" in (tmp_path / "nginx.conf").read_text()
 
     def test_failed_validation_returns_errors_without_writing(self, monkeypatch, tmp_path):
         from kamiwaza_extensions.app_analyzer import AnalysisResult

--- a/tests/unit/extensions/test_convert_cmd.py
+++ b/tests/unit/extensions/test_convert_cmd.py
@@ -96,3 +96,15 @@ class TestRunConvert:
         run_convert(path=str(app_dir), dry_run=False)
         # Verify agent was called
         mock_agent.assert_called_once()
+
+    def test_no_llm_fallback_still_creates_manifest(self, monkeypatch, tmp_path):
+        from kamiwaza_extensions.commands.convert import run_convert
+
+        (tmp_path / "index.html").write_text("<html><body>Hello</body></html>")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        run_convert(path=str(tmp_path), dry_run=False)
+
+        assert (tmp_path / "kamiwaza.json").exists()
+        assert (tmp_path / "CONVERT_NOTES.md").exists()

--- a/tests/unit/extensions/test_convert_cmd.py
+++ b/tests/unit/extensions/test_convert_cmd.py
@@ -1,7 +1,6 @@
 """Unit tests for kz-ext convert command."""
 
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -29,7 +28,7 @@ class TestRunConvert:
         return tmp_path
 
     @patch("kamiwaza_extensions.convert_agent.run_agent")
-    def test_happy_path_creates_kamiwaza_json(self, mock_agent, tmp_path):
+    def test_happy_path_calls_agent(self, mock_agent, tmp_path):
         from kamiwaza_extensions.commands.convert import run_convert
         from kamiwaza_extensions.convert_agent import ConversionPlan
 
@@ -38,10 +37,7 @@ class TestRunConvert:
 
         run_convert(path=str(app_dir), dry_run=False)
 
-        assert (app_dir / "kamiwaza.json").exists()
-        data = json.loads((app_dir / "kamiwaza.json").read_text())
-        assert data["version"] == "0.1.0"
-        assert data["source_type"] == "user_repo"
+        mock_agent.assert_called_once()
 
     @patch("kamiwaza_extensions.convert_agent.run_agent")
     def test_dry_run_does_not_create_kamiwaza_json(self, mock_agent, tmp_path):
@@ -56,19 +52,20 @@ class TestRunConvert:
         assert not (app_dir / "kamiwaza.json").exists()
 
     @patch("kamiwaza_extensions.convert_agent.run_agent")
-    def test_existing_kamiwaza_json_not_overwritten(self, mock_agent, tmp_path):
+    def test_failed_conversion_exits_nonzero(self, mock_agent, tmp_path):
+        import typer
         from kamiwaza_extensions.commands.convert import run_convert
         from kamiwaza_extensions.convert_agent import ConversionPlan
 
         app_dir = self._setup_app(tmp_path)
-        existing = {"name": "original", "version": "2.0.0"}
-        (app_dir / "kamiwaza.json").write_text(json.dumps(existing))
-        mock_agent.return_value = ConversionPlan(summary="Done")
+        mock_agent.return_value = ConversionPlan(
+            success=False,
+            summary="Failed",
+            errors=["No docker-compose file found after conversion."],
+        )
 
-        run_convert(path=str(app_dir), dry_run=False)
-
-        data = json.loads((app_dir / "kamiwaza.json").read_text())
-        assert data["version"] == "2.0.0"  # Not overwritten
+        with pytest.raises(typer.Exit):
+            run_convert(path=str(app_dir), dry_run=False)
 
     def test_nonexistent_path_exits(self):
         import typer

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -191,6 +191,25 @@ class TestHealthChecks:
         assert health_check["httpGet"] == {"path": "/health", "port": 8080}
         assert "exec" not in health_check
 
+    def test_frontend_port_3000_without_explicit_hints_uses_node_probe(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "frontend": {
+                    "image": "registry.test/my-app-frontend:1.0.0-dev",
+                    "ports": ["3000"],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "test")
+        frontend = payload.services[0]
+
+        health_check = frontend.model_dump()["healthCheck"]
+        assert frontend.primary is True
+        assert health_check["exec"]["command"][0] == "node"
+
     def test_non_frontend_primary_uses_http_probe(self, builder, metadata, connection):
         transformed = {
             "services": {

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -171,7 +171,7 @@ class TestHealthChecks:
         health_check = frontend.model_dump()["healthCheck"]
         assert health_check["exec"]["command"][0] == "node"
 
-    def test_generic_frontend_without_node_hints_uses_http_probe(
+    def test_generic_frontend_without_node_hints_uses_root_http_probe(
         self, builder, metadata, connection
     ):
         transformed = {
@@ -188,7 +188,7 @@ class TestHealthChecks:
 
         health_check = frontend.model_dump()["healthCheck"]
         assert frontend.primary is True
-        assert health_check["httpGet"] == {"path": "/health", "port": 8080}
+        assert health_check["httpGet"] == {"path": "/", "port": 8080}
         assert "exec" not in health_check
 
     def test_frontend_port_3000_without_explicit_hints_uses_node_probe(

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -171,6 +171,26 @@ class TestHealthChecks:
         health_check = frontend.model_dump()["healthCheck"]
         assert health_check["exec"]["command"][0] == "node"
 
+    def test_generic_frontend_without_node_hints_uses_http_probe(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "frontend": {
+                    "image": "registry.test/my-app-frontend:1.0.0-dev",
+                    "ports": ["8080"],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "test")
+        frontend = payload.services[0]
+
+        health_check = frontend.model_dump()["healthCheck"]
+        assert frontend.primary is True
+        assert health_check["httpGet"] == {"path": "/health", "port": 8080}
+        assert "exec" not in health_check
+
     def test_non_frontend_primary_uses_http_probe(self, builder, metadata, connection):
         transformed = {
             "services": {

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -548,6 +548,26 @@ class TestGenerateBuildOverrides:
         overrides = generate_build_overrides(spec, compose, extension_dir=ext_dir)
         assert overrides == []
 
+    def test_static_nginx_service_skips_sdk_override_with_platform_from(self, tmp_path):
+        ext_dir = tmp_path / "ext"
+        ext_dir.mkdir()
+        web = ext_dir / "web"
+        web.mkdir()
+        (web / "Dockerfile").write_text(
+            "FROM --platform=linux/amd64 nginx:alpine\n"
+            "COPY index.html /usr/share/nginx/html/index.html\n"
+        )
+
+        spec = self._make_spec(tmp_path)
+        compose = {
+            "services": {
+                "mihari-demo": {"build": {"context": "./web"}, "ports": ["8080:80"]},
+            }
+        }
+
+        overrides = generate_build_overrides(spec, compose, extension_dir=ext_dir)
+        assert overrides == []
+
 
 # ------------------------------------------------------------------
 # apply_build_overlay

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -432,6 +432,25 @@ class TestGenerateComposeOverride:
         override = generate_compose_override(spec, {"services": {}})
         assert override == {"services": {}}
 
+    def test_static_nginx_service_gets_no_override(self, tmp_path):
+        ext_dir = tmp_path / "ext"
+        ext_dir.mkdir()
+        web = ext_dir / "web"
+        web.mkdir()
+        (web / "Dockerfile").write_text(
+            "FROM nginx:alpine\nCOPY index.html /usr/share/nginx/html/index.html\n"
+        )
+
+        spec = self._make_spec(tmp_path)
+        compose = {
+            "services": {
+                "mihari-demo": {"build": {"context": "./web"}, "ports": ["8080:80"]},
+            }
+        }
+
+        override = generate_compose_override(spec, compose, extension_dir=ext_dir)
+        assert override == {"services": {}}
+
 
 # ------------------------------------------------------------------
 # generate_build_overrides (remote deploy)
@@ -509,6 +528,25 @@ class TestGenerateBuildOverrides:
         compose = {"services": {"backend": {"build": ".", "ports": ["8000:8000"]}}}
         overrides = generate_build_overrides(spec, compose)
         assert overrides[0].insert_before_build is False
+
+    def test_static_nginx_service_skips_sdk_override(self, tmp_path):
+        ext_dir = tmp_path / "ext"
+        ext_dir.mkdir()
+        web = ext_dir / "web"
+        web.mkdir()
+        (web / "Dockerfile").write_text(
+            "FROM nginx:alpine\nCOPY index.html /usr/share/nginx/html/index.html\n"
+        )
+
+        spec = self._make_spec(tmp_path)
+        compose = {
+            "services": {
+                "mihari-demo": {"build": {"context": "./web"}, "ports": ["8080:80"]},
+            }
+        }
+
+        overrides = generate_build_overrides(spec, compose, extension_dir=ext_dir)
+        assert overrides == []
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -568,6 +568,27 @@ class TestGenerateBuildOverrides:
         overrides = generate_build_overrides(spec, compose, extension_dir=ext_dir)
         assert overrides == []
 
+    def test_static_nginx_service_skips_sdk_override_with_final_alias(self, tmp_path):
+        ext_dir = tmp_path / "ext"
+        ext_dir.mkdir()
+        web = ext_dir / "web"
+        web.mkdir()
+        (web / "Dockerfile").write_text(
+            "FROM nginx:alpine AS runtime\n"
+            "FROM runtime\n"
+            "COPY index.html /usr/share/nginx/html/index.html\n"
+        )
+
+        spec = self._make_spec(tmp_path)
+        compose = {
+            "services": {
+                "web": {"build": {"context": "./web"}, "ports": ["8080:80"]},
+            }
+        }
+
+        overrides = generate_build_overrides(spec, compose, extension_dir=ext_dir)
+        assert overrides == []
+
 
 # ------------------------------------------------------------------
 # apply_build_overlay

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -589,6 +589,36 @@ class TestGenerateBuildOverrides:
         overrides = generate_build_overrides(spec, compose, extension_dir=ext_dir)
         assert overrides == []
 
+    def test_multistage_node_to_nginx_frontend_gets_build_override(self, tmp_path):
+        ext_dir = tmp_path / "ext"
+        ext_dir.mkdir()
+        web = ext_dir / "web"
+        web.mkdir()
+        (web / "Dockerfile").write_text(
+            "FROM node:20 AS build\n"
+            "WORKDIR /app\n"
+            "COPY package.json package-lock.json ./\n"
+            "RUN npm ci\n"
+            "COPY . .\n"
+            "RUN npm run build\n"
+            "FROM nginx:alpine\n"
+            "COPY --from=build /app/dist /usr/share/nginx/html\n"
+        )
+
+        spec = self._make_spec(tmp_path, python=False)
+        compose = {
+            "services": {
+                "frontend": {"build": {"context": "./web"}, "ports": ["8080:80"]},
+            }
+        }
+
+        overrides = generate_build_overrides(spec, compose, extension_dir=ext_dir)
+
+        assert len(overrides) == 1
+        assert overrides[0].service_name == "frontend"
+        assert "npm pack" in overrides[0].overlay_steps
+        assert overrides[0].insert_before_build is True
+
 
 # ------------------------------------------------------------------
 # apply_build_overlay

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -63,7 +63,7 @@ class TestRunValidate:
         compose = {
             "services": {
                 "web": {
-                    "image": "nginx:alpine",
+                    "image": "nginxinc/nginx-unprivileged:stable-alpine",
                     "ports": ["8080:8080"],
                     "deploy": {"resources": {"limits": {"cpus": "1.0", "memory": "1G"}}},
                 },
@@ -78,6 +78,30 @@ class TestRunValidate:
         assert output["passed"] is True
         assert output["errors"] == []
         assert output["warnings"]
+
+    def test_validate_fails_on_image_only_rootful_nginx_runtime(self, tmp_path, capsys):
+        import typer
+
+        from kamiwaza_extensions.commands.validate import run_validate
+
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx:alpine",
+                    "ports": ["8080:8080"],
+                    "deploy": {"resources": {"limits": {"cpus": "1.0", "memory": "1G"}}},
+                },
+            },
+        }
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(_valid_metadata()))
+        (tmp_path / "docker-compose.yml").write_text(yaml.dump(compose))
+
+        with pytest.raises(typer.Exit):
+            run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["passed"] is False
+        assert any("image-only nginx service" in err for err in output["errors"])
 
     def test_validate_fails_on_platform_incompatible_runtime(self, tmp_path, capsys):
         import typer

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -1,56 +1,95 @@
-"""Tests for the validate CLI command."""
+"""Unit tests for kz-ext validate command."""
 
 import json
 
 import pytest
-from typer.testing import CliRunner
+import yaml
 
-from kamiwaza_extensions.cli import app
-
-runner = CliRunner()
+pytestmark = pytest.mark.unit
 
 
-def _valid_metadata():
+def _valid_metadata() -> dict:
     return {
-        "name": "my-app",
-        "version": "1.0.0",
+        "name": "demo-app",
+        "version": "0.1.0",
         "source_type": "kamiwaza",
-        "visibility": "public",
-        "description": "A test extension",
-        "risk_tier": 0,
+        "visibility": "private",
+        "description": "A demo extension",
+        "risk_tier": 1,
         "verified": False,
     }
 
 
-@pytest.mark.unit
-class TestValidateCommand:
-    def test_validate_passes_with_valid_metadata(self, tmp_path):
-        (tmp_path / "kamiwaza.json").write_text(json.dumps(_valid_metadata()))
-        result = runner.invoke(app, ["validate", str(tmp_path)])
-        assert result.exit_code == 0
-        assert "passed" in result.output.lower()
+def _write_extension_files(tmp_path, compose, dockerfile_text, extra_files=None):
+    (tmp_path / "kamiwaza.json").write_text(json.dumps(_valid_metadata()))
+    (tmp_path / "docker-compose.yml").write_text(yaml.dump(compose))
+    (tmp_path / "Dockerfile").write_text(dockerfile_text)
+    for rel_path, content in (extra_files or {}).items():
+        path = tmp_path / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
 
-    def test_validate_fails_with_invalid_metadata(self, tmp_path):
-        (tmp_path / "kamiwaza.json").write_text(json.dumps({"name": "x"}))
-        result = runner.invoke(app, ["validate", str(tmp_path)])
-        assert result.exit_code == 1
 
-    def test_validate_no_kamiwaza_json(self, tmp_path):
-        result = runner.invoke(app, ["validate", str(tmp_path)])
-        assert result.exit_code == 1
-        assert "No kamiwaza.json" in result.output
+class TestRunValidate:
+    def test_validate_fails_on_platform_incompatible_runtime(self, tmp_path, capsys):
+        import typer
 
-    def test_validate_json_output(self, tmp_path):
-        (tmp_path / "kamiwaza.json").write_text(json.dumps(_valid_metadata()))
-        result = runner.invoke(app, ["validate", str(tmp_path), "--json"])
-        assert result.exit_code == 0
-        data = json.loads(result.output)
-        assert data["passed"] is True
-        assert data["errors"] == []
+        from kamiwaza_extensions.commands.validate import run_validate
 
-    def test_validate_exit_code_0_with_warnings(self, tmp_path):
-        meta = _valid_metadata()
-        meta["preview_image"] = "wrong/path.png"
-        (tmp_path / "kamiwaza.json").write_text(json.dumps(meta))
-        result = runner.invoke(app, ["validate", str(tmp_path)])
-        assert result.exit_code == 0  # warnings don't fail
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:80"],
+                    "deploy": {"resources": {"limits": {"cpus": "1.0", "memory": "1G"}}},
+                },
+            },
+        }
+        _write_extension_files(
+            tmp_path,
+            compose,
+            "FROM nginx:alpine\nCOPY index.html /usr/share/nginx/html/index.html\nEXPOSE 80\n",
+        )
+
+        with pytest.raises(typer.Exit):
+            run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["passed"] is False
+        assert any("container port 80 is privileged" in err for err in output["errors"])
+
+    def test_validate_passes_for_unprivileged_static_runtime(self, tmp_path, capsys):
+        from kamiwaza_extensions.commands.validate import run_validate
+
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                    "deploy": {"resources": {"limits": {"cpus": "1.0", "memory": "1G"}}},
+                },
+            },
+        }
+        _write_extension_files(
+            tmp_path,
+            compose,
+            (
+                "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+                "COPY nginx.conf /etc/nginx/conf.d/default.conf\n"
+                "EXPOSE 8080\n"
+            ),
+            extra_files={
+                "nginx.conf": (
+                    "server {\n"
+                    "    listen 8080;\n"
+                    "    client_body_temp_path /tmp/client_temp;\n"
+                    "}\n"
+                )
+            },
+        )
+
+        run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["passed"] is True
+        assert output["errors"] == []

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -31,6 +31,54 @@ def _write_extension_files(tmp_path, compose, dockerfile_text, extra_files=None)
 
 
 class TestRunValidate:
+    def test_missing_manifest_exits_with_json_error(self, tmp_path, capsys):
+        import typer
+
+        from kamiwaza_extensions.commands.validate import run_validate
+
+        with pytest.raises(typer.Exit):
+            run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["passed"] is False
+        assert any("No kamiwaza.json found" in err for err in output["errors"])
+
+    def test_invalid_manifest_emits_failed_json(self, tmp_path, capsys):
+        import typer
+
+        from kamiwaza_extensions.commands.validate import run_validate
+
+        (tmp_path / "kamiwaza.json").write_text("{bad json")
+
+        with pytest.raises(typer.Exit):
+            run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["passed"] is False
+        assert output["errors"]
+
+    def test_warnings_only_do_not_fail_validation(self, tmp_path, capsys):
+        from kamiwaza_extensions.commands.validate import run_validate
+
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx:alpine",
+                    "ports": ["8080:8080"],
+                    "deploy": {"resources": {"limits": {"cpus": "1.0", "memory": "1G"}}},
+                },
+            },
+        }
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(_valid_metadata()))
+        (tmp_path / "docker-compose.yml").write_text(yaml.dump(compose))
+
+        run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["passed"] is True
+        assert output["errors"] == []
+        assert output["warnings"]
+
     def test_validate_fails_on_platform_incompatible_runtime(self, tmp_path, capsys):
         import typer
 

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -418,6 +418,74 @@ class TestPlatformRuntimeValidator:
         assert result.passed
         assert result.errors == []
 
+    def test_uses_copied_nginx_config_source_not_filename_heuristic(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+            "COPY site.conf /etc/nginx/conf.d/default.conf\n"
+            "EXPOSE 8080\n"
+        )
+        (tmp_path / "site.conf").write_text(
+            "server {\n"
+            "    listen 80;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        (tmp_path / "nginx-preview.conf").write_text(
+            "server {\n"
+            "    listen 8080;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert not result.passed
+        assert any("privileged port 80" in err for err in result.errors)
+
+    def test_ignores_unrelated_nginx_named_config_files(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+            "COPY site.conf /etc/nginx/conf.d/default.conf\n"
+            "EXPOSE 8080\n"
+        )
+        (tmp_path / "site.conf").write_text(
+            "server {\n"
+            "    listen 8080;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        (tmp_path / "nginx-preview.conf").write_text(
+            "server {\n"
+            "    listen 80;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert result.passed
+        assert result.errors == []
+
     def test_rejects_build_path_that_escapes_extension_dir(self, tmp_path, validator):
         compose = {
             "services": {
@@ -465,6 +533,38 @@ class TestPlatformRuntimeValidator:
 
         assert result.passed
         assert not any("privileged port 127" in err for err in result.errors)
+
+    def test_ignores_heredoc_body_when_parsing_dockerfile(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+            "RUN cat <<'EOF' >/tmp/banner\n"
+            "FROM python:3.11\n"
+            "USER root\n"
+            "EOF\n"
+            "COPY nginx.conf /etc/nginx/conf.d/default.conf\n"
+            "EXPOSE 8080\n"
+        )
+        (tmp_path / "nginx.conf").write_text(
+            "server {\n"
+            "    listen 8080;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert result.passed
+        assert result.errors == []
 
     def test_allows_wildcard_bound_nginx_listen_port(self, tmp_path, validator):
         compose = {

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -401,3 +401,85 @@ class TestPlatformRuntimeValidator:
 
         assert result.passed
         assert any("escapes the extension directory" in warning for warning in result.warnings)
+
+    def test_allows_ipv4_bound_nginx_listen_port(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+            "COPY nginx.conf /etc/nginx/conf.d/default.conf\n"
+            "EXPOSE 8080\n"
+        )
+        (tmp_path / "nginx.conf").write_text(
+            "server {\n"
+            "    listen 127.0.0.1:8080;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert result.passed
+        assert not any("privileged port 127" in err for err in result.errors)
+
+    def test_allows_wildcard_bound_nginx_listen_port(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+            "COPY nginx.conf /etc/nginx/conf.d/default.conf\n"
+            "EXPOSE 8080\n"
+        )
+        (tmp_path / "nginx.conf").write_text(
+            "server {\n"
+            "    listen *:8080;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert result.passed
+
+    def test_allows_localhost_bound_nginx_listen_port(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+            "COPY nginx.conf /etc/nginx/conf.d/default.conf\n"
+            "EXPOSE 8080\n"
+        )
+        (tmp_path / "nginx.conf").write_text(
+            "server {\n"
+            "    listen localhost:8080;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert result.passed

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -6,6 +6,7 @@ import pytest
 
 from kamiwaza_extensions.validators.metadata import MetadataValidator
 from kamiwaza_extensions.validators.compose import ComposeValidator
+from kamiwaza_extensions.validators.platform_runtime import PlatformRuntimeValidator
 
 
 def _valid_metadata() -> dict:
@@ -238,3 +239,84 @@ class TestComposeValidator:
         result = validator.validate(f, tmp_path)
         # yaml.safe_load might not error on all bad yaml; check it doesn't crash
         assert isinstance(result, ComposeValidator.__init__.__class__) or True
+
+
+@pytest.mark.unit
+class TestPlatformRuntimeValidator:
+    @pytest.fixture
+    def validator(self):
+        return PlatformRuntimeValidator()
+
+    def _write_compose(self, path, data):
+        import yaml
+
+        path.write_text(yaml.dump(data))
+
+    def test_flags_privileged_port_and_rootful_nginx(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:80"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginx:alpine\nCOPY index.html /usr/share/nginx/html/index.html\nEXPOSE 80\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert not result.passed
+        assert any("container port 80 is privileged" in err for err in result.errors)
+        assert any("does not switch to a non-root user" in err for err in result.errors)
+
+    def test_flags_nginx_without_tmp_runtime_paths(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginx:alpine\nUSER 1001\nCOPY index.html /usr/share/nginx/html/index.html\nEXPOSE 8080\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert not result.passed
+        assert any("/tmp paths" in err for err in result.errors)
+
+    def test_allows_unprivileged_nginx_with_tmp_runtime_paths(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+            "COPY nginx.conf /etc/nginx/conf.d/default.conf\n"
+            "EXPOSE 8080\n"
+        )
+        (tmp_path / "nginx.conf").write_text(
+            "server {\n"
+            "    listen 8080;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert result.passed
+        assert result.errors == []

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -293,6 +293,42 @@ class TestPlatformRuntimeValidator:
         assert not result.passed
         assert any("/tmp paths" in err for err in result.errors)
 
+    def test_flags_image_only_rootful_nginx_service(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx:alpine",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert not result.passed
+        assert any("image-only nginx service" in err for err in result.errors)
+        assert any("could not be inspected" in warning for warning in result.warnings)
+
+    def test_warns_for_image_only_unprivileged_nginx_service(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginxinc/nginx-unprivileged:stable-alpine",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert result.passed
+        assert result.errors == []
+        assert any("could not be inspected" in warning for warning in result.warnings)
+
     def test_allows_unprivileged_nginx_with_tmp_runtime_paths(self, tmp_path, validator):
         compose = {
             "services": {

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -320,3 +320,84 @@ class TestPlatformRuntimeValidator:
 
         assert result.passed
         assert result.errors == []
+
+    def test_flags_unprivileged_nginx_when_final_user_is_root(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "Dockerfile").write_text(
+            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+            "USER root\n"
+            "COPY nginx.conf /etc/nginx/conf.d/default.conf\n"
+            "EXPOSE 8080\n"
+        )
+        (tmp_path / "nginx.conf").write_text(
+            "server {\n"
+            "    listen 8080;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert not result.passed
+        assert any("does not switch to a non-root user" in err for err in result.errors)
+
+    def test_uses_compose_build_context_for_nginx_config_lookup(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": {
+                        "context": ".",
+                        "dockerfile": "docker/Dockerfile",
+                    },
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        (tmp_path / "docker").mkdir()
+        (tmp_path / "docker" / "Dockerfile").write_text(
+            "FROM nginxinc/nginx-unprivileged:stable-alpine\n"
+            "COPY nginx.conf /etc/nginx/conf.d/default.conf\n"
+            "EXPOSE 8080\n"
+        )
+        (tmp_path / "nginx.conf").write_text(
+            "server {\n"
+            "    listen 8080;\n"
+            "    client_body_temp_path /tmp/client_temp;\n"
+            "}\n"
+        )
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert result.passed
+        assert result.errors == []
+
+    def test_rejects_build_path_that_escapes_extension_dir(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "build": {
+                        "context": "..",
+                        "dockerfile": "Dockerfile",
+                    },
+                    "ports": ["8080:8080"],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+
+        result = validator.validate(f, tmp_path)
+
+        assert result.passed
+        assert any("escapes the extension directory" in warning for warning in result.warnings)


### PR DESCRIPTION
## Summary
- extend `kz-ext convert` with a generic AI fallback for arbitrary apps, including html-only repos
- skip Python SDK override injection for static runtime services during `kz-ext dev --sdk-repo`
- harden convert and `kz-ext validate` with platform runtime checks for non-root containers, unprivileged ports, and read-only-root-filesystem-friendly web wrappers

## Testing
- `uv run pytest tests/unit/extensions/test_validators.py tests/unit/extensions/test_validate_cmd.py tests/unit/extensions/test_convert_agent.py`
- `uv run pytest tests/unit/extensions/test_convert_cmd.py tests/unit/extensions/test_e2e_flows.py`
- `uv run ruff check kamiwaza_extensions/validators/platform_runtime.py kamiwaza_extensions/convert_agent.py kamiwaza_extensions/commands/validate.py tests/unit/extensions/test_validators.py tests/unit/extensions/test_validate_cmd.py tests/unit/extensions/test_convert_agent.py`
