### PR TITLE
fix(integration): retry live_server_available ping before skipping

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -946,16 +946,39 @@ def _resolve_live_password_once(
 
 @pytest.fixture(scope="session")
 def live_server_available(live_base_url: str) -> str:
-    """Ensure a running Kamiwaza server is reachable before running live tests."""
+    """Ensure a running Kamiwaza server is reachable before running live tests.
+
+    Retries a few times before skipping: a ``pytest.skip`` raised from a
+    session-scoped fixture is cached for every dependent test, so a single
+    slow request against a cold platform can cascade into a whole-suite skip.
+    """
 
     health_url = f"{live_base_url}/ping"
     os.environ.setdefault("KAMIWAZA_VERIFY_SSL", "false")
     if not _verify_ssl_enabled():
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    try:
-        response = requests.get(health_url, timeout=5, verify=_verify_ssl_enabled())
-    except requests.RequestException as exc:  # pragma: no cover - network guard
-        pytest.skip(f"Kamiwaza server unavailable at {live_base_url}: {exc}")
+
+    attempts = 3
+    per_attempt_timeout = 10
+    backoff_seconds = 2
+    last_exc: Exception | None = None
+    response: requests.Response | None = None
+    for attempt in range(attempts):
+        try:
+            response = requests.get(
+                health_url,
+                timeout=per_attempt_timeout,
+                verify=_verify_ssl_enabled(),
+            )
+            break
+        except requests.RequestException as exc:  # pragma: no cover - network guard
+            last_exc = exc
+            if attempt < attempts - 1:
+                time.sleep(backoff_seconds)
+    if response is None:
+        pytest.skip(
+            f"Kamiwaza server unavailable at {live_base_url} after {attempts} attempts: {last_exc}"
+        )
     if response.status_code >= 500:
         pytest.skip(
             f"Kamiwaza server unhealthy at {health_url}: {response.status_code}"


### PR DESCRIPTION
## Summary

A `pytest.skip` raised inside a session-scoped fixture is cached for every dependent test. `live_server_available` used a single 5-second `/ping` request; one slow response against a cold platform cascaded into a whole-suite skip.

**Observed today** on a freshly reinstalled local platform: 171/172 tests skipped. Every per-test `<skipped>` node in the junit XML carried the same transient message:

> `Kamiwaza server unavailable at https://yod.local/api: HTTPSConnectionPool(host='yod.local', port=443): Read timed out. (read timeout=5)`

A subsequent isolated run of the same first test passed cleanly in 3.8s — the platform was reachable; just one `/ping` got unlucky.

## Change

`tests/integration/conftest.py` — `live_server_available`:
- Retry up to 3 attempts with a 10s per-attempt timeout and 2s backoff before calling `pytest.skip`.
- Skip behaviour on a genuinely unreachable server is unchanged; the final attempt's exception is still surfaced (with an attempt count for clarity).
- `time` is already imported; no new deps.

## Test plan

- [x] `ast.parse` of patched conftest.py succeeds.
- [x] `pytest tests/integration/test_00_current_user.py -v` → 1/1 passed (server reachable; fixture returns cleanly on first attempt).
- [ ] Full live suite rerun on the same local platform — expecting the 172-test run to no longer mass-skip. Happy to paste results into this PR once the rerun completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)