### PR TITLE
feat(extensions): UAC-9d runtime-lib exception surface + CLI plumbing (ENG-3885)

### DIFF
--- a/docs/services/extensions/failure-classes.md
+++ b/docs/services/extensions/failure-classes.md
@@ -71,16 +71,16 @@ doesn't match the extension's expected runtime context.
 
 **Typical causes:**
 
-- Running a local-dev envelope against a production-signed extension (rare;
-extensions no longer verify HMAC as of 2026-04-23, but shape mismatches
-still apply).
+- Running a local-dev envelope against a production-deployed extension.
+  Note: extensions are pass-through consumers of the envelope — they do
+  not verify the HMAC signature (see design §4.2.7 for rationale), but
+  shape mismatches still apply.
 - Envelope fields present but all empty — platform misconfiguration.
 
 **Fix:**
 
-1. Compare `request.headers` against the list in
-  `kamiwaza-sdk/docs/extensions/non-sdk-flow.md` (when available) or
-   `kamiwaza_extensions_lib/identity.py`.
+1. Compare `request.headers` against the header list in
+   `kamiwaza_extensions_lib/identity.py` (``_HEADER_USER_ID``, etc.).
 2. Check that `X-User-Id` and `X-Workroom-Id` are non-empty strings, not
   placeholder tokens.
 3. Verify the deployment environment — a PR preview env often has different
@@ -106,13 +106,15 @@ workroom viewer.
    membership.
 2. The platform enforces workroom membership at data-access time; the
   extension should surface a friendly error, not try to work around it.
-3. Code example:
+3. When the runtime lib raises ``OutOfEnvelopeAccessError`` directly, catch
+   it at the top of your request handler:
 
 ```python
 from kamiwaza_extensions_lib.errors import OutOfEnvelopeAccessError
 
 try:
-    result = client.workrooms.get_resource(identity.workroom_id, resource_id)
+    # ...call a runtime-lib helper that enforces envelope scope...
+    pass
 except OutOfEnvelopeAccessError:
     return JSONResponse(
         {"error": {"class": "out_of_envelope_access",
@@ -120,6 +122,13 @@ except OutOfEnvelopeAccessError:
         status_code=403,
     )
 ```
+
+As of this writing the runtime lib does not automatically translate
+platform HTTP 403s into ``OutOfEnvelopeAccessError``. If you call the
+SDK directly (`client.workrooms.*`, `client.models.*`, etc.), treat a
+403 response as an out-of-envelope condition and return the same 403
+JSON shape shown above. A future mapper is tracked under the runtime-lib
+backlog.
 
 ## `platform_outage` — exit 13
 

--- a/docs/services/extensions/failure-classes.md
+++ b/docs/services/extensions/failure-classes.md
@@ -1,4 +1,4 @@
-# UAC-9d Failure Classes — Runbook
+# Extension Failure Classes — Runbook
 
 When an extension cannot serve a request, the runtime libs raise one of four
 canonical exception classes. Each class has a stable name, a CLI exit code,
@@ -7,18 +7,20 @@ its typical causes, and how to fix it.
 
 ## At a glance
 
-| Class name | Python / TS exception | CLI exit code | `kz-ext doctor` hint |
-|------------|----------------------|---------------|----------------------|
-| `misbound_auth` | `MisboundAuthError` | 10 | Required envelope header missing or malformed |
-| `unexpected_context` | `UnexpectedContextError` | 11 | Envelope shape wrong for this context |
-| `out_of_envelope_access` | `OutOfEnvelopeAccessError` | 12 | Cross-workroom / out-of-scope access attempt |
-| `platform_outage` | `PlatformOutageError` | 13 | Platform API unreachable or returning 5xx |
+
+| Class name               | Python / TS exception      | CLI exit code | `kz-ext doctor` hint                          |
+| ------------------------ | -------------------------- | ------------- | --------------------------------------------- |
+| `misbound_auth`          | `MisboundAuthError`        | 10            | Required envelope header missing or malformed |
+| `unexpected_context`     | `UnexpectedContextError`   | 11            | Envelope shape wrong for this context         |
+| `out_of_envelope_access` | `OutOfEnvelopeAccessError` | 12            | Cross-workroom / out-of-scope access attempt  |
+| `platform_outage`        | `PlatformOutageError`      | 13            | Platform API unreachable or returning 5xx     |
+
 
 The `class_name` strings are canonical — they appear in:
 
 - The JSON body returned by non-SDK extensions (under `{"error": {"class": ...}}`).
 - `kamiwaza_extensions_lib/exception_names.json` (single source of truth).
-- `kz-ext doctor` output (as `UAC-9d: <class_name>` reference entries).
+- `kz-ext doctor` output (as `Failure class: <class_name>` reference entries).
 
 ## `misbound_auth` — exit 10
 
@@ -28,18 +30,18 @@ is missing or empty at the time the runtime lib tried to parse the request.
 **Typical causes:**
 
 - The request reached the extension pod *without* passing through Traefik
-  (e.g., direct in-cluster call, port-forward, or misconfigured ingress).
+(e.g., direct in-cluster call, port-forward, or misconfigured ingress).
 - The platform ForwardAuth layer is not injecting the envelope correctly
-  (transient platform outage or misconfiguration).
+(transient platform outage or misconfiguration).
 - Local development with `KAMIWAZA_USE_AUTH=true` but no platform to populate
-  the envelope — expected failure mode.
+the envelope — expected failure mode.
 
 **Fix:**
 
 1. Confirm the request is reaching the extension *through* Traefik. Check
-   ingress rules and the request URL.
+  ingress rules and the request URL.
 2. Run `kz-ext doctor` — a failed `Kamiwaza connection` check often precedes
-   `misbound_auth`.
+  `misbound_auth`.
 3. For local dev, set `KAMIWAZA_USE_AUTH=false` and restart the extension.
 
 **Code example:**
@@ -70,19 +72,19 @@ doesn't match the extension's expected runtime context.
 **Typical causes:**
 
 - Running a local-dev envelope against a production-signed extension (rare;
-  extensions no longer verify HMAC as of 2026-04-23, but shape mismatches
-  still apply).
+extensions no longer verify HMAC as of 2026-04-23, but shape mismatches
+still apply).
 - Envelope fields present but all empty — platform misconfiguration.
 
 **Fix:**
 
 1. Compare `request.headers` against the list in
-   `kamiwaza-sdk/docs/extensions/non-sdk-flow.md` (when available) or
+  `kamiwaza-sdk/docs/extensions/non-sdk-flow.md` (when available) or
    `kamiwaza_extensions_lib/identity.py`.
 2. Check that `X-User-Id` and `X-Workroom-Id` are non-empty strings, not
-   placeholder tokens.
+  placeholder tokens.
 3. Verify the deployment environment — a PR preview env often has different
-   envelope provenance than staging or prod.
+  envelope provenance than staging or prod.
 
 ## `out_of_envelope_access` — exit 12
 
@@ -92,18 +94,18 @@ does not cover — typically a cross-workroom access attempt.
 **Typical causes:**
 
 - The extension is resolving a workroom ID from user input and calling the
-  platform, but the caller does not have membership in that workroom.
+platform, but the caller does not have membership in that workroom.
 - A stale token referencing a deleted workroom.
 - Extension logic that assumes admin-like access when the caller is a
-  workroom viewer.
+workroom viewer.
 
 **Fix:**
 
 1. Always thread the request's `Identity.workroom_id` through platform API
-   calls — don't substitute a workroom ID from user input without re-checking
+  calls — don't substitute a workroom ID from user input without re-checking
    membership.
 2. The platform enforces workroom membership at data-access time; the
-   extension should surface a friendly error, not try to work around it.
+  extension should surface a friendly error, not try to work around it.
 3. Code example:
 
 ```python
@@ -127,25 +129,25 @@ except OutOfEnvelopeAccessError:
 
 - Platform is down or degraded (check Kamiwaza status).
 - Network partition between the extension and the platform — especially in
-  split-cluster deployments.
+split-cluster deployments.
 - Upstream model-access boundary is failing (5xx propagation).
 
 **Fix:**
 
 1. Run `kz-ext doctor` — the `Kamiwaza connection` check will fail in the
-   same direction.
+  same direction.
 2. Check the platform status page / oncall channels.
 3. For transient failures, the runtime lib's `TokenRefreshMiddleware` already
-   retries once on 401 mid-stream. A double failure surfaces as
+  retries once on 401 mid-stream. A double failure surfaces as
    `PlatformOutageError`.
 4. Do **not** catch and swallow — let it bubble to the top-level error
-   handler so the exit code is preserved.
+  handler so the exit code is preserved.
 
 ## How the exit codes flow
 
 1. The runtime lib raises a `KamiwazaRuntimeError` subclass.
 2. If the exception bubbles into a `kz-ext` subcommand, the CLI's top-level
-   `_handle_exception` catches it and calls `exit_code_for(exc.class_name)`.
+  `_handle_exception` catches it and calls `exit_code_for(exc.class_name)`.
 3. The process exits with the canonical code from `exception_names.json`.
 
 CI and operators can key off the exit code alone:
@@ -180,3 +182,4 @@ drifts from either the `ExitCode` enum or the `kz-ext doctor` output.
 - `§4.2.8 DoctorUACFailureHints + ExitCodeMap`
 - `§5 Q6 Security implications and auth interactions`
 - Linear: [ENG-3885](https://linear.app/kamiwaza/issue/ENG-3885)
+

--- a/docs/services/extensions/uac-9d-failure-classes.md
+++ b/docs/services/extensions/uac-9d-failure-classes.md
@@ -1,0 +1,182 @@
+# UAC-9d Failure Classes — Runbook
+
+When an extension cannot serve a request, the runtime libs raise one of four
+canonical exception classes. Each class has a stable name, a CLI exit code,
+and a fix hint surfaced by `kz-ext doctor`. This runbook explains each class,
+its typical causes, and how to fix it.
+
+## At a glance
+
+| Class name | Python / TS exception | CLI exit code | `kz-ext doctor` hint |
+|------------|----------------------|---------------|----------------------|
+| `misbound_auth` | `MisboundAuthError` | 10 | Required envelope header missing or malformed |
+| `unexpected_context` | `UnexpectedContextError` | 11 | Envelope shape wrong for this context |
+| `out_of_envelope_access` | `OutOfEnvelopeAccessError` | 12 | Cross-workroom / out-of-scope access attempt |
+| `platform_outage` | `PlatformOutageError` | 13 | Platform API unreachable or returning 5xx |
+
+The `class_name` strings are canonical — they appear in:
+
+- The JSON body returned by non-SDK extensions (under `{"error": {"class": ...}}`).
+- `kamiwaza_extensions_lib/exception_names.json` (single source of truth).
+- `kz-ext doctor` output (as `UAC-9d: <class_name>` reference entries).
+
+## `misbound_auth` — exit 10
+
+**What it means:** A required envelope header (`X-User-Id` or `X-Workroom-Id`)
+is missing or empty at the time the runtime lib tried to parse the request.
+
+**Typical causes:**
+
+- The request reached the extension pod *without* passing through Traefik
+  (e.g., direct in-cluster call, port-forward, or misconfigured ingress).
+- The platform ForwardAuth layer is not injecting the envelope correctly
+  (transient platform outage or misconfiguration).
+- Local development with `KAMIWAZA_USE_AUTH=true` but no platform to populate
+  the envelope — expected failure mode.
+
+**Fix:**
+
+1. Confirm the request is reaching the extension *through* Traefik. Check
+   ingress rules and the request URL.
+2. Run `kz-ext doctor` — a failed `Kamiwaza connection` check often precedes
+   `misbound_auth`.
+3. For local dev, set `KAMIWAZA_USE_AUTH=false` and restart the extension.
+
+**Code example:**
+
+```python
+from kamiwaza_extensions_lib.errors import MisboundAuthError
+from kamiwaza_extensions_lib.identity import extract_identity
+
+try:
+    identity = extract_identity(dict(request.headers))
+except MisboundAuthError as exc:
+    # Return 401 to the caller — do not leak internal details.
+    return JSONResponse(
+        {"error": {"class": exc.class_name, "detail": "Authentication required"}},
+        status_code=401,
+    )
+```
+
+Note: the built-in `require_auth()` FastAPI dependency handles this for you —
+you only need to catch `MisboundAuthError` if you are parsing headers manually
+or implementing a non-SDK extension.
+
+## `unexpected_context` — exit 11
+
+**What it means:** The envelope headers are present but the shape or content
+doesn't match the extension's expected runtime context.
+
+**Typical causes:**
+
+- Running a local-dev envelope against a production-signed extension (rare;
+  extensions no longer verify HMAC as of 2026-04-23, but shape mismatches
+  still apply).
+- Envelope fields present but all empty — platform misconfiguration.
+
+**Fix:**
+
+1. Compare `request.headers` against the list in
+   `kamiwaza-sdk/docs/extensions/non-sdk-flow.md` (when available) or
+   `kamiwaza_extensions_lib/identity.py`.
+2. Check that `X-User-Id` and `X-Workroom-Id` are non-empty strings, not
+   placeholder tokens.
+3. Verify the deployment environment — a PR preview env often has different
+   envelope provenance than staging or prod.
+
+## `out_of_envelope_access` — exit 12
+
+**What it means:** The extension attempted to access a resource the envelope
+does not cover — typically a cross-workroom access attempt.
+
+**Typical causes:**
+
+- The extension is resolving a workroom ID from user input and calling the
+  platform, but the caller does not have membership in that workroom.
+- A stale token referencing a deleted workroom.
+- Extension logic that assumes admin-like access when the caller is a
+  workroom viewer.
+
+**Fix:**
+
+1. Always thread the request's `Identity.workroom_id` through platform API
+   calls — don't substitute a workroom ID from user input without re-checking
+   membership.
+2. The platform enforces workroom membership at data-access time; the
+   extension should surface a friendly error, not try to work around it.
+3. Code example:
+
+```python
+from kamiwaza_extensions_lib.errors import OutOfEnvelopeAccessError
+
+try:
+    result = client.workrooms.get_resource(identity.workroom_id, resource_id)
+except OutOfEnvelopeAccessError:
+    return JSONResponse(
+        {"error": {"class": "out_of_envelope_access",
+                   "detail": "You do not have access to this workroom"}},
+        status_code=403,
+    )
+```
+
+## `platform_outage` — exit 13
+
+**What it means:** The platform API is unreachable or returning 5xx responses.
+
+**Typical causes:**
+
+- Platform is down or degraded (check Kamiwaza status).
+- Network partition between the extension and the platform — especially in
+  split-cluster deployments.
+- Upstream model-access boundary is failing (5xx propagation).
+
+**Fix:**
+
+1. Run `kz-ext doctor` — the `Kamiwaza connection` check will fail in the
+   same direction.
+2. Check the platform status page / oncall channels.
+3. For transient failures, the runtime lib's `TokenRefreshMiddleware` already
+   retries once on 401 mid-stream. A double failure surfaces as
+   `PlatformOutageError`.
+4. Do **not** catch and swallow — let it bubble to the top-level error
+   handler so the exit code is preserved.
+
+## How the exit codes flow
+
+1. The runtime lib raises a `KamiwazaRuntimeError` subclass.
+2. If the exception bubbles into a `kz-ext` subcommand, the CLI's top-level
+   `_handle_exception` catches it and calls `exit_code_for(exc.class_name)`.
+3. The process exits with the canonical code from `exception_names.json`.
+
+CI and operators can key off the exit code alone:
+
+```bash
+kz-ext dev
+case $? in
+  0)  echo "OK" ;;
+  10) echo "Platform envelope missing — check Traefik" ;;
+  11) echo "Envelope shape wrong — check deployment context" ;;
+  12) echo "Cross-workroom access — extension logic bug" ;;
+  13) echo "Platform outage — retry later" ;;
+  23) echo "Cluster operator not ready — run kz-ext doctor" ;;
+  *)  echo "Generic failure ($?)" ;;
+esac
+```
+
+Exit code 23 (`CLUSTER_NOT_READY`) is a related but distinct failure — it
+comes from the `cluster_extension_readiness` probe in `kz-ext doctor`, not
+from a runtime-lib exception. See ENG-3888 / §4.2.8 B1a.
+
+## The single-source-of-truth invariant
+
+If you add a new exception class to the hierarchy, update
+`kamiwaza_extensions_lib/exception_names.json` in the same commit. The
+`test_doctor_hint_coverage.py` contract test will fail loudly if the JSON
+drifts from either the `ExitCode` enum or the `kz-ext doctor` output.
+
+## Design references
+
+- `§4.2.7 RuntimeLibExceptionHierarchy + IdentityExtractor + TokenRefreshMiddleware`
+- `§4.2.8 DoctorUACFailureHints + ExitCodeMap`
+- `§5 Q6 Security implications and auth interactions`
+- Linear: [ENG-3885](https://linear.app/kamiwaza/issue/ENG-3885)

--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -8,6 +8,8 @@ import typer
 from rich.console import Console
 
 from kamiwaza_extensions import __version__
+from kamiwaza_extensions.exit_codes import exit_code_for
+from kamiwaza_extensions_lib.errors import KamiwazaRuntimeError
 
 app = typer.Typer(
     name="kz-ext",
@@ -84,20 +86,16 @@ def _handle_exception(exc: Exception) -> None:
     # UAC-9d runtime-lib exceptions map to their canonical exit codes
     # (§4.2.7 / §4.2.8). Keep this branch above the generic fallback so
     # the exit code carries meaning for extension authors and CI.
-    try:
-        from kamiwaza_extensions.exit_codes import exit_code_for
-        from kamiwaza_extensions_lib.errors import KamiwazaRuntimeError
-    except ImportError:
-        KamiwazaRuntimeError = None  # type: ignore[assignment]
-        exit_code_for = None  # type: ignore[assignment]
-
-    if KamiwazaRuntimeError is not None and isinstance(exc, KamiwazaRuntimeError):
+    if isinstance(exc, KamiwazaRuntimeError):
         console.print(f"[red]Error:[/red] {exc}")
         if _state.debug:
             console.print_exception()
         raise typer.Exit(code=int(exit_code_for(exc.class_name))) from exc
 
-    # Try to import Kamiwaza errors for nicer formatting
+    # Try to import Kamiwaza SDK errors for nicer formatting. This import
+    # stays lazy because kamiwaza_sdk is a sibling package and some install
+    # flavours (e.g. a stripped-down `kamiwaza-extensions-only` wheel) may
+    # ship without it.
     try:
         from kamiwaza_sdk.exceptions import KamiwazaError
     except ImportError:

--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -81,6 +81,22 @@ def run_with_error_handling(func):
 
 
 def _handle_exception(exc: Exception) -> None:
+    # UAC-9d runtime-lib exceptions map to their canonical exit codes
+    # (§4.2.7 / §4.2.8). Keep this branch above the generic fallback so
+    # the exit code carries meaning for extension authors and CI.
+    try:
+        from kamiwaza_extensions.exit_codes import exit_code_for
+        from kamiwaza_extensions_lib.errors import KamiwazaRuntimeError
+    except ImportError:
+        KamiwazaRuntimeError = None  # type: ignore[assignment]
+        exit_code_for = None  # type: ignore[assignment]
+
+    if KamiwazaRuntimeError is not None and isinstance(exc, KamiwazaRuntimeError):
+        console.print(f"[red]Error:[/red] {exc}")
+        if _state.debug:
+            console.print_exception()
+        raise typer.Exit(code=int(exit_code_for(exc.class_name))) from exc
+
     # Try to import Kamiwaza errors for nicer formatting
     try:
         from kamiwaza_sdk.exceptions import KamiwazaError

--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -133,7 +133,15 @@ def login(
     if dev:
         url = url or "https://kamiwaza.test/api"
         no_verify_ssl = True
-    run_login(url=url, api_key=api_key, name=name, list_connections=list_connections, use=use, no_verify_ssl=no_verify_ssl)
+    run_login(
+        url=url,
+        api_key=api_key,
+        name=name,
+        list_connections=list_connections,
+        use=use,
+        no_verify_ssl=no_verify_ssl,
+        verbose=_state.verbose,
+    )
 
 
 @app.command()

--- a/kamiwaza_extensions/commands/login.py
+++ b/kamiwaza_extensions/commands/login.py
@@ -68,22 +68,23 @@ def _capture_ui_roles(client, *, verbose: bool = False) -> set[str]:
     describe the PAT's scoped subset, defeating the comparison.
 
     Returns an empty set on any failure. When *verbose* is true, emits
-    a dim diagnostic so operators can distinguish "no downgrade
+    a diagnostic via ``typer.echo`` (same output channel as the
+    downgrade warning below) so operators can distinguish "no downgrade
     detected" from "we couldn't tell" (PR review High #3).
     """
     try:
         user = client.auth.get_current_user()
     except Exception as exc:  # noqa: BLE001 — best-effort diagnostic
         if verbose:
-            console.print(
-                f"[dim]Could not fetch UI role-set for B3 check: {type(exc).__name__}: {exc}[/dim]"
+            typer.echo(
+                f"Could not fetch UI role-set for B3 check: {type(exc).__name__}: {exc}"
             )
         return set()
     roles = getattr(user, "roles", None) or []
     if not isinstance(roles, list):
         if verbose:
-            console.print(
-                "[dim]Could not parse UI role-set for B3 check: roles claim was not a list[/dim]"
+            typer.echo(
+                "Could not parse UI role-set for B3 check: roles claim was not a list"
             )
         return set()
     return {str(r) for r in roles if isinstance(r, str)}
@@ -201,6 +202,7 @@ def _login_with_password(
     if not verify_ssl:
         os.environ["KAMIWAZA_VERIFY_SSL"] = "false"
 
+    pat_name = f"kz-ext-{name}"
     try:
         client = KamiwazaClient(base_url=url)
         client.authenticator = UserPasswordAuthenticator(
@@ -211,13 +213,7 @@ def _login_with_password(
         # the PAT. Post-mint the only credential we have is the scoped PAT,
         # which would reflect only its own roles (§4.8 B3).
         ui_roles = _capture_ui_roles(client, verbose=verbose)
-        pat_response = client.auth.create_pat(PATCreate(name=f"kz-ext-{name}"))
-        pat_token = pat_response.token
-        if not isinstance(pat_token, str) or not pat_token:
-            raise RuntimeError(
-                "Platform did not return a token for the new PAT. Try again, "
-                "or contact the platform team."
-            )
+        pat_response = client.auth.create_pat(PATCreate(name=pat_name))
     except Exception as exc:
         console.print(f"[red]Error:[/red] Authentication failed: {exc}")
         raise typer.Exit(code=1) from exc
@@ -227,6 +223,19 @@ def _login_with_password(
             os.environ.pop("KAMIWAZA_VERIFY_SSL", None)
         else:
             os.environ["KAMIWAZA_VERIFY_SSL"] = old_verify
+
+    # Validate the PAT response *outside* the auth catch-all — this branch
+    # represents a successful authentication followed by a PAT-mint failure,
+    # not an auth failure, and the user should see a different error class.
+    pat_token = pat_response.token
+    if not isinstance(pat_token, str) or not pat_token:
+        console.print(
+            f"[red]Error:[/red] Platform accepted credentials but returned no "
+            f"token for the new PAT '{pat_name}'. The PAT may have been "
+            f"created server-side; consider deleting it via the UI before "
+            f"retrying."
+        )
+        raise typer.Exit(code=1)
 
     # Store the PAT — auth already succeeded server-side at this point
     token = StoredToken(access_token=pat_token, refresh_token=None, expires_at=0.0)

--- a/kamiwaza_extensions/commands/login.py
+++ b/kamiwaza_extensions/commands/login.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import json
 from typing import Optional
 
 import typer
@@ -9,6 +11,83 @@ from rich.console import Console
 from rich.table import Table
 
 console = Console()
+
+
+# ---------------------------------------------------------------------------
+# UAC-9d B3 fix — warn when the minted PAT's roles are a strict subset of the
+# UI role-set. Platform-side fix is tracked separately; this surface catches
+# the surprising case where a user with admin roles logs in and is silently
+# given a non-admin PAT (see §4.8 B3).
+# ---------------------------------------------------------------------------
+
+
+def _decode_pat_roles(token: str) -> set[str]:
+    """Extract the ``roles`` claim from a PAT JWT payload.
+
+    Signature is **not** verified — the platform already authenticated
+    the caller by the time we reach this code. We only read the payload
+    to compare against the UI role-set for B3 diagnostics.
+    """
+    parts = token.split(".")
+    if len(parts) < 2:
+        return set()
+    payload_b64 = parts[1]
+    padding = "=" * (-len(payload_b64) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(f"{payload_b64}{padding}")
+        claims = json.loads(decoded.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return set()
+    roles = claims.get("roles", [])
+    if not isinstance(roles, list):
+        return set()
+    return {str(r) for r in roles if isinstance(r, str)}
+
+
+def _fetch_ui_roles(url: str, pat_token: str, *, verify_ssl: bool = True) -> set[str]:
+    """Best-effort fetch of the user's full role-set via ``/auth/whoami``.
+
+    Returns an empty set on any failure; the caller must treat empty as
+    "unknown" and skip the warning.
+    """
+    import requests
+
+    try:
+        resp = requests.get(
+            f"{url}/auth/whoami",
+            headers={"Authorization": f"Bearer {pat_token}"},
+            timeout=5,
+            verify=verify_ssl,
+        )
+        if not resp.ok:
+            return set()
+        body = resp.json()
+    except (requests.RequestException, ValueError):
+        return set()
+    roles = body.get("roles", []) if isinstance(body, dict) else []
+    if not isinstance(roles, list):
+        return set()
+    return {str(r) for r in roles if isinstance(r, str)}
+
+
+def _warn_if_roles_downgraded(
+    *, pat_roles: set[str], ui_roles: set[str]
+) -> None:
+    """Emit a warning when ``ui_roles`` is a strict superset of ``pat_roles``.
+
+    Silent on: equal sets, PAT superset (unusual), empty UI set (unknown).
+    Uses plain ``print`` so ``capsys`` can observe in tests.
+    """
+    if not ui_roles:
+        return
+    missing = ui_roles - pat_roles
+    if not missing or not pat_roles < ui_roles:
+        return
+    print(
+        f"Warning: minted PAT is scoped to {sorted(pat_roles)} but your UI "
+        f"role-set also includes {sorted(missing)}. Some admin-gated calls "
+        f"may fail; platform-side fix tracked as a follow-on (§4.8 B3)."
+    )
 
 
 def run_login(
@@ -115,6 +194,12 @@ def _login_with_password(mgr, *, url: str, name: str, verify_ssl: bool = True) -
     token = StoredToken(access_token=pat_token, refresh_token=None, expires_at=0.0)
     mgr.add_connection(name=name, url=url, token=token, verify_ssl=verify_ssl)
     console.print(f"[green]Connected to {url} as '{name}'[/green]")
+
+    # §4.8 B3: surface the role-set downgrade case — silent on failure.
+    _warn_if_roles_downgraded(
+        pat_roles=_decode_pat_roles(pat_token),
+        ui_roles=_fetch_ui_roles(url, pat_token, verify_ssl=verify_ssl),
+    )
 
 
 def _validate_token(url: str, token: str, *, verify_ssl: bool = True) -> bool:

--- a/kamiwaza_extensions/commands/login.py
+++ b/kamiwaza_extensions/commands/login.py
@@ -14,10 +14,15 @@ console = Console()
 
 
 # ---------------------------------------------------------------------------
-# UAC-9d B3 fix — warn when the minted PAT's roles are a strict subset of the
+# §4.8 B3 fix — warn when the minted PAT's roles are a strict subset of the
 # UI role-set. Platform-side fix is tracked separately; this surface catches
 # the surprising case where a user with admin roles logs in and is silently
-# given a non-admin PAT (see §4.8 B3).
+# given a non-admin PAT.
+#
+# Correctness note: the UI role-set must be captured against the
+# *password session* (via client.auth.get_current_user), NOT against the
+# just-minted PAT — the PAT only reports its own scoped roles, so a
+# self-referential comparison can never show a downgrade.
 # ---------------------------------------------------------------------------
 
 
@@ -44,27 +49,21 @@ def _decode_pat_roles(token: str) -> set[str]:
     return {str(r) for r in roles if isinstance(r, str)}
 
 
-def _fetch_ui_roles(url: str, pat_token: str, *, verify_ssl: bool = True) -> set[str]:
-    """Best-effort fetch of the user's full role-set via ``/auth/whoami``.
+def _capture_ui_roles(client) -> set[str]:
+    """Best-effort capture of the caller's UI role-set via the SDK's
+    already-authenticated password session.
+
+    Must be called *before* PAT mint — otherwise the returned roles
+    describe the PAT's scoped subset, defeating the comparison.
 
     Returns an empty set on any failure; the caller must treat empty as
     "unknown" and skip the warning.
     """
-    import requests
-
     try:
-        resp = requests.get(
-            f"{url}/auth/whoami",
-            headers={"Authorization": f"Bearer {pat_token}"},
-            timeout=5,
-            verify=verify_ssl,
-        )
-        if not resp.ok:
-            return set()
-        body = resp.json()
-    except (requests.RequestException, ValueError):
+        user = client.auth.get_current_user()
+    except Exception:
         return set()
-    roles = body.get("roles", []) if isinstance(body, dict) else []
+    roles = getattr(user, "roles", None) or []
     if not isinstance(roles, list):
         return set()
     return {str(r) for r in roles if isinstance(r, str)}
@@ -76,14 +75,13 @@ def _warn_if_roles_downgraded(
     """Emit a warning when ``ui_roles`` is a strict superset of ``pat_roles``.
 
     Silent on: equal sets, PAT superset (unusual), empty UI set (unknown).
-    Uses plain ``print`` so ``capsys`` can observe in tests.
+    Uses ``typer.echo`` so ``CliRunner`` / ``capsys`` capture the output
+    through Click's normal stdout path.
     """
-    if not ui_roles:
+    if not ui_roles or not pat_roles < ui_roles:
         return
     missing = ui_roles - pat_roles
-    if not missing or not pat_roles < ui_roles:
-        return
-    print(
+    typer.echo(
         f"Warning: minted PAT is scoped to {sorted(pat_roles)} but your UI "
         f"role-set also includes {sorted(missing)}. Some admin-gated calls "
         f"may fail; platform-side fix tracked as a follow-on (§4.8 B3)."
@@ -178,6 +176,10 @@ def _login_with_password(mgr, *, url: str, name: str, verify_ssl: bool = True) -
             username, password, client.auth,
             token_store=_MemoryTokenStore(),
         )
+        # Capture the UI role-set against the password session BEFORE minting
+        # the PAT. Post-mint the only credential we have is the scoped PAT,
+        # which would reflect only its own roles (§4.8 B3).
+        ui_roles = _capture_ui_roles(client)
         pat_response = client.auth.create_pat(PATCreate(name=f"kz-ext-{name}"))
         pat_token = pat_response.token
     except Exception as exc:
@@ -196,9 +198,10 @@ def _login_with_password(mgr, *, url: str, name: str, verify_ssl: bool = True) -
     console.print(f"[green]Connected to {url} as '{name}'[/green]")
 
     # §4.8 B3: surface the role-set downgrade case — silent on failure.
+    # `ui_roles` was captured above against the password session.
     _warn_if_roles_downgraded(
         pat_roles=_decode_pat_roles(pat_token),
-        ui_roles=_fetch_ui_roles(url, pat_token, verify_ssl=verify_ssl),
+        ui_roles=ui_roles,
     )
 
 

--- a/kamiwaza_extensions/commands/login.py
+++ b/kamiwaza_extensions/commands/login.py
@@ -26,17 +26,28 @@ console = Console()
 # ---------------------------------------------------------------------------
 
 
-def _decode_pat_roles(token: str) -> set[str]:
+_PAT_PAYLOAD_MAX_BYTES = 64 * 1024  # defensive cap on JWT payload size
+
+
+def _decode_pat_roles(token: Optional[str]) -> set[str]:
     """Extract the ``roles`` claim from a PAT JWT payload.
 
     Signature is **not** verified — the platform already authenticated
     the caller by the time we reach this code. We only read the payload
     to compare against the UI role-set for B3 diagnostics.
+
+    Defensive against ``None``/non-string inputs (a malformed
+    ``create_pat`` response should not crash the login command after
+    the connection has been added).
     """
+    if not isinstance(token, str):
+        return set()
     parts = token.split(".")
     if len(parts) < 2:
         return set()
     payload_b64 = parts[1]
+    if len(payload_b64) > _PAT_PAYLOAD_MAX_BYTES:
+        return set()
     padding = "=" * (-len(payload_b64) % 4)
     try:
         decoded = base64.urlsafe_b64decode(f"{payload_b64}{padding}")
@@ -49,22 +60,31 @@ def _decode_pat_roles(token: str) -> set[str]:
     return {str(r) for r in roles if isinstance(r, str)}
 
 
-def _capture_ui_roles(client) -> set[str]:
+def _capture_ui_roles(client, *, verbose: bool = False) -> set[str]:
     """Best-effort capture of the caller's UI role-set via the SDK's
     already-authenticated password session.
 
     Must be called *before* PAT mint — otherwise the returned roles
     describe the PAT's scoped subset, defeating the comparison.
 
-    Returns an empty set on any failure; the caller must treat empty as
-    "unknown" and skip the warning.
+    Returns an empty set on any failure. When *verbose* is true, emits
+    a dim diagnostic so operators can distinguish "no downgrade
+    detected" from "we couldn't tell" (PR review High #3).
     """
     try:
         user = client.auth.get_current_user()
-    except Exception:
+    except Exception as exc:  # noqa: BLE001 — best-effort diagnostic
+        if verbose:
+            console.print(
+                f"[dim]Could not fetch UI role-set for B3 check: {type(exc).__name__}: {exc}[/dim]"
+            )
         return set()
     roles = getattr(user, "roles", None) or []
     if not isinstance(roles, list):
+        if verbose:
+            console.print(
+                "[dim]Could not parse UI role-set for B3 check: roles claim was not a list[/dim]"
+            )
         return set()
     return {str(r) for r in roles if isinstance(r, str)}
 
@@ -72,15 +92,21 @@ def _capture_ui_roles(client) -> set[str]:
 def _warn_if_roles_downgraded(
     *, pat_roles: set[str], ui_roles: set[str]
 ) -> None:
-    """Emit a warning when ``ui_roles`` is a strict superset of ``pat_roles``.
+    """Emit a warning when the UI role-set has roles the PAT is missing.
 
-    Silent on: equal sets, PAT superset (unusual), empty UI set (unknown).
-    Uses ``typer.echo`` so ``CliRunner`` / ``capsys`` capture the output
-    through Click's normal stdout path.
+    Fires on any non-empty ``ui_roles - pat_roles``: catches the strict-
+    subset case AND the overlapping-but-disjoint case
+    (e.g. ``pat={a,b}``, ``ui={a,c}``). Silent on: equal sets, PAT
+    superset, empty UI set (unknown).
+
+    Uses ``typer.echo`` so ``CliRunner`` captures the output through
+    Click's normal stdout path.
     """
-    if not ui_roles or not pat_roles < ui_roles:
+    if not ui_roles:
         return
     missing = ui_roles - pat_roles
+    if not missing:
+        return
     typer.echo(
         f"Warning: minted PAT is scoped to {sorted(pat_roles)} but your UI "
         f"role-set also includes {sorted(missing)}. Some admin-gated calls "
@@ -96,6 +122,7 @@ def run_login(
     list_connections: bool,
     use: Optional[str],
     no_verify_ssl: bool = False,
+    verbose: bool = False,
 ) -> None:
     """Authenticate with a Kamiwaza instance."""
     from kamiwaza_extensions.connections import ConnectionManager
@@ -123,7 +150,9 @@ def run_login(
     if api_key:
         _login_with_api_key(mgr, url=url, api_key=api_key, name=name, verify_ssl=verify_ssl)
     else:
-        _login_with_password(mgr, url=url, name=name, verify_ssl=verify_ssl)
+        _login_with_password(
+            mgr, url=url, name=name, verify_ssl=verify_ssl, verbose=verbose,
+        )
 
 
 def _login_with_api_key(mgr, *, url: str, api_key: str, name: str, verify_ssl: bool = True) -> None:
@@ -142,7 +171,9 @@ def _login_with_api_key(mgr, *, url: str, api_key: str, name: str, verify_ssl: b
     console.print(f"[green]Connected to {url} as '{name}'[/green]")
 
 
-def _login_with_password(mgr, *, url: str, name: str, verify_ssl: bool = True) -> None:
+def _login_with_password(
+    mgr, *, url: str, name: str, verify_ssl: bool = True, verbose: bool = False,
+) -> None:
     from kamiwaza_sdk import KamiwazaClient
     from kamiwaza_sdk.authentication import UserPasswordAuthenticator
     from kamiwaza_sdk.schemas.auth import PATCreate
@@ -179,9 +210,14 @@ def _login_with_password(mgr, *, url: str, name: str, verify_ssl: bool = True) -
         # Capture the UI role-set against the password session BEFORE minting
         # the PAT. Post-mint the only credential we have is the scoped PAT,
         # which would reflect only its own roles (§4.8 B3).
-        ui_roles = _capture_ui_roles(client)
+        ui_roles = _capture_ui_roles(client, verbose=verbose)
         pat_response = client.auth.create_pat(PATCreate(name=f"kz-ext-{name}"))
         pat_token = pat_response.token
+        if not isinstance(pat_token, str) or not pat_token:
+            raise RuntimeError(
+                "Platform did not return a token for the new PAT. Try again, "
+                "or contact the platform team."
+            )
     except Exception as exc:
         console.print(f"[red]Error:[/red] Authentication failed: {exc}")
         raise typer.Exit(code=1) from exc

--- a/kamiwaza_extensions/doctor.py
+++ b/kamiwaza_extensions/doctor.py
@@ -82,7 +82,7 @@ class DoctorChecker:
         """
         return [
             CheckResult(
-                name=f"UAC-9d: {entry['name']}",
+                name=f"Failure class: {entry['name']}",
                 status="pass",
                 message=entry["doctor_hint"],
                 fix=entry["doctor_hint"],

--- a/kamiwaza_extensions/doctor.py
+++ b/kamiwaza_extensions/doctor.py
@@ -6,6 +6,8 @@ import json
 import subprocess
 import sys
 from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
 from pathlib import Path
 from typing import List, Literal, Optional
 
@@ -14,6 +16,17 @@ from packaging.version import InvalidVersion, Version
 
 from kamiwaza_extensions import __version__
 from kamiwaza_extensions.connections import ConnectionManager
+
+
+@lru_cache(maxsize=1)
+def _uac_9d_hints() -> list[dict]:
+    """Load UAC-9d class hints from the runtime lib's canonical JSON."""
+    data = json.loads(
+        resources.files("kamiwaza_extensions_lib")
+        .joinpath("exception_names.json")
+        .read_text(encoding="utf-8")
+    )
+    return list(data["classes"])
 
 
 @dataclass
@@ -50,7 +63,32 @@ class DoctorChecker:
         sdk_results = self._check_sdk_override()
         results.extend(sdk_results)
 
+        # UAC-9d reference hints (always emitted)
+        results.extend(self._uac_9d_reference_hints())
+
         return results
+
+    # ------------------------------------------------------------------
+    # UAC-9d reference hints
+    # ------------------------------------------------------------------
+
+    def _uac_9d_reference_hints(self) -> List[CheckResult]:
+        """Reference entries for each UAC-9d runtime-lib exception class.
+
+        These are always-pass informational entries; they surface the
+        canonical doctor_hint so extension authors seeing an exception
+        in their logs can find the matching diagnosis + fix in
+        ``kz-ext doctor`` output (§4.2.8 DoctorUACFailureHints).
+        """
+        return [
+            CheckResult(
+                name=f"UAC-9d: {entry['name']}",
+                status="pass",
+                message=entry["doctor_hint"],
+                fix=entry["doctor_hint"],
+            )
+            for entry in _uac_9d_hints()
+        ]
 
     # ------------------------------------------------------------------
     # System checks

--- a/kamiwaza_extensions/exit_codes.py
+++ b/kamiwaza_extensions/exit_codes.py
@@ -1,0 +1,29 @@
+"""Exit codes for the kz-ext CLI.
+
+Canonical mapping of UAC-9d runtime-lib exception classes to process
+exit codes, plus standard CLI and cluster/registry failure codes.
+
+Design reference: §4.2.8 `DoctorUACFailureHints` + `ExitCodeMap`.
+"""
+
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class ExitCode(IntEnum):
+    OK = 0
+    FAILURE = 1
+    VALIDATION = 2
+
+    # UAC-9d runtime-lib exception classes
+    MISBOUND_AUTH = 10
+    UNEXPECTED_CONTEXT = 11
+    OUT_OF_ENVELOPE_ACCESS = 12
+    PLATFORM_OUTAGE = 13
+
+    # Cluster and registry failures
+    REGISTRY_AUTH = 20
+    CLUSTER_UNREACHABLE = 21
+    CRD_PATCH_UNSUPPORTED = 22
+    CLUSTER_NOT_READY = 23

--- a/kamiwaza_extensions/exit_codes.py
+++ b/kamiwaza_extensions/exit_codes.py
@@ -8,7 +8,10 @@ Design reference: §4.2.8 `DoctorUACFailureHints` + `ExitCodeMap`.
 
 from __future__ import annotations
 
+import json
 from enum import IntEnum
+from functools import lru_cache
+from importlib import resources
 
 
 class ExitCode(IntEnum):
@@ -27,3 +30,23 @@ class ExitCode(IntEnum):
     CLUSTER_UNREACHABLE = 21
     CRD_PATCH_UNSUPPORTED = 22
     CLUSTER_NOT_READY = 23
+
+
+@lru_cache(maxsize=1)
+def _exception_name_to_exit_code() -> dict[str, int]:
+    """Load class-name → exit-code map from the runtime lib's canonical JSON."""
+    data = json.loads(
+        resources.files("kamiwaza_extensions_lib")
+        .joinpath("exception_names.json")
+        .read_text(encoding="utf-8")
+    )
+    return {entry["name"]: entry["exit_code"] for entry in data["classes"]}
+
+
+def exit_code_for(class_name: str) -> ExitCode:
+    """Return the ExitCode for a runtime-lib exception ``class_name``.
+
+    Unknown class names fall back to ``ExitCode.FAILURE``.
+    """
+    code = _exception_name_to_exit_code().get(class_name)
+    return ExitCode(code) if code is not None else ExitCode.FAILURE

--- a/kamiwaza_extensions_lib/__init__.py
+++ b/kamiwaza_extensions_lib/__init__.py
@@ -10,23 +10,44 @@ and 20+ service modules.
 
 __version__ = "0.1.0"
 
-from .identity import Identity, get_identity
-from .auth import require_auth, require_role, forward_auth_headers
-from .session import create_session_router
-from .config import AuthConfig
+from .auth import forward_auth_headers, require_auth, require_role
 from .client import KamiwazaExtClient
+from .config import AuthConfig
+from .errors import (
+    KamiwazaRuntimeError,
+    MisboundAuthError,
+    OutOfEnvelopeAccessError,
+    PlatformOutageError,
+    UnexpectedContextError,
+)
+from .identity import (
+    Identity,
+    anonymous_identity,
+    extract_identity,
+    get_identity,
+    identity_from_headers,
+)
 from .models import AvailableModel, get_model_client, list_available_models
+from .session import create_session_router
 
 __all__ = [
-    "Identity",
-    "get_identity",
+    "AuthConfig",
+    "AvailableModel",
     "require_auth",
     "require_role",
     "forward_auth_headers",
     "create_session_router",
-    "AuthConfig",
     "KamiwazaExtClient",
-    "AvailableModel",
+    "Identity",
+    "identity_from_headers",
+    "get_identity",
+    "extract_identity",
+    "anonymous_identity",
+    "KamiwazaRuntimeError",
+    "MisboundAuthError",
+    "UnexpectedContextError",
+    "OutOfEnvelopeAccessError",
+    "PlatformOutageError",
     "get_model_client",
     "list_available_models",
 ]

--- a/kamiwaza_extensions_lib/auth.py
+++ b/kamiwaza_extensions_lib/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Mapping
 from typing import Optional
 
@@ -10,6 +11,8 @@ from fastapi import Depends, HTTPException, Request
 from .config import AuthConfig
 from .errors import MisboundAuthError
 from .identity import Identity, anonymous_identity, extract_identity, get_identity
+
+logger = logging.getLogger(__name__)
 
 # Headers to forward when calling other Kamiwaza services. The set must
 # stay aligned with the envelope ``Identity`` reads (kept in
@@ -68,7 +71,22 @@ async def require_auth(request: Request) -> Identity:
     try:
         return extract_identity(dict(request.headers))
     except MisboundAuthError as exc:
-        raise HTTPException(status_code=401, detail=str(exc)) from exc
+        # The raw exception text names the missing header — useful for
+        # operators triaging a misconfigured platform, harmful as a 401
+        # response body (information disclosure to clients). Log full
+        # context server-side; return a scrubbed user-facing detail with
+        # the canonical class name in WWW-Authenticate per RFC 6750.
+        logger.warning(
+            "MisboundAuthError on %s %s: %s",
+            request.method,
+            request.url.path,
+            exc,
+        )
+        raise HTTPException(
+            status_code=401,
+            detail="Authentication required",
+            headers={"WWW-Authenticate": f'Bearer error="{exc.class_name}"'},
+        ) from exc
 
 
 def require_role(role: str) -> Callable:

--- a/kamiwaza_extensions_lib/auth.py
+++ b/kamiwaza_extensions_lib/auth.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import Depends, HTTPException, Request
 
 from .config import AuthConfig
-from .identity import Identity, get_identity
+from .identity import Identity, anonymous_identity, get_identity
 
 # Headers to forward when calling other Kamiwaza services.
 _FORWARD_HEADERS = frozenset(
@@ -48,7 +48,8 @@ async def require_auth(request: Request) -> Identity:
     identity = await get_identity(request)
     config = AuthConfig.from_env()
     if not config.use_auth:
-        return identity
+        # Local dev — unified anonymous shape, matching /session (§4.8 P5).
+        return identity if identity.is_authenticated else anonymous_identity()
     if not identity.is_authenticated:
         raise HTTPException(status_code=401, detail="Authentication required")
     return identity

--- a/kamiwaza_extensions_lib/auth.py
+++ b/kamiwaza_extensions_lib/auth.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping
-from typing import Optional
 
 from fastapi import Depends, HTTPException, Request
 
@@ -54,7 +53,7 @@ async def require_auth(request: Request) -> Identity:
     Otherwise, parses the platform envelope strictly via
     ``extract_identity`` — a request that reaches the extension without
     a complete envelope (e.g. missing ``X-Workroom-Id``) is rejected
-    with HTTP 401 carrying the canonical ``MisboundAuthError`` message.
+    with HTTP 401 carrying a scrubbed user-facing detail.
     Without this strict path the new ``MisboundAuthError`` class would
     be defined but never raised on the auth surface the rest of the
     codebase actually uses.
@@ -69,7 +68,7 @@ async def require_auth(request: Request) -> Identity:
         identity = await get_identity(request)
         return identity if identity.is_authenticated else anonymous_identity()
     try:
-        return extract_identity(dict(request.headers))
+        return extract_identity(request.headers)
     except MisboundAuthError as exc:
         # The raw exception text names the missing header — useful for
         # operators triaging a misconfigured platform, harmful as a 401

--- a/kamiwaza_extensions_lib/auth.py
+++ b/kamiwaza_extensions_lib/auth.py
@@ -11,7 +11,11 @@ from .config import AuthConfig
 from .errors import MisboundAuthError
 from .identity import Identity, anonymous_identity, extract_identity, get_identity
 
-# Headers to forward when calling other Kamiwaza services.
+# Headers to forward when calling other Kamiwaza services. The set must
+# stay aligned with the envelope ``Identity`` reads (kept in
+# kamiwaza_extensions_lib.identity) — silently dropping any platform-set
+# header here would prevent downstream services from re-establishing the
+# caller's workroom role or system-high classification.
 _FORWARD_HEADERS = frozenset(
     {
         "authorization",
@@ -21,6 +25,8 @@ _FORWARD_HEADERS = frozenset(
         "x-user-email",
         "x-user-name",
         "x-user-roles",
+        "x-user-system-high",
+        "x-user-workroom-role",
         "x-workroom-id",
         "x-request-id",
     }

--- a/kamiwaza_extensions_lib/auth.py
+++ b/kamiwaza_extensions_lib/auth.py
@@ -8,7 +8,8 @@ from typing import Optional
 from fastapi import Depends, HTTPException, Request
 
 from .config import AuthConfig
-from .identity import Identity, anonymous_identity, get_identity
+from .errors import MisboundAuthError
+from .identity import Identity, anonymous_identity, extract_identity, get_identity
 
 # Headers to forward when calling other Kamiwaza services.
 _FORWARD_HEADERS = frozenset(
@@ -41,18 +42,27 @@ async def require_auth(request: Request) -> Identity:
     When ``KAMIWAZA_USE_AUTH`` is ``false`` (local dev), returns an
     anonymous identity without raising.
 
+    Otherwise, parses the platform envelope strictly via
+    ``extract_identity`` — a request that reaches the extension without
+    a complete envelope (e.g. missing ``X-Workroom-Id``) is rejected
+    with HTTP 401 carrying the canonical ``MisboundAuthError`` message.
+    Without this strict path the new ``MisboundAuthError`` class would
+    be defined but never raised on the auth surface the rest of the
+    codebase actually uses.
+
     Raises:
-        HTTPException(401): If auth is enabled and the user is not
-            authenticated.
+        HTTPException(401): If auth is enabled and the request envelope
+            is missing or malformed.
     """
-    identity = await get_identity(request)
     config = AuthConfig.from_env()
     if not config.use_auth:
         # Local dev — unified anonymous shape, matching /session (§4.8 P5).
+        identity = await get_identity(request)
         return identity if identity.is_authenticated else anonymous_identity()
-    if not identity.is_authenticated:
-        raise HTTPException(status_code=401, detail="Authentication required")
-    return identity
+    try:
+        return extract_identity(dict(request.headers))
+    except MisboundAuthError as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
 
 
 def require_role(role: str) -> Callable:

--- a/kamiwaza_extensions_lib/errors.py
+++ b/kamiwaza_extensions_lib/errors.py
@@ -1,0 +1,41 @@
+"""UAC-9d runtime-lib exception hierarchy.
+
+Each class carries a canonical ``class_name`` string matching the
+entries in ``exception_names.json``.  The CLI's ``exit_code_for()``
+uses the class_name to produce the process exit code; ``kz-ext doctor``
+uses it to surface a fix hint.
+
+Design reference: §4.2.7 RuntimeLibExceptionHierarchy.
+"""
+
+from __future__ import annotations
+
+
+class KamiwazaRuntimeError(Exception):
+    """Base class for runtime-lib exceptions surfaced to extension authors."""
+
+    class_name: str = "kamiwaza_runtime_error"
+
+
+class MisboundAuthError(KamiwazaRuntimeError):
+    """Required envelope header missing or malformed (post-Traefik)."""
+
+    class_name = "misbound_auth"
+
+
+class UnexpectedContextError(KamiwazaRuntimeError):
+    """Envelope missing or shape mismatch (e.g., local-dev envelope in prod)."""
+
+    class_name = "unexpected_context"
+
+
+class OutOfEnvelopeAccessError(KamiwazaRuntimeError):
+    """Attempt to access resources outside envelope (cross-workroom etc.)."""
+
+    class_name = "out_of_envelope_access"
+
+
+class PlatformOutageError(KamiwazaRuntimeError):
+    """Platform API 5xx or unreachable."""
+
+    class_name = "platform_outage"

--- a/kamiwaza_extensions_lib/exception_names.json
+++ b/kamiwaza_extensions_lib/exception_names.json
@@ -1,0 +1,24 @@
+{
+  "classes": [
+    {
+      "name": "misbound_auth",
+      "exit_code": 10,
+      "doctor_hint": "Required envelope header missing or malformed. Verify the request reached the extension via Traefik (not a direct in-cluster call) and that the platform is healthy."
+    },
+    {
+      "name": "unexpected_context",
+      "exit_code": 11,
+      "doctor_hint": "Envelope headers missing or wrong shape; check you are running in the expected context (local dev vs. cluster)."
+    },
+    {
+      "name": "out_of_envelope_access",
+      "exit_code": 12,
+      "doctor_hint": "Extension attempted cross-workroom or out-of-scope access. Verify the X-Workroom-Id and user permissions."
+    },
+    {
+      "name": "platform_outage",
+      "exit_code": 13,
+      "doctor_hint": "Platform API unreachable or returning 5xx. Try `kz-ext doctor` and check platform status."
+    }
+  ]
+}

--- a/kamiwaza_extensions_lib/identity.py
+++ b/kamiwaza_extensions_lib/identity.py
@@ -19,6 +19,7 @@ serialized error responses) would leak the credential.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Optional
 
 from fastapi import Request
@@ -89,7 +90,7 @@ def _parse_roles(raw: str) -> list[str]:
     return [r.strip() for r in raw.split(",") if r.strip()]
 
 
-def _lower(headers: dict[str, str]) -> dict[str, str]:
+def _lower(headers: Mapping[str, str]) -> dict[str, str]:
     return {k.lower(): v for k, v in headers.items()}
 
 
@@ -114,8 +115,8 @@ def _project_identity_fields(lower: dict[str, str]) -> dict:
     }
 
 
-def identity_from_headers(headers: dict[str, str]) -> Identity:
-    """Build an Identity from a plain header dict.  Permissive — never raises.
+def identity_from_headers(headers: Mapping[str, str]) -> Identity:
+    """Build an Identity from request headers.  Permissive — never raises.
 
     Missing fields become ``None``/defaults; ``is_authenticated`` reflects
     whether ``x-user-id`` was supplied.
@@ -130,7 +131,7 @@ def identity_from_headers(headers: dict[str, str]) -> Identity:
     )
 
 
-def extract_identity(headers: dict[str, str]) -> Identity:
+def extract_identity(headers: Mapping[str, str]) -> Identity:
     """Strict header parsing for UAC-9d.
 
     Raises ``MisboundAuthError`` when ``X-User-Id`` or ``X-Workroom-Id``
@@ -160,4 +161,4 @@ async def get_identity(request: Request) -> Identity:
 
     Never raises; see ``identity_from_headers``.
     """
-    return identity_from_headers(dict(request.headers))
+    return identity_from_headers(request.headers)

--- a/kamiwaza_extensions_lib/identity.py
+++ b/kamiwaza_extensions_lib/identity.py
@@ -105,16 +105,22 @@ def identity_from_headers(headers: dict[str, str]) -> Identity:
     )
 
 
+def _stripped(headers: dict[str, str], key: str) -> Optional[str]:
+    """Return the stripped header value or None if absent / blank."""
+    return (headers.get(key) or "").strip() or None
+
+
 def extract_identity(headers: dict[str, str]) -> Identity:
     """Strict header parsing for UAC-9d.
 
     Raises ``MisboundAuthError`` when ``X-User-Id`` or ``X-Workroom-Id``
-    is missing or empty — the request did not reach the extension via
-    Traefik, or the platform did not populate the envelope.
+    is missing or empty (including whitespace-only values — the request
+    did not reach the extension via Traefik, or the platform did not
+    populate the envelope).
     """
     lower = _lower(headers)
-    user_id = lower.get(_HEADER_USER_ID) or None
-    workroom_id = lower.get(_HEADER_WORKROOM_ID) or None
+    user_id = _stripped(lower, _HEADER_USER_ID)
+    workroom_id = _stripped(lower, _HEADER_WORKROOM_ID)
     if not user_id:
         raise MisboundAuthError("Required envelope header X-User-Id missing or empty")
     if not workroom_id:
@@ -123,14 +129,14 @@ def extract_identity(headers: dict[str, str]) -> Identity:
         )
     return Identity(
         user_id=user_id,
-        email=lower.get(_HEADER_USER_EMAIL) or None,
-        name=lower.get(_HEADER_USER_NAME) or None,
+        email=_stripped(lower, _HEADER_USER_EMAIL),
+        name=_stripped(lower, _HEADER_USER_NAME),
         roles=_parse_roles(lower.get(_HEADER_USER_ROLES, "")),
         system_high=_parse_bool(lower.get(_HEADER_USER_SYSTEM_HIGH, "")),
         workroom_id=workroom_id,
-        workroom_role=lower.get(_HEADER_USER_WORKROOM_ROLE) or None,
-        auth_token=lower.get(_HEADER_AUTH_TOKEN) or None,
-        request_id=lower.get(_HEADER_REQUEST_ID) or None,
+        workroom_role=_stripped(lower, _HEADER_USER_WORKROOM_ROLE),
+        auth_token=_stripped(lower, _HEADER_AUTH_TOKEN),
+        request_id=_stripped(lower, _HEADER_REQUEST_ID),
         is_authenticated=True,
     )
 

--- a/kamiwaza_extensions_lib/identity.py
+++ b/kamiwaza_extensions_lib/identity.py
@@ -53,6 +53,21 @@ class Identity(BaseModel):
     is_authenticated: bool = False
 
 
+#: Canonical display name used for the anonymous Identity under USE_AUTH=false.
+#: Shared by ``require_auth`` and the ``/session`` endpoint so the frontend sees
+#: a consistent placeholder (§4.8 P5).
+ANONYMOUS_NAME = "Anonymous"
+
+
+def anonymous_identity() -> "Identity":
+    """Return the canonical anonymous Identity used under ``USE_AUTH=false``.
+
+    Guarantees ``require_auth()`` and the ``/session`` endpoint produce a
+    byte-identical Identity shape for local dev (§4.2.12 P5).
+    """
+    return Identity(name=ANONYMOUS_NAME, is_authenticated=False)
+
+
 def _parse_roles(raw: str) -> list[str]:
     """Split comma-separated roles, filtering blanks."""
     return [r.strip() for r in raw.split(",") if r.strip()]

--- a/kamiwaza_extensions_lib/identity.py
+++ b/kamiwaza_extensions_lib/identity.py
@@ -8,6 +8,13 @@ Two entry points:
 * ``extract_identity`` — strict; raises ``MisboundAuthError`` when
   required envelope headers are missing or empty.  Matches the UAC-9d
   contract (design §4.2.7).
+
+Note on ``X-Auth-Token``: deliberately *not* stored on ``Identity``.
+The bearer credential lives in request headers; consumers that need it
+(``TokenRefreshMiddleware``, ``/session`` expiry decoder, etc.) read it
+from ``request.headers`` directly.  Putting it on the model would mean
+any ``identity.model_dump()`` call (logs, metrics, exception payloads,
+serialized error responses) would leak the credential.
 """
 
 from __future__ import annotations
@@ -15,7 +22,7 @@ from __future__ import annotations
 from typing import Optional
 
 from fastapi import Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from .errors import MisboundAuthError
 
@@ -27,7 +34,6 @@ _HEADER_USER_ROLES = "x-user-roles"
 _HEADER_USER_SYSTEM_HIGH = "x-user-system-high"
 _HEADER_WORKROOM_ID = "x-workroom-id"
 _HEADER_USER_WORKROOM_ROLE = "x-user-workroom-role"
-_HEADER_AUTH_TOKEN = "x-auth-token"
 _HEADER_REQUEST_ID = "x-request-id"
 
 
@@ -36,21 +42,29 @@ class Identity(BaseModel):
 
     Pydantic model — supports ``.model_dump()`` for JSON serialization.
 
-    ``extra`` defaults to ``"ignore"``; unknown kwargs are dropped at
-    construction.  This is deliberate: Identity is only constructed
-    internally with explicit kwargs (see ``identity_from_headers`` and
-    ``extract_identity``), so surfacing untrusted extras via
-    ``model_dump()`` would be a leak, not a feature.
+    ``extra="ignore"`` is set explicitly: unknown kwargs are dropped at
+    construction.  Identity is only constructed internally with explicit
+    kwargs (see ``identity_from_headers`` and ``extract_identity``), so
+    surfacing untrusted extras via ``model_dump()`` would be a leak, not
+    a feature.  The explicit setting also guards against future Pydantic
+    v2 default changes.
+
+    ``system_high`` is the platform's ``X-User-System-High`` header — a
+    classification string (e.g. ``"U"``, ``"TS"`` per
+    ``kamiwaza_sdk/services/enclaves.py``), NOT a boolean.  Consumers
+    making trust decisions should compare to the platform's classification
+    constants, not truthiness.
     """
+
+    model_config = ConfigDict(extra="ignore")
 
     user_id: Optional[str] = None
     email: Optional[str] = None
     name: Optional[str] = None
     roles: list[str] = Field(default_factory=list)
-    system_high: bool = False
+    system_high: Optional[str] = None
     workroom_id: Optional[str] = None
     workroom_role: Optional[str] = None
-    auth_token: Optional[str] = None
     request_id: Optional[str] = None
     is_authenticated: bool = False
 
@@ -75,12 +89,29 @@ def _parse_roles(raw: str) -> list[str]:
     return [r.strip() for r in raw.split(",") if r.strip()]
 
 
-def _parse_bool(raw: str) -> bool:
-    return raw.strip().lower() in {"1", "true", "yes"}
-
-
 def _lower(headers: dict[str, str]) -> dict[str, str]:
     return {k.lower(): v for k, v in headers.items()}
+
+
+def _stripped(headers: dict[str, str], key: str) -> Optional[str]:
+    """Return the stripped header value or None if absent / blank."""
+    return (headers.get(key) or "").strip() or None
+
+
+def _project_identity_fields(lower: dict[str, str]) -> dict:
+    """Project the lower-cased header dict onto Identity field kwargs.
+
+    Shared by ``identity_from_headers`` (permissive) and ``extract_identity``
+    (strict) so the projection rule lives in exactly one place.
+    """
+    return {
+        "email": _stripped(lower, _HEADER_USER_EMAIL),
+        "name": _stripped(lower, _HEADER_USER_NAME),
+        "roles": _parse_roles(lower.get(_HEADER_USER_ROLES, "")),
+        "system_high": _stripped(lower, _HEADER_USER_SYSTEM_HIGH),
+        "workroom_role": _stripped(lower, _HEADER_USER_WORKROOM_ROLE),
+        "request_id": _stripped(lower, _HEADER_REQUEST_ID),
+    }
 
 
 def identity_from_headers(headers: dict[str, str]) -> Identity:
@@ -90,24 +121,13 @@ def identity_from_headers(headers: dict[str, str]) -> Identity:
     whether ``x-user-id`` was supplied.
     """
     lower = _lower(headers)
-    user_id = lower.get(_HEADER_USER_ID) or None
+    user_id = _stripped(lower, _HEADER_USER_ID)
     return Identity(
         user_id=user_id,
-        email=lower.get(_HEADER_USER_EMAIL) or None,
-        name=lower.get(_HEADER_USER_NAME) or None,
-        roles=_parse_roles(lower.get(_HEADER_USER_ROLES, "")),
-        system_high=_parse_bool(lower.get(_HEADER_USER_SYSTEM_HIGH, "")),
-        workroom_id=lower.get(_HEADER_WORKROOM_ID) or None,
-        workroom_role=lower.get(_HEADER_USER_WORKROOM_ROLE) or None,
-        auth_token=lower.get(_HEADER_AUTH_TOKEN) or None,
-        request_id=lower.get(_HEADER_REQUEST_ID) or None,
+        workroom_id=_stripped(lower, _HEADER_WORKROOM_ID),
         is_authenticated=user_id is not None,
+        **_project_identity_fields(lower),
     )
-
-
-def _stripped(headers: dict[str, str], key: str) -> Optional[str]:
-    """Return the stripped header value or None if absent / blank."""
-    return (headers.get(key) or "").strip() or None
 
 
 def extract_identity(headers: dict[str, str]) -> Identity:
@@ -129,15 +149,9 @@ def extract_identity(headers: dict[str, str]) -> Identity:
         )
     return Identity(
         user_id=user_id,
-        email=_stripped(lower, _HEADER_USER_EMAIL),
-        name=_stripped(lower, _HEADER_USER_NAME),
-        roles=_parse_roles(lower.get(_HEADER_USER_ROLES, "")),
-        system_high=_parse_bool(lower.get(_HEADER_USER_SYSTEM_HIGH, "")),
         workroom_id=workroom_id,
-        workroom_role=_stripped(lower, _HEADER_USER_WORKROOM_ROLE),
-        auth_token=_stripped(lower, _HEADER_AUTH_TOKEN),
-        request_id=_stripped(lower, _HEADER_REQUEST_ID),
         is_authenticated=True,
+        **_project_identity_fields(lower),
     )
 
 

--- a/kamiwaza_extensions_lib/identity.py
+++ b/kamiwaza_extensions_lib/identity.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import Optional
 
 from fastapi import Request
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 from .errors import MisboundAuthError
 
@@ -34,12 +34,14 @@ _HEADER_REQUEST_ID = "x-request-id"
 class Identity(BaseModel):
     """User identity extracted from platform headers.
 
-    Pydantic model — supports ``.model_dump()`` for JSON serialization
-    and pass-through of unknown fields via ``extra="allow"`` for
-    forward compatibility as the envelope evolves.
-    """
+    Pydantic model — supports ``.model_dump()`` for JSON serialization.
 
-    model_config = ConfigDict(extra="allow")
+    ``extra`` defaults to ``"ignore"``; unknown kwargs are dropped at
+    construction.  This is deliberate: Identity is only constructed
+    internally with explicit kwargs (see ``identity_from_headers`` and
+    ``extract_identity``), so surfacing untrusted extras via
+    ``model_dump()`` would be a leak, not a feature.
+    """
 
     user_id: Optional[str] = None
     email: Optional[str] = None

--- a/kamiwaza_extensions_lib/identity.py
+++ b/kamiwaza_extensions_lib/identity.py
@@ -1,4 +1,14 @@
-"""Identity extraction from platform-injected headers."""
+"""Identity extraction from platform-injected headers.
+
+Two entry points:
+
+* ``identity_from_headers`` — permissive; never raises.  Used when the
+  caller wants to handle missing-envelope cases itself (local dev,
+  ``USE_AUTH=false``, ``/session`` anonymous responses).
+* ``extract_identity`` — strict; raises ``MisboundAuthError`` when
+  required envelope headers are missing or empty.  Matches the UAC-9d
+  contract (design §4.2.7).
+"""
 
 from __future__ import annotations
 
@@ -7,30 +17,32 @@ from typing import Optional
 
 from fastapi import Request
 
+from .errors import MisboundAuthError
 
 # Headers set by Kamiwaza ForwardAuth on authenticated requests.
 _HEADER_USER_ID = "x-user-id"
 _HEADER_USER_EMAIL = "x-user-email"
 _HEADER_USER_NAME = "x-user-name"
 _HEADER_USER_ROLES = "x-user-roles"
+_HEADER_USER_SYSTEM_HIGH = "x-user-system-high"
 _HEADER_WORKROOM_ID = "x-workroom-id"
+_HEADER_USER_WORKROOM_ROLE = "x-user-workroom-role"
+_HEADER_AUTH_TOKEN = "x-auth-token"
 _HEADER_REQUEST_ID = "x-request-id"
 
 
 @dataclass
 class Identity:
-    """User identity extracted from platform headers.
-
-    Always constructed via ``get_identity()``; never raises on missing
-    headers.  Check ``is_authenticated`` to determine whether the
-    request came from a logged-in user.
-    """
+    """User identity extracted from platform headers."""
 
     user_id: Optional[str] = None
     email: Optional[str] = None
     name: Optional[str] = None
     roles: list[str] = field(default_factory=list)
+    system_high: bool = False
     workroom_id: Optional[str] = None
+    workroom_role: Optional[str] = None
+    auth_token: Optional[str] = None
     request_id: Optional[str] = None
     is_authenticated: bool = False
 
@@ -40,30 +52,69 @@ def _parse_roles(raw: str) -> list[str]:
     return [r.strip() for r in raw.split(",") if r.strip()]
 
 
-def identity_from_headers(headers: dict[str, str]) -> Identity:
-    """Build an Identity from a plain header dict (lowercase keys).
+def _parse_bool(raw: str) -> bool:
+    return raw.strip().lower() in {"1", "true", "yes"}
 
-    This is the underlying parser; ``get_identity`` wraps it for
-    FastAPI requests.
+
+def _lower(headers: dict[str, str]) -> dict[str, str]:
+    return {k.lower(): v for k, v in headers.items()}
+
+
+def identity_from_headers(headers: dict[str, str]) -> Identity:
+    """Build an Identity from a plain header dict.  Permissive — never raises.
+
+    Missing fields become ``None``/defaults; ``is_authenticated`` reflects
+    whether ``x-user-id`` was supplied.
     """
-    lower = {k.lower(): v for k, v in headers.items()}
+    lower = _lower(headers)
     user_id = lower.get(_HEADER_USER_ID) or None
     return Identity(
         user_id=user_id,
         email=lower.get(_HEADER_USER_EMAIL) or None,
         name=lower.get(_HEADER_USER_NAME) or None,
         roles=_parse_roles(lower.get(_HEADER_USER_ROLES, "")),
+        system_high=_parse_bool(lower.get(_HEADER_USER_SYSTEM_HIGH, "")),
         workroom_id=lower.get(_HEADER_WORKROOM_ID) or None,
+        workroom_role=lower.get(_HEADER_USER_WORKROOM_ROLE) or None,
+        auth_token=lower.get(_HEADER_AUTH_TOKEN) or None,
         request_id=lower.get(_HEADER_REQUEST_ID) or None,
         is_authenticated=user_id is not None,
     )
 
 
-async def get_identity(request: Request) -> Identity:
-    """Extract identity from a FastAPI request.
+def extract_identity(headers: dict[str, str]) -> Identity:
+    """Strict header parsing for UAC-9d.
 
-    Always returns an ``Identity`` — never raises.  When no identity
-    headers are present, ``is_authenticated`` is ``False`` and all
-    fields are ``None``.
+    Raises ``MisboundAuthError`` when ``X-User-Id`` or ``X-Workroom-Id``
+    is missing or empty — the request did not reach the extension via
+    Traefik, or the platform did not populate the envelope.
+    """
+    lower = _lower(headers)
+    user_id = lower.get(_HEADER_USER_ID) or None
+    workroom_id = lower.get(_HEADER_WORKROOM_ID) or None
+    if not user_id:
+        raise MisboundAuthError("Required envelope header X-User-Id missing or empty")
+    if not workroom_id:
+        raise MisboundAuthError(
+            "Required envelope header X-Workroom-Id missing or empty"
+        )
+    return Identity(
+        user_id=user_id,
+        email=lower.get(_HEADER_USER_EMAIL) or None,
+        name=lower.get(_HEADER_USER_NAME) or None,
+        roles=_parse_roles(lower.get(_HEADER_USER_ROLES, "")),
+        system_high=_parse_bool(lower.get(_HEADER_USER_SYSTEM_HIGH, "")),
+        workroom_id=workroom_id,
+        workroom_role=lower.get(_HEADER_USER_WORKROOM_ROLE) or None,
+        auth_token=lower.get(_HEADER_AUTH_TOKEN) or None,
+        request_id=lower.get(_HEADER_REQUEST_ID) or None,
+        is_authenticated=True,
+    )
+
+
+async def get_identity(request: Request) -> Identity:
+    """Permissive Identity extraction from a FastAPI ``Request``.
+
+    Never raises; see ``identity_from_headers``.
     """
     return identity_from_headers(dict(request.headers))

--- a/kamiwaza_extensions_lib/identity.py
+++ b/kamiwaza_extensions_lib/identity.py
@@ -12,10 +12,10 @@ Two entry points:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Optional
 
 from fastapi import Request
+from pydantic import BaseModel, ConfigDict, Field
 
 from .errors import MisboundAuthError
 
@@ -31,14 +31,20 @@ _HEADER_AUTH_TOKEN = "x-auth-token"
 _HEADER_REQUEST_ID = "x-request-id"
 
 
-@dataclass
-class Identity:
-    """User identity extracted from platform headers."""
+class Identity(BaseModel):
+    """User identity extracted from platform headers.
+
+    Pydantic model — supports ``.model_dump()`` for JSON serialization
+    and pass-through of unknown fields via ``extra="allow"`` for
+    forward compatibility as the envelope evolves.
+    """
+
+    model_config = ConfigDict(extra="allow")
 
     user_id: Optional[str] = None
     email: Optional[str] = None
     name: Optional[str] = None
-    roles: list[str] = field(default_factory=list)
+    roles: list[str] = Field(default_factory=list)
     system_high: bool = False
     workroom_id: Optional[str] = None
     workroom_role: Optional[str] = None

--- a/kamiwaza_extensions_lib/session.py
+++ b/kamiwaza_extensions_lib/session.py
@@ -9,7 +9,7 @@ from urllib.parse import quote
 from fastapi import APIRouter, Request
 
 from .config import AuthConfig
-from .identity import get_identity
+from .identity import anonymous_identity, get_identity
 
 
 def _decode_jwt_exp(token: str) -> int | None:
@@ -79,25 +79,10 @@ def create_session_router(prefix: str = "") -> APIRouter:
         expires_at = _session_expires_at(request) if identity.is_authenticated else None
 
         if not config.use_auth and not identity.is_authenticated:
-            return {
-                "user_id": None,
-                "email": None,
-                "name": "Anonymous",
-                "roles": [],
-                "workroom_id": None,
-                "is_authenticated": False,
-                "expires_at": None,
-            }
+            # Unified anonymous shape with require_auth (§4.8 P5).
+            return {**anonymous_identity().model_dump(), "expires_at": None}
 
-        return {
-            "user_id": identity.user_id,
-            "email": identity.email,
-            "name": identity.name,
-            "roles": identity.roles,
-            "workroom_id": identity.workroom_id,
-            "is_authenticated": identity.is_authenticated,
-            "expires_at": expires_at,
-        }
+        return {**identity.model_dump(), "expires_at": expires_at}
 
     @router.get("/auth/login-url")
     async def login_url(request: Request) -> dict:

--- a/kamiwaza_extensions_lib/session.py
+++ b/kamiwaza_extensions_lib/session.py
@@ -11,6 +11,28 @@ from fastapi import APIRouter, Request
 from .config import AuthConfig
 from .identity import anonymous_identity, get_identity
 
+# Fields that are safe to expose in /session responses. Anything on
+# ``Identity`` not in this set — notably ``auth_token`` (a Bearer
+# credential), ``system_high`` (a classification flag), and
+# ``request_id`` — MUST NOT cross the HTTP boundary to the browser.
+# Allowlist (not denylist) so new Identity fields default to *private*.
+SESSION_PUBLIC_FIELDS = frozenset(
+    {
+        "user_id",
+        "email",
+        "name",
+        "roles",
+        "workroom_id",
+        "workroom_role",
+        "is_authenticated",
+    }
+)
+
+
+def _public_session_payload(identity) -> dict:
+    """Project the public subset of an Identity for the /session response."""
+    return identity.model_dump(include=SESSION_PUBLIC_FIELDS)
+
 
 def _decode_jwt_exp(token: str) -> int | None:
     """Extract the ``exp`` claim from a JWT **without** signature verification.
@@ -80,9 +102,9 @@ def create_session_router(prefix: str = "") -> APIRouter:
 
         if not config.use_auth and not identity.is_authenticated:
             # Unified anonymous shape with require_auth (§4.8 P5).
-            return {**anonymous_identity().model_dump(), "expires_at": None}
+            return {**_public_session_payload(anonymous_identity()), "expires_at": None}
 
-        return {**identity.model_dump(), "expires_at": expires_at}
+        return {**_public_session_payload(identity), "expires_at": expires_at}
 
     @router.get("/auth/login-url")
     async def login_url(request: Request) -> dict:

--- a/kamiwaza_extensions_lib/session.py
+++ b/kamiwaza_extensions_lib/session.py
@@ -83,7 +83,7 @@ def _session_expires_at(request: Request) -> int | None:
 
     prefix = "bearer "
     if authorization.lower().startswith(prefix):
-        return _decode_jwt_exp(authorization[len(prefix):].strip())
+        return _decode_jwt_exp(authorization[len(prefix) :].strip())
     return _decode_jwt_exp(authorization.strip())
 
 
@@ -128,7 +128,7 @@ def create_session_router(prefix: str = "") -> APIRouter:
         # as "logged out" so the frontend's SessionProvider routes to
         # the login flow rather than appearing authenticated.
         try:
-            identity = extract_identity(dict(request.headers))
+            identity = extract_identity(request.headers)
         except MisboundAuthError:
             return {
                 **_public_session_payload(identity_from_headers({})),
@@ -162,8 +162,10 @@ def create_session_router(prefix: str = "") -> APIRouter:
         # Terminate the platform session server-side so the user is
         # actually logged out (the client only redirects to redirect_url).
         from .auth import forward_auth_headers
+
         try:
             import httpx
+
             headers = forward_auth_headers(request.headers)
             async with httpx.AsyncClient(
                 verify=config.verify_ssl,

--- a/kamiwaza_extensions_lib/session.py
+++ b/kamiwaza_extensions_lib/session.py
@@ -12,10 +12,12 @@ from .config import AuthConfig
 from .identity import anonymous_identity, get_identity
 
 # Fields that are safe to expose in /session responses. Anything on
-# ``Identity`` not in this set — notably ``auth_token`` (a Bearer
-# credential), ``system_high`` (a classification flag), and
-# ``request_id`` — MUST NOT cross the HTTP boundary to the browser.
-# Allowlist (not denylist) so new Identity fields default to *private*.
+# ``Identity`` not in this set — notably ``system_high`` (a classification
+# string) and ``request_id`` — MUST NOT cross the HTTP boundary to the
+# browser. The bearer credential (``X-Auth-Token``) is deliberately *not*
+# on the Identity model at all; see kamiwaza_extensions_lib.identity for
+# the rationale. Allowlist (not denylist) so new Identity fields default
+# to *private*.
 SESSION_PUBLIC_FIELDS = frozenset(
     {
         "user_id",

--- a/kamiwaza_extensions_lib/session.py
+++ b/kamiwaza_extensions_lib/session.py
@@ -9,7 +9,13 @@ from urllib.parse import quote
 from fastapi import APIRouter, Request
 
 from .config import AuthConfig
-from .identity import anonymous_identity, get_identity
+from .errors import MisboundAuthError
+from .identity import (
+    anonymous_identity,
+    extract_identity,
+    get_identity,
+    identity_from_headers,
+)
 
 # Fields that are safe to expose in /session responses. Anything on
 # ``Identity`` not in this set — notably ``system_high`` (a classification
@@ -99,14 +105,39 @@ def create_session_router(prefix: str = "") -> APIRouter:
     @router.get("/session")
     async def session(request: Request) -> dict:
         config = AuthConfig.from_env()
-        identity = await get_identity(request)
-        expires_at = _session_expires_at(request) if identity.is_authenticated else None
 
-        if not config.use_auth and not identity.is_authenticated:
-            # Unified anonymous shape with require_auth (§4.8 P5).
-            return {**_public_session_payload(anonymous_identity()), "expires_at": None}
+        # USE_AUTH=false: permissive — local dev returns anonymous when no
+        # envelope is present, otherwise reflects whatever headers were set.
+        if not config.use_auth:
+            identity = await get_identity(request)
+            if not identity.is_authenticated:
+                return {
+                    **_public_session_payload(anonymous_identity()),
+                    "expires_at": None,
+                }
+            return {
+                **_public_session_payload(identity),
+                "expires_at": _session_expires_at(request),
+            }
 
-        return {**_public_session_payload(identity), "expires_at": expires_at}
+        # USE_AUTH=true: validate the envelope strictly so /session and
+        # require_auth report the same auth state. Without this symmetry,
+        # a malformed envelope (e.g., X-User-Id present but X-Workroom-Id
+        # missing) shows a logged-in /session while every protected call
+        # returns 401 — frontend split-brain. Treat malformed envelopes
+        # as "logged out" so the frontend's SessionProvider routes to
+        # the login flow rather than appearing authenticated.
+        try:
+            identity = extract_identity(dict(request.headers))
+        except MisboundAuthError:
+            return {
+                **_public_session_payload(identity_from_headers({})),
+                "expires_at": None,
+            }
+        return {
+            **_public_session_payload(identity),
+            "expires_at": _session_expires_at(request),
+        }
 
     @router.get("/auth/login-url")
     async def login_url(request: Request) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ exclude = ["tests*", "examples*"]
 [tool.setuptools.package-data]
 kamiwaza_sdk = ["py.typed"]
 kamiwaza_extensions = ["templates/**/*", "templates/**/.*"]
-kamiwaza_extensions_lib = ["py.typed"]
+kamiwaza_extensions_lib = ["py.typed", "exception_names.json"]
 
 [dependency-groups]
 dev = [

--- a/tests/unit/extensions/test_cli.py
+++ b/tests/unit/extensions/test_cli.py
@@ -69,3 +69,27 @@ class TestErrorHandling:
 
         with pytest.raises(ClickExit):
             failing_func()
+
+    # TS-8: RuntimeLibException → exit code matches exit_code_for(class_name)
+    @pytest.mark.parametrize(
+        "error_cls, expected_code",
+        [
+            ("MisboundAuthError", 10),
+            ("UnexpectedContextError", 11),
+            ("OutOfEnvelopeAccessError", 12),
+            ("PlatformOutageError", 13),
+        ],
+    )
+    def test_runtime_lib_exception_maps_to_exit_code(self, error_cls, expected_code):
+        from kamiwaza_extensions import cli
+        import kamiwaza_extensions_lib.errors as errors_module
+
+        cls = getattr(errors_module, error_cls)
+
+        @cli.run_with_error_handling
+        def failing_func():
+            raise cls("boom")
+
+        with pytest.raises(ClickExit) as exc_info:
+            failing_func()
+        assert exc_info.value.exit_code == expected_code

--- a/tests/unit/extensions/test_cli.py
+++ b/tests/unit/extensions/test_cli.py
@@ -93,3 +93,20 @@ class TestErrorHandling:
         with pytest.raises(ClickExit) as exc_info:
             failing_func()
         assert exc_info.value.exit_code == expected_code
+
+    def test_unknown_runtime_lib_subclass_falls_back_to_failure(self):
+        """A custom KamiwazaRuntimeError subclass with an unmapped class_name
+        should exit with the generic FAILURE code (1), not silently crash."""
+        from kamiwaza_extensions import cli
+        from kamiwaza_extensions_lib.errors import KamiwazaRuntimeError
+
+        class CustomRuntimeError(KamiwazaRuntimeError):
+            class_name = "some_novel_class_name_not_in_catalog"
+
+        @cli.run_with_error_handling
+        def failing_func():
+            raise CustomRuntimeError("surprise")
+
+        with pytest.raises(ClickExit) as exc_info:
+            failing_func()
+        assert exc_info.value.exit_code == 1  # ExitCode.FAILURE

--- a/tests/unit/extensions/test_doctor_hint_coverage.py
+++ b/tests/unit/extensions/test_doctor_hint_coverage.py
@@ -1,0 +1,58 @@
+"""Contract test: every UAC-9d class has a doctor hint + exit-code mapping.
+
+Traces to: ENG-3885 (§4.2.8 DoctorUACFailureHints).
+
+This test is the canonical coverage check for the exception_names.json
+source of truth — it enforces the 1:1 invariant between runtime-lib
+class names, CLI exit codes, and doctor reference entries.
+"""
+
+import json
+from importlib import resources
+
+import pytest
+
+
+@pytest.fixture
+def exception_classes() -> list[dict]:
+    """Load the canonical list of UAC-9d exception classes."""
+    raw = (
+        resources.files("kamiwaza_extensions_lib")
+        .joinpath("exception_names.json")
+        .read_text(encoding="utf-8")
+    )
+    return json.loads(raw)["classes"]
+
+
+@pytest.mark.unit
+class TestDoctorHintCoverage:
+    # TS-3: every class in exception_names.json has a CheckResult + ExitCode
+    def test_exit_code_mapping_complete(self, exception_classes):
+        from kamiwaza_extensions.exit_codes import exit_code_for
+
+        for entry in exception_classes:
+            assert int(exit_code_for(entry["name"])) == entry["exit_code"], (
+                f"exit_code_for({entry['name']!r}) does not match "
+                f"exception_names.json (expected {entry['exit_code']})"
+            )
+
+    def test_doctor_surfaces_hint_for_each_class(self, exception_classes):
+        from kamiwaza_extensions.doctor import DoctorChecker
+
+        results = DoctorChecker().run_all()
+        names = {r.name for r in results}
+        messages_by_name = {r.name: (r.message, r.fix) for r in results}
+
+        for entry in exception_classes:
+            expected_name = f"UAC-9d: {entry['name']}"
+            assert expected_name in names, (
+                f"Doctor missing CheckResult for class {entry['name']!r} "
+                f"(expected a result named {expected_name!r})"
+            )
+            # Hint text must appear somewhere in the CheckResult
+            message, fix = messages_by_name[expected_name]
+            hint = entry["doctor_hint"]
+            assert hint in message or hint in (fix or ""), (
+                f"Doctor hint for {entry['name']!r} missing the canonical "
+                f"text from exception_names.json"
+            )

--- a/tests/unit/extensions/test_doctor_hint_coverage.py
+++ b/tests/unit/extensions/test_doctor_hint_coverage.py
@@ -44,7 +44,7 @@ class TestDoctorHintCoverage:
         messages_by_name = {r.name: (r.message, r.fix) for r in results}
 
         for entry in exception_classes:
-            expected_name = f"UAC-9d: {entry['name']}"
+            expected_name = f"Failure class: {entry['name']}"
             assert expected_name in names, (
                 f"Doctor missing CheckResult for class {entry['name']!r} "
                 f"(expected a result named {expected_name!r})"

--- a/tests/unit/extensions/test_doctor_hint_coverage.py
+++ b/tests/unit/extensions/test_doctor_hint_coverage.py
@@ -37,9 +37,16 @@ class TestDoctorHintCoverage:
             )
 
     def test_doctor_surfaces_hint_for_each_class(self, exception_classes):
+        """Call the hint-emitting method directly rather than ``run_all()``.
+
+        ``run_all()`` shells out to docker, probes HTTP endpoints, and walks
+        cwd for ``kamiwaza.json`` — 20-30s of subprocess timeouts on machines
+        without Docker. For a contract test focused on the hint surface, we
+        only need the hint slice.
+        """
         from kamiwaza_extensions.doctor import DoctorChecker
 
-        results = DoctorChecker().run_all()
+        results = DoctorChecker()._uac_9d_reference_hints()
         names = {r.name for r in results}
         messages_by_name = {r.name: (r.message, r.fix) for r in results}
 

--- a/tests/unit/extensions/test_exit_codes.py
+++ b/tests/unit/extensions/test_exit_codes.py
@@ -1,0 +1,33 @@
+"""Tests for kamiwaza_extensions.exit_codes.
+
+Traces to: ENG-3885 (UAC-9d CLI plumbing), design §4.2.8 ExitCodeMap.
+"""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestExitCode:
+    # TS-1: ExitCode enum has all required values (0/1/2, 10-13, 20-23)
+    def test_standard_codes(self):
+        from kamiwaza_extensions.exit_codes import ExitCode
+
+        assert ExitCode.OK == 0
+        assert ExitCode.FAILURE == 1
+        assert ExitCode.VALIDATION == 2
+
+    def test_uac_9d_codes(self):
+        from kamiwaza_extensions.exit_codes import ExitCode
+
+        assert ExitCode.MISBOUND_AUTH == 10
+        assert ExitCode.UNEXPECTED_CONTEXT == 11
+        assert ExitCode.OUT_OF_ENVELOPE_ACCESS == 12
+        assert ExitCode.PLATFORM_OUTAGE == 13
+
+    def test_cluster_and_registry_codes(self):
+        from kamiwaza_extensions.exit_codes import ExitCode
+
+        assert ExitCode.REGISTRY_AUTH == 20
+        assert ExitCode.CLUSTER_UNREACHABLE == 21
+        assert ExitCode.CRD_PATCH_UNSUPPORTED == 22
+        assert ExitCode.CLUSTER_NOT_READY == 23

--- a/tests/unit/extensions/test_exit_codes.py
+++ b/tests/unit/extensions/test_exit_codes.py
@@ -31,3 +31,32 @@ class TestExitCode:
         assert ExitCode.CLUSTER_UNREACHABLE == 21
         assert ExitCode.CRD_PATCH_UNSUPPORTED == 22
         assert ExitCode.CLUSTER_NOT_READY == 23
+
+
+@pytest.mark.unit
+class TestExitCodeFor:
+    # TS-2: exit_code_for('misbound_auth')=10; same for all 4 UAC-9d classes
+    def test_misbound_auth(self):
+        from kamiwaza_extensions.exit_codes import ExitCode, exit_code_for
+
+        assert exit_code_for("misbound_auth") == ExitCode.MISBOUND_AUTH
+
+    def test_unexpected_context(self):
+        from kamiwaza_extensions.exit_codes import ExitCode, exit_code_for
+
+        assert exit_code_for("unexpected_context") == ExitCode.UNEXPECTED_CONTEXT
+
+    def test_out_of_envelope_access(self):
+        from kamiwaza_extensions.exit_codes import ExitCode, exit_code_for
+
+        assert exit_code_for("out_of_envelope_access") == ExitCode.OUT_OF_ENVELOPE_ACCESS
+
+    def test_platform_outage(self):
+        from kamiwaza_extensions.exit_codes import ExitCode, exit_code_for
+
+        assert exit_code_for("platform_outage") == ExitCode.PLATFORM_OUTAGE
+
+    def test_unknown_class_returns_failure(self):
+        from kamiwaza_extensions.exit_codes import ExitCode, exit_code_for
+
+        assert exit_code_for("some_unknown_class") == ExitCode.FAILURE

--- a/tests/unit/extensions/test_login.py
+++ b/tests/unit/extensions/test_login.py
@@ -1,5 +1,8 @@
 """Tests for the login command."""
 
+import base64
+import json
+
 import pytest
 from unittest.mock import patch, MagicMock
 from typer.testing import CliRunner
@@ -7,6 +10,79 @@ from typer.testing import CliRunner
 from kamiwaza_extensions.cli import app
 
 runner = CliRunner()
+
+
+def _encode_jwt(payload: dict) -> str:
+    """Produce a JWT-shaped string with *payload* as the body (no signature)."""
+    header = base64.urlsafe_b64encode(b'{"alg":"none","typ":"JWT"}').rstrip(b"=").decode()
+    body = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    )
+    return f"{header}.{body}.signature-ignored"
+
+
+@pytest.mark.unit
+class TestPATRoleDecoding:
+    """TS-32: decode PAT roles claim (no signature verification)."""
+
+    def test_returns_roles_from_jwt_body(self):
+        from kamiwaza_extensions.commands.login import _decode_pat_roles
+
+        token = _encode_jwt({"sub": "u1", "roles": ["member", "editor"]})
+        assert _decode_pat_roles(token) == {"member", "editor"}
+
+    def test_returns_empty_when_no_roles_claim(self):
+        from kamiwaza_extensions.commands.login import _decode_pat_roles
+
+        token = _encode_jwt({"sub": "u1"})
+        assert _decode_pat_roles(token) == set()
+
+    def test_returns_empty_on_malformed_token(self):
+        from kamiwaza_extensions.commands.login import _decode_pat_roles
+
+        assert _decode_pat_roles("not-a-jwt") == set()
+
+
+@pytest.mark.unit
+class TestRoleSetWarning:
+    """TS-32: warn when UI role-set is a strict superset of PAT role-set."""
+
+    def test_warns_on_strict_superset(self, capsys):
+        from kamiwaza_extensions.commands.login import _warn_if_roles_downgraded
+
+        _warn_if_roles_downgraded(
+            pat_roles={"member"},
+            ui_roles={"member", "admin"},
+        )
+        out = capsys.readouterr().out
+        assert "admin" in out
+        assert "PAT" in out or "role" in out.lower()
+
+    def test_quiet_when_equal(self, capsys):
+        from kamiwaza_extensions.commands.login import _warn_if_roles_downgraded
+
+        _warn_if_roles_downgraded(
+            pat_roles={"member", "admin"},
+            ui_roles={"member", "admin"},
+        )
+        assert capsys.readouterr().out == ""
+
+    def test_quiet_when_pat_is_superset(self, capsys):
+        """PAT roles larger than UI — unusual but not a downgrade; no warning."""
+        from kamiwaza_extensions.commands.login import _warn_if_roles_downgraded
+
+        _warn_if_roles_downgraded(
+            pat_roles={"member", "admin"},
+            ui_roles={"member"},
+        )
+        assert capsys.readouterr().out == ""
+
+    def test_quiet_when_ui_roles_empty(self, capsys):
+        """If /whoami failed or returned nothing, don't guess — stay silent."""
+        from kamiwaza_extensions.commands.login import _warn_if_roles_downgraded
+
+        _warn_if_roles_downgraded(pat_roles={"member"}, ui_roles=set())
+        assert capsys.readouterr().out == ""
 
 
 @pytest.mark.unit

--- a/tests/unit/extensions/test_login.py
+++ b/tests/unit/extensions/test_login.py
@@ -42,6 +42,26 @@ class TestPATRoleDecoding:
 
         assert _decode_pat_roles("not-a-jwt") == set()
 
+    def test_returns_empty_for_none_token(self):
+        """If create_pat returns no token (or a non-string), decoding must
+        not crash — login already stored the connection and a NoneType
+        AttributeError here would surprise the user (PR review High #4)."""
+        from kamiwaza_extensions.commands.login import _decode_pat_roles
+
+        assert _decode_pat_roles(None) == set()
+        assert _decode_pat_roles(123) == set()  # type: ignore[arg-type]
+
+    def test_returns_empty_for_oversized_payload(self):
+        """Defensive cap on attacker-controlled JWT payload size (Medium Low #1)."""
+        from kamiwaza_extensions.commands.login import (
+            _PAT_PAYLOAD_MAX_BYTES,
+            _decode_pat_roles,
+        )
+
+        bloated = "a" * (_PAT_PAYLOAD_MAX_BYTES + 1)
+        token = f"hdr.{bloated}.sig"
+        assert _decode_pat_roles(token) == set()
+
 
 @pytest.mark.unit
 class TestCaptureUIRoles:
@@ -87,10 +107,35 @@ class TestCaptureUIRoles:
 
         assert _capture_ui_roles(client) == set()
 
+    def test_verbose_emits_diagnostic_on_sdk_exception(self, capsys):
+        """PR review High #3: silent failure masks the B3 warning. Under
+        --verbose, operators should see why the role-set capture failed."""
+        from kamiwaza_extensions.commands.login import _capture_ui_roles
+
+        client = MagicMock()
+        client.auth.get_current_user.side_effect = RuntimeError("network down")
+
+        assert _capture_ui_roles(client, verbose=True) == set()
+        out = capsys.readouterr().out
+        # Diagnostic surfaces the exception type AND message
+        assert "RuntimeError" in out
+        assert "network down" in out
+
+    def test_quiet_mode_emits_no_diagnostic_on_failure(self, capsys):
+        """Default behavior must remain silent — the warning is best-effort
+        and we don't pollute stdout when nothing went wrong from the user's POV."""
+        from kamiwaza_extensions.commands.login import _capture_ui_roles
+
+        client = MagicMock()
+        client.auth.get_current_user.side_effect = RuntimeError("network down")
+
+        assert _capture_ui_roles(client) == set()
+        assert capsys.readouterr().out == ""
+
 
 @pytest.mark.unit
 class TestRoleSetWarning:
-    """TS-32: warn when UI role-set is a strict superset of PAT role-set."""
+    """TS-32: warn when UI role-set has roles the PAT is missing."""
 
     def _run(self, **kwargs) -> str:
         """Invoke the helper via a CliRunner so typer.echo is captured."""
@@ -109,6 +154,14 @@ class TestRoleSetWarning:
         out = self._run(pat_roles={"member"}, ui_roles={"member", "admin"})
         assert "admin" in out
         assert "PAT" in out or "role" in out.lower()
+
+    def test_warns_on_overlapping_disjoint(self):
+        """PR review High #6: pat={a,b}, ui={a,c} — c is a real downgrade
+        even though pat is not a strict subset. Pre-fix this case was silent."""
+        out = self._run(pat_roles={"a", "b"}, ui_roles={"a", "c"})
+        assert "c" in out
+        # Confirm the missing-set in the message is just {c}, not the full set
+        assert "['c']" in out
 
     def test_quiet_when_equal(self):
         assert self._run(

--- a/tests/unit/extensions/test_login.py
+++ b/tests/unit/extensions/test_login.py
@@ -235,3 +235,60 @@ class TestLoginCommand:
                 assert result.exit_code == 1
                 assert "Could not validate" in result.output
                 mgr.add_connection.assert_not_called()
+
+
+@pytest.mark.unit
+class TestLoginPATResponseValidation:
+    """PR re-review Medium #2: a successful auth followed by a missing-token
+    PAT response should surface a distinct error from "Authentication failed",
+    must not store the connection, and should hint at orphan PAT cleanup."""
+
+    def _setup(self, monkeypatch, pat_token):
+        """Patch the SDK client so create_pat returns the given token."""
+        pat_response = MagicMock()
+        pat_response.token = pat_token
+        sdk_client = MagicMock()
+        sdk_client.auth.create_pat.return_value = pat_response
+        sdk_client.auth.get_current_user.return_value = MagicMock(roles=[])
+
+        # Patch construction so KamiwazaClient(...) returns our mock and
+        # the UserPasswordAuthenticator constructor does nothing.
+        monkeypatch.setattr(
+            "kamiwaza_sdk.KamiwazaClient", lambda **kw: sdk_client,
+        )
+        monkeypatch.setattr(
+            "kamiwaza_sdk.authentication.UserPasswordAuthenticator",
+            lambda *a, **kw: MagicMock(),
+        )
+
+    def test_none_pat_token_surfaces_distinct_error(self, monkeypatch):
+        self._setup(monkeypatch, pat_token=None)
+        with patch("kamiwaza_extensions.connections.ConnectionManager") as MockMgr:
+            mgr = MockMgr.return_value
+            result = runner.invoke(
+                app,
+                ["login", "https://test.example/api"],
+                input="alice\nsecret\n",
+            )
+        assert result.exit_code == 1
+        # NOT prefixed with "Authentication failed" — auth succeeded; PAT
+        # mint did not.
+        assert "Authentication failed" not in result.output
+        assert "no token" in result.output.lower() or "did not return" in result.output.lower()
+        # Hint at orphan-PAT cleanup mentions the PAT name
+        assert "kz-ext-default" in result.output
+        # Connection MUST NOT be added with a None access_token
+        mgr.add_connection.assert_not_called()
+
+    def test_empty_pat_token_surfaces_distinct_error(self, monkeypatch):
+        self._setup(monkeypatch, pat_token="")
+        with patch("kamiwaza_extensions.connections.ConnectionManager") as MockMgr:
+            mgr = MockMgr.return_value
+            result = runner.invoke(
+                app,
+                ["login", "https://test.example/api"],
+                input="alice\nsecret\n",
+            )
+        assert result.exit_code == 1
+        assert "Authentication failed" not in result.output
+        mgr.add_connection.assert_not_called()

--- a/tests/unit/extensions/test_login.py
+++ b/tests/unit/extensions/test_login.py
@@ -44,45 +44,86 @@ class TestPATRoleDecoding:
 
 
 @pytest.mark.unit
+class TestCaptureUIRoles:
+    """TS-32: UI roles come from the password-session /auth/users/me call,
+    not from the just-minted PAT (which would be self-referential)."""
+
+    def test_reads_roles_from_sdk_current_user(self):
+        from kamiwaza_extensions.commands.login import _capture_ui_roles
+
+        user = MagicMock()
+        user.roles = ["member", "admin"]
+        client = MagicMock()
+        client.auth.get_current_user.return_value = user
+
+        assert _capture_ui_roles(client) == {"member", "admin"}
+        client.auth.get_current_user.assert_called_once_with()
+
+    def test_returns_empty_on_sdk_exception(self):
+        from kamiwaza_extensions.commands.login import _capture_ui_roles
+
+        client = MagicMock()
+        client.auth.get_current_user.side_effect = RuntimeError("network")
+
+        assert _capture_ui_roles(client) == set()
+
+    def test_returns_empty_when_roles_missing(self):
+        from kamiwaza_extensions.commands.login import _capture_ui_roles
+
+        user = MagicMock()
+        user.roles = None
+        client = MagicMock()
+        client.auth.get_current_user.return_value = user
+
+        assert _capture_ui_roles(client) == set()
+
+    def test_returns_empty_when_roles_not_a_list(self):
+        from kamiwaza_extensions.commands.login import _capture_ui_roles
+
+        user = MagicMock()
+        user.roles = "admin"  # wrong shape
+        client = MagicMock()
+        client.auth.get_current_user.return_value = user
+
+        assert _capture_ui_roles(client) == set()
+
+
+@pytest.mark.unit
 class TestRoleSetWarning:
     """TS-32: warn when UI role-set is a strict superset of PAT role-set."""
 
-    def test_warns_on_strict_superset(self, capsys):
+    def _run(self, **kwargs) -> str:
+        """Invoke the helper via a CliRunner so typer.echo is captured."""
+        import typer
         from kamiwaza_extensions.commands.login import _warn_if_roles_downgraded
 
-        _warn_if_roles_downgraded(
-            pat_roles={"member"},
-            ui_roles={"member", "admin"},
-        )
-        out = capsys.readouterr().out
+        app = typer.Typer()
+
+        @app.command()
+        def _cmd() -> None:
+            _warn_if_roles_downgraded(**kwargs)
+
+        return runner.invoke(app, []).output
+
+    def test_warns_on_strict_superset(self):
+        out = self._run(pat_roles={"member"}, ui_roles={"member", "admin"})
         assert "admin" in out
         assert "PAT" in out or "role" in out.lower()
 
-    def test_quiet_when_equal(self, capsys):
-        from kamiwaza_extensions.commands.login import _warn_if_roles_downgraded
+    def test_quiet_when_equal(self):
+        assert self._run(
+            pat_roles={"member", "admin"}, ui_roles={"member", "admin"}
+        ) == ""
 
-        _warn_if_roles_downgraded(
-            pat_roles={"member", "admin"},
-            ui_roles={"member", "admin"},
-        )
-        assert capsys.readouterr().out == ""
-
-    def test_quiet_when_pat_is_superset(self, capsys):
+    def test_quiet_when_pat_is_superset(self):
         """PAT roles larger than UI — unusual but not a downgrade; no warning."""
-        from kamiwaza_extensions.commands.login import _warn_if_roles_downgraded
+        assert self._run(
+            pat_roles={"member", "admin"}, ui_roles={"member"}
+        ) == ""
 
-        _warn_if_roles_downgraded(
-            pat_roles={"member", "admin"},
-            ui_roles={"member"},
-        )
-        assert capsys.readouterr().out == ""
-
-    def test_quiet_when_ui_roles_empty(self, capsys):
-        """If /whoami failed or returned nothing, don't guess — stay silent."""
-        from kamiwaza_extensions.commands.login import _warn_if_roles_downgraded
-
-        _warn_if_roles_downgraded(pat_roles={"member"}, ui_roles=set())
-        assert capsys.readouterr().out == ""
+    def test_quiet_when_ui_roles_empty(self):
+        """If capture failed or returned nothing, don't guess — stay silent."""
+        assert self._run(pat_roles={"member"}, ui_roles=set()) == ""
 
 
 @pytest.mark.unit

--- a/tests/unit/extensions_lib/test_auth.py
+++ b/tests/unit/extensions_lib/test_auth.py
@@ -131,7 +131,41 @@ class TestRequireAuth:
         with pytest.raises(HTTPException) as exc_info:
             await require_auth(request)
         assert exc_info.value.status_code == 401
-        assert "X-Workroom-Id" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_missing_user_id_rejected_under_strict_auth(self, monkeypatch):
+        """Symmetry counterpart to the workroom-id test: missing X-User-Id
+        with X-Workroom-Id present must also reject (PR re-review request)."""
+        monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+        request = MagicMock()
+        request.headers = {"x-workroom-id": "wrk-456"}  # no x-user-id
+
+        with pytest.raises(HTTPException) as exc_info:
+            await require_auth(request)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_401_detail_does_not_leak_envelope_internals(self, monkeypatch):
+        """The 401 body should be scrubbed to the canonical "Authentication
+        required" — the raw exception text naming the missing header is
+        useful for server-side triage, harmful as an HTTP response body
+        (PR re-review Medium #1)."""
+        monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+        request = MagicMock()
+        request.method = "GET"
+        request.url.path = "/protected"
+        request.headers = {"x-user-id": "usr-123"}  # missing workroom-id
+
+        with pytest.raises(HTTPException) as exc_info:
+            await require_auth(request)
+        assert exc_info.value.detail == "Authentication required"
+        # Per-header detail leaked into the public 401 body would be a
+        # regression — these strings come from MisboundAuthError messages.
+        assert "X-Workroom-Id" not in str(exc_info.value.detail)
+        assert "X-User-Id" not in str(exc_info.value.detail)
+        # Canonical class name lives in WWW-Authenticate per RFC 6750.
+        assert exc_info.value.headers is not None
+        assert 'error="misbound_auth"' in exc_info.value.headers["WWW-Authenticate"]
 
     @pytest.mark.asyncio
     async def test_whitespace_only_workroom_id_rejected(self, monkeypatch):

--- a/tests/unit/extensions_lib/test_auth.py
+++ b/tests/unit/extensions_lib/test_auth.py
@@ -24,6 +24,8 @@ class TestForwardAuthHeaders:
             "X-User-Email": "alice@example.com",
             "X-User-Name": "Alice",
             "X-User-Roles": "admin,user",
+            "X-User-System-High": "TS",
+            "X-User-Workroom-Role": "editor",
             "X-Workroom-Id": "wrk-456",
             "X-Request-Id": "req-789",
             "Content-Type": "application/json",
@@ -40,8 +42,22 @@ class TestForwardAuthHeaders:
             "X-User-Email": "alice@example.com",
             "X-User-Name": "Alice",
             "X-User-Roles": "admin,user",
+            "X-User-System-High": "TS",
+            "X-User-Workroom-Role": "editor",
             "X-Workroom-Id": "wrk-456",
             "X-Request-Id": "req-789",
+        }
+
+    def test_forwards_classification_and_workroom_role(self):
+        """Regression guard: the new envelope headers MUST be forwarded so
+        downstream services can re-establish the caller's classification
+        and workroom role when the extension calls another Kamiwaza service."""
+        result = forward_auth_headers(
+            {"X-User-System-High": "U", "X-User-Workroom-Role": "viewer"}
+        )
+        assert result == {
+            "X-User-System-High": "U",
+            "X-User-Workroom-Role": "viewer",
         }
 
     def test_returns_empty_when_no_auth_headers(self):

--- a/tests/unit/extensions_lib/test_auth.py
+++ b/tests/unit/extensions_lib/test_auth.py
@@ -76,13 +76,19 @@ class TestForwardAuthHeaders:
 @pytest.mark.unit
 class TestRequireAuth:
     @pytest.mark.asyncio
-    async def test_authenticated_request(self):
+    async def test_authenticated_request(self, monkeypatch):
+        monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
         request = MagicMock()
-        request.headers = {"x-user-id": "usr-123", "x-user-email": "a@b.com"}
+        request.headers = {
+            "x-user-id": "usr-123",
+            "x-user-email": "a@b.com",
+            "x-workroom-id": "wrk-456",
+        }
 
         identity = await require_auth(request)
 
         assert identity.user_id == "usr-123"
+        assert identity.workroom_id == "wrk-456"
         assert identity.is_authenticated is True
 
     @pytest.mark.asyncio
@@ -90,6 +96,34 @@ class TestRequireAuth:
         monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
         request = MagicMock()
         request.headers = {}
+
+        with pytest.raises(HTTPException) as exc_info:
+            await require_auth(request)
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_missing_workroom_id_rejected_under_strict_auth(self, monkeypatch):
+        """Critical: a request with X-User-Id but no X-Workroom-Id MUST NOT
+        reach protected handlers. Pre-fix, the permissive get_identity()
+        path treated such requests as authenticated with workroom_id=None
+        — exactly the malformed envelope MisboundAuthError exists to catch.
+        """
+        monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+        request = MagicMock()
+        request.headers = {"x-user-id": "usr-123"}  # no x-workroom-id
+
+        with pytest.raises(HTTPException) as exc_info:
+            await require_auth(request)
+        assert exc_info.value.status_code == 401
+        assert "X-Workroom-Id" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_workroom_id_rejected(self, monkeypatch):
+        """Whitespace-only headers must be treated as empty, not as
+        workroom_id="   ", or a misconfigured Traefik bypasses the gate."""
+        monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+        request = MagicMock()
+        request.headers = {"x-user-id": "usr-123", "x-workroom-id": "   "}
 
         with pytest.raises(HTTPException) as exc_info:
             await require_auth(request)
@@ -106,6 +140,19 @@ class TestRequireAuth:
         assert identity.is_authenticated is False
         # Should not raise — local dev mode
 
+    @pytest.mark.asyncio
+    async def test_local_dev_mode_does_not_validate_envelope(self, monkeypatch):
+        """USE_AUTH=false uses the permissive parser — extension authors
+        running locally without a platform must not hit MisboundAuthError."""
+        monkeypatch.setenv("KAMIWAZA_USE_AUTH", "false")
+        request = MagicMock()
+        request.headers = {"x-user-id": "usr-123"}  # no workroom — fine in dev
+
+        identity = await require_auth(request)
+
+        assert identity.user_id == "usr-123"
+        assert identity.workroom_id is None
+
 
 @pytest.mark.unit
 class TestRequireRole:
@@ -115,6 +162,7 @@ class TestRequireRole:
         request = MagicMock()
         request.headers = {
             "x-user-id": "usr-123",
+            "x-workroom-id": "wrk-456",
             "x-user-roles": "admin,user",
         }
 

--- a/tests/unit/extensions_lib/test_client.py
+++ b/tests/unit/extensions_lib/test_client.py
@@ -1,8 +1,10 @@
 """Tests for kamiwaza_extensions_lib.client."""
 
-import pytest
-import httpx
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
 
 from kamiwaza_extensions_lib.client import KamiwazaExtClient
 
@@ -68,9 +70,7 @@ class TestKamiwazaExtClientInit:
         async_client = client._client()
         assert async_client.timeout == httpx.Timeout(15.0)
         # Clean up
-        import asyncio
-
-        asyncio.get_event_loop().run_until_complete(async_client.aclose())
+        asyncio.run(async_client.aclose())
 
 
 @pytest.mark.unit
@@ -106,7 +106,7 @@ class TestKamiwazaExtClientMethods:
             mock_instance.__aexit__ = AsyncMock(return_value=False)
             MockClient.return_value = mock_instance
 
-            result = await client.chat_completions(
+            await client.chat_completions(
                 {"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]}
             )
 

--- a/tests/unit/extensions_lib/test_errors.py
+++ b/tests/unit/extensions_lib/test_errors.py
@@ -1,0 +1,118 @@
+"""Tests for kamiwaza_extensions_lib.errors.
+
+Traces to: ENG-3885 (UAC-9d runtime-lib exception hierarchy), design §4.2.7.
+"""
+
+import pytest
+
+
+@pytest.mark.unit
+class TestRuntimeErrorHierarchy:
+    def test_base_class_has_class_name(self):
+        from kamiwaza_extensions_lib.errors import KamiwazaRuntimeError
+
+        err = KamiwazaRuntimeError("boom")
+        assert err.class_name == "kamiwaza_runtime_error"
+        assert str(err) == "boom"
+
+    def test_misbound_auth_error(self):
+        from kamiwaza_extensions_lib.errors import (
+            KamiwazaRuntimeError,
+            MisboundAuthError,
+        )
+
+        err = MisboundAuthError("missing X-User-Id")
+        assert isinstance(err, KamiwazaRuntimeError)
+        assert err.class_name == "misbound_auth"
+
+    def test_unexpected_context_error(self):
+        from kamiwaza_extensions_lib.errors import (
+            KamiwazaRuntimeError,
+            UnexpectedContextError,
+        )
+
+        err = UnexpectedContextError("wrong context")
+        assert isinstance(err, KamiwazaRuntimeError)
+        assert err.class_name == "unexpected_context"
+
+    def test_out_of_envelope_access_error(self):
+        from kamiwaza_extensions_lib.errors import (
+            KamiwazaRuntimeError,
+            OutOfEnvelopeAccessError,
+        )
+
+        err = OutOfEnvelopeAccessError("cross-workroom attempt")
+        assert isinstance(err, KamiwazaRuntimeError)
+        assert err.class_name == "out_of_envelope_access"
+
+    def test_platform_outage_error(self):
+        from kamiwaza_extensions_lib.errors import (
+            KamiwazaRuntimeError,
+            PlatformOutageError,
+        )
+
+        err = PlatformOutageError("5xx from platform")
+        assert isinstance(err, KamiwazaRuntimeError)
+        assert err.class_name == "platform_outage"
+
+
+@pytest.mark.unit
+class TestExtractIdentity:
+    """Strict header parsing: raises MisboundAuthError on missing envelope.
+
+    Contrast with identity_from_headers (permissive — never raises).
+    """
+
+    # TS-4: MisboundAuthError raised when X-User-Id missing
+    def test_raises_when_user_id_missing(self):
+        from kamiwaza_extensions_lib.errors import MisboundAuthError
+        from kamiwaza_extensions_lib.identity import extract_identity
+
+        with pytest.raises(MisboundAuthError):
+            extract_identity({"x-workroom-id": "wrk-456"})
+
+    def test_raises_when_user_id_empty(self):
+        from kamiwaza_extensions_lib.errors import MisboundAuthError
+        from kamiwaza_extensions_lib.identity import extract_identity
+
+        with pytest.raises(MisboundAuthError):
+            extract_identity({"x-user-id": "", "x-workroom-id": "wrk-456"})
+
+    # TS-5: MisboundAuthError raised when X-Workroom-Id missing
+    def test_raises_when_workroom_id_missing(self):
+        from kamiwaza_extensions_lib.errors import MisboundAuthError
+        from kamiwaza_extensions_lib.identity import extract_identity
+
+        with pytest.raises(MisboundAuthError):
+            extract_identity({"x-user-id": "usr-123"})
+
+    def test_raises_when_workroom_id_empty(self):
+        from kamiwaza_extensions_lib.errors import MisboundAuthError
+        from kamiwaza_extensions_lib.identity import extract_identity
+
+        with pytest.raises(MisboundAuthError):
+            extract_identity({"x-user-id": "usr-123", "x-workroom-id": ""})
+
+    def test_happy_path_returns_authenticated_identity(self):
+        from kamiwaza_extensions_lib.identity import extract_identity
+
+        identity = extract_identity(
+            {
+                "x-user-id": "usr-123",
+                "x-user-email": "alice@example.com",
+                "x-user-name": "Alice",
+                "x-user-roles": "admin,user",
+                "x-workroom-id": "wrk-456",
+                "x-user-workroom-role": "editor",
+                "x-request-id": "req-789",
+            }
+        )
+
+        assert identity.user_id == "usr-123"
+        assert identity.email == "alice@example.com"
+        assert identity.name == "Alice"
+        assert identity.roles == ["admin", "user"]
+        assert identity.workroom_id == "wrk-456"
+        assert identity.workroom_role == "editor"
+        assert identity.request_id == "req-789"
+        assert identity.is_authenticated is True

--- a/tests/unit/extensions_lib/test_errors.py
+++ b/tests/unit/extensions_lib/test_errors.py
@@ -7,6 +7,27 @@ import pytest
 
 
 @pytest.mark.unit
+class TestPackageExports:
+    def test_runtime_public_surface_reexported_from_package_root(self):
+        """Package root exports the runtime-lib UAC-9d public surface."""
+        import kamiwaza_extensions_lib as lib
+
+        expected_exports = {
+            "KamiwazaRuntimeError",
+            "MisboundAuthError",
+            "UnexpectedContextError",
+            "OutOfEnvelopeAccessError",
+            "PlatformOutageError",
+            "extract_identity",
+            "anonymous_identity",
+        }
+
+        assert expected_exports <= set(lib.__all__)
+        for name in expected_exports:
+            assert getattr(lib, name) is not None
+
+
+@pytest.mark.unit
 class TestRuntimeErrorHierarchy:
     def test_base_class_has_class_name(self):
         from kamiwaza_extensions_lib.errors import KamiwazaRuntimeError

--- a/tests/unit/extensions_lib/test_errors.py
+++ b/tests/unit/extensions_lib/test_errors.py
@@ -93,6 +93,16 @@ class TestExtractIdentity:
         with pytest.raises(MisboundAuthError):
             extract_identity({"x-user-id": "usr-123", "x-workroom-id": ""})
 
+    def test_raises_when_required_header_is_whitespace_only(self):
+        """Whitespace-only header values are semantically empty."""
+        from kamiwaza_extensions_lib.errors import MisboundAuthError
+        from kamiwaza_extensions_lib.identity import extract_identity
+
+        with pytest.raises(MisboundAuthError):
+            extract_identity({"x-user-id": "   ", "x-workroom-id": "wrk-1"})
+        with pytest.raises(MisboundAuthError):
+            extract_identity({"x-user-id": "usr-1", "x-workroom-id": "\t\n "})
+
     def test_happy_path_returns_authenticated_identity(self):
         from kamiwaza_extensions_lib.identity import extract_identity
 

--- a/tests/unit/extensions_lib/test_identity.py
+++ b/tests/unit/extensions_lib/test_identity.py
@@ -179,10 +179,31 @@ class TestIdentityPydantic:
         assert dumped["roles"] == ["admin", "user"]
         assert dumped["workroom_id"] == "wrk-456"
         assert dumped["workroom_role"] == "editor"
-        assert dumped["auth_token"] == "jwt-abc"
         assert dumped["request_id"] == "req-789"
-        assert dumped["system_high"] is True
+        assert dumped["system_high"] == "true"
         assert dumped["is_authenticated"] is True
+        # auth_token is intentionally NOT a field on Identity — the bearer
+        # credential lives in headers and would leak via every model_dump()
+        # call (logs, metrics, exception payloads).
+        assert "auth_token" not in dumped
+
+    def test_system_high_preserves_classification_string(self):
+        """X-User-System-High carries a classification ("U", "TS", ...) not a bool.
+        The string must round-trip unchanged so trust decisions can compare it."""
+        for marker in ("U", "TS", "S", "C"):
+            identity = identity_from_headers(
+                {"x-user-id": "u", "x-user-system-high": marker}
+            )
+            assert identity.system_high == marker
+
+    def test_unknown_kwargs_dropped_dont_leak_via_model_dump(self):
+        """extra='ignore' guard: future Pydantic-default changes can't silently
+        turn Identity into an extra-leaking surface."""
+        from kamiwaza_extensions_lib.identity import Identity
+
+        identity = Identity(user_id="u", secret_field="should-be-dropped")  # type: ignore[call-arg]
+        dumped = identity.model_dump()
+        assert "secret_field" not in dumped
 
     def test_model_dump_for_anonymous(self):
         identity = identity_from_headers({})

--- a/tests/unit/extensions_lib/test_identity.py
+++ b/tests/unit/extensions_lib/test_identity.py
@@ -152,3 +152,41 @@ class TestGetIdentity:
         identity = await get_identity(request)
 
         assert identity.is_authenticated is False
+
+
+@pytest.mark.unit
+class TestIdentityPydantic:
+    """TS-6: Identity.model_dump() produces dict with all envelope fields."""
+
+    def test_model_dump_round_trip(self):
+        identity = identity_from_headers(
+            {
+                "x-user-id": "usr-123",
+                "x-user-email": "alice@example.com",
+                "x-user-name": "Alice",
+                "x-user-roles": "admin,user",
+                "x-workroom-id": "wrk-456",
+                "x-user-workroom-role": "editor",
+                "x-auth-token": "jwt-abc",
+                "x-request-id": "req-789",
+                "x-user-system-high": "true",
+            }
+        )
+        dumped = identity.model_dump()
+        assert dumped["user_id"] == "usr-123"
+        assert dumped["email"] == "alice@example.com"
+        assert dumped["name"] == "Alice"
+        assert dumped["roles"] == ["admin", "user"]
+        assert dumped["workroom_id"] == "wrk-456"
+        assert dumped["workroom_role"] == "editor"
+        assert dumped["auth_token"] == "jwt-abc"
+        assert dumped["request_id"] == "req-789"
+        assert dumped["system_high"] is True
+        assert dumped["is_authenticated"] is True
+
+    def test_model_dump_for_anonymous(self):
+        identity = identity_from_headers({})
+        dumped = identity.model_dump()
+        assert dumped["user_id"] is None
+        assert dumped["is_authenticated"] is False
+        assert dumped["roles"] == []

--- a/tests/unit/extensions_lib/test_identity.py
+++ b/tests/unit/extensions_lib/test_identity.py
@@ -190,3 +190,68 @@ class TestIdentityPydantic:
         assert dumped["user_id"] is None
         assert dumped["is_authenticated"] is False
         assert dumped["roles"] == []
+
+
+@pytest.mark.unit
+class TestAnonymousIdentity:
+    """TS-7: unified anonymous shape under USE_AUTH=false (§4.8 P5)."""
+
+    def test_returns_named_anonymous_identity(self):
+        from kamiwaza_extensions_lib.identity import Identity, anonymous_identity
+
+        identity = anonymous_identity()
+        assert isinstance(identity, Identity)
+        assert identity.name == "Anonymous"
+        assert identity.user_id is None
+        assert identity.email is None
+        assert identity.is_authenticated is False
+        assert identity.roles == []
+
+    def test_require_auth_returns_anonymous_under_use_auth_false(self, monkeypatch):
+        """require_auth() under USE_AUTH=false yields Identity(name='Anonymous')."""
+        import asyncio
+
+        from kamiwaza_extensions_lib.auth import require_auth
+
+        monkeypatch.setenv("KAMIWAZA_USE_AUTH", "false")
+        request = MagicMock()
+        request.headers = {}
+
+        identity = asyncio.get_event_loop().run_until_complete(require_auth(request))
+        assert identity.name == "Anonymous"
+        assert identity.is_authenticated is False
+
+    def test_require_auth_and_session_produce_matching_identity(self, monkeypatch):
+        """Under USE_AUTH=false with no envelope, both paths yield the same
+        Identity shape (byte-identical ``Identity.model_dump()`` subset)."""
+        import asyncio
+
+        from fastapi.testclient import TestClient
+        from fastapi import FastAPI
+
+        from kamiwaza_extensions_lib.auth import require_auth
+        from kamiwaza_extensions_lib.session import create_session_router
+
+        monkeypatch.setenv("KAMIWAZA_USE_AUTH", "false")
+
+        # /session path
+        app = FastAPI()
+        app.include_router(create_session_router())
+        client = TestClient(app)
+        session_body = client.get("/session").json()
+
+        # require_auth path
+        request = MagicMock()
+        request.headers = {}
+        identity = asyncio.get_event_loop().run_until_complete(require_auth(request))
+        identity_fields = identity.model_dump()
+
+        # Every Identity field in /session response must match require_auth's output
+        identity_keys_in_session = {
+            k: session_body[k] for k in identity_fields if k in session_body
+        }
+        assert identity_keys_in_session == {
+            k: identity_fields[k] for k in identity_keys_in_session
+        }
+        assert session_body["name"] == "Anonymous"
+        assert session_body["is_authenticated"] is False

--- a/tests/unit/extensions_lib/test_identity.py
+++ b/tests/unit/extensions_lib/test_identity.py
@@ -1,9 +1,16 @@
 """Tests for kamiwaza_extensions_lib.identity."""
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock
+import asyncio
+from unittest.mock import MagicMock
 
-from kamiwaza_extensions_lib.identity import Identity, get_identity, identity_from_headers
+import pytest
+
+from kamiwaza_extensions_lib.identity import (
+    Identity,
+    anonymous_identity,
+    get_identity,
+    identity_from_headers,
+)
 
 
 class TestIdentityFromHeaders:
@@ -199,8 +206,6 @@ class TestIdentityPydantic:
     def test_unknown_kwargs_dropped_dont_leak_via_model_dump(self):
         """extra='ignore' guard: future Pydantic-default changes can't silently
         turn Identity into an extra-leaking surface."""
-        from kamiwaza_extensions_lib.identity import Identity
-
         identity = Identity(user_id="u", secret_field="should-be-dropped")  # type: ignore[call-arg]
         dumped = identity.model_dump()
         assert "secret_field" not in dumped
@@ -218,8 +223,6 @@ class TestAnonymousIdentity:
     """TS-7: unified anonymous shape under USE_AUTH=false (§4.8 P5)."""
 
     def test_returns_named_anonymous_identity(self):
-        from kamiwaza_extensions_lib.identity import Identity, anonymous_identity
-
         identity = anonymous_identity()
         assert isinstance(identity, Identity)
         assert identity.name == "Anonymous"
@@ -230,25 +233,21 @@ class TestAnonymousIdentity:
 
     def test_require_auth_returns_anonymous_under_use_auth_false(self, monkeypatch):
         """require_auth() under USE_AUTH=false yields Identity(name='Anonymous')."""
-        import asyncio
-
         from kamiwaza_extensions_lib.auth import require_auth
 
         monkeypatch.setenv("KAMIWAZA_USE_AUTH", "false")
         request = MagicMock()
         request.headers = {}
 
-        identity = asyncio.get_event_loop().run_until_complete(require_auth(request))
+        identity = asyncio.run(require_auth(request))
         assert identity.name == "Anonymous"
         assert identity.is_authenticated is False
 
     def test_require_auth_and_session_produce_matching_identity(self, monkeypatch):
         """Under USE_AUTH=false with no envelope, both paths yield the same
         Identity shape (byte-identical ``Identity.model_dump()`` subset)."""
-        import asyncio
-
-        from fastapi.testclient import TestClient
         from fastapi import FastAPI
+        from fastapi.testclient import TestClient
 
         from kamiwaza_extensions_lib.auth import require_auth
         from kamiwaza_extensions_lib.session import create_session_router
@@ -264,7 +263,7 @@ class TestAnonymousIdentity:
         # require_auth path
         request = MagicMock()
         request.headers = {}
-        identity = asyncio.get_event_loop().run_until_complete(require_auth(request))
+        identity = asyncio.run(require_auth(request))
         identity_fields = identity.model_dump()
 
         # Every Identity field in /session response must match require_auth's output

--- a/tests/unit/extensions_lib/test_session.py
+++ b/tests/unit/extensions_lib/test_session.py
@@ -60,6 +60,36 @@ class TestSessionEndpoint:
         assert data["is_authenticated"] is True
         assert data["expires_at"] == 1711900800
 
+    def test_authenticated_session_does_not_leak_sensitive_fields(self, monkeypatch):
+        """Guard against regressions: /session MUST NOT expose the Bearer
+        credential (``auth_token``), classification flag (``system_high``),
+        or correlation tracer (``request_id``) to the browser."""
+        client = _make_app(monkeypatch)
+        resp = client.get(
+            "/session",
+            headers={
+                "x-user-id": "usr-123",
+                "x-user-email": "alice@example.com",
+                "x-user-name": "Alice",
+                "x-user-roles": "admin",
+                "x-workroom-id": "wrk-456",
+                "x-user-workroom-role": "editor",
+                "x-auth-token": "secret-bearer-jwt",
+                "x-user-system-high": "true",
+                "x-request-id": "req-abc",
+            },
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        # Positive: public fields present
+        assert data["user_id"] == "usr-123"
+        assert data["workroom_role"] == "editor"
+        # Negative: private fields absent
+        assert "auth_token" not in data
+        assert "system_high" not in data
+        assert "request_id" not in data
+
     def test_unauthenticated_session_with_auth_enabled(self, monkeypatch):
         client = _make_app(monkeypatch, use_auth="true")
         resp = client.get("/session")

--- a/tests/unit/extensions_lib/test_session.py
+++ b/tests/unit/extensions_lib/test_session.py
@@ -90,6 +90,38 @@ class TestSessionEndpoint:
         assert "system_high" not in data
         assert "request_id" not in data
 
+    def test_malformed_envelope_reported_as_logged_out(self, monkeypatch):
+        """PR re-review High #1: a request with X-User-Id but no X-Workroom-Id
+        triggers MisboundAuthError on require_auth (HTTP 401), so /session must
+        also report this as logged-out — otherwise the frontend appears
+        authenticated while every API call returns 401 (split-brain)."""
+        client = _make_app(monkeypatch, use_auth="true")
+        resp = client.get(
+            "/session",
+            headers={"x-user-id": "usr-123"},  # missing x-workroom-id
+        )
+
+        # Endpoint returns 200 (so the SessionProvider doesn't crash) but
+        # the body matches the no-envelope/logged-out shape.
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_authenticated"] is False
+        assert data["user_id"] is None
+        assert data["workroom_id"] is None
+        assert data["expires_at"] is None
+
+    def test_whitespace_only_envelope_reported_as_logged_out(self, monkeypatch):
+        """Symmetry with require_auth: whitespace-only headers don't satisfy
+        the strict envelope check."""
+        client = _make_app(monkeypatch, use_auth="true")
+        resp = client.get(
+            "/session",
+            headers={"x-user-id": "usr-123", "x-workroom-id": "   "},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["is_authenticated"] is False
+
     def test_unauthenticated_session_with_auth_enabled(self, monkeypatch):
         client = _make_app(monkeypatch, use_auth="true")
         resp = client.get("/session")
@@ -117,6 +149,7 @@ class TestSessionEndpoint:
             "/session",
             headers={
                 "x-user-id": "usr-123",
+                "x-workroom-id": "wrk-456",  # required for strict envelope check
                 "authorization": f"Bearer {token}",
             },
         )


### PR DESCRIPTION
## Summary

Python side of ENG-3885 — UAC-9d runtime-lib exception hierarchy and CLI plumbing, plus two walkthrough fixes (§4.8 P5, B3) that live in the same subsystem.

Part of D210 Milestone 1 (Phase A). TypeScript mirror will land in a follow-up PR.

## What's in this PR

**Runtime lib (`kamiwaza_extensions_lib/`):**
- `errors.py` (new) — `KamiwazaRuntimeError` base + 4 UAC-9d subclasses, each carrying a canonical `class_name`.
- `exception_names.json` (new) — single source of truth for `class_name` → `exit_code` → `doctor_hint`.
- `identity.py` — new strict `extract_identity()` raising `MisboundAuthError` on missing `X-User-Id`/`X-Workroom-Id`; permissive `identity_from_headers()` preserved. Added `workroom_role`, `auth_token`, `system_high` fields. Converted `Identity` to Pydantic (`.model_dump()` works).
- `anonymous_identity()` helper so `require_auth()` and `/session` return a byte-identical `Identity(name="Anonymous")` under `USE_AUTH=false` (fixes §4.8 P5 — the "Hello, None" papercut).
- `session.py` — `/session` now serializes via `Identity.model_dump()` rather than hand-rolling the dict.

**CLI (`kamiwaza_extensions/`):**
- `exit_codes.py` (new) — `ExitCode` IntEnum with 0/1/2, UAC-9d 10–13, and cluster/registry 20–23 (incl. `CLUSTER_NOT_READY=23` consumed by ENG-3888).
- `exit_code_for(class_name)` loads from `exception_names.json` via `importlib.resources`; unknown class names fall back to `FAILURE`.
- `cli.py::_handle_exception` — UAC-9d branch maps `KamiwazaRuntimeError` → the canonical exit code.
- `doctor.py` — reference-entry pass emits one `CheckResult` per UAC-9d class with the canonical doctor hint.
- `commands/login.py` — after PAT mint, decodes the JWT + calls `/auth/whoami`; warns when UI role-set is a strict superset of the PAT's claim (§4.8 B3).

**Contract test (`tests/unit/extensions/test_doctor_hint_coverage.py`):** the single invariant binding the 3 moving pieces — for every class in `exception_names.json`, asserts a matching `CheckResult` in doctor output AND `exit_code_for()` mapping.

## Test scenarios covered

| ID | Scenario | Commit |
|---|---|---|
| TS-1 | ExitCode enum values (0/1/2, 10-13, 20-23) | `2c2df7a` |
| TS-2 | exit_code_for() maps all 4 UAC-9d class names | `b4243b4` |
| TS-3 | test_doctor_hint_coverage contract | `fb6b6ca` |
| TS-4 | MisboundAuthError raised when X-User-Id missing | `2635be2` |
| TS-5 | MisboundAuthError raised when X-Workroom-Id missing | `2635be2` |
| TS-6 | Identity.model_dump() (Pydantic conversion) | `a93e79f` |
| TS-7 | require_auth + /session produce byte-identical Identity under USE_AUTH=false | `9c5d340` |
| TS-8 | CLI handler: RuntimeLibException → exit_code_for(class_name) | `5468576` |
| TS-32 | kz-ext login warns on UI ⊋ PAT role-set | `04621b9` |

**9/9 in-scope test scenarios pass.** Full unit suite: **591 passed**, **+28 new tests**, zero regressions.

## Known follow-ups (NOT in this PR)

- **TypeScript mirror** — `@kamiwaza-ai/extensions-lib`: `errors.ts`, `identity.ts` Pydantic-equivalent shape, `AuthGuard` passthrough (P6 of ENG-3889). Separate PR so we can ship the Python side without blocking on the TS build.
- **Docs** — UAC-9d failure-classes runbook (`docs/services/extensions/uac-9d-failure-classes.md`) and `kamiwaza-extensions-lib` v0.2 CHANGELOG. Docs PR once TS mirror lands.
- **P6** (AuthGuard passthrough) — handled in the TS-side portion of ENG-3889, not here.

## Cross-references

- Linear: [ENG-3885](https://linear.app/kamiwaza/issue/ENG-3885) (In Progress)
- Design: §4.2.7 RuntimeLibExceptionHierarchy + IdentityExtractor, §4.2.8 DoctorUACFailureHints + ExitCodeMap, §4.2.12 StarterBackendHardening (P5), §4.8 P4/P5/B3
- Exit code 23 (`CLUSTER_NOT_READY`) is defined here but consumed by ENG-3888 (cluster readiness probe), which will import it once this lands.

## Test plan

- [x] `make test` passes on this branch (591 unit tests, 0 regressions)
- [x] New contract test enforces 1:1 coverage between `exception_names.json`, `exit_codes.py`, and `doctor.py`
- [ ] TypeScript mirror PR lands before M1 exit
- [ ] Docs PR lands before M1 exit
- [ ] Manual: `kz-ext doctor` on a dev machine shows the 4 UAC-9d entries
- [ ] Manual: simulate role-set downgrade on login to confirm warning fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)