### PR TITLE
feat(extensions): OperatorImagePin + cluster readiness probe + DevRemote timeout (ENG-3888)

### DIFF
--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -367,8 +367,21 @@ def run_dev_remote(
         try:
             ext = poller.wait_for_ready(client, dev_name, timeout=timeout)
         except DeploymentTimeoutError as exc:
+            from kamiwaza_extensions.dev_diagnostics import diagnose_dev_timeout
+            from kamiwaza_extensions.constants import EXTENSIONS_NAMESPACE
+            from kamiwaza_extensions.exit_codes import ExitCode
+
+            diagnosis = diagnose_dev_timeout(dev_name, EXTENSIONS_NAMESPACE)
             console.print(f"\n[red]Error:[/red] {exc}")
-            raise typer.Exit(code=1) from exc
+            console.print(f"  [dim]{diagnosis.message}[/dim]")
+            if diagnosis.fix:
+                console.print(f"  [dim]Fix: {diagnosis.fix}[/dim]")
+            exit_code = (
+                int(ExitCode.CLUSTER_NOT_READY)
+                if diagnosis.category == "operator-not-ready"
+                else 1
+            )
+            raise typer.Exit(code=exit_code) from exc
         except DeploymentFailedError as exc:
             console.print(f"\n[red]Error:[/red] {exc}")
             raise typer.Exit(code=1) from exc

--- a/kamiwaza_extensions/commands/doctor.py
+++ b/kamiwaza_extensions/commands/doctor.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import typer
 from rich.console import Console
 
+from kamiwaza_extensions.exit_codes import ExitCode
+
 console = Console()
 
 
@@ -15,7 +17,7 @@ def run_doctor() -> None:
     checker = DoctorChecker()
     results = checker.run_all()
 
-    has_failure = False
+    fail_exit_code: int | None = None
     for result in results:
         if result.status == "pass":
             icon = "[green]✓[/green]"
@@ -23,11 +25,14 @@ def run_doctor() -> None:
             icon = "[yellow]![/yellow]"
         else:
             icon = "[red]✗[/red]"
-            has_failure = True
+            # First failing CheckResult with an explicit exit_code wins; a
+            # generic failure falls back to ExitCode.FAILURE.
+            if fail_exit_code is None:
+                fail_exit_code = result.exit_code or int(ExitCode.FAILURE)
 
         console.print(f"  {icon} {result.name}: {result.message}")
         if result.fix and result.status != "pass":
             console.print(f"      Fix: {result.fix}", style="dim")
 
-    if has_failure:
-        raise typer.Exit(code=1)
+    if fail_exit_code is not None:
+        raise typer.Exit(code=fail_exit_code)

--- a/kamiwaza_extensions/dev_diagnostics.py
+++ b/kamiwaza_extensions/dev_diagnostics.py
@@ -1,0 +1,166 @@
+"""Diagnostics emitted when ``kz-ext dev`` fails or times out.
+
+Inspects the ``extension-operator`` Deployment + Pod state and the extension
+CR events to distinguish *operator-not-ready* from *your-app-failed-to-start*.
+
+Design reference: §4.2.16 ``OperatorImagePin`` consumer + §4.8 B1b.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import Optional
+
+from kamiwaza_extensions.platform_compat import (
+    OPERATOR_COMPATIBLE_TAGS,
+    OPERATOR_DEPLOYMENT,
+    OPERATOR_NAMESPACE,
+    is_compatible_tag,
+    parse_image_ref,
+)
+
+
+@dataclass
+class TimeoutDiagnosis:
+    """Structured diagnosis of why ``kz-ext dev`` timed out."""
+
+    category: str  # "operator-not-ready" | "app-failure" | "unknown"
+    message: str
+    fix: Optional[str] = None
+
+
+def diagnose_dev_timeout(extension_name: str, extensions_namespace: str) -> TimeoutDiagnosis:
+    """Diagnose a ``DeploymentTimeoutError`` from ``kz-ext dev``.
+
+    Order of checks (most actionable first):
+      1. extension-operator Pod in ``ImagePullBackOff`` → operator-not-ready,
+         name the kubelet error.
+      2. extension-operator image tag not in ``OPERATOR_COMPATIBLE_TAGS`` →
+         operator-not-ready, name the mismatch.
+      3. extension-operator Deployment not Available → operator-not-ready.
+      4. Otherwise → app-failure (fall through to caller's existing message).
+    """
+    backoff = _operator_pod_backoff()
+    if backoff is not None:
+        return TimeoutDiagnosis(
+            category="operator-not-ready",
+            message=f"extension-operator pod is in ImagePullBackOff: {backoff}",
+            fix=(
+                "The cluster's extension-operator cannot pull its image. "
+                "Re-run the platform installer with a published tag "
+                f"(expected one of: {', '.join(OPERATOR_COMPATIBLE_TAGS)})."
+            ),
+        )
+
+    deploy = _operator_deployment()
+    if deploy is None:
+        return TimeoutDiagnosis(
+            category="unknown",
+            message=(
+                f"Extension '{extension_name}' did not become Ready, and "
+                "extension-operator state could not be inspected."
+            ),
+        )
+
+    image_ref = _container_image(deploy)
+    _, tag = parse_image_ref(image_ref) if image_ref else ("", None)
+    if tag and not is_compatible_tag(tag):
+        expected = ", ".join(OPERATOR_COMPATIBLE_TAGS)
+        return TimeoutDiagnosis(
+            category="operator-not-ready",
+            message=(
+                f"Extension operator is running '{tag}' which was not "
+                f"published for this CLI version; expected one of: {expected}."
+            ),
+            fix="Re-install the platform with a compatible operator image.",
+        )
+
+    if not _deployment_available(deploy):
+        return TimeoutDiagnosis(
+            category="operator-not-ready",
+            message="extension-operator Deployment is not Available.",
+            fix=(
+                "Inspect: kubectl describe deploy/extension-operator "
+                f"-n {OPERATOR_NAMESPACE}"
+            ),
+        )
+
+    return TimeoutDiagnosis(
+        category="app-failure",
+        message=(
+            f"Extension '{extension_name}' failed to start within the "
+            "timeout. Operator is healthy — inspect your extension's pod logs."
+        ),
+        fix=f"kz-ext logs --name {extension_name}",
+    )
+
+
+def _operator_deployment() -> Optional[dict]:
+    try:
+        result = subprocess.run(
+            [
+                "kubectl", "get", "deploy", OPERATOR_DEPLOYMENT,
+                "-n", OPERATOR_NAMESPACE, "-o", "json",
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode != 0:
+            return None
+        return json.loads(result.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return None
+
+
+def _operator_pod_backoff() -> Optional[str]:
+    try:
+        result = subprocess.run(
+            [
+                "kubectl", "get", "pods",
+                "-n", OPERATOR_NAMESPACE,
+                "-l", f"app.kubernetes.io/name={OPERATOR_DEPLOYMENT}",
+                "-o", "json",
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+        if result.returncode != 0:
+            return None
+        payload = json.loads(result.stdout)
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        return None
+
+    for pod in payload.get("items", []):
+        statuses = (pod.get("status", {}) or {}).get("containerStatuses", []) or []
+        for cs in statuses:
+            waiting = (cs.get("state", {}) or {}).get("waiting", {}) or {}
+            reason = waiting.get("reason", "")
+            if reason in ("ImagePullBackOff", "ErrImagePull"):
+                return waiting.get("message") or reason
+    return None
+
+
+def _container_image(deploy: dict) -> str:
+    try:
+        return (
+            deploy.get("spec", {})
+            .get("template", {})
+            .get("spec", {})
+            .get("containers", [{}])[0]
+            .get("image", "")
+        )
+    except (IndexError, AttributeError, TypeError):
+        return ""
+
+
+def _deployment_available(deploy: dict) -> bool:
+    status = deploy.get("status", {}) or {}
+    observed = status.get("observedGeneration")
+    spec_gen = deploy.get("metadata", {}).get("generation")
+    if observed is not None and observed != spec_gen:
+        return False
+    conditions = status.get("conditions", []) or []
+    return any(
+        c.get("type") == "Available" and c.get("status") == "True"
+        for c in conditions
+    )

--- a/kamiwaza_extensions/doctor.py
+++ b/kamiwaza_extensions/doctor.py
@@ -35,6 +35,7 @@ class CheckResult:
     status: Literal["pass", "fail", "warn"]
     message: str
     fix: Optional[str] = None
+    exit_code: Optional[int] = None
 
 
 class DoctorChecker:
@@ -54,6 +55,9 @@ class DoctorChecker:
 
         # Connection checks (if configured)
         results.append(self._check_connection())
+
+        # Cluster extension readiness — operator image / CRD / Deployment
+        results.append(self.cluster_extension_readiness())
 
         # Extension checks (if in extension directory)
         ext_results = self._check_extension_context()
@@ -203,6 +207,204 @@ class DoctorChecker:
             f"{conn.name}: no health endpoint found",
             fix=f"Server is reachable but health check failed",
         )
+
+    # ------------------------------------------------------------------
+    # Cluster extension readiness (B1a / §4.2.8)
+    # ------------------------------------------------------------------
+
+    def cluster_extension_readiness(self) -> CheckResult:
+        """Check that the cluster can actually run extensions.
+
+        Probes (in order):
+          1. ``kamiwazaextensions.extensions.kamiwaza.io`` CRD installed.
+          2. ``extension-operator`` Deployment in ``kamiwaza-system`` is
+             ``Available`` and observed-generation matches.
+          3. Operator image tag is in ``OPERATOR_COMPATIBLE_TAGS`` (warn on
+             mismatch when otherwise Available; fail on ``ImagePullBackOff``
+             surfacing the kubelet error).
+
+        On failure, ``exit_code`` is set to ``ExitCode.CLUSTER_NOT_READY``
+        (23) so the ``doctor`` command can surface it distinctly from the
+        generic CLI failure path.
+        """
+        from kamiwaza_extensions.exit_codes import ExitCode
+        from kamiwaza_extensions.platform_compat import (
+            EXTENSION_CRD,
+            OPERATOR_COMPATIBLE_TAGS,
+            OPERATOR_DEPLOYMENT,
+            OPERATOR_NAMESPACE,
+            is_compatible_tag,
+            parse_image_ref,
+        )
+
+        name = "Cluster extension readiness"
+        not_ready = int(ExitCode.CLUSTER_NOT_READY)
+
+        # kubectl availability — soft skip
+        kubectl_check = self._kubectl_available()
+        if not kubectl_check:
+            return CheckResult(
+                name, "warn",
+                "kubectl not available; cluster readiness probe skipped",
+                fix="Install kubectl and configure access to the target cluster",
+            )
+
+        # 1. CRD presence
+        crd_status, crd_err = self._kubectl_get(["crd", EXTENSION_CRD])
+        if crd_status != 0:
+            return CheckResult(
+                name, "fail",
+                f"Extension CRD '{EXTENSION_CRD}' not installed on cluster",
+                fix=f"Install or upgrade the kamiwaza platform on this cluster: {crd_err}",
+                exit_code=not_ready,
+            )
+
+        # 2. Operator Deployment + image
+        deploy_status, deploy_payload = self._kubectl_get_json(
+            ["deploy", OPERATOR_DEPLOYMENT, "-n", OPERATOR_NAMESPACE]
+        )
+        if deploy_status != 0 or not isinstance(deploy_payload, dict):
+            return CheckResult(
+                name, "fail",
+                f"extension-operator Deployment not found in '{OPERATOR_NAMESPACE}'",
+                fix="Re-run the platform installer on this cluster",
+                exit_code=not_ready,
+            )
+
+        # Image tag
+        image_ref = ""
+        try:
+            image_ref = (
+                deploy_payload.get("spec", {})
+                .get("template", {})
+                .get("spec", {})
+                .get("containers", [{}])[0]
+                .get("image", "")
+            )
+        except (IndexError, AttributeError, TypeError):
+            image_ref = ""
+        _, image_tag = parse_image_ref(image_ref) if image_ref else ("", None)
+
+        # ImagePullBackOff detection — most actionable signal
+        backoff_msg = self._operator_pod_backoff_message()
+        if backoff_msg:
+            expected = ", ".join(OPERATOR_COMPATIBLE_TAGS)
+            return CheckResult(
+                name, "fail",
+                f"extension-operator pod is in ImagePullBackOff: {backoff_msg}",
+                fix=(
+                    f"Operator image '{image_ref}' cannot be pulled. "
+                    f"Expected one of: {expected}. "
+                    f"Re-run the platform installer with a published tag."
+                ),
+                exit_code=not_ready,
+            )
+
+        # Available condition
+        status_obj = deploy_payload.get("status", {}) or {}
+        observed_gen = status_obj.get("observedGeneration")
+        spec_gen = deploy_payload.get("metadata", {}).get("generation")
+        conditions = status_obj.get("conditions", []) or []
+        available = any(
+            c.get("type") == "Available" and c.get("status") == "True"
+            for c in conditions
+        )
+        if not available or (observed_gen is not None and observed_gen != spec_gen):
+            return CheckResult(
+                name, "fail",
+                "extension-operator Deployment is not Available",
+                fix=(
+                    "Operator is not ready to reconcile extensions. "
+                    "Inspect: kubectl describe deploy/extension-operator "
+                    f"-n {OPERATOR_NAMESPACE}"
+                ),
+                exit_code=not_ready,
+            )
+
+        # 3. Tag compatibility — warn (not fail) when Available but mismatched
+        if not is_compatible_tag(image_tag):
+            expected = ", ".join(OPERATOR_COMPATIBLE_TAGS)
+            return CheckResult(
+                name, "warn",
+                f"extension-operator running '{image_tag}' (Available)",
+                fix=(
+                    f"Tag '{image_tag}' is not in this CLI's compatible set "
+                    f"({expected}). Behavior may diverge from this CLI version."
+                ),
+            )
+
+        return CheckResult(
+            name, "pass",
+            f"CRD installed, extension-operator Available ({image_tag})",
+        )
+
+    @staticmethod
+    def _kubectl_available() -> bool:
+        try:
+            result = subprocess.run(
+                ["kubectl", "version", "--client=true", "-o", "json"],
+                capture_output=True, text=True, timeout=10,
+            )
+            return result.returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+
+    @staticmethod
+    def _kubectl_get(args: list[str]) -> tuple[int, str]:
+        try:
+            result = subprocess.run(
+                ["kubectl", "get", *args],
+                capture_output=True, text=True, timeout=15,
+            )
+            return result.returncode, (result.stderr.strip() or result.stdout.strip())
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            return 1, str(exc)
+
+    @staticmethod
+    def _kubectl_get_json(args: list[str]) -> tuple[int, object]:
+        try:
+            result = subprocess.run(
+                ["kubectl", "get", *args, "-o", "json"],
+                capture_output=True, text=True, timeout=15,
+            )
+            if result.returncode != 0:
+                return result.returncode, result.stderr.strip()
+            return 0, json.loads(result.stdout)
+        except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+            return 1, str(exc)
+
+    @staticmethod
+    def _operator_pod_backoff_message() -> Optional[str]:
+        """Return the kubelet ImagePullBackOff message for the operator pod, if any."""
+        from kamiwaza_extensions.platform_compat import (
+            OPERATOR_DEPLOYMENT,
+            OPERATOR_NAMESPACE,
+        )
+
+        try:
+            result = subprocess.run(
+                [
+                    "kubectl", "get", "pods",
+                    "-n", OPERATOR_NAMESPACE,
+                    "-l", f"app.kubernetes.io/name={OPERATOR_DEPLOYMENT}",
+                    "-o", "json",
+                ],
+                capture_output=True, text=True, timeout=15,
+            )
+            if result.returncode != 0:
+                return None
+            payload = json.loads(result.stdout)
+        except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+            return None
+
+        for pod in payload.get("items", []):
+            statuses = (pod.get("status", {}) or {}).get("containerStatuses", []) or []
+            for cs in statuses:
+                waiting = (cs.get("state", {}) or {}).get("waiting", {}) or {}
+                reason = waiting.get("reason", "")
+                if reason in ("ImagePullBackOff", "ErrImagePull"):
+                    return waiting.get("message") or reason
+        return None
 
     # ------------------------------------------------------------------
     # Extension context checks

--- a/kamiwaza_extensions/platform_compat.py
+++ b/kamiwaza_extensions/platform_compat.py
@@ -1,0 +1,60 @@
+"""Platform compatibility constants for the kz-ext CLI.
+
+Records the ``extension-operator`` image + tag set that this CLI version is
+known-compatible with. Makes the previously-implicit SDK → operator contract
+explicit.
+
+Design reference: §4.2.16 ``OperatorImagePin``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Tuple
+
+OPERATOR_IMAGE = "ghcr.io/kamiwaza-internal/operators/images/extension-operator"
+
+# Tags this CLI version is known-compatible with. Maintained as part of
+# each SDK release cut; CI sanity-check confirms each tag resolves at GHCR.
+OPERATOR_COMPATIBLE_TAGS: Tuple[str, ...] = (
+    "release-0.12.1",
+    "release-0.12.2",
+)
+
+OPERATOR_NAMESPACE = "kamiwaza-system"
+OPERATOR_DEPLOYMENT = "extension-operator"
+EXTENSION_CRD = "kamiwazaextensions.extensions.kamiwaza.io"
+
+_RELEASE_TAG_RE = re.compile(r"^release-\d+\.\d+\.\d+$")
+
+
+def parse_image_ref(image_ref: str) -> Tuple[str, Optional[str]]:
+    """Split an image reference into ``(repository, tag)``.
+
+    Handles registries with port numbers like ``ghcr.io/x/y:tag`` and
+    digests like ``ghcr.io/x/y@sha256:...`` (digest returned as the tag).
+    """
+    if "@" in image_ref:
+        repo, _, digest = image_ref.partition("@")
+        return repo, digest
+    slash = image_ref.rfind("/")
+    after_slash = image_ref[slash + 1 :] if slash >= 0 else image_ref
+    if ":" in after_slash:
+        name, _, tag = after_slash.rpartition(":")
+        prefix = image_ref[: slash + 1] if slash >= 0 else ""
+        return f"{prefix}{name}", tag
+    return image_ref, None
+
+
+def is_compatible_tag(tag: Optional[str]) -> bool:
+    """Return ``True`` if ``tag`` is in ``OPERATOR_COMPATIBLE_TAGS``."""
+    return tag is not None and tag in OPERATOR_COMPATIBLE_TAGS
+
+
+def validate_compatible_tag_grammar(tag: str) -> bool:
+    """Return ``True`` if ``tag`` matches the canonical ``release-X.Y.Z`` grammar.
+
+    Used by the CI sanity-check to catch typos in ``OPERATOR_COMPATIBLE_TAGS``
+    before the GHCR resolve step runs.
+    """
+    return bool(_RELEASE_TAG_RE.match(tag))

--- a/tests/integration/test_operator_compatible_tags.py
+++ b/tests/integration/test_operator_compatible_tags.py
@@ -1,0 +1,67 @@
+"""GHCR resolve sanity-check for OPERATOR_COMPATIBLE_TAGS (TS-13).
+
+Out-of-band check that every tag in :data:`OPERATOR_COMPATIBLE_TAGS`
+resolves at GHCR. Marked ``integration`` so it does not run in the default
+``make test`` path; runs as part of release CI to catch a list that drifted
+from what was actually published.
+
+Design reference: §4.2.16 OperatorImagePin maintenance contract.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import requests
+
+from kamiwaza_extensions.platform_compat import (
+    OPERATOR_COMPATIBLE_TAGS,
+    OPERATOR_IMAGE,
+)
+
+# OPERATOR_IMAGE is "ghcr.io/<owner>/<repo>" — split into the registry path
+# expected by GHCR's OCI distribution API.
+_GHCR_HOST = "ghcr.io"
+_OWNER_REPO = OPERATOR_IMAGE.removeprefix(f"{_GHCR_HOST}/")
+
+
+def _ghcr_token(scope: str) -> str | None:
+    """Fetch an anonymous read token for a GHCR repo, if the repo is public."""
+    resp = requests.get(
+        f"https://{_GHCR_HOST}/token",
+        params={"scope": f"repository:{scope}:pull"},
+        timeout=10,
+    )
+    if not resp.ok:
+        return None
+    return resp.json().get("token")
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("tag", OPERATOR_COMPATIBLE_TAGS)
+def test_compatible_tag_resolves_at_ghcr(tag: str) -> None:
+    if os.environ.get("KAMIWAZA_SKIP_GHCR_CHECK"):
+        pytest.skip("KAMIWAZA_SKIP_GHCR_CHECK set")
+
+    headers = {"Accept": "application/vnd.oci.image.manifest.v1+json"}
+    token = _ghcr_token(_OWNER_REPO)
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    resp = requests.head(
+        f"https://{_GHCR_HOST}/v2/{_OWNER_REPO}/manifests/{tag}",
+        headers=headers,
+        timeout=15,
+    )
+
+    if resp.status_code == 401:
+        pytest.skip(
+            f"GHCR repo {_OWNER_REPO} requires authentication; cannot verify "
+            "from anonymous CI runner."
+        )
+
+    assert resp.status_code == 200, (
+        f"OPERATOR_COMPATIBLE_TAGS contains {tag!r} but it does not resolve "
+        f"at {_GHCR_HOST}/{_OWNER_REPO}:{tag} (HTTP {resp.status_code})"
+    )

--- a/tests/unit/extensions/test_dev_diagnostics.py
+++ b/tests/unit/extensions/test_dev_diagnostics.py
@@ -1,0 +1,120 @@
+"""Tests for kz-ext dev timeout diagnostics (B1b / §4.2.16)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kamiwaza_extensions.dev_diagnostics import diagnose_dev_timeout
+from kamiwaza_extensions.platform_compat import OPERATOR_COMPATIBLE_TAGS, OPERATOR_IMAGE
+
+
+def _deploy_json(image: str, available: bool = True) -> str:
+    return json.dumps({
+        "metadata": {"name": "extension-operator", "generation": 1},
+        "spec": {
+            "template": {"spec": {"containers": [{"image": image}]}},
+        },
+        "status": {
+            "observedGeneration": 1,
+            "conditions": [
+                {"type": "Available", "status": "True" if available else "False"},
+            ],
+        },
+    })
+
+
+def _pods_json(reason: str | None = None, message: str | None = None) -> str:
+    if reason is None:
+        return json.dumps({"items": []})
+    return json.dumps({
+        "items": [
+            {
+                "status": {
+                    "containerStatuses": [
+                        {"state": {"waiting": {"reason": reason, "message": message or reason}}},
+                    ],
+                },
+            },
+        ],
+    })
+
+
+def _kubectl_stub(deploy_stdout: str | None, pods_stdout: str):
+    """Build subprocess.run side-effect.
+
+    Calls the diagnostics make:
+      1. kubectl get pods ... -o json (operator pod ImagePullBackOff scan)
+      2. kubectl get deploy ... -o json (operator Deployment payload)
+    """
+    def _run(cmd, *args, **kwargs):
+        if cmd[1] == "get" and cmd[2] == "pods":
+            return MagicMock(returncode=0, stdout=pods_stdout, stderr="")
+        if cmd[1] == "get" and cmd[2] == "deploy":
+            if deploy_stdout is None:
+                return MagicMock(returncode=1, stdout="", stderr="not found")
+            return MagicMock(returncode=0, stdout=deploy_stdout, stderr="")
+        return MagicMock(returncode=1, stdout="", stderr="")
+    return _run
+
+
+@pytest.mark.unit
+class TestDiagnoseDevTimeout:
+    # TS-12: timeout handler distinguishes operator-not-ready from app-failure
+    def test_image_pull_back_off_classified_as_operator_not_ready(self):
+        compat = f"{OPERATOR_IMAGE}:{OPERATOR_COMPATIBLE_TAGS[0]}"
+        with patch(
+            "subprocess.run",
+            side_effect=_kubectl_stub(
+                _deploy_json(compat),
+                _pods_json(reason="ImagePullBackOff", message="manifest not found"),
+            ),
+        ):
+            d = diagnose_dev_timeout("my-app-dev-abc", "kamiwaza-extensions")
+        assert d.category == "operator-not-ready"
+        assert "ImagePullBackOff" in d.message
+        assert OPERATOR_COMPATIBLE_TAGS[0] in (d.fix or "")
+
+    def test_image_tag_mismatch_classified_as_operator_not_ready(self):
+        with patch(
+            "subprocess.run",
+            side_effect=_kubectl_stub(
+                _deploy_json(f"{OPERATOR_IMAGE}:v0.1.1"),
+                _pods_json(),
+            ),
+        ):
+            d = diagnose_dev_timeout("my-app-dev-abc", "kamiwaza-extensions")
+        assert d.category == "operator-not-ready"
+        assert "v0.1.1" in d.message
+        assert OPERATOR_COMPATIBLE_TAGS[0] in d.message
+
+    def test_deployment_not_available_classified_as_operator_not_ready(self):
+        compat = f"{OPERATOR_IMAGE}:{OPERATOR_COMPATIBLE_TAGS[0]}"
+        with patch(
+            "subprocess.run",
+            side_effect=_kubectl_stub(_deploy_json(compat, available=False), _pods_json()),
+        ):
+            d = diagnose_dev_timeout("my-app-dev-abc", "kamiwaza-extensions")
+        assert d.category == "operator-not-ready"
+        assert "Available" in d.message
+
+    def test_healthy_operator_classified_as_app_failure(self):
+        compat = f"{OPERATOR_IMAGE}:{OPERATOR_COMPATIBLE_TAGS[0]}"
+        with patch(
+            "subprocess.run",
+            side_effect=_kubectl_stub(_deploy_json(compat), _pods_json()),
+        ):
+            d = diagnose_dev_timeout("my-app-dev-abc", "kamiwaza-extensions")
+        assert d.category == "app-failure"
+        assert "my-app-dev-abc" in d.message
+        assert "kz-ext logs" in (d.fix or "")
+
+    def test_unknown_when_operator_state_unreadable(self):
+        with patch(
+            "subprocess.run",
+            side_effect=_kubectl_stub(None, _pods_json()),
+        ):
+            d = diagnose_dev_timeout("my-app-dev-abc", "kamiwaza-extensions")
+        assert d.category == "unknown"

--- a/tests/unit/extensions/test_doctor_cluster_readiness.py
+++ b/tests/unit/extensions/test_doctor_cluster_readiness.py
@@ -1,0 +1,172 @@
+"""Tests for DoctorChecker.cluster_extension_readiness (B1a / §4.2.8)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kamiwaza_extensions.doctor import DoctorChecker
+from kamiwaza_extensions.exit_codes import ExitCode
+from kamiwaza_extensions.platform_compat import OPERATOR_COMPATIBLE_TAGS, OPERATOR_IMAGE
+
+
+def _deploy_payload(image: str, available: bool = True, gen: int = 1, observed: int | None = 1) -> dict:
+    return {
+        "metadata": {"name": "extension-operator", "generation": gen},
+        "spec": {
+            "template": {
+                "spec": {"containers": [{"name": "operator", "image": image}]},
+            },
+        },
+        "status": {
+            "observedGeneration": observed if observed is not None else gen,
+            "conditions": [
+                {"type": "Available", "status": "True" if available else "False"},
+            ],
+        },
+    }
+
+
+def _pods_payload(reason: str | None = None, message: str | None = None) -> dict:
+    if reason is None:
+        return {"items": [{"status": {"containerStatuses": [{"state": {"running": {}}}]}}]}
+    state = {"waiting": {"reason": reason, "message": message or reason}}
+    return {"items": [{"status": {"containerStatuses": [{"state": state}]}}]}
+
+
+def _stub_kubectl(crd_returncode: int, deploy_payload: dict | None, pods_payload: dict):
+    """Build a subprocess.run side-effect for the four kubectl shell-outs.
+
+    Order called by the probe:
+      1. kubectl version --client=true -o json     (availability check)
+      2. kubectl get crd kamiwazaextensions...     (CRD presence)
+      3. kubectl get deploy extension-operator...  (Deployment JSON)
+      4. kubectl get pods -l app...                (Pod backoff scan)
+    """
+    def _run(cmd, *args, **kwargs):
+        if cmd[1] == "version":
+            return MagicMock(returncode=0, stdout="{}", stderr="")
+        if cmd[1] == "get" and cmd[2] == "crd":
+            return MagicMock(returncode=crd_returncode, stdout="", stderr="not found" if crd_returncode else "")
+        if cmd[1] == "get" and cmd[2] == "deploy":
+            payload = "" if deploy_payload is None else json.dumps(deploy_payload)
+            return MagicMock(
+                returncode=0 if deploy_payload is not None else 1,
+                stdout=payload,
+                stderr="" if deploy_payload is not None else "not found",
+            )
+        if cmd[1] == "get" and cmd[2] == "pods":
+            return MagicMock(returncode=0, stdout=json.dumps(pods_payload), stderr="")
+        return MagicMock(returncode=1, stdout="", stderr="unhandled")
+    return _run
+
+
+@pytest.mark.unit
+class TestClusterReadinessHappyPath:
+    # TS-9
+    def test_pass_when_crd_present_operator_available_and_image_compatible(self, tmp_path):
+        checker = DoctorChecker(config_dir=tmp_path / ".kamiwaza")
+        compat = f"{OPERATOR_IMAGE}:{OPERATOR_COMPATIBLE_TAGS[0]}"
+        with patch(
+            "subprocess.run",
+            side_effect=_stub_kubectl(0, _deploy_payload(compat), _pods_payload()),
+        ):
+            result = checker.cluster_extension_readiness()
+        assert result.status == "pass"
+        assert OPERATOR_COMPATIBLE_TAGS[0] in result.message
+        assert result.exit_code is None
+
+
+@pytest.mark.unit
+class TestClusterReadinessFailures:
+    # TS-10
+    def test_fails_with_cluster_not_ready_on_image_pull_back_off(self, tmp_path):
+        checker = DoctorChecker(config_dir=tmp_path / ".kamiwaza")
+        compat = f"{OPERATOR_IMAGE}:{OPERATOR_COMPATIBLE_TAGS[0]}"
+        kubelet_msg = "manifest for extension-operator:v0.1.1 not found"
+        with patch(
+            "subprocess.run",
+            side_effect=_stub_kubectl(
+                0,
+                _deploy_payload(compat),
+                _pods_payload(reason="ImagePullBackOff", message=kubelet_msg),
+            ),
+        ):
+            result = checker.cluster_extension_readiness()
+        assert result.status == "fail"
+        assert result.exit_code == int(ExitCode.CLUSTER_NOT_READY) == 23
+        assert "ImagePullBackOff" in result.message
+        assert kubelet_msg in result.message
+        # Fix names the expected tag set so the user knows what is published.
+        assert OPERATOR_COMPATIBLE_TAGS[0] in (result.fix or "")
+
+    def test_fails_when_crd_missing(self, tmp_path):
+        checker = DoctorChecker(config_dir=tmp_path / ".kamiwaza")
+        with patch(
+            "subprocess.run",
+            side_effect=_stub_kubectl(1, None, _pods_payload()),
+        ):
+            result = checker.cluster_extension_readiness()
+        assert result.status == "fail"
+        assert result.exit_code == int(ExitCode.CLUSTER_NOT_READY)
+        assert "CRD" in result.message
+
+    def test_fails_when_operator_deployment_missing(self, tmp_path):
+        checker = DoctorChecker(config_dir=tmp_path / ".kamiwaza")
+        with patch(
+            "subprocess.run",
+            side_effect=_stub_kubectl(0, None, _pods_payload()),
+        ):
+            result = checker.cluster_extension_readiness()
+        assert result.status == "fail"
+        assert result.exit_code == int(ExitCode.CLUSTER_NOT_READY)
+        assert "extension-operator Deployment" in result.message
+
+    def test_fails_when_deployment_unavailable(self, tmp_path):
+        checker = DoctorChecker(config_dir=tmp_path / ".kamiwaza")
+        compat = f"{OPERATOR_IMAGE}:{OPERATOR_COMPATIBLE_TAGS[0]}"
+        with patch(
+            "subprocess.run",
+            side_effect=_stub_kubectl(
+                0,
+                _deploy_payload(compat, available=False),
+                _pods_payload(),
+            ),
+        ):
+            result = checker.cluster_extension_readiness()
+        assert result.status == "fail"
+        assert result.exit_code == int(ExitCode.CLUSTER_NOT_READY)
+
+
+@pytest.mark.unit
+class TestClusterReadinessTagMismatchWarning:
+    # TS-11
+    def test_warns_when_tag_outside_compatible_set_but_available(self, tmp_path):
+        checker = DoctorChecker(config_dir=tmp_path / ".kamiwaza")
+        with patch(
+            "subprocess.run",
+            side_effect=_stub_kubectl(
+                0,
+                _deploy_payload(f"{OPERATOR_IMAGE}:v0.1.1"),
+                _pods_payload(),
+            ),
+        ):
+            result = checker.cluster_extension_readiness()
+        assert result.status == "warn"
+        assert "v0.1.1" in result.message
+        assert OPERATOR_COMPATIBLE_TAGS[0] in (result.fix or "")
+        # Warn does not propagate an exit code — the doctor command should
+        # not exit non-zero just because the tag list grew without us.
+        assert result.exit_code is None
+
+
+@pytest.mark.unit
+class TestClusterReadinessKubectlMissing:
+    def test_warns_when_kubectl_unavailable(self, tmp_path):
+        checker = DoctorChecker(config_dir=tmp_path / ".kamiwaza")
+        with patch("subprocess.run", side_effect=FileNotFoundError()):
+            result = checker.cluster_extension_readiness()
+        assert result.status == "warn"
+        assert "kubectl" in result.message.lower()

--- a/tests/unit/extensions/test_platform_compat.py
+++ b/tests/unit/extensions/test_platform_compat.py
@@ -1,0 +1,67 @@
+"""Tests for platform_compat module (OperatorImagePin)."""
+
+from __future__ import annotations
+
+import pytest
+
+from kamiwaza_extensions.platform_compat import (
+    OPERATOR_COMPATIBLE_TAGS,
+    OPERATOR_IMAGE,
+    is_compatible_tag,
+    parse_image_ref,
+    validate_compatible_tag_grammar,
+)
+
+
+@pytest.mark.unit
+class TestPlatformCompatConstants:
+    def test_operator_image_is_full_repo(self):
+        assert OPERATOR_IMAGE.startswith("ghcr.io/")
+        assert OPERATOR_IMAGE.endswith("/extension-operator")
+
+    def test_compatible_tags_non_empty(self):
+        assert len(OPERATOR_COMPATIBLE_TAGS) >= 1
+
+    def test_every_compatible_tag_matches_release_grammar(self):
+        # TS-13 sanity-check (offline portion): every tag in the pin list
+        # must follow the canonical release-X.Y.Z grammar so a typo can be
+        # caught before the GHCR resolve step runs.
+        for tag in OPERATOR_COMPATIBLE_TAGS:
+            assert validate_compatible_tag_grammar(tag), (
+                f"{tag!r} does not match release-X.Y.Z grammar"
+            )
+
+
+@pytest.mark.unit
+class TestParseImageRef:
+    def test_simple_tag(self):
+        repo, tag = parse_image_ref("ghcr.io/x/y:release-0.12.1")
+        assert repo == "ghcr.io/x/y"
+        assert tag == "release-0.12.1"
+
+    def test_no_tag(self):
+        repo, tag = parse_image_ref("ghcr.io/x/y")
+        assert repo == "ghcr.io/x/y"
+        assert tag is None
+
+    def test_registry_with_port(self):
+        repo, tag = parse_image_ref("registry.local:5000/x/y:v1")
+        assert repo == "registry.local:5000/x/y"
+        assert tag == "v1"
+
+    def test_digest(self):
+        repo, tag = parse_image_ref("ghcr.io/x/y@sha256:abc123")
+        assert repo == "ghcr.io/x/y"
+        assert tag == "sha256:abc123"
+
+
+@pytest.mark.unit
+class TestIsCompatibleTag:
+    def test_compatible(self):
+        assert is_compatible_tag(OPERATOR_COMPATIBLE_TAGS[0]) is True
+
+    def test_incompatible(self):
+        assert is_compatible_tag("v0.1.1") is False
+
+    def test_none(self):
+        assert is_compatible_tag(None) is False


### PR DESCRIPTION
## Summary

Closes ENG-3888 (Urgent, M1 milestone). Builds on ENG-3885 (#76, merged) which defined the exit-codes module and exception hierarchy.

Adds the explicit SDK→extension-operator contract that was previously implicit:
- New \`platform_compat.py\` constants (\`OPERATOR_IMAGE\`, \`OPERATOR_COMPATIBLE_TAGS\`)
- \`DoctorChecker.cluster_extension_readiness()\` probe — CRD presence, operator Deployment Available + observed-generation match, ImagePullBackOff detection, image-tag membership in compat set
- \`CheckResult.exit_code\` field surfacing \`ExitCode.CLUSTER_NOT_READY=23\` from failed probes
- \`commands/dev.py\` runs diagnosis on \`DeploymentTimeoutError\`, exits 23 if operator-not-ready (vs 1 for app-failure)

So a first-time developer on a cluster whose operator is in ImagePullBackOff no longer sees a misleading "extension failed to start" — they see the operator-image diagnosis with the kubelet error and the expected tag set.

## Test plan
- [x] \`make test\` — 810 passed, 8 skipped (no regressions vs develop baseline)
- [x] 22 new unit tests covering TS-9..12 + image-parse helpers + offline TS-13 grammar check
- [x] 1 integration test (\`tests/integration/test_operator_compatible_tags.py\`) resolves each compatible tag at GHCR — runs in release CI
- [x] \`uv run ruff check\` clean for modified files (pre-existing F541 in unmodified parts of doctor.py only)
- [x] \`uv run mypy\` clean for new code

## Design refs
- §4.2.8 \`DoctorUACFailureHints\` (B1a fix)
- §4.2.16 \`OperatorImagePin\`
- §4.8 B1 walkthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)