### PR TITLE
feat(extensions): CatalogDedupGuard + revision field for catalog publish (ENG-3884)

### DIFF
--- a/kamiwaza_extensions/catalog_publisher.py
+++ b/kamiwaza_extensions/catalog_publisher.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import socket
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -21,6 +22,11 @@ from kamiwaza_extensions.profile_manager import PublishProfile
 from kamiwaza_extensions.registry_builder import RegistryBuilder
 
 console = Console(stderr=True)
+
+# Revision grammar (Open Q #8 resolution): 1-64 chars, starts with
+# alphanumeric, allows lowercase letters, digits, hyphens, and dots.
+# Compatible with default revision_tagger output and plain Git SHAs.
+REVISION_GRAMMAR = re.compile(r"^[a-z0-9][-a-z0-9.]{0,63}$")
 
 # Maps extension_type to the catalog JSON filename.
 _TYPE_FILE_MAP: Dict[str, str] = {
@@ -58,6 +64,84 @@ class CatalogPublishError(RuntimeError):
     """A catalog publish operation failed."""
 
     pass
+
+
+class CatalogDedupError(ValueError):
+    """A publish was rejected because (name, semver, revision) already exists.
+
+    Maps to ``ExitCode.VALIDATION`` (2) at the CLI boundary so CI re-runs,
+    network retries, and developer re-invocations are idempotent rather
+    than silently overwriting.
+    """
+
+    def __init__(self, name: str, version: str, revision: str) -> None:
+        self.extension_name = name
+        self.version = version
+        self.revision = revision
+        super().__init__(
+            f"Catalog already has '{name}' v{version} at revision "
+            f"'{revision}'. Use --force to override (CI should not)."
+        )
+
+
+class CatalogDedupGuard:
+    """Reject duplicate ``(name, semver, revision)`` triples in the catalog.
+
+    Validates revision grammar early and scans existing entries for the
+    triple before merge proceeds. Stateless — every check is independent.
+    """
+
+    @staticmethod
+    def validate_revision(revision: str) -> None:
+        """Raise ``ValueError`` if ``revision`` does not match the grammar."""
+        if not REVISION_GRAMMAR.match(revision):
+            raise ValueError(
+                f"Invalid revision '{revision}': must match "
+                f"^[a-z0-9][-a-z0-9.]{{0,63}}$"
+            )
+
+    def check(
+        self,
+        existing_entries: List[Dict[str, Any]],
+        new_entry: Dict[str, Any],
+        *,
+        force: bool = False,
+    ) -> None:
+        """Raise ``CatalogDedupError`` if the triple already exists.
+
+        Args:
+            existing_entries: Current catalog array.
+            new_entry: Entry being published.
+            force: If True, log a warning and return without raising.
+
+        Raises:
+            ValueError: If ``new_entry`` has a malformed ``revision``.
+            CatalogDedupError: On a duplicate triple when ``force`` is False.
+        """
+        revision = new_entry.get("revision")
+        # Entries without a revision are not subject to dedup — that's the
+        # ENG-3591 path (release publishes without --revision).
+        if revision is None:
+            return
+
+        self.validate_revision(revision)
+
+        name = new_entry.get("name", "")
+        version = new_entry.get("version", "")
+
+        for existing in existing_entries:
+            if (
+                existing.get("name") == name
+                and existing.get("version") == version
+                and existing.get("revision") == revision
+            ):
+                if force:
+                    console.print(
+                        f"[yellow]Warning:[/yellow] --force overriding catalog "
+                        f"dedup for '{name}' v{version} revision '{revision}'."
+                    )
+                    return
+                raise CatalogDedupError(name, version, revision)
 
 
 class CatalogPublisher:
@@ -135,15 +219,19 @@ class CatalogPublisher:
         force: bool = False,
         dry_run: bool = False,
         preview_image_path: Optional[Path] = None,
+        revision: Optional[str] = None,
     ) -> PublishResult:
         """Full publish flow: lock, backup, download, merge, upload, verify, unlock.
 
         Args:
             entry: Catalog entry dict (from ``RegistryBuilder.build_entry``).
             extension_type: One of ``"app"``, ``"tool"``, or ``"service"``.
-            force: Overwrite existing entry with same version.
+            force: Overwrite existing entry with same (name, semver, revision).
             dry_run: Perform merge logic but skip all S3 writes.
             preview_image_path: Local path to preview image to upload.
+            revision: Optional revision identifier to attach to the entry
+                (CI commit SHA, etc.). When set, the entry is keyed by
+                ``(name, semver, revision)`` triple via ``CatalogDedupGuard``.
 
         Returns:
             A ``PublishResult`` describing what was done.
@@ -151,13 +239,20 @@ class CatalogPublisher:
         Raises:
             CatalogPublishError: On lock contention, upload failure, or
                 verification mismatch.
-            ValueError: On invalid extension_type or merge rejection.
+            CatalogDedupError: On duplicate (name, semver, revision) without ``force``.
+            ValueError: On invalid extension_type or invalid revision grammar.
         """
         if extension_type not in _TYPE_FILE_MAP:
             raise ValueError(
                 f"Invalid extension_type '{extension_type}'. "
                 f"Must be one of: {', '.join(_TYPE_FILE_MAP)}"
             )
+
+        # Attach revision to the entry; validate grammar early so we fail
+        # before acquiring the S3 lock or modifying state.
+        if revision is not None:
+            CatalogDedupGuard.validate_revision(revision)
+            entry = {**entry, "revision": revision}
 
         type_file = _TYPE_FILE_MAP[extension_type]
         s3_key = f"{self._garden_dir}{type_file}"
@@ -171,8 +266,9 @@ class CatalogPublisher:
             # Backup current state
             backup_path = self._backup_current(type_file)
 
-            # Download, merge, upload
+            # Download, dedup-check, merge, upload
             existing = self._download_entries(type_file)
+            CatalogDedupGuard().check(existing, entry, force=force)
             merged, action = self._builder.merge_into_registry(
                 entry, existing, force=force,
             )
@@ -534,6 +630,7 @@ class CatalogPublisher:
         console.print("[yellow]Dry run -- no S3 writes will be performed.[/yellow]")
 
         existing = self._download_entries(type_file)
+        CatalogDedupGuard().check(existing, entry, force=force)
         _merged, action = self._builder.merge_into_registry(
             entry, existing, force=force,
         )

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -90,8 +90,13 @@ def run_publish(
     verbose: bool = False,
 ) -> None:
     """Build, push, and publish extension to catalog."""
-    from kamiwaza_extensions.catalog_publisher import CatalogPublisher, CatalogPublishError
+    from kamiwaza_extensions.catalog_publisher import (
+        CatalogDedupError,
+        CatalogPublishError,
+        CatalogPublisher,
+    )
     from kamiwaza_extensions.compose_transformer import ComposeTransformer
+    from kamiwaza_extensions.exit_codes import ExitCode
     from kamiwaza_extensions.extension_detector import ExtensionDetector
     from kamiwaza_extensions.image_builder import ImageBuilder, ImageBuildError
     from kamiwaza_extensions.image_pusher import ImagePusher, ImagePushError
@@ -216,6 +221,9 @@ def run_publish(
             console.print(
                 f"  Would publish to:      {result.catalog_file} ({result.action})"
             )
+        except CatalogDedupError as exc:
+            console.print(f"\n[red]Error:[/red] {exc}")
+            raise typer.Exit(code=int(ExitCode.VALIDATION)) from exc
         except (CatalogPublishError, ValueError) as exc:
             console.print(f"\n[red]Error:[/red] {exc}")
             raise typer.Exit(code=1) from exc
@@ -304,6 +312,10 @@ def run_publish(
             dry_run=False,
             preview_image_path=preview_image_path,
         )
+    except CatalogDedupError as exc:
+        console.print("  [red]\u2717 publish rejected[/red]")
+        console.print(f"\n[red]Error:[/red] {exc}")
+        raise typer.Exit(code=int(ExitCode.VALIDATION)) from exc
     except CatalogPublishError as exc:
         console.print(f"  [red]\u2717 publish failed[/red]")
         console.print(f"\n[red]Error:[/red] {exc}")

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -56,6 +56,7 @@ class RegistryBuilder:
         registry: str,
         version: str,
         stage: str = "prod",
+        revision: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Generate a catalog entry dict from *metadata* and *transformed_compose*.
 
@@ -66,6 +67,9 @@ class RegistryBuilder:
             registry: Docker registry prefix (e.g. ``"kamiwazaai"``).
             version: Semver version string for this release.
             stage: One of ``"prod"``, ``"stage"``, ``"dev"``, or any custom name.
+            revision: Optional revision identifier. When provided, included
+                as a top-level ``revision`` field on the entry; consumed by
+                ``CatalogDedupGuard`` to make CI re-publishes idempotent.
 
         Returns:
             A dict matching the Kamiwaza catalog entry schema.
@@ -92,6 +96,9 @@ class RegistryBuilder:
             "compose_yml": compose_yml,
             "docker_images": docker_images,
         }
+
+        if revision is not None:
+            entry["revision"] = revision
 
         # Optional fields -- only include when present in metadata.
         kamiwaza_version = metadata.get("kamiwaza_version")

--- a/kamiwaza_sdk/schemas/apps.py
+++ b/kamiwaza_sdk/schemas/apps.py
@@ -1,7 +1,7 @@
 # kamiwaza_sdk/schemas/apps.py
 
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime
 from uuid import UUID
 from enum import Enum
@@ -120,6 +120,11 @@ class ImagePullResult(BaseModel):
 class GardenApp(BaseModel):
     """Pre-built garden application."""
 
+    # Forward compatibility: catalog entries gained a top-level `revision`
+    # field in M1 (ENG-3884). Older clients reading newer catalogs preserve
+    # unknown fields rather than dropping them.
+    model_config = ConfigDict(extra="allow")
+
     name: str
     version: str
     description: str
@@ -131,3 +136,4 @@ class GardenApp(BaseModel):
     author: Optional[str] = None
     license: Optional[str] = None
     homepage: Optional[str] = None
+    revision: Optional[str] = None

--- a/tests/unit/extensions/test_catalog_dedup_guard.py
+++ b/tests/unit/extensions/test_catalog_dedup_guard.py
@@ -1,0 +1,172 @@
+"""Tests for CatalogDedupGuard + revision plumbing (ENG-3884 / §4.2.5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from kamiwaza_extensions.catalog_publisher import (
+    CatalogDedupError,
+    CatalogDedupGuard,
+)
+from kamiwaza_extensions.exit_codes import ExitCode
+
+
+def _entry(name: str, version: str, revision: str | None = None) -> dict:
+    out = {"name": name, "version": version, "description": "x"}
+    if revision is not None:
+        out["revision"] = revision
+    return out
+
+
+@pytest.mark.unit
+class TestRevisionGrammar:
+    # TS-24: revision grammar enforced; invalid rejected with exit 2
+    @pytest.mark.parametrize(
+        "valid",
+        [
+            "a", "0", "abc-def", "1.0.0", "release-0.12.1",
+            "0.12.1-dev-a1b2c3d.1714000000",
+            "abcdef0123456789",
+            "a" * 64,
+        ],
+    )
+    def test_accepts_valid_revisions(self, valid):
+        CatalogDedupGuard.validate_revision(valid)  # no raise
+
+    @pytest.mark.parametrize(
+        "invalid",
+        [
+            "",  # empty
+            "-foo",  # leading hyphen not allowed
+            ".foo",  # leading dot not allowed
+            "Foo",  # uppercase
+            "foo bar",  # space
+            "foo_bar",  # underscore
+            "foo/bar",  # slash
+            "a" * 65,  # too long
+        ],
+    )
+    def test_rejects_invalid_revisions(self, invalid):
+        with pytest.raises(ValueError, match="Invalid revision"):
+            CatalogDedupGuard.validate_revision(invalid)
+
+
+@pytest.mark.unit
+class TestDedupCheck:
+    # TS-22: duplicate (name, semver, revision) → CatalogDedupError → exit 2
+    def test_rejects_duplicate_triple(self):
+        guard = CatalogDedupGuard()
+        existing = [_entry("hello", "1.0.0", revision="abc123")]
+        with pytest.raises(CatalogDedupError) as exc_info:
+            guard.check(existing, _entry("hello", "1.0.0", revision="abc123"))
+        # Carries enough context to print an actionable error
+        assert exc_info.value.extension_name == "hello"
+        assert exc_info.value.version == "1.0.0"
+        assert exc_info.value.revision == "abc123"
+        # CatalogDedupError is a ValueError subclass — CLI maps to exit 2
+        assert isinstance(exc_info.value, ValueError)
+        # Sanity check: ExitCode.VALIDATION is 2
+        assert int(ExitCode.VALIDATION) == 2
+
+    # TS-23: --force overrides dedup with warning
+    def test_force_bypasses_dedup_with_warning(self, capsys):
+        guard = CatalogDedupGuard()
+        existing = [_entry("hello", "1.0.0", revision="abc123")]
+        # Should not raise
+        guard.check(
+            existing,
+            _entry("hello", "1.0.0", revision="abc123"),
+            force=True,
+        )
+
+    def test_inserts_when_revision_differs(self):
+        guard = CatalogDedupGuard()
+        existing = [_entry("hello", "1.0.0", revision="abc123")]
+        guard.check(existing, _entry("hello", "1.0.0", revision="def456"))
+
+    def test_inserts_when_version_differs(self):
+        guard = CatalogDedupGuard()
+        existing = [_entry("hello", "1.0.0", revision="abc123")]
+        guard.check(existing, _entry("hello", "1.0.1", revision="abc123"))
+
+    def test_inserts_when_name_differs(self):
+        guard = CatalogDedupGuard()
+        existing = [_entry("hello", "1.0.0", revision="abc123")]
+        guard.check(existing, _entry("other", "1.0.0", revision="abc123"))
+
+    def test_no_revision_skips_dedup(self):
+        # Entries published without --revision (e.g. release publishes via
+        # ENG-3591's flag-omitted path) are not subject to dedup.
+        guard = CatalogDedupGuard()
+        existing = [_entry("hello", "1.0.0")]
+        guard.check(existing, _entry("hello", "1.0.0"))  # no raise
+
+    def test_invalid_revision_raises_value_error_before_lookup(self):
+        guard = CatalogDedupGuard()
+        # Even with an empty existing list, a malformed revision fails early.
+        with pytest.raises(ValueError, match="Invalid revision"):
+            guard.check([], _entry("hello", "1.0.0", revision="BAD CASE"))
+
+
+@pytest.mark.unit
+class TestForwardCompatGardenApp:
+    # TS-25: Older CLI reads newer catalog with revision field
+    def test_garden_app_accepts_revision_field(self):
+        from kamiwaza_sdk.schemas.apps import GardenApp
+
+        # Newer catalog entry includes a `revision` field
+        payload = {
+            "name": "hello",
+            "version": "1.0.0",
+            "description": "test",
+            "compose_yml": "services: {}",
+            "revision": "abc123",
+        }
+        app = GardenApp(**payload)
+        assert app.revision == "abc123"
+        assert app.name == "hello"
+
+    def test_garden_app_accepts_unknown_future_field(self):
+        from kamiwaza_sdk.schemas.apps import GardenApp
+
+        # An older client reading a future catalog should not crash on
+        # fields it has never heard of.
+        payload = {
+            "name": "hello",
+            "version": "1.0.0",
+            "description": "test",
+            "compose_yml": "services: {}",
+            "future_field_we_have_not_invented_yet": {"nested": True},
+        }
+        # Should not raise
+        GardenApp(**payload)
+
+
+@pytest.mark.unit
+class TestRegistryBuilderRevision:
+    def test_build_entry_includes_revision_when_set(self):
+        from kamiwaza_extensions.registry_builder import RegistryBuilder
+
+        builder = RegistryBuilder()
+        entry = builder.build_entry(
+            metadata={"name": "hello", "description": "x"},
+            transformed_compose={"services": {}},
+            registry="example.io",
+            version="1.0.0",
+            stage="prod",
+            revision="abc123",
+        )
+        assert entry["revision"] == "abc123"
+
+    def test_build_entry_omits_revision_when_none(self):
+        from kamiwaza_extensions.registry_builder import RegistryBuilder
+
+        builder = RegistryBuilder()
+        entry = builder.build_entry(
+            metadata={"name": "hello", "description": "x"},
+            transformed_compose={"services": {}},
+            registry="example.io",
+            version="1.0.0",
+            stage="prod",
+        )
+        assert "revision" not in entry


### PR DESCRIPTION
## Summary

Closes ENG-3884 (M1 milestone). Coordinates with John Strick's ENG-3591 on the \`CatalogPublisher.publish(..., revision=...)\` kwarg name; the \`--revision\` CLI flag itself lands in ENG-3591.

Makes CI re-runs, network retries, and developer re-invocations of \`kz-ext publish\` idempotent. The catalog now rejects duplicate \`(name, semver, revision)\` triples with \`ExitCode.VALIDATION\` (2) instead of silently overwriting; \`--force\` overrides with a warning.

- New \`CatalogDedupGuard\` class with \`validate_revision()\` (grammar \`^[a-z0-9][-a-z0-9.]{0,63}$\`) and \`check()\`
- New \`CatalogDedupError\` (ValueError subclass) carrying name/version/revision
- \`CatalogPublisher.publish(..., revision=...)\` plumbs revision through the lock → backup → download → dedup → merge → upload pipeline
- \`RegistryBuilder.build_entry(..., revision=...)\` includes the field on the entry only when supplied (release publishes without --revision are not subject to dedup)
- \`GardenApp\` schema sets \`extra="allow"\` and adds optional \`revision\` field — older CLIs reading newer catalogs preserve unknown fields

## Test plan
- [x] \`make test\` — 815 passed, 8 skipped (no regressions)
- [x] 27 new unit tests covering grammar (valid + invalid), dedup rejection, --force override, no-revision skip, forward-compat consumer parsing
- [x] \`uv run ruff check\` clean (matches baseline F541 count on commands/publish.py)

## Design refs
- §4.2.5 \`PublishRevisionFlag\` + \`CatalogDedupGuard\`
- §4.6.2 catalog manifest data-model change
- §4.8 F14 dedup rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)