### PR TITLE
fix(extensions): sanitize upstream model errors in starter backend (ENG-3919)

### DIFF
--- a/examples/chatbot-app/backend/app/main.py
+++ b/examples/chatbot-app/backend/app/main.py
@@ -194,28 +194,25 @@ async def chat(request: Request, identity: Identity = Depends(require_auth)):
             return response.model_dump()
         except APIStatusError as exc:
             last_error = exc
+            # Log the full upstream body server-side so operators can debug;
+            # never include `exc.body` in the response — it can carry
+            # internal hostnames, paths, or stack traces (ENG-3919).
             logger.warning(
-                "Chat completion failed for requested_model=%s resolved_model=%s attempt_model=%s endpoint=%s status=%s",
+                "Chat completion failed for requested_model=%s resolved_model=%s attempt_model=%s endpoint=%s status=%s body=%s",
                 requested_model,
                 resolved_model,
                 model_name,
                 endpoint or "<default>",
                 exc.status_code,
+                exc.body,
             )
             if exc.status_code != 404:
-                detail = None
-                if isinstance(exc.body, dict):
-                    detail = exc.body.get("detail") or exc.body.get("message")
                 raise HTTPException(
                     status_code=exc.status_code or 502,
-                    detail=detail or f"Upstream model request failed with status {exc.status_code}.",
+                    detail=f"Upstream model request failed with status {exc.status_code}.",
                 ) from exc
 
-    detail = None
-    if last_error and isinstance(last_error.body, dict):
-        detail = last_error.body.get("detail") or last_error.body.get("message")
     raise HTTPException(
         status_code=last_error.status_code if last_error else 502,
-        detail=detail
-        or f"Unable to reach the selected model after trying: {', '.join(attempted_models)}.",
+        detail=f"Unable to reach the selected model after trying: {', '.join(attempted_models)}.",
     )

--- a/kamiwaza_extensions/templates/app/backend/app/main.py
+++ b/kamiwaza_extensions/templates/app/backend/app/main.py
@@ -194,28 +194,25 @@ async def chat(request: Request, identity: Identity = Depends(require_auth)):
             return response.model_dump()
         except APIStatusError as exc:
             last_error = exc
+            # Log the full upstream body server-side so operators can debug;
+            # never include `exc.body` in the response — it can carry
+            # internal hostnames, paths, or stack traces (ENG-3919).
             logger.warning(
-                "Chat completion failed for requested_model=%s resolved_model=%s attempt_model=%s endpoint=%s status=%s",
+                "Chat completion failed for requested_model=%s resolved_model=%s attempt_model=%s endpoint=%s status=%s body=%s",
                 requested_model,
                 resolved_model,
                 model_name,
                 endpoint or "<default>",
                 exc.status_code,
+                exc.body,
             )
             if exc.status_code != 404:
-                detail = None
-                if isinstance(exc.body, dict):
-                    detail = exc.body.get("detail") or exc.body.get("message")
                 raise HTTPException(
                     status_code=exc.status_code or 502,
-                    detail=detail or f"Upstream model request failed with status {exc.status_code}.",
+                    detail=f"Upstream model request failed with status {exc.status_code}.",
                 ) from exc
 
-    detail = None
-    if last_error and isinstance(last_error.body, dict):
-        detail = last_error.body.get("detail") or last_error.body.get("message")
     raise HTTPException(
         status_code=last_error.status_code if last_error else 502,
-        detail=detail
-        or f"Unable to reach the selected model after trying: {', '.join(attempted_models)}.",
+        detail=f"Unable to reach the selected model after trying: {', '.join(attempted_models)}.",
     )

--- a/tests/unit/extensions/test_app_starter_smoke.py
+++ b/tests/unit/extensions/test_app_starter_smoke.py
@@ -192,6 +192,100 @@ def test_chatbot_example_matches_scaffolded_app_core_files(tmp_path, monkeypatch
             assert scaffolded_path.read_text() == example_path.read_text()
 
 
+def _exercise_backend_chat_error_path(
+    extension_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+) -> None:
+    """Drive the chat endpoint into APIStatusError and assert sanitization.
+
+    The starter must NEVER echo upstream model-service body content (which
+    can contain hostnames, paths, or stack traces) back to the browser
+    (ENG-3919). Verified by injecting a sensitive ``exc.body`` and asserting
+    the response detail does not leak it.
+    """
+    import httpx
+    from openai import APIStatusError
+
+    module = _load_backend_module(extension_dir / "backend", module_name)
+
+    async def fake_list_available_models(_request):
+        return [
+            SimpleNamespace(
+                id="dep-1",
+                name="Qwen smoke",
+                repo_id=None,
+                _extra={"endpoint": "https://kamiwaza.test/runtime/models/dep-1/v1"},
+            )
+        ]
+
+    sensitive_body = {
+        "detail": "Internal hostname db-internal.svc unreachable at /v1/chat/completions",
+        "stack": "Traceback ... internal_module.run_inference",
+    }
+    fake_response = httpx.Response(
+        503,
+        request=httpx.Request("POST", "https://kamiwaza.test/runtime/models/dep-1/v1"),
+    )
+
+    class FakeCompletions:
+        async def create(self, model, messages):
+            raise APIStatusError(
+                message="upstream failed", response=fake_response, body=sensitive_body,
+            )
+
+    class FakeChatClient:
+        def __init__(self):
+            self.chat = type("ChatNamespace", (), {"completions": FakeCompletions()})()
+
+    async def fake_build_chat_client(_request, _endpoint):
+        return FakeChatClient()
+
+    monkeypatch.setattr(module, "list_available_models", fake_list_available_models)
+    monkeypatch.setattr(module, "_build_chat_client", fake_build_chat_client)
+    module.app.dependency_overrides[module.require_auth] = lambda: object()
+
+    try:
+        client = TestClient(module.app)
+        response = client.post(
+            "/api/chat",
+            json={
+                "model": "dep-1",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    finally:
+        module.app.dependency_overrides.clear()
+        sys.modules.pop(module_name, None)
+
+    assert response.status_code == 503
+    detail = response.json().get("detail", "")
+    # Generic, status-code-based message — no upstream content leaked.
+    assert "503" in detail
+    assert "db-internal.svc" not in detail
+    assert "Traceback" not in detail
+    assert "/v1/chat/completions" not in detail
+    assert "internal_module" not in detail
+
+
+@pytest.mark.unit
+def test_template_sanitizes_upstream_model_errors(tmp_path, monkeypatch):
+    # Template path (used for new scaffolds going forward).
+    extension_dir = _scaffold_app(tmp_path, monkeypatch, name="sanitize-template-app")
+    _exercise_backend_chat_error_path(
+        extension_dir, monkeypatch, module_name="sanitize_template_main",
+    )
+
+
+@pytest.mark.unit
+def test_example_sanitizes_upstream_model_errors(tmp_path, monkeypatch):
+    # Example path (the checked-in chatbot-app).
+    extension_dir = _copy_example(tmp_path)
+    _exercise_backend_chat_error_path(
+        extension_dir, monkeypatch, module_name="sanitize_example_main",
+    )
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("source_name", "factory"),


### PR DESCRIPTION
## Summary

Closes ENG-3919 (M1 milestone, security). Raised during review of SDK PR #69.

The starter backend forwarded the OpenAI client's \`APIStatusError.body\` directly to FastAPI's \`HTTPException.detail\` for non-404 failures, which let upstream model-service internals (hostnames, paths, stack traces) reach browser clients. Because the starter is copied into new apps, the leak would propagate.

- Drop \`exc.body.get(\"detail\")\` / \`exc.body.get(\"message\")\` extraction from both the chat-completion error path and the post-loop fallback
- Return only a generic, status-code-based message
- Log the full upstream body server-side (\`logger.warning\` includes \`body=%s\`) so operators retain the diagnostic context
- Same fix applied to \`examples/chatbot-app/backend/app/main.py\` and \`kamiwaza_extensions/templates/app/backend/app/main.py\` (kept in sync by \`test_chatbot_example_matches_scaffolded_app_core_files\`)

## Test plan
- [x] \`make test\` — 790 passed (788 baseline + 2 new sanitization tests)
- [x] 2 new unit tests inject a sensitive \`exc.body\` into a mocked OpenAI client and assert the response detail contains the status code but none of the upstream content (db hostname, stack trace, endpoint URLs)
- [x] Sync test still green — template and example identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)