### PR TITLE
fix(extensions): drop api_url from unauthenticated /api/info (ENG-3920)

### DIFF
--- a/examples/chatbot-app/backend/app/main.py
+++ b/examples/chatbot-app/backend/app/main.py
@@ -41,10 +41,12 @@ async def health():
 
 @app.get("/api/info")
 async def info():
+    # Unauthenticated endpoint — keep the response narrow. `api_url` would
+    # leak cluster-internal hostnames like `http://api:7777/api` to anyone
+    # who can hit the extension's public surface (ENG-3920).
     config = AuthConfig.from_env()
     return {
         "app_name": config.app_name,
-        "api_url": config.api_url,
         "use_auth": config.use_auth,
     }
 

--- a/kamiwaza_extensions/templates/app/backend/app/main.py
+++ b/kamiwaza_extensions/templates/app/backend/app/main.py
@@ -41,10 +41,12 @@ async def health():
 
 @app.get("/api/info")
 async def info():
+    # Unauthenticated endpoint — keep the response narrow. `api_url` would
+    # leak cluster-internal hostnames like `http://api:7777/api` to anyone
+    # who can hit the extension's public surface (ENG-3920).
     config = AuthConfig.from_env()
     return {
         "app_name": config.app_name,
-        "api_url": config.api_url,
         "use_auth": config.use_auth,
     }
 

--- a/tests/unit/extensions/test_app_starter_smoke.py
+++ b/tests/unit/extensions/test_app_starter_smoke.py
@@ -192,6 +192,53 @@ def test_chatbot_example_matches_scaffolded_app_core_files(tmp_path, monkeypatch
             assert scaffolded_path.read_text() == example_path.read_text()
 
 
+def _exercise_info_endpoint(
+    extension_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    module_name: str,
+) -> None:
+    """Hit the unauthenticated ``/api/info`` and assert it does not leak
+    cluster-internal URLs (ENG-3920).
+    """
+    # AuthConfig.from_env() reads several KAMIWAZA_* env vars; provide values
+    # that include a sentinel cluster-internal URL so the test fails loudly
+    # if the field is ever re-introduced.
+    sentinel = "http://api:7777/api"
+    monkeypatch.setenv("KAMIWAZA_API_URL", sentinel)
+    monkeypatch.setenv("KAMIWAZA_APP_NAME", "test-app")
+    monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+
+    module = _load_backend_module(extension_dir / "backend", module_name)
+    try:
+        client = TestClient(module.app)
+        response = client.get("/api/info")
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "api_url" not in body
+    assert sentinel not in response.text
+    assert body["app_name"] == "test-app"
+    assert body["use_auth"] is True
+
+
+@pytest.mark.unit
+def test_template_info_endpoint_does_not_leak_internal_api_url(tmp_path, monkeypatch):
+    extension_dir = _scaffold_app(tmp_path, monkeypatch, name="info-template-app")
+    _exercise_info_endpoint(
+        extension_dir, monkeypatch, module_name="info_template_main",
+    )
+
+
+@pytest.mark.unit
+def test_example_info_endpoint_does_not_leak_internal_api_url(tmp_path, monkeypatch):
+    extension_dir = _copy_example(tmp_path)
+    _exercise_info_endpoint(
+        extension_dir, monkeypatch, module_name="info_example_main",
+    )
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("source_name", "factory"),


### PR DESCRIPTION
## Summary

Closes ENG-3920 (M1 milestone, security). Raised during review of SDK PR #69.

\`/api/info\` is unauthenticated and was returning \`config.api_url\`, which in cluster deployments is the internal service address (e.g. \`http://api:7777/api\`). Anyone hitting the extension's public surface could read this without credentials. Removed.

- \`app_name\` and \`use_auth\` remain — they are not internal-topology identifiers
- Same change applied to template + example (kept in sync by the existing sync test)
- 2 new smoke tests set a sentinel cluster-internal URL via env var and assert it never appears in the \`/api/info\` response body

No frontend code in either tree consumes \`api_url\` from \`/api/info\` (verified via grep), so this is non-breaking for the starter UI.

## Test plan
- [x] \`make test\` — 790 passed (788 baseline + 2 new info-endpoint tests)
- [x] No frontend consumers of \`api_url\` from \`/api/info\` in template or example
- [x] Sync test still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)