### PR TITLE
fix(extensions): starter-backend hardening P2/P5/P6 (ENG-3889)

### DIFF
--- a/examples/chatbot-app/docker-compose.yml
+++ b/examples/chatbot-app/docker-compose.yml
@@ -3,8 +3,12 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+    # Host port auto-assigned by Docker — `3000:3000` collided with the
+    # kind-cluster control plane on developer laptops running Kamiwaza
+    # locally. `kz-ext dev local` still discovers the assigned host port
+    # via `docker compose port`. (ENG-3889 P2 / §4.8)
     ports:
-      - "3000:3000"
+      - "3000"
     environment:
       - BACKEND_URL=http://backend:8000
     volumes:
@@ -17,7 +21,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8000"
     environment:
       - KAMIWAZA_API_URL=${KAMIWAZA_API_URL:-}
       - KAMIWAZA_PUBLIC_API_URL=${KAMIWAZA_PUBLIC_API_URL:-}

--- a/examples/chatbot-app/frontend/src/app/page.tsx
+++ b/examples/chatbot-app/frontend/src/app/page.tsx
@@ -552,6 +552,26 @@ function Dashboard() {
 }
 
 export default function Home() {
+    // Under USE_AUTH=false the backend's /session returns the canonical
+    // anonymous Identity (`name === "Anonymous"`, `is_authenticated === false`).
+    // AuthGuard would otherwise fetch /auth/login-url and wait for it to
+    // resolve before rendering — wasted round-trip and a "Verifying session…"
+    // flash on every local-dev page load (ENG-3889 P6 / §4.8 P6).
+    const sessionApi = useSession() as SessionApiCompat;
+    const { session, loading } = sessionApi;
+    const sessionView = session as
+        | { isAuthenticated?: boolean; name?: string | null }
+        | null;
+    const isAnonymousLocalDev =
+        !loading
+        && sessionView !== null
+        && sessionView.isAuthenticated === false
+        && sessionView.name === "Anonymous";
+
+    if (isAnonymousLocalDev) {
+        return <Dashboard />;
+    }
+
     const Guard = AuthGuard as ComponentType<{
         children: ReactNode;
         fallback?: ReactNode;

--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -176,12 +176,34 @@ class DevLocalRunner:
         for svc_name, svc_config in services.items():
             ports = svc_config.get("ports", [])
             for port_spec in ports:
-                host_port, _ = parse_port_mapping(str(port_spec))
+                host_port, container_port = parse_port_mapping(str(port_spec))
                 if host_port is None:
-                    continue
+                    # Bare-port spec (e.g. "3000") — Docker assigns the host
+                    # port. Resolve it via `docker compose port`. (ENG-3889 P2)
+                    if container_port is not None:
+                        host_port = self._docker_compose_port(svc_name, container_port)
+                    if host_port is None:
+                        continue
                 if svc_name in remaps:
                     host_port = remaps[svc_name][1]
                 console.print(f"[dim]{svc_name}:[/dim] http://localhost:{host_port}")
+
+    @staticmethod
+    def _docker_compose_port(service: str, container_port: int) -> Optional[int]:
+        """Look up the host port Docker assigned to ``service:container_port``."""
+        try:
+            result = subprocess.run(
+                ["docker", "compose", "port", service, str(container_port)],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode != 0:
+                return None
+            line = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+            if ":" in line:
+                return int(line.rsplit(":", 1)[1])
+        except (FileNotFoundError, subprocess.TimeoutExpired, ValueError, IndexError):
+            return None
+        return None
 
     # ------------------------------------------------------------------
     # Subprocess management
@@ -230,13 +252,23 @@ def build_env_overlay(connection: ConnectionInfo, extension_name: str) -> Dict[s
 
 
 def parse_port_mapping(port_spec: str) -> Tuple[Optional[int], Optional[int]]:
-    """Parse a compose port mapping like '3000:3000' into (host_port, container_port).
+    """Parse a compose port mapping into ``(host_port, container_port)``.
 
-    Returns (None, None) for container-only specs like '3000'.
+    Examples::
+
+        '3000:3000'      -> (3000, 3000)
+        '8080:3000'      -> (8080, 3000)
+        '127.0.0.1:3000:3000' -> (3000, 3000)
+        '8000:8000/tcp'  -> (8000, 8000)
+        '3000'           -> (None, 3000)   # bare container port; host auto-assigned
+        ''               -> (None, None)
     """
     port_spec = str(port_spec).strip()
     # Remove protocol suffix if present (e.g., "8000:8000/tcp")
     port_spec = port_spec.split("/")[0]
+
+    if not port_spec:
+        return None, None
 
     if ":" in port_spec:
         parts = port_spec.rsplit(":", 1)
@@ -244,7 +276,12 @@ def parse_port_mapping(port_spec: str) -> Tuple[Optional[int], Optional[int]]:
             return int(parts[0].split(":")[-1]), int(parts[1])
         except (ValueError, IndexError):
             return None, None
-    return None, None
+
+    # Bare container-port spec — host port is auto-assigned by Docker.
+    try:
+        return None, int(port_spec)
+    except ValueError:
+        return None, None
 
 
 def is_port_available(port: int, host: str = "0.0.0.0") -> bool:

--- a/kamiwaza_extensions/templates/app/docker-compose.yml
+++ b/kamiwaza_extensions/templates/app/docker-compose.yml
@@ -3,8 +3,12 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+    # Host port auto-assigned by Docker — `3000:3000` collided with the
+    # kind-cluster control plane on developer laptops running Kamiwaza
+    # locally. `kz-ext dev local` still discovers the assigned host port
+    # via `docker compose port`. (ENG-3889 P2 / §4.8)
     ports:
-      - "3000:3000"
+      - "3000"
     environment:
       - BACKEND_URL=http://backend:8000
     volumes:
@@ -17,7 +21,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     ports:
-      - "8000:8000"
+      - "8000"
     environment:
       - KAMIWAZA_API_URL=${KAMIWAZA_API_URL:-}
       - KAMIWAZA_PUBLIC_API_URL=${KAMIWAZA_PUBLIC_API_URL:-}

--- a/kamiwaza_extensions/templates/app/frontend/src/app/page.tsx
+++ b/kamiwaza_extensions/templates/app/frontend/src/app/page.tsx
@@ -552,6 +552,26 @@ function Dashboard() {
 }
 
 export default function Home() {
+    // Under USE_AUTH=false the backend's /session returns the canonical
+    // anonymous Identity (`name === "Anonymous"`, `is_authenticated === false`).
+    // AuthGuard would otherwise fetch /auth/login-url and wait for it to
+    // resolve before rendering — wasted round-trip and a "Verifying session…"
+    // flash on every local-dev page load (ENG-3889 P6 / §4.8 P6).
+    const sessionApi = useSession() as SessionApiCompat;
+    const { session, loading } = sessionApi;
+    const sessionView = session as
+        | { isAuthenticated?: boolean; name?: string | null }
+        | null;
+    const isAnonymousLocalDev =
+        !loading
+        && sessionView !== null
+        && sessionView.isAuthenticated === false
+        && sessionView.name === "Anonymous";
+
+    if (isAnonymousLocalDev) {
+        return <Dashboard />;
+    }
+
     const Guard = AuthGuard as ComponentType<{
         children: ReactNode;
         fallback?: ReactNode;

--- a/tests/unit/extensions/test_app_starter_smoke.py
+++ b/tests/unit/extensions/test_app_starter_smoke.py
@@ -192,6 +192,108 @@ def test_chatbot_example_matches_scaffolded_app_core_files(tmp_path, monkeypatch
             assert scaffolded_path.read_text() == example_path.read_text()
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "compose_path",
+    [
+        Path("kamiwaza_extensions/templates/app/docker-compose.yml"),
+        Path("examples/chatbot-app/docker-compose.yml"),
+    ],
+)
+def test_compose_does_not_pin_host_ports(compose_path):
+    # ENG-3889 P2: bare container-port specs let Docker auto-assign the
+    # host port so `docker compose up` does not collide with kind-cluster
+    # ports on developer laptops running Kamiwaza locally.
+    import yaml
+
+    data = yaml.safe_load((REPO_ROOT / compose_path).read_text())
+    services = data.get("services", {})
+    assert services, f"{compose_path} has no services"
+
+    for svc_name, svc_config in services.items():
+        for port_spec in svc_config.get("ports", []):
+            assert ":" not in str(port_spec), (
+                f"{compose_path}::{svc_name} has a host:container port mapping "
+                f"({port_spec!r}); use a bare container port to avoid host-port "
+                f"collisions on developer laptops."
+            )
+
+
+@pytest.mark.unit
+def test_anonymous_identity_byte_identical_between_require_auth_and_session(
+    tmp_path, monkeypatch,
+):
+    """ENG-3889 P5: under USE_AUTH=false, ``require_auth()`` and ``/session``
+    must return the same canonical anonymous Identity so the frontend sees
+    a single shape (§4.8 P5).
+    """
+    import asyncio
+
+    from kamiwaza_extensions_lib.auth import require_auth
+    from kamiwaza_extensions_lib.identity import Identity, anonymous_identity
+
+    monkeypatch.setenv("KAMIWAZA_USE_AUTH", "false")
+
+    # Drive require_auth() against a header-less request (USE_AUTH=false path).
+    extension_dir = _scaffold_app(tmp_path, monkeypatch, name="anon-shape-app")
+    module = _load_backend_module(extension_dir / "backend", "anon_shape_main")
+    try:
+        client = TestClient(module.app)
+        response = client.get("/session")
+        assert response.status_code == 200
+
+        from fastapi import Request
+
+        scope = {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/health",
+            "headers": [],
+        }
+        request = Request(scope)
+        identity_from_require = asyncio.run(require_auth(request))
+    finally:
+        sys.modules.pop("anon_shape_main", None)
+
+    canonical = anonymous_identity()
+    # Public-fields subset surfaced by /session — must match the runtime lib's
+    # canonical Anonymous identity exactly.
+    public_fields = {
+        "user_id", "email", "name", "roles", "workroom_id",
+        "workroom_role", "is_authenticated",
+    }
+    canonical_public = canonical.model_dump(include=public_fields)
+    session_public = {k: response.json().get(k) for k in public_fields}
+    assert session_public == canonical_public
+
+    # require_auth() returns the full Identity (a model_dump match is the
+    # strongest equality we can assert without relying on Identity hashability)
+    assert isinstance(identity_from_require, Identity)
+    assert identity_from_require.model_dump() == canonical.model_dump()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "page_path",
+    [
+        Path("kamiwaza_extensions/templates/app/frontend/src/app/page.tsx"),
+        Path("examples/chatbot-app/frontend/src/app/page.tsx"),
+    ],
+)
+def test_home_short_circuits_authguard_for_anonymous_session(page_path):
+    """ENG-3889 P6: the scaffold's Home component must skip AuthGuard when
+    ``/session`` reports the canonical ``Anonymous`` identity, so first-load
+    under USE_AUTH=false does not stick on 'Verifying session…'.
+    """
+    src = (REPO_ROOT / page_path).read_text()
+    # Cheap but sufficient — the short-circuit relies on these two predicates
+    # being present together. If either disappears the local-dev render path
+    # silently regresses to the AuthGuard round-trip.
+    assert "isAnonymousLocalDev" in src
+    assert 'name === "Anonymous"' in src
+    assert "isAuthenticated === false" in src
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
     ("source_name", "factory"),

--- a/tests/unit/extensions/test_dev_local.py
+++ b/tests/unit/extensions/test_dev_local.py
@@ -78,7 +78,10 @@ class TestParsePortMapping:
         assert parse_port_mapping("8080:3000") == (8080, 3000)
 
     def test_container_only(self):
-        assert parse_port_mapping("3000") == (None, None)
+        # Bare container-port spec — host port is auto-assigned by Docker.
+        # (ENG-3889 P2: scaffolded compose now uses bare specs to avoid
+        # host-port collisions with the kind-cluster control plane.)
+        assert parse_port_mapping("3000") == (None, 3000)
 
     def test_with_protocol(self):
         assert parse_port_mapping("8000:8000/tcp") == (8000, 8000)
@@ -87,7 +90,7 @@ class TestParsePortMapping:
         assert parse_port_mapping("127.0.0.1:3000:3000") == (3000, 3000)
 
     def test_integer_input(self):
-        assert parse_port_mapping(3000) == (None, None)
+        assert parse_port_mapping(3000) == (None, 3000)
 
     def test_empty_string(self):
         assert parse_port_mapping("") == (None, None)


### PR DESCRIPTION
## Summary

Closes ENG-3889 (M1 milestone). Three Preston-walkthrough papercuts that broke the first-run experience under \`USE_AUTH=false\` on developer laptops running Kamiwaza locally.

**P2 — host-port collision (kind cluster owns 3000):**
- \`docker-compose.yml\` (template + example) declares bare container ports \`[\"3000\"]\` / \`[\"8000\"]\`. Docker auto-assigns the host port, avoiding collision with \`kamiwaza-dev-control-plane\` and any other 3000/8000-bound service
- \`parse_port_mapping(\"3000\")\` now returns \`(None, 3000)\` instead of \`(None, None)\` so callers can resolve the auto-assigned host port via \`docker compose port\`
- \`_print_urls\` queries Docker for the assigned port when the spec is bare
- The remap logic in \`_compute_port_remaps\` continues to skip bare specs (no host port to remap), so behavior under USE_AUTH=true is unchanged

**P5 — anonymous Identity unification** (already shipped via ENG-3885):
- New backend test asserts \`require_auth()\` and \`/session\` return the same canonical \`Identity(name=\"Anonymous\", is_authenticated=False)\` under USE_AUTH=false. Regression guard — the runtime lib already does the right thing; this test catches future drift

**P6 — AuthGuard \"Verifying session…\" sticking under USE_AUTH=false:**
- Template + example \`page.tsx\` short-circuit AuthGuard when the session loads as the canonical Anonymous identity (\`name === \"Anonymous\"\`, \`isAuthenticated === false\`). Renders Dashboard immediately instead of waiting on the \`/auth/login-url\` round-trip
- Under USE_AUTH=true the original AuthGuard path is unchanged

## Test plan
- [x] \`make test\` — 793 passed (788 baseline + 5 new tests)
- [x] Parametrized compose-port assertion (template + example)
- [x] Backend Identity-equality assertion verifying P5
- [x] Source-grep on \`page.tsx\` for the short-circuit predicates so a refactor cannot silently regress P6

## Design refs
- §4.2.12 \`StarterBackendHardening\` (P2/P5/P6)
- §4.8 P2/P5/P6

🤖 Generated with [Claude Code](https://claude.com/claude-code)