### PR TITLE
feat(extensions): D210 M2 — Go reference extension + e2e CI (ENG-3894)

### DIFF
--- a/.github/workflows/extension-go-reference-e2e.yml
+++ b/.github/workflows/extension-go-reference-e2e.yml
@@ -1,0 +1,240 @@
+name: extensions/go-reference-e2e
+
+# D210 §4.2.11 / Linear ENG-3894 / M2 task T2.12.
+#
+# Exercises the full scaffold→build→deploy→invoke→publish loop for the Go
+# reference extension on every D210-bearing PR. M2 exit criterion is "green
+# on 3 consecutive PRs."
+#
+# Two phases:
+#
+#   Phase A (always runs):  cluster-free smoke
+#     - go test (parity vectors from docs/extensions/non-sdk-flow/test-vectors.json)
+#     - kz-ext validate against the example
+#     - docker build (distroless)
+#     - docker compose up + /health + /tools/echo + 401-on-missing-envelope
+#
+#   Phase B (gated):  cluster deploy + invoke + publish
+#     Runs only when ``vars.KAMIWAZA_E2E_ENABLED == 'true'`` *and* the matching
+#     repo secrets are configured (see Phase B job env). Until M2 cluster
+#     infra lands, Phase A is the executable contract; Phase B emits a
+#     ``skipped — cluster not configured`` summary so PR authors see the gap
+#     explicitly rather than silently passing.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - 'examples/extensions/go-reference/**'
+      - 'docs/extensions/non-sdk-flow.md'
+      - 'docs/extensions/non-sdk-flow/**'
+      - 'kamiwaza_extensions_lib/identity.py'
+      - 'kamiwaza_extensions_lib/errors.py'
+      - 'tests/unit/extensions_lib/test_identity_extractor_parity.py'
+      - '.github/workflows/extension-go-reference-e2e.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - 'examples/extensions/go-reference/**'
+      - 'docs/extensions/non-sdk-flow.md'
+      - 'docs/extensions/non-sdk-flow/**'
+
+permissions:
+  contents: read
+
+# D210-bearing PRs trigger via the ``D210`` label as well as path-based
+# changes; the gate below short-circuits everything else so we don't burn CI
+# minutes on unrelated PRs that brush these paths.
+jobs:
+  smoke:
+    name: Phase A — cluster-free smoke
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'D210'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: examples/extensions/go-reference/go.mod
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.7.5"
+          enable-cache: true
+
+      - name: Install kz-ext + Python parity test deps
+        run: uv sync
+
+      - name: go vet
+        working-directory: examples/extensions/go-reference
+        run: go vet ./...
+
+      - name: go test (parity vectors + middleware/handler coverage)
+        working-directory: examples/extensions/go-reference
+        run: go test -count=1 -race -v ./...
+
+      # Cross-language parity: run the Python parity test on the same
+      # vectors. Divergence between Python and Go fails here OR in `go test`.
+      - name: Python parity test (same vectors)
+        run: uv run pytest tests/unit/extensions_lib/test_identity_extractor_parity.py -v
+
+      - name: kz-ext validate
+        run: uv run kz-ext validate examples/extensions/go-reference
+
+      - name: docker build (distroless)
+        working-directory: examples/extensions/go-reference
+        run: docker build -t go-reference-e2e:ci .
+
+      - name: docker compose smoke (auth-on)
+        working-directory: examples/extensions/go-reference
+        env:
+          KAMIWAZA_USE_AUTH: "true"
+          COMPOSE_PROJECT_NAME: gorefe2e
+        run: |
+          set -euo pipefail
+          docker compose up -d --build
+          # Resolve the mapped host port; we don't pin one (flow doc §6).
+          for _ in $(seq 1 30); do
+            HOST_PORT=$(docker compose port tool 8000 2>/dev/null | cut -d: -f2 || true)
+            if [ -n "${HOST_PORT}" ]; then break; fi
+            sleep 1
+          done
+          if [ -z "${HOST_PORT}" ]; then
+            echo "::error::extension never published a host port"
+            docker compose logs --no-color
+            exit 1
+          fi
+          BASE="http://localhost:${HOST_PORT}"
+
+          # Wait for /health to come back healthy.
+          for _ in $(seq 1 30); do
+            if curl -fsS "${BASE}/health" >/dev/null; then break; fi
+            sleep 1
+          done
+          curl -fsS "${BASE}/health" | tee /tmp/health.json
+          test "$(jq -r .status /tmp/health.json)" = "ok"
+
+          # Happy-path envelope → 200 with a populated identity.
+          curl -fsS -XPOST "${BASE}/tools/echo" \
+            -H "Content-Type: application/json" \
+            -H "X-User-Id: u1" \
+            -H "X-User-Email: alice@example.com" \
+            -H "X-User-Roles: member,editor" \
+            -H "X-Workroom-Id: w1" \
+            -H "X-User-Workroom-Role: editor" \
+            -H "X-Auth-Token: dev-fake-jwt" \
+            -d '{"message":"hello"}' | tee /tmp/echo.json
+          test "$(jq -r .echo /tmp/echo.json)" = "hello"
+          test "$(jq -r .identity.user_id /tmp/echo.json)" = "u1"
+          test "$(jq -r .identity.workroom_id /tmp/echo.json)" = "w1"
+
+          # Missing X-User-Id under auth-on → canonical misbound_auth.
+          STATUS=$(curl -s -o /tmp/err.json -w '%{http_code}' -XPOST "${BASE}/tools/echo" \
+            -H "Content-Type: application/json" \
+            -H "X-Workroom-Id: w1" \
+            -d '{"message":"hello"}')
+          test "${STATUS}" = "401"
+          test "$(jq -r .error.class /tmp/err.json)" = "misbound_auth"
+
+      - name: docker compose logs on failure
+        if: failure()
+        working-directory: examples/extensions/go-reference
+        run: docker compose logs --no-color || true
+
+      - name: docker compose down
+        if: always()
+        working-directory: examples/extensions/go-reference
+        run: docker compose down -v || true
+
+  cluster:
+    name: Phase B — cluster deploy + invoke + publish
+    needs: smoke
+    runs-on: ubuntu-latest
+    # Phase B touches a real cluster with real credentials. Restrict to:
+    #   1. push events to main/develop (always trusted), OR
+    #   2. PRs whose head ref lives in *this* repo (not a fork) and which
+    #      either weren't labeled or carry the D210 label.
+    # Forks never see secrets on `pull_request` so they fail safely without
+    # this gate; the explicit head-repo check defends against a maintainer
+    # labeling a same-repo branch PR with hostile workflow changes.
+    if: >
+      (
+        github.event_name == 'push' ||
+        (github.event.pull_request.head.repo.full_name == github.repository &&
+         (github.event.action != 'labeled' || github.event.label.name == 'D210'))
+      ) &&
+      vars.KAMIWAZA_E2E_ENABLED == 'true'
+    env:
+      KAMIWAZA_API_URL: ${{ secrets.KAMIWAZA_E2E_API_URL }}
+      KAMIWAZA_API_KEY: ${{ secrets.KAMIWAZA_E2E_API_KEY }}
+      KAMIWAZA_PUBLISH_PROFILE: ${{ vars.KAMIWAZA_E2E_PUBLISH_PROFILE }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: examples/extensions/go-reference/go.mod
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.7.5"
+          enable-cache: true
+
+      - name: Install kz-ext
+        run: uv sync
+
+      - name: kz-ext login
+        run: uv run kz-ext login "$KAMIWAZA_API_URL" --api-key "$KAMIWAZA_API_KEY" --name e2e --no-verify-ssl
+
+      - name: kz-ext dev (build + push + deploy)
+        working-directory: examples/extensions/go-reference
+        run: uv run kz-ext dev --revision "${GITHUB_SHA::7}"
+
+      - name: invoke deployed extension
+        working-directory: examples/extensions/go-reference
+        run: |
+          set -euo pipefail
+          # The deployed URL is surfaced by `kz-ext status`; we parse the
+          # human-readable output to find the platform-routed URL so the
+          # request actually traverses Traefik ForwardAuth (the only place
+          # the envelope contract is exercised end-to-end).
+          # TODO: replace this regex with `kz-ext status --json` once that
+          # flag exists. Parsing human output is brittle to any cosmetic
+          # CLI change (color codes, table reformat, label rename).
+          STATUS=$(uv run kz-ext status)
+          echo "$STATUS"
+          DEPLOY_URL=$(echo "$STATUS" | grep -Eo 'https?://[^[:space:]]+/extensions/[^[:space:]]+' | head -1)
+          test -n "$DEPLOY_URL" || { echo "::error::no deploy URL in status output"; exit 1; }
+          curl -fsS -k "${DEPLOY_URL}/health"
+          curl -fsS -k -XPOST "${DEPLOY_URL}/tools/echo" \
+            -H "Authorization: Bearer ${KAMIWAZA_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d '{"message":"e2e"}'
+
+      - name: kz-ext publish
+        working-directory: examples/extensions/go-reference
+        run: uv run kz-ext publish --stage "$KAMIWAZA_PUBLISH_PROFILE" --revision "${GITHUB_SHA::7}"
+
+  cluster-skipped:
+    name: Phase B — skipped (cluster not configured)
+    needs: smoke
+    runs-on: ubuntu-latest
+    # Mirrors the cluster job's eligibility condition; only the
+    # KAMIWAZA_E2E_ENABLED variable flips between the two so they remain
+    # mutually exclusive — keep the predicates in sync.
+    if: >
+      (
+        github.event_name == 'push' ||
+        (github.event.pull_request.head.repo.full_name == github.repository &&
+         (github.event.action != 'labeled' || github.event.label.name == 'D210'))
+      ) &&
+      vars.KAMIWAZA_E2E_ENABLED != 'true'
+    steps:
+      - name: Note skipped phase
+        run: |
+          echo "::notice::Phase B (cluster deploy + invoke + publish) skipped — set repo variable KAMIWAZA_E2E_ENABLED=true and provide KAMIWAZA_E2E_API_URL/KAMIWAZA_E2E_API_KEY/KAMIWAZA_E2E_PUBLISH_PROFILE to enable. Tracked under ENG-3894 / D210 M2 T2.12."

--- a/.github/workflows/extension-go-reference-e2e.yml
+++ b/.github/workflows/extension-go-reference-e2e.yml
@@ -172,12 +172,23 @@ jobs:
     env:
       KAMIWAZA_API_URL: ${{ secrets.KAMIWAZA_E2E_API_URL }}
       KAMIWAZA_API_KEY: ${{ secrets.KAMIWAZA_E2E_API_KEY }}
+      # Container registry that `kz-ext dev` pushes the built image to.
+      # Without this, dev.py:294-305 falls through to a "registry.<host>"
+      # heuristic that only works on clusters provisioned with that DNS;
+      # set it explicitly so the workflow doesn't depend on cluster DNS.
+      KAMIWAZA_REGISTRY: ${{ secrets.KAMIWAZA_E2E_REGISTRY }}
       # Publish-profile fields. The "Provision e2e publish profile" step
       # below creates ~/.kamiwaza/profiles/e2e.json from these so
       # `kz-ext publish --stage e2e` can resolve the profile.
       KZ_PUBLISH_REGISTRY: ${{ secrets.KZ_PUBLISH_REGISTRY }}
       KZ_PUBLISH_CATALOG_ENDPOINT: ${{ secrets.KZ_PUBLISH_CATALOG_ENDPOINT }}
       KZ_PUBLISH_CATALOG_BUCKET: ${{ secrets.KZ_PUBLISH_CATALOG_BUCKET }}
+      # AWS credentials read by boto3 at publish time when the e2e profile
+      # uses --catalog-credentials env. Catalog uploads to S3-compatible
+      # storage (AWS S3 / Cloudflare R2 / etc.) need both KEY_ID and
+      # SECRET_ACCESS_KEY in the process environment.
+      AWS_ACCESS_KEY_ID: ${{ secrets.KZ_PUBLISH_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.KZ_PUBLISH_AWS_SECRET_ACCESS_KEY }}
 
     steps:
       - uses: actions/checkout@v4
@@ -218,16 +229,21 @@ jobs:
         working-directory: examples/extensions/go-reference
         run: |
           set -euo pipefail
-          # The deployed URL is surfaced by `kz-ext status`; we parse the
-          # human-readable output to find the platform-routed URL so the
-          # request actually traverses Traefik ForwardAuth (the only place
-          # the envelope contract is exercised end-to-end).
+          # The deployed URL is surfaced by `kz-ext status`. Two important
+          # capture details:
+          #   1. The status command writes via Console(stderr=True) (see
+          #      kamiwaza_extensions/commands/status.py), so we MUST
+          #      capture stderr too — `2>&1` redirects stderr into stdout.
+          #   2. Deployed extension URLs use the platform's runtime path
+          #      `/runtime/(apps|tools|services)/<name>` (per
+          #      PayloadBuilder), NOT `/extensions/...` which is the
+          #      management API. Match the runtime pattern.
           # TODO: replace this regex with `kz-ext status --json` once that
           # flag exists. Parsing human output is brittle to any cosmetic
           # CLI change (color codes, table reformat, label rename).
-          STATUS=$(NO_COLOR=1 uv run kz-ext status)
+          STATUS=$(NO_COLOR=1 uv run kz-ext status 2>&1)
           echo "$STATUS"
-          DEPLOY_URL=$(echo "$STATUS" | grep -Eo 'https?://[^[:space:]]+/extensions/[^[:space:]]+' | head -1)
+          DEPLOY_URL=$(echo "$STATUS" | grep -Eo 'https?://[^[:space:]]+/runtime/(apps|tools|services)/[^[:space:]]+' | head -1)
           test -n "$DEPLOY_URL" || { echo "::error::no deploy URL in status output"; exit 1; }
           curl -fsS -k "${DEPLOY_URL}/health"
           curl -fsS -k -XPOST "${DEPLOY_URL}/tools/echo" \
@@ -255,5 +271,5 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "::notice::Phase B (cluster deploy + invoke + publish) does not run on PRs by design — Phase A (cluster-free smoke) is the executable contract for PRs. Phase B runs on push to main/develop when KAMIWAZA_E2E_ENABLED=true. See workflow header comment for the security rationale."
           else
-            echo "::notice::Phase B skipped — set repo variable KAMIWAZA_E2E_ENABLED=true and provide secrets KAMIWAZA_E2E_API_URL, KAMIWAZA_E2E_API_KEY, KZ_PUBLISH_REGISTRY, KZ_PUBLISH_CATALOG_ENDPOINT, KZ_PUBLISH_CATALOG_BUCKET (plus AWS_* for catalog upload). Tracked under ENG-3894 / D210 M2 T2.12."
+            echo "::notice::Phase B skipped — set repo variable KAMIWAZA_E2E_ENABLED=true and provide secrets KAMIWAZA_E2E_API_URL, KAMIWAZA_E2E_API_KEY, KAMIWAZA_E2E_REGISTRY, KZ_PUBLISH_REGISTRY, KZ_PUBLISH_CATALOG_ENDPOINT, KZ_PUBLISH_CATALOG_BUCKET, KZ_PUBLISH_AWS_ACCESS_KEY_ID, KZ_PUBLISH_AWS_SECRET_ACCESS_KEY. Tracked under ENG-3894 / D210 M2 T2.12."
           fi

--- a/.github/workflows/extension-go-reference-e2e.yml
+++ b/.github/workflows/extension-go-reference-e2e.yml
@@ -3,27 +3,36 @@ name: extensions/go-reference-e2e
 # D210 §4.2.11 / Linear ENG-3894 / M2 task T2.12.
 #
 # Exercises the full scaffold→build→deploy→invoke→publish loop for the Go
-# reference extension on every D210-bearing PR. M2 exit criterion is "green
-# on 3 consecutive PRs."
+# reference extension on every PR that touches D210-related paths. M2 exit
+# criterion is "green on 3 consecutive PRs."
 #
 # Two phases:
 #
-#   Phase A (always runs):  cluster-free smoke
-#     - go test (parity vectors from docs/extensions/non-sdk-flow/test-vectors.json)
-#     - kz-ext validate against the example
+#   Phase A (PR + push): cluster-free smoke
+#     - go vet + go test -race (parity vectors + middleware/handler suite)
+#     - Python parity test on the same canonical vectors
+#     - kz-ext validate
 #     - docker build (distroless)
 #     - docker compose up + /health + /tools/echo + 401-on-missing-envelope
 #
-#   Phase B (gated):  cluster deploy + invoke + publish
-#     Runs only when ``vars.KAMIWAZA_E2E_ENABLED == 'true'`` *and* the matching
-#     repo secrets are configured (see Phase B job env). Until M2 cluster
-#     infra lands, Phase A is the executable contract; Phase B emits a
-#     ``skipped — cluster not configured`` summary so PR authors see the gap
-#     explicitly rather than silently passing.
+#   Phase B (push to main/develop ONLY): cluster deploy + invoke + publish
+#     Phase B is intentionally NOT triggered on PRs. PR-head code that
+#     receives cluster credentials (even from a same-repo branch) is the
+#     "preventing pwn requests" failure mode — see
+#     https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#     The PR contract is Phase A; Phase B exercises the cluster path
+#     post-merge so any cluster-only regression is caught before the next
+#     release without putting credentials in PR code's reach.
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    # NOTE: deliberately NOT triggering on `labeled`. GitHub applies the
+    # paths: filter before evaluating job-level if-conditions, so a
+    # `labeled` event on a PR whose changed files are outside the path
+    # list never creates a workflow run at all. The path filter is the
+    # authoritative gate for "D210-bearing PR" — touching any of these
+    # paths IS what makes a PR D210-bearing.
+    types: [opened, synchronize, reopened]
     paths:
       - 'examples/extensions/go-reference/**'
       - 'docs/extensions/non-sdk-flow.md'
@@ -38,21 +47,20 @@ on:
       - 'examples/extensions/go-reference/**'
       - 'docs/extensions/non-sdk-flow.md'
       - 'docs/extensions/non-sdk-flow/**'
+      - 'kamiwaza_extensions_lib/identity.py'
+      - 'kamiwaza_extensions_lib/errors.py'
+      - '.github/workflows/extension-go-reference-e2e.yml'
 
 permissions:
   contents: read
 
-# D210-bearing PRs trigger via the ``D210`` label as well as path-based
-# changes; the gate below short-circuits everything else so we don't burn CI
-# minutes on unrelated PRs that brush these paths.
 jobs:
   smoke:
     name: Phase A — cluster-free smoke
     runs-on: ubuntu-latest
-    if: >
-      github.event_name == 'push' ||
-      github.event.action != 'labeled' ||
-      github.event.label.name == 'D210'
+    env:
+      # Hoisted so docker compose down/logs target the same project as up.
+      COMPOSE_PROJECT_NAME: gorefe2e
 
     steps:
       - uses: actions/checkout@v4
@@ -94,7 +102,6 @@ jobs:
         working-directory: examples/extensions/go-reference
         env:
           KAMIWAZA_USE_AUTH: "true"
-          COMPOSE_PROJECT_NAME: gorefe2e
         run: |
           set -euo pipefail
           docker compose up -d --build
@@ -155,24 +162,22 @@ jobs:
     name: Phase B — cluster deploy + invoke + publish
     needs: smoke
     runs-on: ubuntu-latest
-    # Phase B touches a real cluster with real credentials. Restrict to:
-    #   1. push events to main/develop (always trusted), OR
-    #   2. PRs whose head ref lives in *this* repo (not a fork) and which
-    #      either weren't labeled or carry the D210 label.
-    # Forks never see secrets on `pull_request` so they fail safely without
-    # this gate; the explicit head-repo check defends against a maintainer
-    # labeling a same-repo branch PR with hostile workflow changes.
-    if: >
-      (
-        github.event_name == 'push' ||
-        (github.event.pull_request.head.repo.full_name == github.repository &&
-         (github.event.action != 'labeled' || github.event.label.name == 'D210'))
-      ) &&
-      vars.KAMIWAZA_E2E_ENABLED == 'true'
+    # PUSH-ONLY by design. Phase B receives real cluster credentials and
+    # runs the PR/branch's checked-out code; allowing PR triggers (even
+    # same-repo) is a credential-exfiltration vector — the contributor
+    # who pushed the branch could include hostile changes that exfiltrate
+    # KAMIWAZA_E2E_API_KEY when the workflow runs. Restrict to push events
+    # on protected branches only; the PR contract is Phase A.
+    if: github.event_name == 'push' && vars.KAMIWAZA_E2E_ENABLED == 'true'
     env:
       KAMIWAZA_API_URL: ${{ secrets.KAMIWAZA_E2E_API_URL }}
       KAMIWAZA_API_KEY: ${{ secrets.KAMIWAZA_E2E_API_KEY }}
-      KAMIWAZA_PUBLISH_PROFILE: ${{ vars.KAMIWAZA_E2E_PUBLISH_PROFILE }}
+      # Publish-profile fields. The "Provision e2e publish profile" step
+      # below creates ~/.kamiwaza/profiles/e2e.json from these so
+      # `kz-ext publish --stage e2e` can resolve the profile.
+      KZ_PUBLISH_REGISTRY: ${{ secrets.KZ_PUBLISH_REGISTRY }}
+      KZ_PUBLISH_CATALOG_ENDPOINT: ${{ secrets.KZ_PUBLISH_CATALOG_ENDPOINT }}
+      KZ_PUBLISH_CATALOG_BUCKET: ${{ secrets.KZ_PUBLISH_CATALOG_BUCKET }}
 
     steps:
       - uses: actions/checkout@v4
@@ -191,6 +196,20 @@ jobs:
       - name: kz-ext login
         run: uv run kz-ext login "$KAMIWAZA_API_URL" --api-key "$KAMIWAZA_API_KEY" --name e2e --no-verify-ssl
 
+      - name: Provision e2e publish profile
+        # `kz-ext publish --stage e2e` resolves the profile from
+        # ~/.kamiwaza/profiles/e2e.json. Create it inline from the
+        # KZ_PUBLISH_* env vars rather than checking it in. The profile
+        # uses catalog-credentials=env so the actual S3 credentials are
+        # picked up from AWS_* env vars at publish time (operator
+        # responsibility — set those as additional repo secrets).
+        run: |
+          uv run kz-ext config publish-profile e2e \
+            --registry "$KZ_PUBLISH_REGISTRY" \
+            --catalog-endpoint "$KZ_PUBLISH_CATALOG_ENDPOINT" \
+            --catalog-bucket "$KZ_PUBLISH_CATALOG_BUCKET" \
+            --catalog-credentials env
+
       - name: kz-ext dev (build + push + deploy)
         working-directory: examples/extensions/go-reference
         run: uv run kz-ext dev --revision "${GITHUB_SHA::7}"
@@ -206,7 +225,7 @@ jobs:
           # TODO: replace this regex with `kz-ext status --json` once that
           # flag exists. Parsing human output is brittle to any cosmetic
           # CLI change (color codes, table reformat, label rename).
-          STATUS=$(uv run kz-ext status)
+          STATUS=$(NO_COLOR=1 uv run kz-ext status)
           echo "$STATUS"
           DEPLOY_URL=$(echo "$STATUS" | grep -Eo 'https?://[^[:space:]]+/extensions/[^[:space:]]+' | head -1)
           test -n "$DEPLOY_URL" || { echo "::error::no deploy URL in status output"; exit 1; }
@@ -218,23 +237,23 @@ jobs:
 
       - name: kz-ext publish
         working-directory: examples/extensions/go-reference
-        run: uv run kz-ext publish --stage "$KAMIWAZA_PUBLISH_PROFILE" --revision "${GITHUB_SHA::7}"
+        run: uv run kz-ext publish --stage e2e --revision "${GITHUB_SHA::7}"
 
   cluster-skipped:
-    name: Phase B — skipped (cluster not configured)
+    name: Phase B — skipped (PR or cluster not configured)
     needs: smoke
     runs-on: ubuntu-latest
-    # Mirrors the cluster job's eligibility condition; only the
-    # KAMIWAZA_E2E_ENABLED variable flips between the two so they remain
-    # mutually exclusive — keep the predicates in sync.
-    if: >
-      (
-        github.event_name == 'push' ||
-        (github.event.pull_request.head.repo.full_name == github.repository &&
-         (github.event.action != 'labeled' || github.event.label.name == 'D210'))
-      ) &&
-      vars.KAMIWAZA_E2E_ENABLED != 'true'
+    # Surfaces an explicit notice on every PR (Phase B is push-only by
+    # design) AND on push events when the cluster isn't enabled. No
+    # head-repo gate here — fork PRs should still see the notice so
+    # contributors understand Phase B's scope without having to read the
+    # workflow file.
+    if: github.event_name == 'pull_request' || vars.KAMIWAZA_E2E_ENABLED != 'true'
     steps:
       - name: Note skipped phase
         run: |
-          echo "::notice::Phase B (cluster deploy + invoke + publish) skipped — set repo variable KAMIWAZA_E2E_ENABLED=true and provide KAMIWAZA_E2E_API_URL/KAMIWAZA_E2E_API_KEY/KAMIWAZA_E2E_PUBLISH_PROFILE to enable. Tracked under ENG-3894 / D210 M2 T2.12."
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "::notice::Phase B (cluster deploy + invoke + publish) does not run on PRs by design — Phase A (cluster-free smoke) is the executable contract for PRs. Phase B runs on push to main/develop when KAMIWAZA_E2E_ENABLED=true. See workflow header comment for the security rationale."
+          else
+            echo "::notice::Phase B skipped — set repo variable KAMIWAZA_E2E_ENABLED=true and provide secrets KAMIWAZA_E2E_API_URL, KAMIWAZA_E2E_API_KEY, KZ_PUBLISH_REGISTRY, KZ_PUBLISH_CATALOG_ENDPOINT, KZ_PUBLISH_CATALOG_BUCKET (plus AWS_* for catalog upload). Tracked under ENG-3894 / D210 M2 T2.12."
+          fi

--- a/examples/extensions/go-reference/.dockerignore
+++ b/examples/extensions/go-reference/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+README.md
+docker-compose.yml
+*.test

--- a/examples/extensions/go-reference/Dockerfile
+++ b/examples/extensions/go-reference/Dockerfile
@@ -1,0 +1,16 @@
+# Multi-stage build → distroless runtime per non-sdk-flow.md §6
+# (recommended for non-Python extensions).
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+# go.sum* glob keeps the cache layer working when the module gains its
+# first dependency (today the module is stdlib-only and ships no go.sum).
+COPY go.mod go.sum* ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/extension .
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/extension /extension
+EXPOSE 8000
+USER nonroot:nonroot
+ENTRYPOINT ["/extension"]

--- a/examples/extensions/go-reference/README.md
+++ b/examples/extensions/go-reference/README.md
@@ -1,0 +1,111 @@
+# Go reference extension (non-SDK)
+
+A working Go implementation of the contract in
+[`docs/extensions/non-sdk-flow.md`](../../../docs/extensions/non-sdk-flow.md).
+This is the canonical reference for authors building Kamiwaza extensions in
+languages other than Python or TypeScript — every section here mirrors a
+section of the flow doc.
+
+> **Status:** scaffold-equivalent reference. Header parsing only — no HMAC,
+> no shared secret. Trust boundary is Traefik (flow doc §8). Tracked in
+> [ENG-3894](https://linear.app/kamiwaza/issue/ENG-3894).
+
+## Layout
+
+```
+go-reference/
+├── go.mod
+├── main.go                          HTTP server + identity middleware
+├── main_test.go                     Middleware + handler tests
+├── internal/identity/
+│   ├── extractor.go                 Header → Identity (no crypto)
+│   └── extractor_test.go            Consumes the canonical test vectors + edge cases
+├── Dockerfile                       Multi-stage build → distroless runtime
+├── docker-compose.yml
+└── kamiwaza.json                    type: tool
+```
+
+## Run locally
+
+```bash
+docker compose up -d --build
+HOST_PORT=$(docker compose port tool 8000 | cut -d: -f2)
+
+# Health
+curl -s "http://localhost:${HOST_PORT}/health"
+# → {"status":"ok"}
+
+# Sample tool — anonymous mode (KAMIWAZA_USE_AUTH=false in compose default).
+curl -s -XPOST "http://localhost:${HOST_PORT}/tools/echo" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"hello"}'
+# → {"echo":"hello","identity":null}
+
+# Sample tool — auth-on with a simulated envelope.
+KAMIWAZA_USE_AUTH=true docker compose up -d --build
+HOST_PORT=$(docker compose port tool 8000 | cut -d: -f2)
+curl -s -XPOST "http://localhost:${HOST_PORT}/tools/echo" \
+  -H "Content-Type: application/json" \
+  -H "X-User-Id: u1" \
+  -H "X-User-Email: alice@example.com" \
+  -H "X-User-Roles: member,editor" \
+  -H "X-Workroom-Id: w1" \
+  -H "X-User-Workroom-Role: editor" \
+  -H "X-Auth-Token: dev-fake-jwt" \
+  -d '{"message":"hello"}'
+# → 200 {"echo":"hello","identity":{"user_id":"u1",...}}
+
+# Missing X-User-Id under auth-on → canonical misbound_auth.
+curl -i -XPOST "http://localhost:${HOST_PORT}/tools/echo" \
+  -H "Content-Type: application/json" \
+  -H "X-Workroom-Id: w1" \
+  -d '{"message":"hello"}'
+# → 401 {"error":{"class":"misbound_auth","message":"Required envelope header X-User-Id missing or empty"}}
+```
+
+## Run the parity tests
+
+The extractor tests consume
+[`docs/extensions/non-sdk-flow/test-vectors.json`](../../../docs/extensions/non-sdk-flow/test-vectors.json)
+— the same fixture the Python and TypeScript runtime libs use. A behavior
+divergence between languages fails the corresponding case in all three
+suites simultaneously.
+
+```bash
+# From the repo root or this directory.
+go test ./...
+```
+
+## Section-by-section mapping to the flow doc
+
+| Flow doc §                | Implemented by                                                              |
+| ------------------------- | --------------------------------------------------------------------------- |
+| §1 Runtime contract       | `main.go` — `0.0.0.0:$PORT`, `/health`, SIGTERM ≤ 30s, JSON logs to stdout. |
+| §2 Envelope headers       | `internal/identity/extractor.go` — case-insensitive read via `http.Header`. |
+| §3 Identity parsing       | `internal/identity/extractor.go::Extract`. Strict mode raises `MisboundAuthError` on missing `X-User-Id` / `X-Workroom-Id`. |
+| §4 Model-access pattern   | Not exercised in this minimal reference — when calling back into the platform, forward the request's `X-Auth-Token` header to `KAMIWAZA_API_URL`. Do not store it on `Identity`. |
+| §5 Failure semantics      | `main.go::writeError` — `{"error":{"class","message"}}` body, HTTP 401 for `misbound_auth`. |
+| §6 Packaging              | `Dockerfile` (multi-stage → distroless), `docker-compose.yml` (no fixed host port), `kamiwaza.json` (`type: tool`). |
+| §7 Publishing             | `kz-ext publish --stage <profile> --revision $(git rev-parse --short HEAD)` — language-agnostic. |
+| §8 Trust boundary         | `internal/identity/extractor.go` package doc — no HMAC verification; trust is gateway-asserted. |
+
+## What this reference deliberately does *not* do
+
+- No HMAC verification, no canonicalization, no TTL check, no shared
+  secret. The flow doc §3 + §8 walk through why.
+- No `X-Auth-Token` field on `Identity`. The bearer credential lives in
+  request scope; `Identity` is safe to log and serialize.
+- No MCP / FastMCP framing. The Python tool template uses `FastMCP` for
+  ergonomics; non-SDK extensions are just HTTP servers — `tools/echo` is a
+  plain JSON endpoint demonstrating the contract without dragging in a
+  protocol surface that's unrelated to the envelope.
+- No `kz_ext_version` field in `kamiwaza.json`. The Python tool template
+  stamps it via the scaffolder; for a hand-authored non-SDK reference it
+  serves no purpose (CLI compatibility checks fall through to a warning).
+
+## Updating the test vectors
+
+`docs/extensions/non-sdk-flow/test-vectors.json` is the single source of
+truth. Add a new vector there; Python, TypeScript, and Go consumers all
+pick it up automatically. If you change the schema, update §3 of the flow
+doc and the parity tests in all three languages.

--- a/examples/extensions/go-reference/docker-compose.yml
+++ b/examples/extensions/go-reference/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  tool:
+    build: .
+    # No fixed host port — the platform allocates one (non-sdk-flow.md §6).
+    # Local dev maps with `docker compose up -d` will get a random host
+    # port; resolve via `docker compose port tool 8000`.
+    ports:
+      - "8000"
+    environment:
+      KAMIWAZA_USE_AUTH: ${KAMIWAZA_USE_AUTH:-false}
+      # KAMIWAZA_API_URL / KAMIWAZA_EXTENSION_NAME / KAMIWAZA_EXTENSION_VERSION
+      # are forwarded for completeness — main.go does not read them today.
+      # When the reference grows a model-access example (flow doc §4), it
+      # will read KAMIWAZA_API_URL here.
+      KAMIWAZA_API_URL: ${KAMIWAZA_API_URL:-}
+      KAMIWAZA_EXTENSION_NAME: ${KAMIWAZA_EXTENSION_NAME:-tool-go-reference}
+      KAMIWAZA_EXTENSION_VERSION: ${KAMIWAZA_EXTENSION_VERSION:-0.1.0}
+      LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/examples/extensions/go-reference/go.mod
+++ b/examples/extensions/go-reference/go.mod
@@ -1,0 +1,3 @@
+module github.com/kamiwaza/kamiwaza-sdk/examples/extensions/go-reference
+
+go 1.22

--- a/examples/extensions/go-reference/internal/identity/extractor.go
+++ b/examples/extensions/go-reference/internal/identity/extractor.go
@@ -1,0 +1,74 @@
+// Package identity parses the Kamiwaza envelope headers stamped by Traefik's
+// ForwardAuth middleware into an Identity value. Header parsing only — no
+// HMAC, no shared secret, no canonicalization, no TTL check. The trust
+// boundary is Traefik (kamiwaza-sdk/docs/extensions/non-sdk-flow.md §8).
+package identity
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Identity mirrors the fields pinned by docs/extensions/non-sdk-flow/test-vectors.json.
+// X-Auth-Token is deliberately not stored: the bearer credential lives in
+// request scope (read it from r.Header directly when forwarding to the
+// platform) so identity payloads never leak it through logs or error bodies.
+type Identity struct {
+	UserID       *string  `json:"user_id"`
+	Email        *string  `json:"email"`
+	Name         *string  `json:"name"`
+	Roles        []string `json:"roles"`
+	SystemHigh   *string  `json:"system_high"`
+	WorkroomID   *string  `json:"workroom_id"`
+	WorkroomRole *string  `json:"workroom_role"`
+	RequestID    *string  `json:"request_id"`
+}
+
+// MisboundAuthError is the canonical "request did not come through Traefik,
+// or platform did not populate the envelope" failure (non-sdk-flow.md §5).
+// Maps to HTTP 401 with class "misbound_auth". The message is read-only
+// from outside the package via Error().
+type MisboundAuthError struct{ msg string }
+
+func (e *MisboundAuthError) Error() string { return e.msg }
+
+// Extract reads envelope headers into an Identity. Returns *MisboundAuthError
+// when X-User-Id or X-Workroom-Id is missing or whitespace-only.
+func Extract(h http.Header) (*Identity, error) {
+	userID := strip(h.Get("X-User-Id"))
+	workroomID := strip(h.Get("X-Workroom-Id"))
+	if userID == nil {
+		return nil, &MisboundAuthError{msg: "Required envelope header X-User-Id missing or empty"}
+	}
+	if workroomID == nil {
+		return nil, &MisboundAuthError{msg: "Required envelope header X-Workroom-Id missing or empty"}
+	}
+	return &Identity{
+		UserID:       userID,
+		Email:        strip(h.Get("X-User-Email")),
+		Name:         strip(h.Get("X-User-Name")),
+		Roles:        parseRoles(h.Get("X-User-Roles")),
+		SystemHigh:   strip(h.Get("X-User-System-High")),
+		WorkroomID:   workroomID,
+		WorkroomRole: strip(h.Get("X-User-Workroom-Role")),
+		RequestID:    strip(h.Get("X-Request-Id")),
+	}, nil
+}
+
+func strip(v string) *string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return nil
+	}
+	return &v
+}
+
+func parseRoles(raw string) []string {
+	out := []string{}
+	for _, p := range strings.Split(raw, ",") {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/examples/extensions/go-reference/internal/identity/extractor_test.go
+++ b/examples/extensions/go-reference/internal/identity/extractor_test.go
@@ -1,0 +1,214 @@
+// Parity test: this Go extractor consumes the same canonical vectors as the
+// Python (kamiwaza_extensions_lib.identity.extract_identity) and TS
+// (@kamiwaza-ai/extensions-lib) runtime libs. If a vector behavior diverges
+// between languages, the corresponding test fails in all three languages at
+// the same case.
+//
+// Vectors live at kamiwaza-sdk/docs/extensions/non-sdk-flow/test-vectors.json
+// (canonical, see ENG-3892 / D210 §4.2.11).
+package identity
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+type vector struct {
+	Case             string                 `json:"case"`
+	Headers          map[string]string      `json:"headers"`
+	ExpectedIdentity map[string]interface{} `json:"expected_identity,omitempty"`
+	ShouldFailClass  string                 `json:"should_fail_class,omitempty"`
+}
+
+// vectorsPath walks up from this test file until it finds the repo root
+// (identified by pyproject.toml — kamiwaza-sdk's top-level marker), then
+// resolves the canonical test-vectors.json from there. Walking instead of
+// counting `..` segments keeps the test resilient to subtree relocation.
+func vectorsPath(t *testing.T) string {
+	t.Helper()
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed — cannot locate test file")
+	}
+	dir := filepath.Dir(here)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "pyproject.toml")); err == nil {
+			return filepath.Join(dir, "docs", "extensions", "non-sdk-flow", "test-vectors.json")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("repo root marker pyproject.toml not found above %s", filepath.Dir(here))
+		}
+		dir = parent
+	}
+}
+
+func loadVectors(t *testing.T) []vector {
+	t.Helper()
+	raw, err := os.ReadFile(vectorsPath(t))
+	if err != nil {
+		t.Fatalf("read vectors: %v", err)
+	}
+	var vecs []vector
+	if err := json.Unmarshal(raw, &vecs); err != nil {
+		t.Fatalf("parse vectors: %v", err)
+	}
+	if len(vecs) == 0 {
+		t.Fatal("no vectors loaded")
+	}
+	return vecs
+}
+
+func headersFromMap(m map[string]string) http.Header {
+	h := http.Header{}
+	for k, v := range m {
+		h.Set(k, v)
+	}
+	return h
+}
+
+func TestExtract_VectorParity(t *testing.T) {
+	for _, v := range loadVectors(t) {
+		t.Run(v.Case, func(t *testing.T) {
+			id, err := Extract(headersFromMap(v.Headers))
+			switch {
+			case v.ExpectedIdentity != nil:
+				if err != nil {
+					t.Fatalf("unexpected error on happy-path vector: %v", err)
+				}
+				assertProjectedEqual(t, id, v.ExpectedIdentity)
+			case v.ShouldFailClass == "misbound_auth":
+				var mb *MisboundAuthError
+				if !errors.As(err, &mb) {
+					t.Fatalf("expected MisboundAuthError, got err=%v identity=%+v", err, id)
+				}
+			default:
+				t.Fatalf("vector %q: unrecognized failure class %q", v.Case, v.ShouldFailClass)
+			}
+		})
+	}
+}
+
+// assertProjectedEqual marshals the Identity to its JSON shape and compares
+// every key the vector pins. A regression that drops a field entirely from
+// the marshalled shape is caught — `_, present := got[key]` distinguishes
+// "absent" from "explicit null".
+func assertProjectedEqual(t *testing.T, id *Identity, expected map[string]interface{}) {
+	t.Helper()
+	enc, err := json.Marshal(id)
+	if err != nil {
+		t.Fatalf("marshal identity: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(enc, &got); err != nil {
+		t.Fatalf("unmarshal identity: %v", err)
+	}
+	for key, want := range expected {
+		actual, present := got[key]
+		if !present {
+			t.Errorf("field %q missing from marshalled Identity (regression: field dropped from struct)", key)
+			continue
+		}
+		if !reflect.DeepEqual(actual, want) {
+			t.Errorf("field %q: want %#v, got %#v", key, want, actual)
+		}
+	}
+}
+
+func TestExtract_WhitespaceOnlyUserID(t *testing.T) {
+	h := headersFromMap(map[string]string{
+		"X-User-Id":     "   ",
+		"X-Workroom-Id": "w1",
+	})
+	_, err := Extract(h)
+	var mb *MisboundAuthError
+	if !errors.As(err, &mb) {
+		t.Fatalf("whitespace-only X-User-Id should raise misbound_auth, got %v", err)
+	}
+}
+
+func TestExtract_OptionalFieldsAbsent_ProduceNullJSON(t *testing.T) {
+	h := headersFromMap(map[string]string{
+		"X-User-Id":     "u1",
+		"X-Workroom-Id": "w1",
+	})
+	id, err := Extract(h)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	enc, _ := json.Marshal(id)
+	var got map[string]interface{}
+	_ = json.Unmarshal(enc, &got)
+	for _, key := range []string{"email", "name", "system_high", "workroom_role", "request_id"} {
+		actual, present := got[key]
+		if !present {
+			t.Errorf("field %q dropped from marshalled Identity", key)
+			continue
+		}
+		if actual != nil {
+			t.Errorf("field %q: want JSON null, got %#v", key, actual)
+		}
+	}
+}
+
+func TestExtract_CaseInsensitiveHeaders(t *testing.T) {
+	// http.Header.Set canonicalizes; pin that lowercase input still works.
+	h := http.Header{}
+	h.Set("x-user-id", "u1")
+	h.Set("x-workroom-id", "w1")
+	id, err := Extract(h)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.UserID == nil || *id.UserID != "u1" {
+		t.Fatalf("user_id: got %v", id.UserID)
+	}
+}
+
+func TestParseRoles(t *testing.T) {
+	cases := map[string][]string{
+		"":                       {},
+		",":                      {},
+		",,,":                    {},
+		"member":                 {"member"},
+		"member,editor":          {"member", "editor"},
+		" ,member, ":             {"member"},
+		"member,":                {"member"},
+		" member , , editor ":    {"member", "editor"},
+		"member, editor, admin ": {"member", "editor", "admin"},
+	}
+	for input, want := range cases {
+		got := parseRoles(input)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("parseRoles(%q): want %v, got %v", input, want, got)
+		}
+	}
+}
+
+func TestStrip(t *testing.T) {
+	cases := map[string]*string{
+		"":      nil,
+		"   ":   nil,
+		"\t\n":  nil,
+		" foo ": ptr("foo"),
+	}
+	for input, want := range cases {
+		got := strip(input)
+		switch {
+		case want == nil && got == nil:
+			// ok
+		case want == nil || got == nil:
+			t.Errorf("strip(%q): want %v, got %v", input, want, got)
+		case *got != *want:
+			t.Errorf("strip(%q): want %q, got %q", input, *want, *got)
+		}
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/examples/extensions/go-reference/internal/identity/extractor_test.go
+++ b/examples/extensions/go-reference/internal/identity/extractor_test.go
@@ -158,7 +158,13 @@ func TestExtract_OptionalFieldsAbsent_ProduceNullJSON(t *testing.T) {
 }
 
 func TestExtract_CaseInsensitiveHeaders(t *testing.T) {
-	// http.Header.Set canonicalizes; pin that lowercase input still works.
+	// http.Header is case-insensitive at the API surface: Set canonicalizes
+	// on insert, Get canonicalizes the lookup key. Real HTTP requests
+	// parsed by net/http always have canonical keys (the server canonicalizes
+	// inbound), so we don't need to test the non-canonical-map-keys case
+	// (which would not work — Get's canonical lookup would miss them).
+	// What we DO want to lock in: caller code that uses lowercase strings
+	// in Set/Get works correctly through Extract.
 	h := http.Header{}
 	h.Set("x-user-id", "u1")
 	h.Set("x-workroom-id", "w1")

--- a/examples/extensions/go-reference/kamiwaza.json
+++ b/examples/extensions/go-reference/kamiwaza.json
@@ -1,0 +1,13 @@
+{
+  "name": "tool-go-reference",
+  "version": "0.1.0",
+  "type": "tool",
+  "source_type": "user_repo",
+  "visibility": "private",
+  "description": "Reference Go (non-SDK) extension demonstrating the canonical envelope-header contract from docs/extensions/non-sdk-flow.md",
+  "risk_tier": 0,
+  "verified": false,
+  "tags": ["reference", "non-sdk", "go"],
+  "env_defaults": {},
+  "required_env_vars": []
+}

--- a/examples/extensions/go-reference/main.go
+++ b/examples/extensions/go-reference/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -127,7 +128,12 @@ func handleEcho(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "kamiwaza_runtime_error", "invalid JSON body")
 		return
 	}
-	if dec.More() {
+	// dec.More() reports whether another element exists in the *current*
+	// array/object — at top level after a single object it returns false
+	// even for trailing `}` or `]`. Require a second Decode to return EOF
+	// to enforce single-document bodies.
+	var trailing struct{}
+	if err := dec.Decode(&trailing); err != io.EOF {
 		writeError(w, http.StatusBadRequest, "kamiwaza_runtime_error", "trailing data after JSON body")
 		return
 	}
@@ -192,11 +198,16 @@ func getenv(key, fallback string) string {
 	return fallback
 }
 
-// parseUseAuth matches kamiwaza_extensions_lib/config.py's truthy/falsy
-// rules: default (empty after trim) → on; case-insensitive false/0/no →
-// off. Anything else (including "True", "TRUE", "yes", "1") → on.
+// parseUseAuth matches kamiwaza_extensions_lib/config.py:57 byte-for-byte:
+//
+//	os.environ.get("KAMIWAZA_USE_AUTH", "true").lower() not in ("false","0","no")
+//
+// Python does NOT trim whitespace; trimming here would diverge — e.g.
+// `KAMIWAZA_USE_AUTH=" false "` would be auth-off in Go (trimmed to
+// "false") but auth-on in Python (literal " false " is not in the falsy
+// set). For a canonical reference any divergence is a footgun.
 func parseUseAuth(v string) bool {
-	switch strings.ToLower(strings.TrimSpace(v)) {
+	switch strings.ToLower(v) {
 	case "false", "0", "no":
 		return false
 	default:

--- a/examples/extensions/go-reference/main.go
+++ b/examples/extensions/go-reference/main.go
@@ -33,7 +33,11 @@ func main() {
 	logger := newLogger(getenv("LOG_LEVEL", "info"))
 	slog.SetDefault(logger)
 
-	useAuth := getenv("KAMIWAZA_USE_AUTH", "false") == "true"
+	// parseUseAuth mirrors kamiwaza_extensions_lib/config.py: default
+	// "true" (fail-secure), case-insensitive false/0/no treated as off.
+	// Defaulting to off here would mean a Go reference that fails OPEN
+	// where Python fails secure — wrong defaults to ship as canonical.
+	useAuth := parseUseAuth(os.Getenv("KAMIWAZA_USE_AUTH"))
 	port := getenv("PORT", "8000")
 
 	mux := http.NewServeMux()
@@ -54,13 +58,17 @@ func main() {
 
 	// SIGTERM/SIGINT trigger a graceful shutdown. ListenAndServe runs in a
 	// goroutine so the signal handler can call Shutdown on the same Server.
+	// The buffered chan + ErrServerClosed filter guarantee: on signal, the
+	// goroutine's defer closes errs and the select reads zero-value (nil);
+	// on real listener error, the send fires before defer close and the
+	// select reads the error.
 	errs := make(chan error, 1)
 	go func() {
+		defer close(errs)
 		logger.Info("listening", "addr", srv.Addr, "use_auth", useAuth)
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errs <- err
 		}
-		close(errs)
 	}()
 
 	stop := make(chan os.Signal, 1)
@@ -90,21 +98,37 @@ func handleHealth(w http.ResponseWriter, _ *http.Request) {
 
 // handleEcho reads the parsed Identity from context and echoes a payload back.
 // Demonstrates the contract end-to-end: middleware → identity → tool handler.
+//
+// Application-level errors (405 wrong method, 400 bad JSON, 413 oversize
+// body) all map to non-sdk-flow.md §5's catch-all class
+// `kamiwaza_runtime_error`. The §5 table lists `kamiwaza_runtime_error`
+// alongside HTTP 500 as the typical status, but the class is a category
+// label — the HTTP status follows standard HTTP semantics independent of
+// the class. Inventing new class names (e.g. "bad_request") would teach
+// downstream non-SDK authors to proliferate non-canonical labels.
 func handleEcho(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		// 405 is HTTP-protocol-level and not in flow doc §5's class set;
-		// "bad_request" is an application-level class outside the
-		// canonical platform-failure list (which only covers envelope /
-		// trust-boundary failures).
-		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+		w.Header().Set("Allow", http.MethodPost)
+		writeError(w, http.StatusMethodNotAllowed, "kamiwaza_runtime_error", "method not allowed")
 		return
 	}
 	var body struct {
 		Message string `json:"message"`
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&body); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "kamiwaza_runtime_error", "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "kamiwaza_runtime_error", "invalid JSON body")
+		return
+	}
+	if dec.More() {
+		writeError(w, http.StatusBadRequest, "kamiwaza_runtime_error", "trailing data after JSON body")
 		return
 	}
 	id, _ := r.Context().Value(identityCtxKey{}).(*identity.Identity)
@@ -166,6 +190,18 @@ func getenv(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// parseUseAuth matches kamiwaza_extensions_lib/config.py's truthy/falsy
+// rules: default (empty after trim) → on; case-insensitive false/0/no →
+// off. Anything else (including "True", "TRUE", "yes", "1") → on.
+func parseUseAuth(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "false", "0", "no":
+		return false
+	default:
+		return true
+	}
 }
 
 func newLogger(level string) *slog.Logger {

--- a/examples/extensions/go-reference/main.go
+++ b/examples/extensions/go-reference/main.go
@@ -1,0 +1,184 @@
+// Reference Go implementation of the Kamiwaza non-SDK extension contract.
+// See kamiwaza-sdk/docs/extensions/non-sdk-flow.md (canonical) and §4.2.11
+// of the D210 system design.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/kamiwaza/kamiwaza-sdk/examples/extensions/go-reference/internal/identity"
+)
+
+// shutdownGrace is the upper bound on the SIGTERM drain mandated by the
+// runtime contract (non-sdk-flow.md §1: "respond to SIGTERM with a graceful
+// shutdown drain (≤ 30s)").
+const shutdownGrace = 30 * time.Second
+
+// maxBodyBytes caps request bodies on tool endpoints. The trust boundary is
+// Traefik (non-sdk-flow.md §8) but a forged in-cluster caller could still
+// hit the extension directly until the Istio follow-on lands; bound the
+// JSON decode to keep that failure mode local.
+const maxBodyBytes int64 = 1 << 20 // 1 MiB
+
+func main() {
+	logger := newLogger(getenv("LOG_LEVEL", "info"))
+	slog.SetDefault(logger)
+
+	useAuth := getenv("KAMIWAZA_USE_AUTH", "false") == "true"
+	port := getenv("PORT", "8000")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", handleHealth)
+	mux.Handle("/tools/echo", identityMiddleware(useAuth, http.HandlerFunc(handleEcho)))
+
+	// Timeouts defend against slowloris and stalled clients. A reference
+	// extension is held up to other authors as the canonical shape — omit
+	// these and the omission propagates into production code.
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	// SIGTERM/SIGINT trigger a graceful shutdown. ListenAndServe runs in a
+	// goroutine so the signal handler can call Shutdown on the same Server.
+	errs := make(chan error, 1)
+	go func() {
+		logger.Info("listening", "addr", srv.Addr, "use_auth", useAuth)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errs <- err
+		}
+		close(errs)
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+	select {
+	case sig := <-stop:
+		logger.Info("shutdown signal received", "signal", sig.String())
+	case err := <-errs:
+		if err != nil {
+			logger.Error("listener error", "err", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownGrace)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		logger.Error("graceful shutdown failed", "err", err)
+		os.Exit(1)
+	}
+}
+
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleEcho reads the parsed Identity from context and echoes a payload back.
+// Demonstrates the contract end-to-end: middleware → identity → tool handler.
+func handleEcho(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		// 405 is HTTP-protocol-level and not in flow doc §5's class set;
+		// "bad_request" is an application-level class outside the
+		// canonical platform-failure list (which only covers envelope /
+		// trust-boundary failures).
+		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method not allowed")
+		return
+	}
+	var body struct {
+		Message string `json:"message"`
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	id, _ := r.Context().Value(identityCtxKey{}).(*identity.Identity)
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"identity": id,
+		"echo":     body.Message,
+	})
+}
+
+// identityCtxKey is the request-scope key under which a parsed Identity is
+// stored. Unexported so callers can't fish it out from outside this package.
+type identityCtxKey struct{}
+
+// identityMiddleware parses the envelope on every request when KAMIWAZA_USE_AUTH
+// is true. On parse failure, returns the canonical 401/misbound_auth response
+// shape from non-sdk-flow.md §5. When false (local dev), the handler runs
+// without an Identity in context.
+func identityMiddleware(useAuth bool, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !useAuth {
+			next.ServeHTTP(w, r)
+			return
+		}
+		id, err := identity.Extract(r.Header)
+		if err != nil {
+			var mb *identity.MisboundAuthError
+			if errors.As(err, &mb) {
+				writeError(w, http.StatusUnauthorized, "misbound_auth", mb.Error())
+				return
+			}
+			// Defensive: Extract today returns only nil or *MisboundAuthError.
+			// This branch surfaces any future error type as a generic 500 so
+			// adding a new error class without classifying it here is loud.
+			writeError(w, http.StatusInternalServerError, "kamiwaza_runtime_error", "identity extraction failed")
+			return
+		}
+		ctx := context.WithValue(r.Context(), identityCtxKey{}, id)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// writeError emits the canonical failure JSON: {"error":{"class","message"}}.
+// Never include stack traces, internal hostnames, or upstream response bodies
+// (non-sdk-flow.md §5).
+func writeError(w http.ResponseWriter, status int, class, message string) {
+	writeJSON(w, status, map[string]interface{}{
+		"error": map[string]string{"class": class, "message": message},
+	})
+}
+
+func getenv(key, fallback string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func newLogger(level string) *slog.Logger {
+	var lvl slog.Level
+	switch strings.ToLower(level) {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "warn", "warning":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: lvl}))
+}

--- a/examples/extensions/go-reference/main_test.go
+++ b/examples/extensions/go-reference/main_test.go
@@ -1,0 +1,158 @@
+// Tests for the HTTP layer: identity middleware (auth on/off, missing
+// envelope → canonical 401) and the sample tool handler (POST happy path,
+// 405 on wrong method, 400 on malformed body).
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kamiwaza/kamiwaza-sdk/examples/extensions/go-reference/internal/identity"
+)
+
+func TestHandleHealth(t *testing.T) {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	handleHealth(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rr.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["status"] != "ok" {
+		t.Errorf("status field: want %q, got %q", "ok", body["status"])
+	}
+}
+
+func TestIdentityMiddleware_AuthOff_BypassesExtract(t *testing.T) {
+	var observed *identity.Identity
+	var observedOK bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observed, observedOK = r.Context().Value(identityCtxKey{}).(*identity.Identity)
+		w.WriteHeader(http.StatusOK)
+	})
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil) // no headers at all
+	identityMiddleware(false, next).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rr.Code)
+	}
+	if observedOK || observed != nil {
+		t.Errorf("identity should be absent under auth-off, got %+v ok=%v", observed, observedOK)
+	}
+}
+
+func TestIdentityMiddleware_AuthOn_PopulatesContext(t *testing.T) {
+	var observed *identity.Identity
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observed, _ = r.Context().Value(identityCtxKey{}).(*identity.Identity)
+		w.WriteHeader(http.StatusOK)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-User-Id", "u1")
+	req.Header.Set("X-Workroom-Id", "w1")
+	rr := httptest.NewRecorder()
+	identityMiddleware(true, next).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rr.Code)
+	}
+	if observed == nil || observed.UserID == nil || *observed.UserID != "u1" {
+		t.Fatalf("identity not populated: %+v", observed)
+	}
+}
+
+func TestIdentityMiddleware_AuthOn_MissingEnvelope_Returns401MisboundAuth(t *testing.T) {
+	called := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true })
+	req := httptest.NewRequest(http.MethodPost, "/", nil) // no envelope headers
+	rr := httptest.NewRecorder()
+	identityMiddleware(true, next).ServeHTTP(rr, req)
+	if called {
+		t.Fatal("next handler must not be called when envelope is missing under auth-on")
+	}
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status: want 401, got %d", rr.Code)
+	}
+	// Pin the canonical JSON shape from non-sdk-flow.md §5.
+	var body struct {
+		Error struct {
+			Class   string `json:"class"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Error.Class != "misbound_auth" {
+		t.Errorf("error.class: want %q, got %q", "misbound_auth", body.Error.Class)
+	}
+	if body.Error.Message == "" {
+		t.Error("error.message should be non-empty")
+	}
+}
+
+func TestHandleEcho_NonPost_Returns405(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/tools/echo", nil)
+	rr := httptest.NewRecorder()
+	handleEcho(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status: want 405, got %d", rr.Code)
+	}
+}
+
+func TestHandleEcho_BadJSON_Returns400(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/tools/echo", strings.NewReader("not json"))
+	rr := httptest.NewRecorder()
+	handleEcho(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status: want 400, got %d", rr.Code)
+	}
+}
+
+func TestHandleEcho_AuthOff_ReturnsNullIdentity(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/tools/echo", strings.NewReader(`{"message":"hi"}`))
+	rr := httptest.NewRecorder()
+	handleEcho(rr, req) // no identity in context (auth-off path)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rr.Code)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["echo"] != "hi" {
+		t.Errorf("echo: want %q, got %v", "hi", body["echo"])
+	}
+	if v, ok := body["identity"]; !ok || v != nil {
+		t.Errorf("identity: want explicit null, got present=%v value=%v", ok, v)
+	}
+}
+
+func TestHandleEcho_AuthOn_ReturnsPopulatedIdentity(t *testing.T) {
+	id := &identity.Identity{UserID: stringPtr("u1"), WorkroomID: stringPtr("w1")}
+	req := httptest.NewRequest(http.MethodPost, "/tools/echo", strings.NewReader(`{"message":"hi"}`))
+	req = req.WithContext(context.WithValue(req.Context(), identityCtxKey{}, id))
+	rr := httptest.NewRecorder()
+	handleEcho(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", rr.Code)
+	}
+	var body struct {
+		Echo     string             `json:"echo"`
+		Identity *identity.Identity `json:"identity"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Identity == nil || body.Identity.UserID == nil || *body.Identity.UserID != "u1" {
+		t.Errorf("identity: want u1, got %+v", body.Identity)
+	}
+}
+
+func stringPtr(s string) *string { return &s }

--- a/examples/extensions/go-reference/main_test.go
+++ b/examples/extensions/go-reference/main_test.go
@@ -178,13 +178,25 @@ func TestHandleEcho_UnknownField_Returns400(t *testing.T) {
 	}
 }
 
-// Trailing JSON after the first object is rejected — pins dec.More() check.
+// Trailing JSON after the first object is rejected. Three flavors all
+// must fail — they would NOT all be caught by the previous `dec.More()`
+// check at top level (which only reports more elements within an
+// already-open array/object), motivating the second-Decode-expect-EOF
+// pattern in handleEcho.
 func TestHandleEcho_TrailingData_Returns400(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/tools/echo", strings.NewReader(`{"message":"hi"} {"junk":1}`))
-	rr := httptest.NewRecorder()
-	handleEcho(rr, req)
-	if rr.Code != http.StatusBadRequest {
-		t.Fatalf("status: want 400, got %d", rr.Code)
+	cases := []string{
+		`{"message":"hi"} {"junk":1}`, // another full object
+		`{"message":"hi"}}`,           // trailing close-brace
+		`{"message":"hi"}]`,           // trailing close-bracket
+		`{"message":"hi"}garbage`,     // trailing identifier
+	}
+	for _, body := range cases {
+		req := httptest.NewRequest(http.MethodPost, "/tools/echo", strings.NewReader(body))
+		rr := httptest.NewRecorder()
+		handleEcho(rr, req)
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("body %q: status want 400, got %d", body, rr.Code)
+		}
 	}
 }
 
@@ -244,26 +256,29 @@ func TestHandleEcho_AuthOn_ReturnsPopulatedIdentity(t *testing.T) {
 }
 
 // Pins the parity contract: parseUseAuth must agree with Python's truthy
-// rules from kamiwaza_extensions_lib/config.py:57. A regression here is
-// the kind of fail-open default that turns a "reference" into a footgun.
+// rules from kamiwaza_extensions_lib/config.py:57 byte-for-byte. A
+// regression here is the kind of fail-open default that turns a
+// "reference" into a footgun. Note: Python does NOT trim whitespace, so
+// padded values like " false " are auth-ON in Python (the literal
+// " false " is not in the falsy set) — this Go version matches.
 func TestParseUseAuth(t *testing.T) {
 	cases := []struct {
 		in   string
 		want bool
 	}{
-		{"", true},         // unset/default → fail-secure
-		{"   ", true},      // whitespace-only → default
-		{"true", true},     // explicit on
-		{"True", true},     // case-insensitive
-		{"TRUE", true},     // case-insensitive
-		{"yes", true},      // anything non-falsy
-		{"1", true},        // anything non-falsy
-		{"false", false},   // explicit off
-		{"FALSE", false},   // case-insensitive off
-		{"False", false},   // case-insensitive off
-		{"0", false},       // explicit off
-		{"no", false},      // explicit off
-		{" false ", false}, // trimmed
+		{"", true},        // unset/default → fail-secure
+		{"   ", true},     // whitespace-only → not in falsy set → on
+		{"true", true},    // explicit on
+		{"True", true},    // case-insensitive
+		{"TRUE", true},    // case-insensitive
+		{"yes", true},     // anything non-falsy
+		{"1", true},       // anything non-falsy
+		{"false", false},  // explicit off
+		{"FALSE", false},  // case-insensitive off
+		{"False", false},  // case-insensitive off
+		{"0", false},      // explicit off
+		{"no", false},     // explicit off
+		{" false ", true}, // padded — Python doesn't trim, so neither do we
 	}
 	for _, c := range cases {
 		if got := parseUseAuth(c.in); got != c.want {

--- a/examples/extensions/go-reference/main_test.go
+++ b/examples/extensions/go-reference/main_test.go
@@ -1,6 +1,6 @@
 // Tests for the HTTP layer: identity middleware (auth on/off, missing
 // envelope → canonical 401) and the sample tool handler (POST happy path,
-// 405 on wrong method, 400 on malformed body).
+// 405 on wrong method, 400/413 on malformed/oversize body).
 package main
 
 import (
@@ -48,6 +48,24 @@ func TestIdentityMiddleware_AuthOff_BypassesExtract(t *testing.T) {
 	}
 }
 
+// Auth-off must not parse identity even when envelope headers are present
+// — defends against a future "helpful" optimization that runs Extract on
+// the auth-off path too.
+func TestIdentityMiddleware_AuthOff_IgnoresEnvelopeHeaders(t *testing.T) {
+	var observed *identity.Identity
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		observed, _ = r.Context().Value(identityCtxKey{}).(*identity.Identity)
+	})
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("X-User-Id", "u1")
+	req.Header.Set("X-Workroom-Id", "w1")
+	rr := httptest.NewRecorder()
+	identityMiddleware(false, next).ServeHTTP(rr, req)
+	if observed != nil {
+		t.Errorf("auth-off must not populate identity even with envelope, got %+v", observed)
+	}
+}
+
 func TestIdentityMiddleware_AuthOn_PopulatesContext(t *testing.T) {
 	var observed *identity.Identity
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -64,6 +82,31 @@ func TestIdentityMiddleware_AuthOn_PopulatesContext(t *testing.T) {
 	}
 	if observed == nil || observed.UserID == nil || *observed.UserID != "u1" {
 		t.Fatalf("identity not populated: %+v", observed)
+	}
+}
+
+// Wire-up integration: the identityMiddleware must populate the context
+// key that handleEcho reads. Tested separately from the unit-level
+// middleware test to catch a key-mismatch regression that would slip past
+// either test alone.
+func TestIdentityMiddleware_HandleEcho_WireUp(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/tools/echo", strings.NewReader(`{"message":"hi"}`))
+	req.Header.Set("X-User-Id", "u1")
+	req.Header.Set("X-Workroom-Id", "w1")
+	rr := httptest.NewRecorder()
+	identityMiddleware(true, http.HandlerFunc(handleEcho)).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: want 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	var body struct {
+		Echo     string             `json:"echo"`
+		Identity *identity.Identity `json:"identity"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Identity == nil || body.Identity.UserID == nil || *body.Identity.UserID != "u1" {
+		t.Errorf("identity not threaded middleware → handler: %+v", body.Identity)
 	}
 }
 
@@ -97,12 +140,18 @@ func TestIdentityMiddleware_AuthOn_MissingEnvelope_Returns401MisboundAuth(t *tes
 	}
 }
 
-func TestHandleEcho_NonPost_Returns405(t *testing.T) {
+func TestHandleEcho_NonPost_Returns405WithAllowHeader(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/tools/echo", nil)
 	rr := httptest.NewRecorder()
 	handleEcho(rr, req)
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status: want 405, got %d", rr.Code)
+	}
+	if got := rr.Header().Get("Allow"); got != http.MethodPost {
+		t.Errorf("Allow header: want %q, got %q", http.MethodPost, got)
+	}
+	if class := decodeErrorClass(t, rr); class != "kamiwaza_runtime_error" {
+		t.Errorf("error.class: want kamiwaza_runtime_error, got %q", class)
 	}
 }
 
@@ -112,6 +161,45 @@ func TestHandleEcho_BadJSON_Returns400(t *testing.T) {
 	handleEcho(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status: want 400, got %d", rr.Code)
+	}
+	if class := decodeErrorClass(t, rr); class != "kamiwaza_runtime_error" {
+		t.Errorf("error.class: want kamiwaza_runtime_error, got %q", class)
+	}
+}
+
+// Strict decoder rejects unknown fields — exercised here so a future
+// permissive-decode regression breaks the test.
+func TestHandleEcho_UnknownField_Returns400(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/tools/echo", strings.NewReader(`{"message":"hi","extra":"x"}`))
+	rr := httptest.NewRecorder()
+	handleEcho(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status: want 400, got %d", rr.Code)
+	}
+}
+
+// Trailing JSON after the first object is rejected — pins dec.More() check.
+func TestHandleEcho_TrailingData_Returns400(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/tools/echo", strings.NewReader(`{"message":"hi"} {"junk":1}`))
+	rr := httptest.NewRecorder()
+	handleEcho(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status: want 400, got %d", rr.Code)
+	}
+}
+
+// MaxBytesReader rejection: body of maxBodyBytes+1 must surface as 413.
+// Locks the cap in so a future change to the literal is caught by tests.
+func TestHandleEcho_OversizeBody_Returns413(t *testing.T) {
+	big := strings.NewReader(`{"message":"` + strings.Repeat("a", int(maxBodyBytes)) + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/tools/echo", big)
+	rr := httptest.NewRecorder()
+	handleEcho(rr, req)
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status: want 413, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if class := decodeErrorClass(t, rr); class != "kamiwaza_runtime_error" {
+		t.Errorf("error.class: want kamiwaza_runtime_error, got %q", class)
 	}
 }
 
@@ -153,6 +241,48 @@ func TestHandleEcho_AuthOn_ReturnsPopulatedIdentity(t *testing.T) {
 	if body.Identity == nil || body.Identity.UserID == nil || *body.Identity.UserID != "u1" {
 		t.Errorf("identity: want u1, got %+v", body.Identity)
 	}
+}
+
+// Pins the parity contract: parseUseAuth must agree with Python's truthy
+// rules from kamiwaza_extensions_lib/config.py:57. A regression here is
+// the kind of fail-open default that turns a "reference" into a footgun.
+func TestParseUseAuth(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", true},         // unset/default → fail-secure
+		{"   ", true},      // whitespace-only → default
+		{"true", true},     // explicit on
+		{"True", true},     // case-insensitive
+		{"TRUE", true},     // case-insensitive
+		{"yes", true},      // anything non-falsy
+		{"1", true},        // anything non-falsy
+		{"false", false},   // explicit off
+		{"FALSE", false},   // case-insensitive off
+		{"False", false},   // case-insensitive off
+		{"0", false},       // explicit off
+		{"no", false},      // explicit off
+		{" false ", false}, // trimmed
+	}
+	for _, c := range cases {
+		if got := parseUseAuth(c.in); got != c.want {
+			t.Errorf("parseUseAuth(%q): want %v, got %v", c.in, c.want, got)
+		}
+	}
+}
+
+func decodeErrorClass(t *testing.T, rr *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body struct {
+		Error struct {
+			Class string `json:"class"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	return body.Error.Class
 }
 
 func stringPtr(s string) *string { return &s }


### PR DESCRIPTION
## Summary
- New `examples/extensions/go-reference/` — canonical Go non-SDK extension implementing the contract from `docs/extensions/non-sdk-flow.md` (header parsing only, no HMAC, no shared secret per design §4.4.2 revised). HTTP server with `/health`, `/tools/echo`, identity middleware, distroless multi-stage Dockerfile, slowloris-defending timeouts, 1 MiB body cap.
- New `.github/workflows/extension-go-reference-e2e.yml` — Phase A cluster-free smoke (`go test -race` + Python parity + `kz-ext validate` + docker build + compose-up smoke covering `/health`, happy-path envelope invoke, and missing-envelope 401) runs on every D210-bearing PR. Phase B (cluster deploy/invoke/publish) is gated on `KAMIWAZA_E2E_ENABLED` repo variable + same-repo PR head; a `cluster-skipped` sibling job emits an explicit `::notice::` when Phase B is unconfigured.
- Cross-language parity: Go `Extract` consumes the same `docs/extensions/non-sdk-flow/test-vectors.json` as the Python and TypeScript runtime libs, byte-for-byte. The Python parity test (`tests/unit/extensions_lib/test_identity_extractor_parity.py`) and the new Go tests (`extractor_test.go`, `main_test.go`) consume the JSON identically.

## Design refs
- §4.2.11 `GoReferenceExtension`
- §4.4.2 Identity / AuthN (revised — verify-in-extension dropped)
- §6.2 M2 tasks T2.11 + T2.12

## Acceptance (per ENG-3894)
- [x] Go reference runs locally via \`docker compose up\` (README walks through it)
- [x] All test vectors pass in Go tests identically to Python (verified locally)
- [x] No HMAC code anywhere in the Go reference
- [ ] \`extensions/go-reference-e2e\` CI green on 3 consecutive PRs (observational; M2 exit criterion — counter starts on this PR)

## Test plan
- [x] \`uv run kz-ext validate examples/extensions/go-reference\` passes (1 expected resource-limits warning, common to all extensions)
- [x] \`uv run pytest tests/unit/extensions_lib/test_identity_extractor_parity.py\` — 4/4 vectors green (verified locally)
- [ ] CI Phase A green on this PR — go vet + go test -race + docker build + compose smoke
- [ ] Add \`D210\` label to this PR to confirm the label-gated trigger path
- [ ] Phase B remains skipped (\`KAMIWAZA_E2E_ENABLED\` unset); visible via the \`cluster-skipped\` job's \`::notice::\`

## Local review (`/devloop:local-review`)
Two-iteration multi-agent review (SecurityArch, LogicTests, QualityStandards). Final verdict **PASS** — all six dimensions ≥ 7/10, zero Critical issues. Important follow-ups (none blocking, captured for separate tickets):
- 413 vs 400 on body-overflow (currently \`MaxBytesReader\` overflow surfaces as 400 \`bad_request\`)
- README §5 mapping row to mention the application-level \`bad_request\` class
- Wire-up test joining \`identityMiddleware\` → \`handleEcho\`
- Map-based table tests → slices for deterministic ordering
- \`Allow: POST\` header on 405 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)