### PR TITLE
fix(extensions): D210 M3 dry-run findings — F-002…F-014 (ENG-3901)

### DIFF
--- a/kamiwaza-ai-extensions-lib/src/local-dev-auth/index.ts
+++ b/kamiwaza-ai-extensions-lib/src/local-dev-auth/index.ts
@@ -50,6 +50,17 @@ const TOKEN_ENV = "KAMIWAZA_BEARER_TOKEN";
 const WORKROOM_ENV = "KAMIWAZA_DEV_WORKROOM_ID";
 
 /**
+ * Documented "no specific workroom" sentinel — the all-f UUID. Platform
+ * authorization treats this as "global / unscoped" and lets the request
+ * through; the IdentityExtractor canonical test vectors carry it as the
+ * `global-workroom-sentinel` case (see
+ * `docs/extensions/non-sdk-flow/test-vectors.json`). Used as the
+ * `X-Workroom-Id` default when the developer hasn't set
+ * `KAMIWAZA_DEV_WORKROOM_ID` to a real workroom they belong to.
+ */
+const GLOBAL_WORKROOM_SENTINEL = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+/**
  * Forwarded-auth envelope headers that the platform gateway owns in
  * production. Under the local-dev bridge we MUST clear all of these
  * before injecting our synthesized values — otherwise a client-supplied
@@ -251,12 +262,22 @@ export function _buildBridgedHeaders(
     // x-workroom-id is required by strict extract_identity() under
     // KAMIWAZA_USE_AUTH=true (session.py:131, identity.py:149). Without
     // it, every protected route 401s. Honor an explicit override from
-    // KAMIWAZA_DEV_WORKROOM_ID; otherwise fall back to the JWT sub so the
-    // strict identity path succeeds and the workroom_id is stable
-    // per-developer. The synthesized workroom_id is only consumed by
-    // the extension's local authz path — it's never sent to the
-    // platform (which only sees the bearer).
-    out.set("x-workroom-id", config.workroomOverride || claims.sub);
+    // KAMIWAZA_DEV_WORKROOM_ID; otherwise default to the
+    // **global-workroom sentinel** (``ffffffff-ffff-ffff-ffff-ffffffffffff``).
+    //
+    // Earlier default of ``claims.sub`` (the JWT user_id) silently broke
+    // every backend → platform call: runtime-lib forwards X-Workroom-Id
+    // on its ``_PLATFORM_AUTH_HEADER_KEYS`` whitelist, and the platform's
+    // workroom-membership check rejects an X-Workroom-Id that isn't a
+    // workroom the user actually belongs to (403). The user_id is
+    // guaranteed to NOT match any real workroom (different UUID space).
+    // The sentinel is the documented "no specific workroom" value
+    // (``docs/extensions/non-sdk-flow.md`` + ``test-vectors.json``); the
+    // platform treats it as "global / unscoped" and lets the call
+    // through. Developers who want to test against a real workroom can
+    // still set ``KAMIWAZA_DEV_WORKROOM_ID`` explicitly. Discovered
+    // during ENG-3901 dry run as F-009.
+    out.set("x-workroom-id", config.workroomOverride || GLOBAL_WORKROOM_SENTINEL);
     if (typeof claims.email === "string" && claims.email) {
         out.set("x-user-email", claims.email);
     }

--- a/kamiwaza-ai-extensions-lib/tests/local-dev-auth.test.ts
+++ b/kamiwaza-ai-extensions-lib/tests/local-dev-auth.test.ts
@@ -108,9 +108,13 @@ describe("_buildBridgedHeaders", () => {
         expect(out.get("x-user-id")).toBe("user-42");
         expect(out.get("x-user-email")).toBe("alice@example.com");
         expect(out.get("x-user-name")).toBe("Alice");
-        // PR #87 review fix — x-workroom-id is required by strict
-        // extract_identity() under KAMIWAZA_USE_AUTH=true. Defaults to JWT sub.
-        expect(out.get("x-workroom-id")).toBe("user-42");
+        // ENG-3901 / F-009 — x-workroom-id defaults to the documented
+        // global-workroom sentinel (all-f UUID) so backend → platform
+        // calls don't 403 on a fake workroom = user_id. Earlier default
+        // of claims.sub silently broke every authenticated platform call.
+        expect(out.get("x-workroom-id")).toBe(
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        );
         expect(out.get("x-existing")).toBe("preserved");
     });
 
@@ -125,14 +129,37 @@ describe("_buildBridgedHeaders", () => {
         expect(out.get("x-user-id")).toBe("user-42");
     });
 
-    it("treats whitespace-only KAMIWAZA_DEV_WORKROOM_ID as unset", () => {
+    it("treats whitespace-only KAMIWAZA_DEV_WORKROOM_ID as unset (falls through to sentinel)", () => {
         const token = makeJwt({ sub: "user-7" });
         process.env[GATE] = "1";
         process.env[TOKEN] = token;
         process.env[WORKROOM] = "   ";
 
         const out = _buildBridgedHeaders(new Headers());
-        expect(out.get("x-workroom-id")).toBe("user-7");
+        // Whitespace-only override is treated as no override → sentinel
+        // default (NOT claims.sub — see ENG-3901 / F-009).
+        expect(out.get("x-workroom-id")).toBe(
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        );
+        expect(out.get("x-user-id")).toBe("user-7");
+    });
+
+    it("ENG-3901 / F-009: never defaults x-workroom-id to user_id (would 403 on platform)", () => {
+        // Explicit regression guard. The platform's workroom-membership
+        // check rejects an X-Workroom-Id that isn't a real workroom the
+        // user belongs to. Defaulting the synthesized value to claims.sub
+        // (an unrelated UUID) was guaranteed to fail. The fix: fall
+        // through to the documented "no specific workroom" sentinel.
+        const token = makeJwt({ sub: "user-cafebabe" });
+        process.env[GATE] = "1";
+        process.env[TOKEN] = token;
+        delete process.env[WORKROOM];
+
+        const out = _buildBridgedHeaders(new Headers());
+        expect(out.get("x-workroom-id")).not.toBe("user-cafebabe");
+        expect(out.get("x-workroom-id")).toBe(
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        );
     });
 
     it("TS-19: parses realm_access.roles into x-user-roles", () => {
@@ -155,8 +182,12 @@ describe("_buildBridgedHeaders", () => {
         expect(out.get("x-user-email")).toBeNull();
         expect(out.get("x-user-name")).toBeNull();
         expect(out.get("x-user-roles")).toBeNull();
-        // x-workroom-id is always set (required by strict extract_identity)
-        expect(out.get("x-workroom-id")).toBe("user-1");
+        // x-workroom-id is always set (required by strict
+        // extract_identity); defaults to the global-workroom sentinel
+        // (ENG-3901 / F-009).
+        expect(out.get("x-workroom-id")).toBe(
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        );
     });
 
     it("TS-20: malformed token (cannot decode) → warn + envelope cleared", () => {
@@ -244,8 +275,12 @@ describe("_buildBridgedHeaders", () => {
         expect(out.get("authorization")).toBe(`Bearer ${token}`);
         expect(out.get("x-user-id")).toBe("user-bridge");
         expect(out.get("x-user-email")).toBe("u@x");
-        // x-workroom-id falls back to JWT sub (no override env set)
-        expect(out.get("x-workroom-id")).toBe("user-bridge");
+        // x-workroom-id defaults to the global-workroom sentinel when no
+        // override env is set (ENG-3901 / F-009). Earlier default of
+        // claims.sub silently 403'd every backend → platform call.
+        expect(out.get("x-workroom-id")).toBe(
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        );
 
         // Spoofed envelope fields the JWT didn't set must be CLEARED,
         // not preserved from the incoming request.

--- a/kamiwaza_extensions/commands/create.py
+++ b/kamiwaza_extensions/commands/create.py
@@ -29,8 +29,8 @@ def run_create(*, type_: str, name: str) -> None:
     # Next.js layer to inject envelope headers, so the bridge doesn't apply.
     # (ENG-3901 dry-run finding F-005.)
     dev_local_cmd = "kz-ext dev local --auth" if type_ == "app" else "kz-ext dev local"
-    console.print(f"\n  Next steps:")
-    console.print(f"    kz-ext validate")
+    console.print("\n  Next steps:")
+    console.print("    kz-ext validate")
     console.print(f"    {dev_local_cmd}")
     # F-007: the scaffold's docker-compose.yml uses an auto-assigned host
     # port (bare `"3000"` not `"3000:3000"`) to avoid colliding with the

--- a/kamiwaza_extensions/commands/create.py
+++ b/kamiwaza_extensions/commands/create.py
@@ -13,13 +13,31 @@ def run_create(*, type_: str, name: str) -> None:
     from kamiwaza_extensions.scaffolder import Scaffolder, VALID_TYPES
 
     if type_ not in VALID_TYPES:
-        console.print(f"[red]Error:[/red] Invalid type '{type_}'. Must be one of: {', '.join(VALID_TYPES)}")
+        console.print(
+            f"[red]Error:[/red] Invalid type '{type_}'. Must be one of: {', '.join(VALID_TYPES)}"
+        )
         raise typer.Exit(code=1)
 
     scaffolder = Scaffolder()
     scaffolder.create(type_=type_, name=name)
 
     console.print(f"\n[green]✓ Created {type_} extension:[/green] {name}")
+    # `--auth` is the right default for app-type extensions: the scaffolded
+    # frontend ships with USE_AUTH=true and the local-dev auth bridge wired
+    # in, so without `--auth` every protected route 401s and the developer
+    # only sees the platform login UI. tool / service shapes don't have a
+    # Next.js layer to inject envelope headers, so the bridge doesn't apply.
+    # (ENG-3901 dry-run finding F-005.)
+    dev_local_cmd = "kz-ext dev local --auth" if type_ == "app" else "kz-ext dev local"
     console.print(f"\n  Next steps:")
     console.print(f"    kz-ext validate")
-    console.print(f"    kz-ext dev local")
+    console.print(f"    {dev_local_cmd}")
+    # F-007: the scaffold's docker-compose.yml uses an auto-assigned host
+    # port (bare `"3000"` not `"3000:3000"`) to avoid colliding with the
+    # platform UI when both run side-by-side. `kz-ext dev local` prints the
+    # resolved URL once compose binds (ENG-3901 / F-008); call it out here
+    # so first-time developers don't go to localhost:3000 by instinct.
+    console.print(
+        "[dim]  (the host port is auto-assigned; "
+        "kz-ext dev local prints the URL once containers are up)[/dim]"
+    )

--- a/kamiwaza_extensions/commands/status.py
+++ b/kamiwaza_extensions/commands/status.py
@@ -31,9 +31,7 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
 
     token = conn_mgr.get_token()
     if token is None:
-        console.print(
-            "[red]Error:[/red] Token expired. Run: [bold]kz-ext login[/bold]"
-        )
+        console.print("[red]Error:[/red] Token expired. Run: [bold]kz-ext login[/bold]")
         raise typer.Exit(code=1)
 
     # Resolve extension name
@@ -74,9 +72,7 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
         # Email match is case-insensitive (review re-re-re-review PR #84
         # M4) — some IdPs vary casing across token refreshes.
         same_deployer = bool(
-            state
-            and current_email
-            and state.deployer.lower() == current_email.lower()
+            state and current_email and state.deployer.lower() == current_email.lower()
         )
         if state and state.last_dev_name and same_cluster and same_deployer:
             dev_name = state.last_dev_name
@@ -88,10 +84,9 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
         dev_name = name
 
     from kamiwaza_extensions.constants import ssl_env_override
+
     with ssl_env_override(connection):
-        client = KamiwazaClient(
-            base_url=connection.url, api_key=token.access_token
-        )
+        client = KamiwazaClient(base_url=connection.url, api_key=token.access_token)
 
         # P10 fix: hit /api/extensions/{name} (always present) instead of
         # /api/extensions/{name}/status (404 on every cluster currently
@@ -102,12 +97,8 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
             ext = client.extensions.get_extension(dev_name)
         except APIError as exc:
             if exc.status_code == 404:
-                console.print(
-                    f"[red]Error:[/red] Extension '{dev_name}' not found."
-                )
-                console.print(
-                    "  Run: [bold]kz-ext dev[/bold] to deploy first."
-                )
+                console.print(f"[red]Error:[/red] Extension '{dev_name}' not found.")
+                console.print("  Run: [bold]kz-ext dev[/bold] to deploy first.")
                 raise typer.Exit(code=1) from exc
             raise
 
@@ -119,13 +110,15 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
             console.print(f"URL:        [blue]{url}[/blue]")
 
         # Surface deployer annotation (§4.2.9 DeployedImageAnnotation).
-        deployer = _read_annotation(ext, "kamiwaza.ai/deployer")
+        # Namespace is ``kamiwaza.io/*`` per ENG-3901 / F-010 — the platform's
+        # annotation filter only persists ``kamiwaza.io/*`` keys.
+        deployer = _read_annotation(ext, "kamiwaza.io/deployer")
         if deployer:
             console.print(f"Last deployed by: [bold]{deployer}[/bold]")
-        deployed_at = _read_annotation(ext, "kamiwaza.ai/deployed-at")
+        deployed_at = _read_annotation(ext, "kamiwaza.io/deployed-at")
         if deployed_at:
             console.print(f"Deployed at:      {deployed_at}")
-        revision = _read_annotation(ext, "kamiwaza.ai/revision")
+        revision = _read_annotation(ext, "kamiwaza.io/revision")
         if revision:
             console.print(f"Revision:         {revision}")
         console.print()

--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -52,6 +52,7 @@ class DevLocalRunner:
             build_typescript_lib,
             generate_compose_override,
             generate_local_build_dockerfile_patches,
+            is_typescript_dist_stale,
             print_override_diagnostics,
             resolve_sdk_override,
             validate_sdk_override,
@@ -146,10 +147,18 @@ class DevLocalRunner:
                 console.print("[red]SDK override disabled due to errors above[/red]")
                 override_spec = None
             else:
-                # Build TypeScript if needed
+                # Build TypeScript when explicitly requested, when dist/ is
+                # missing entirely, or when src/ is newer than dist/. The
+                # last case is what makes ``--sdk-repo`` work without
+                # surprise: a stale dist after a ``git pull`` would otherwise
+                # surface as a "Module not found" inside the consumer's
+                # Next.js build, which is hard to diagnose. Treating stale
+                # dist as a build trigger keeps the bind-mounted artifacts
+                # in lockstep with the SDK source the developer is editing.
                 if override_spec.typescript and (
                     override_spec.build_typescript
                     or not override_spec.typescript_dist_path.is_dir()
+                    or is_typescript_dist_stale(override_spec)
                 ):
                     if not build_typescript_lib(override_spec):
                         console.print(

--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -10,6 +10,8 @@ import socket
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -351,17 +353,35 @@ class DevLocalRunner:
             # 9. Print access URLs (pre-up). For bare-port specs the host
             # port isn't assigned yet — emit a hint instead so users know
             # what to expect. Detach mode (10b) re-prints with the resolved
-            # host port after `compose up -d` returns.
+            # host port after `compose up -d` returns; foreground mode
+            # delegates to a background polling thread (10a) so the URL
+            # surfaces while compose is still streaming logs.
             self._print_urls(info.compose_data, remaps, post_up=False)
+
+            # 10a. Foreground mode: spawn a background thread that polls
+            # ``docker compose port`` until the bare-port assignments are
+            # visible, then prints the URL line. Without this, the user
+            # sees "host port assigned by Docker" but never gets the
+            # actual URL (it scrolls past in the build / Next.js startup
+            # logs and is easy to miss). Daemon thread so it dies with
+            # the process if compose exits early. (ENG-3901 / F-008)
+            url_poll_thread: Optional[threading.Thread] = None
+            if not detach and self._has_bare_ports(info.compose_data):
+                url_poll_thread = threading.Thread(
+                    target=self._poll_and_print_urls,
+                    args=(info.compose_data, remaps, compose_prefix, str(info.path)),
+                    daemon=True,
+                    name="kz-ext-url-poll",
+                )
+                url_poll_thread.start()
 
             # 10. Run subprocess with signal forwarding
             rc = self._run_subprocess(cmd, env=env, cwd=str(info.path))
 
             # 10b. Detach mode only: re-resolve bare-port URLs once Docker
-            # has actually published them. Foreground mode blocks on
-            # compose logs until the user Ctrl+Cs, so there is no
-            # post-up moment to reach. Pass the same compose prefix +
-            # cwd so the port query targets the project that was started.
+            # has actually published them. Foreground mode handled by 10a
+            # above. Pass the same compose prefix + cwd so the port query
+            # targets the project that was started.
             if detach and rc == 0:
                 self._print_urls(
                     info.compose_data,
@@ -446,6 +466,75 @@ class DevLocalRunner:
                 if svc_name in remaps:
                     host_port = remaps[svc_name][1]
                 console.print(f"[dim]{svc_name}:[/dim] http://localhost:{host_port}")
+
+    @staticmethod
+    def _has_bare_ports(compose_data: Optional[dict]) -> bool:
+        """True iff any service in ``compose_data`` has a bare-port spec
+        (e.g. ``"3000"``) whose host port Docker will auto-assign.
+
+        Mapped specs (``"3000:3000"``) are already known and printed by
+        the pre-up pass. Only bare specs need post-up resolution.
+        """
+        if not compose_data:
+            return False
+        for svc_config in compose_data.get("services", {}).values():
+            for port_spec in svc_config.get("ports", []) or []:
+                host_port, _ = parse_port_mapping(str(port_spec))
+                if host_port is None:
+                    return True
+        return False
+
+    def _poll_and_print_urls(
+        self,
+        compose_data: dict,
+        remaps: Dict[str, Tuple[int, int]],
+        compose_cmd: List[str],
+        cwd: str,
+    ) -> None:
+        """Background-thread loop: poll ``docker compose port`` until the
+        bare-port host ports are assigned, then print the URLs.
+
+        Runs in a daemon thread alongside the foreground compose process.
+        Polls at ~1.5s intervals up to ~60s (long enough for a cold image
+        pull + Next.js build) before giving up silently. The user can
+        always fall back to ``docker compose port`` themselves; this is
+        a "make the common case easy" affordance, not a hard guarantee.
+        """
+        # Initial delay so we don't compete with compose's own "Building" /
+        # "Pulling" / "Creating" output for the user's eye.
+        time.sleep(2.0)
+        deadline = time.monotonic() + 60.0
+        services_with_bare_ports = [
+            (svc_name, container_port)
+            for svc_name, svc_config in compose_data.get("services", {}).items()
+            for port_spec in svc_config.get("ports", []) or []
+            for host_port, container_port in [parse_port_mapping(str(port_spec))]
+            if host_port is None and container_port is not None
+        ]
+        printed: Dict[str, int] = {}
+        while time.monotonic() < deadline and len(printed) < len(
+            services_with_bare_ports
+        ):
+            for svc_name, container_port in services_with_bare_ports:
+                if svc_name in printed:
+                    continue
+                host_port = self._docker_compose_port(
+                    svc_name,
+                    container_port,
+                    compose_cmd=compose_cmd,
+                    cwd=cwd,
+                )
+                if host_port is None:
+                    continue
+                if svc_name in remaps:
+                    host_port = remaps[svc_name][1]
+                console.print(
+                    f"\n[bold green]{svc_name}:[/bold green] "
+                    f"[link]http://localhost:{host_port}[/link]"
+                )
+                printed[svc_name] = host_port
+            if len(printed) < len(services_with_bare_ports):
+                time.sleep(1.5)
 
     @staticmethod
     def _docker_compose_port(

--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -13,7 +13,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 from rich.console import Console
@@ -183,6 +183,11 @@ class DevLocalRunner:
         sdk_build_dockerfiles: List[str] = []
         extra_hosts_file: Optional[str] = None
         auth_env_file: Optional[str] = None
+        # Initialised here (not in 10a) so the ``finally`` cleanup always
+        # has them in scope — even if an exception bubbles out of the
+        # try body before the polling thread would have been spawned.
+        url_poll_thread: Optional[threading.Thread] = None
+        url_poll_stop = threading.Event()
 
         try:
             if info.compose_data:
@@ -238,6 +243,7 @@ class DevLocalRunner:
                 )
                 if df_patches:
                     build_overlay_services: dict = {}
+                    base_services = (info.compose_data or {}).get("services", {})
                     for svc, patched in df_patches.items():
                         df_fd = tempfile.NamedTemporaryFile(
                             mode="w",
@@ -248,9 +254,25 @@ class DevLocalRunner:
                         df_fd.write(patched)
                         df_fd.close()
                         sdk_build_dockerfiles.append(df_fd.name)
-                        build_overlay_services[svc] = {
-                            "build": {"dockerfile": df_fd.name},
-                        }
+                        # Carry forward the original build.context (and any
+                        # other build fields) so the patched Dockerfile is
+                        # built from the same root the scaffold expects —
+                        # COPY paths in the patched Dockerfile resolve
+                        # relative to ``context``. Compose's overlay merge
+                        # would normally preserve unspecified keys, but
+                        # being explicit insulates us from any compose
+                        # version that flips merge semantics for ``build:``
+                        # (Codex P1 review on PR #91).
+                        base_build = (base_services.get(svc) or {}).get("build")
+                        merged_build: Dict[str, Any] = {}
+                        if isinstance(base_build, str):
+                            # Compose short-form ``build: ./frontend`` —
+                            # promote to long-form so context survives.
+                            merged_build["context"] = base_build
+                        elif isinstance(base_build, dict):
+                            merged_build.update(base_build)
+                        merged_build["dockerfile"] = df_fd.name
+                        build_overlay_services[svc] = {"build": merged_build}
                     fd = tempfile.NamedTemporaryFile(
                         mode="w", suffix=".yml", prefix="kz-sdk-build-", delete=False
                     )
@@ -328,7 +350,8 @@ class DevLocalRunner:
                 compose_prefix += ["-f", sdk_override_file]
             # The build patch must apply to the same services the runtime
             # override touches; place it after sdk_override_file so its
-            # ``build.dockerfile_inline`` wins over any earlier build spec.
+            # ``build.dockerfile`` (absolute path to a temp Dockerfile)
+            # wins over any earlier build spec.
             if sdk_build_patch_file:
                 compose_prefix += ["-f", sdk_build_patch_file]
             if extra_hosts_file:
@@ -365,11 +388,18 @@ class DevLocalRunner:
             # actual URL (it scrolls past in the build / Next.js startup
             # logs and is easy to miss). Daemon thread so it dies with
             # the process if compose exits early. (ENG-3901 / F-008)
-            url_poll_thread: Optional[threading.Thread] = None
+            #
+            # The stop event lets the ``finally`` cleanup signal the
+            # poller to exit before unlinking the compose override files
+            # the poller passes to ``docker compose port``. Without it
+            # the poller could wake from ``time.sleep`` after the temp
+            # YAMLs are gone and shell out to compose with stale ``-f``
+            # paths (PR #91 round-2 review High consensus).
             if not detach and self._has_bare_ports(info.compose_data):
                 url_poll_thread = threading.Thread(
                     target=self._poll_and_print_urls,
-                    args=(info.compose_data, remaps, compose_prefix, str(info.path)),
+                    args=(info.compose_data, compose_prefix, str(info.path)),
+                    kwargs={"stop_event": url_poll_stop},
                     daemon=True,
                     name="kz-ext-url-poll",
                 )
@@ -393,6 +423,13 @@ class DevLocalRunner:
 
             return rc
         finally:
+            # Signal the URL-poll thread to stop BEFORE unlinking the
+            # compose override files it depends on; give it a brief join
+            # window so an in-flight ``docker compose port`` call doesn't
+            # see freshly-deleted ``-f`` paths.
+            url_poll_stop.set()
+            if url_poll_thread is not None and url_poll_thread.is_alive():
+                url_poll_thread.join(timeout=2.0)
             cleanup_paths: List[Optional[str]] = [
                 patched_compose_file,
                 sdk_override_file,
@@ -487,9 +524,10 @@ class DevLocalRunner:
     def _poll_and_print_urls(
         self,
         compose_data: dict,
-        remaps: Dict[str, Tuple[int, int]],
         compose_cmd: List[str],
         cwd: str,
+        *,
+        stop_event: Optional[threading.Event] = None,
     ) -> None:
         """Background-thread loop: poll ``docker compose port`` until the
         bare-port host ports are assigned, then print the URLs.
@@ -499,24 +537,43 @@ class DevLocalRunner:
         pull + Next.js build) before giving up silently. The user can
         always fall back to ``docker compose port`` themselves; this is
         a "make the common case easy" affordance, not a hard guarantee.
+
+        If ``stop_event`` is set (the runner's ``finally`` block signals
+        it), the loop returns promptly so the cleanup can unlink the
+        compose override files this thread depends on.
         """
+        if stop_event is None:
+            stop_event = threading.Event()
         # Initial delay so we don't compete with compose's own "Building" /
-        # "Pulling" / "Creating" output for the user's eye.
-        time.sleep(2.0)
+        # "Pulling" / "Creating" output for the user's eye. Use the stop
+        # event's wait so a fast Ctrl+C doesn't have to bleed off this
+        # delay before exiting.
+        if stop_event.wait(2.0):
+            return
         deadline = time.monotonic() + 60.0
-        services_with_bare_ports = [
+        services_with_bare_ports: List[Tuple[str, int]] = [
             (svc_name, container_port)
             for svc_name, svc_config in compose_data.get("services", {}).items()
             for port_spec in svc_config.get("ports", []) or []
             for host_port, container_port in [parse_port_mapping(str(port_spec))]
             if host_port is None and container_port is not None
         ]
-        printed: Dict[str, int] = {}
-        while time.monotonic() < deadline and len(printed) < len(
-            services_with_bare_ports
+        # Key on ``(svc_name, container_port)`` so multi-port services
+        # (e.g. a frontend exposing both 3000 and 4173 for HMR) get every
+        # URL printed, and the loop's completion check actually
+        # terminates rather than spinning to the 60s deadline (Codex P3
+        # / Claude review on PR #91).
+        printed: Dict[Tuple[str, int], int] = {}
+        while (
+            not stop_event.is_set()
+            and time.monotonic() < deadline
+            and len(printed) < len(services_with_bare_ports)
         ):
             for svc_name, container_port in services_with_bare_ports:
-                if svc_name in printed:
+                if stop_event.is_set():
+                    return
+                key = (svc_name, container_port)
+                if key in printed:
                     continue
                 host_port = self._docker_compose_port(
                     svc_name,
@@ -526,15 +583,14 @@ class DevLocalRunner:
                 )
                 if host_port is None:
                     continue
-                if svc_name in remaps:
-                    host_port = remaps[svc_name][1]
                 console.print(
                     f"\n[bold green]{svc_name}:[/bold green] "
                     f"[link]http://localhost:{host_port}[/link]"
                 )
-                printed[svc_name] = host_port
+                printed[key] = host_port
             if len(printed) < len(services_with_bare_ports):
-                time.sleep(1.5)
+                if stop_event.wait(1.5):
+                    return
 
     @staticmethod
     def _docker_compose_port(

--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -51,6 +51,7 @@ class DevLocalRunner:
             SdkOverrideSpec,
             build_typescript_lib,
             generate_compose_override,
+            generate_local_build_dockerfile_patches,
             print_override_diagnostics,
             resolve_sdk_override,
             validate_sdk_override,
@@ -114,11 +115,11 @@ class DevLocalRunner:
                 env.pop(var, None)
 
         if connection:
-            overlay = build_env_overlay(
-                connection, info.name, auth=auth, bridge=bridge
-            )
+            overlay = build_env_overlay(connection, info.name, auth=auth, bridge=bridge)
             env.update(overlay)
-            console.print(f"[dim]Using connection:[/dim] {connection.name} ({connection.url})")
+            console.print(
+                f"[dim]Using connection:[/dim] {connection.name} ({connection.url})"
+            )
             if auth:
                 who = (bridge.user_id if bridge else None) or "?"
                 console.print(
@@ -127,7 +128,9 @@ class DevLocalRunner:
             else:
                 console.print("[dim]KAMIWAZA_USE_AUTH=false (local dev mode)[/dim]")
         else:
-            console.print("[yellow]No Kamiwaza connection configured — running in standalone mode[/yellow]")
+            console.print(
+                "[yellow]No Kamiwaza connection configured — running in standalone mode[/yellow]"
+            )
 
         # 5. Resolve SDK override
         override_spec = resolve_sdk_override(sdk_repo, info.path)
@@ -149,7 +152,9 @@ class DevLocalRunner:
                     or not override_spec.typescript_dist_path.is_dir()
                 ):
                     if not build_typescript_lib(override_spec):
-                        console.print("[yellow]Continuing without TypeScript override[/yellow]")
+                        console.print(
+                            "[yellow]Continuing without TypeScript override[/yellow]"
+                        )
                         override_spec = SdkOverrideSpec(
                             sdk_repo=override_spec.sdk_repo,
                             python=override_spec.python,
@@ -163,6 +168,8 @@ class DevLocalRunner:
         remaps: Dict[str, Tuple[int, int]] = {}
         patched_compose_file: Optional[str] = None
         sdk_override_file: Optional[str] = None
+        sdk_build_patch_file: Optional[str] = None
+        sdk_build_dockerfiles: List[str] = []
         extra_hosts_file: Optional[str] = None
         auth_env_file: Optional[str] = None
 
@@ -192,7 +199,9 @@ class DevLocalRunner:
             # 7. Generate SDK override compose file
             if override_spec and info.compose_data:
                 sdk_override_data = generate_compose_override(
-                    override_spec, info.compose_data, extension_dir=info.path,
+                    override_spec,
+                    info.compose_data,
+                    extension_dir=info.path,
                 )
                 fd = tempfile.NamedTemporaryFile(
                     mode="w", suffix=".yml", prefix="kz-sdk-", delete=False
@@ -200,6 +209,47 @@ class DevLocalRunner:
                 yaml.dump(sdk_override_data, fd, default_flow_style=False)
                 fd.close()
                 sdk_override_file = fd.name
+
+                # 7a. Patch each Python backend service's Dockerfile to strip
+                # the kamiwaza-extensions-lib pin before pip install runs.
+                # Without this, the build phase fails when the pinned version
+                # is not yet on PyPI; the runtime PYTHONPATH overlay (set in
+                # generate_compose_override above) only kicks in once the
+                # image exists. Patched Dockerfiles are written to temp files
+                # and pointed at via compose's ``build.dockerfile`` (absolute
+                # path). Using ``dockerfile_inline`` would conflict with the
+                # scaffold's explicit ``dockerfile: Dockerfile`` field —
+                # compose treats them as mutually exclusive.
+                df_patches = generate_local_build_dockerfile_patches(
+                    override_spec,
+                    info.compose_data,
+                    info.path,
+                )
+                if df_patches:
+                    build_overlay_services: dict = {}
+                    for svc, patched in df_patches.items():
+                        df_fd = tempfile.NamedTemporaryFile(
+                            mode="w",
+                            suffix=".Dockerfile",
+                            prefix=f"kz-sdk-df-{svc}-",
+                            delete=False,
+                        )
+                        df_fd.write(patched)
+                        df_fd.close()
+                        sdk_build_dockerfiles.append(df_fd.name)
+                        build_overlay_services[svc] = {
+                            "build": {"dockerfile": df_fd.name},
+                        }
+                    fd = tempfile.NamedTemporaryFile(
+                        mode="w", suffix=".yml", prefix="kz-sdk-build-", delete=False
+                    )
+                    yaml.dump(
+                        {"services": build_overlay_services},
+                        fd,
+                        default_flow_style=False,
+                    )
+                    fd.close()
+                    sdk_build_patch_file = fd.name
 
             # 7b. Generate extra_hosts overlay when --auth is set. We always
             # inject host.docker.internal:host-gateway under --auth so
@@ -265,6 +315,11 @@ class DevLocalRunner:
             compose_prefix = compose_cmd + ["-f", compose_file_arg]
             if sdk_override_file:
                 compose_prefix += ["-f", sdk_override_file]
+            # The build patch must apply to the same services the runtime
+            # override touches; place it after sdk_override_file so its
+            # ``build.dockerfile_inline`` wins over any earlier build spec.
+            if sdk_build_patch_file:
+                compose_prefix += ["-f", sdk_build_patch_file]
             if extra_hosts_file:
                 compose_prefix += ["-f", extra_hosts_file]
             if auth_env_file:
@@ -272,6 +327,7 @@ class DevLocalRunner:
             if (
                 patched_compose_file
                 or sdk_override_file
+                or sdk_build_patch_file
                 or extra_hosts_file
                 or auth_env_file
             ):
@@ -308,12 +364,15 @@ class DevLocalRunner:
 
             return rc
         finally:
-            for tmp in (
+            cleanup_paths: List[Optional[str]] = [
                 patched_compose_file,
                 sdk_override_file,
+                sdk_build_patch_file,
                 extra_hosts_file,
                 auth_env_file,
-            ):
+            ]
+            cleanup_paths.extend(sdk_build_dockerfiles)
+            for tmp in cleanup_paths:
                 if tmp:
                     try:
                         os.unlink(tmp)
@@ -368,7 +427,8 @@ class DevLocalRunner:
                         continue
                     if container_port is not None:
                         host_port = self._docker_compose_port(
-                            svc_name, container_port,
+                            svc_name,
+                            container_port,
                             compose_cmd=compose_cmd,
                             cwd=cwd,
                         )
@@ -409,11 +469,16 @@ class DevLocalRunner:
         try:
             result = subprocess.run(
                 [*compose_cmd, "port", service, str(container_port)],
-                capture_output=True, text=True, timeout=10, cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=cwd,
             )
             if result.returncode != 0:
                 return None
-            line = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+            line = (
+                result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+            )
             if ":" in line:
                 return int(line.rsplit(":", 1)[1])
         except (FileNotFoundError, subprocess.TimeoutExpired, ValueError, IndexError):
@@ -545,13 +610,12 @@ def _write_compose_overlay(
     """
     import copy
 
-    overlay = {
-        "services": {
-            svc: copy.deepcopy(per_service) for svc in services.keys()
-        }
-    }
+    overlay = {"services": {svc: copy.deepcopy(per_service) for svc in services.keys()}}
     fd = tempfile.NamedTemporaryFile(
-        mode="w", suffix=".yml", prefix=prefix, delete=False,
+        mode="w",
+        suffix=".yml",
+        prefix=prefix,
+        delete=False,
     )
     yaml.dump(overlay, fd, default_flow_style=False)
     fd.close()
@@ -729,7 +793,9 @@ def find_available_port(start: int, host: str = "0.0.0.0", max_tries: int = 100)
             break
         if is_port_available(candidate, host):
             return candidate
-    raise RuntimeError(f"No available port found in range {start}–{start + max_tries - 1}")
+    raise RuntimeError(
+        f"No available port found in range {start}–{start + max_tries - 1}"
+    )
 
 
 def resolve_port_conflicts(
@@ -809,7 +875,11 @@ def detect_compose_command() -> List[str]:
             timeout=10,
         )
         return ["docker", "compose"]
-    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ):
         pass
 
     # Try v1 standalone
@@ -821,7 +891,11 @@ def detect_compose_command() -> List[str]:
             timeout=10,
         )
         return ["docker-compose"]
-    except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        subprocess.TimeoutExpired,
+    ):
         pass
 
     raise FileNotFoundError(

--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -551,13 +551,21 @@ class DevLocalRunner:
         if stop_event.wait(2.0):
             return
         deadline = time.monotonic() + 60.0
-        services_with_bare_ports: List[Tuple[str, int]] = [
-            (svc_name, container_port)
-            for svc_name, svc_config in compose_data.get("services", {}).items()
-            for port_spec in svc_config.get("ports", []) or []
-            for host_port, container_port in [parse_port_mapping(str(port_spec))]
-            if host_port is None and container_port is not None
-        ]
+        # Dedupe ``(svc_name, container_port)`` so a (technically illegal
+        # but YAML-valid) duplicate bare-port spec like ``ports: ["3000",
+        # "3000"]`` doesn't make the loop's completion check
+        # (``len(printed) < len(services_with_bare_ports)``) permanently
+        # true and spin until the 60s deadline (Claude review on PR #91).
+        # ``dict.fromkeys`` preserves insertion order; sets would not.
+        services_with_bare_ports: List[Tuple[str, int]] = list(
+            dict.fromkeys(
+                (svc_name, container_port)
+                for svc_name, svc_config in compose_data.get("services", {}).items()
+                for port_spec in svc_config.get("ports", []) or []
+                for host_port, container_port in [parse_port_mapping(str(port_spec))]
+                if host_port is None and container_port is not None
+            )
+        )
         # Key on ``(svc_name, container_port)`` so multi-port services
         # (e.g. a frontend exposing both 3000 and 4173 for HMR) get every
         # URL printed, and the loop's completion check actually

--- a/kamiwaza_extensions/dev_state.py
+++ b/kamiwaza_extensions/dev_state.py
@@ -44,9 +44,9 @@ class DevState:
     # `kz-ext dev` invocation differs from the prior on any of these,
     # `_is_resumable` returns False — skipping build/push under a different
     # set of inputs would silently redeploy stale or never-built images.
-    last_service: Optional[str] = None    # `--service` filter, if any
-    last_sdk_repo: Optional[str] = None   # `--sdk-repo` override path, if any
-    last_registry: str = ""               # KAMIWAZA_REGISTRY / derived
+    last_service: Optional[str] = None  # `--service` filter, if any
+    last_sdk_repo: Optional[str] = None  # `--sdk-repo` override path, if any
+    last_registry: str = ""  # KAMIWAZA_REGISTRY / derived
 
     def is_step_complete(self, step: str) -> bool:
         if not self.last_successful_step:
@@ -65,7 +65,7 @@ def decode_email(access_token: str) -> Optional[str]:
 
     Returns ``None`` if the token cannot be decoded. Used by callers
     (``commands.dev``, ``commands.status``) to populate the
-    ``kamiwaza.ai/deployer`` annotation, the ``deployer`` field of
+    ``kamiwaza.io/deployer`` annotation, the ``deployer`` field of
     ``dev-state.json``, and the deployer-match guard in ``kz-ext status``.
 
     Lifted to ``dev_state`` from ``commands.dev`` so ``commands.status``

--- a/kamiwaza_extensions/doctor.py
+++ b/kamiwaza_extensions/doctor.py
@@ -1019,11 +1019,20 @@ class DoctorChecker:
             )
         declared = deps.get("@kamiwaza-ai/extensions-lib")
         if declared is None:
+            # ENG-3901 / F-003: surface CLI version + upgrade hint so a
+            # stale ``kz-ext`` (with a stale bundled compat range) doesn't
+            # silently mislead. Mirrors the Python sibling check above.
             return CheckResult(
                 "Runtime lib (TypeScript)",
                 "warn",
                 "@kamiwaza-ai/extensions-lib not found in package.json",
-                fix=f'Add "@kamiwaza-ai/extensions-lib": "{compat_range or "^0.4.0"}" to package.json dependencies',
+                fix=(
+                    f'Add "@kamiwaza-ai/extensions-lib": '
+                    f'"{compat_range or "^0.4.0"}" to package.json '
+                    f"dependencies (range from kz-ext {__version__}; "
+                    "if this looks stale, upgrade kz-ext first: "
+                    "pip install --upgrade kamiwaza-sdk)"
+                ),
             )
         if compat_range:
             # Round-5 C1: parse the bundle's TS range with the npm-semver
@@ -1046,11 +1055,20 @@ class DoctorChecker:
                     supported_upper,
                 )
                 if reason is not None:
+                    # ENG-3901 / F-003: same CLI-version hint as the
+                    # Python check — a stale ``kz-ext`` ships a stale
+                    # bundle, and the suggested range would be wrong.
                     return CheckResult(
                         "Runtime lib (TypeScript)",
                         "warn",
                         f"@kamiwaza-ai/extensions-lib {declared} is outside CLI compatibility range {compat_range} ({reason})",
-                        fix=f'Update to "@kamiwaza-ai/extensions-lib": "{compat_range}"',
+                        fix=(
+                            f'Update to "@kamiwaza-ai/extensions-lib": '
+                            f'"{compat_range}" '
+                            f"(range from kz-ext {__version__}; "
+                            "if this looks stale, upgrade kz-ext first: "
+                            "pip install --upgrade kamiwaza-sdk)"
+                        ),
                     )
         return CheckResult(
             "Runtime lib (TypeScript)",

--- a/kamiwaza_extensions/doctor.py
+++ b/kamiwaza_extensions/doctor.py
@@ -19,7 +19,6 @@ from packaging.version import InvalidVersion, Version
 from kamiwaza_extensions import __version__
 from kamiwaza_extensions.connections import ConnectionManager
 
-
 # kubectl prints distinct stderr for "resource is genuinely absent" vs
 # "I can't even reach the API server / I'm not authorized / wrong context".
 # The former is a real platform-install problem; the latter is a config
@@ -118,9 +117,7 @@ def _spec_bounds(spec_set: SpecifierSet) -> tuple[Optional[Version], Optional[Ve
             # Version normalises ``"0.3"`` and ``"0.3.0"`` to equal values,
             # so we can't recover the segment count from ``ver``.
             implied_upper = _tilde_eq_upper(raw)
-            if implied_upper is not None and (
-                upper is None or implied_upper < upper
-            ):
+            if implied_upper is not None and (upper is None or implied_upper < upper):
                 upper = implied_upper
     return lower, upper
 
@@ -402,14 +399,19 @@ class DoctorChecker:
         if v >= (3, 10):
             return CheckResult("Python version", "pass", f"{version_str}")
         return CheckResult(
-            "Python version", "fail", f"{version_str} (requires >= 3.10)",
+            "Python version",
+            "fail",
+            f"{version_str} (requires >= 3.10)",
             fix="Install Python 3.10 or newer",
         )
 
     def _check_docker_installed(self) -> CheckResult:
         try:
             result = subprocess.run(
-                ["docker", "--version"], capture_output=True, text=True, timeout=10,
+                ["docker", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             if result.returncode == 0:
                 version = result.stdout.strip().split(",")[0]
@@ -417,7 +419,9 @@ class DoctorChecker:
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
         return CheckResult(
-            "Docker installed", "fail", "Not found",
+            "Docker installed",
+            "fail",
+            "Not found",
             fix="Install Docker Desktop: https://docs.docker.com/get-docker/",
         )
 
@@ -425,7 +429,10 @@ class DoctorChecker:
         # Try v2
         try:
             result = subprocess.run(
-                ["docker", "compose", "version"], capture_output=True, text=True, timeout=10,
+                ["docker", "compose", "version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             if result.returncode == 0:
                 return CheckResult("Docker Compose", "pass", result.stdout.strip())
@@ -434,28 +441,38 @@ class DoctorChecker:
         # Try v1
         try:
             result = subprocess.run(
-                ["docker-compose", "--version"], capture_output=True, text=True, timeout=10,
+                ["docker-compose", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             if result.returncode == 0:
                 return CheckResult("Docker Compose", "pass", result.stdout.strip())
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
         return CheckResult(
-            "Docker Compose", "fail", "Not found",
+            "Docker Compose",
+            "fail",
+            "Not found",
             fix="Install Docker Desktop (includes Compose v2) or pip install docker-compose",
         )
 
     def _check_docker_running(self) -> CheckResult:
         try:
             result = subprocess.run(
-                ["docker", "info"], capture_output=True, text=True, timeout=10,
+                ["docker", "info"],
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             if result.returncode == 0:
                 return CheckResult("Docker running", "pass", "Docker daemon is running")
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
         return CheckResult(
-            "Docker running", "fail", "Docker daemon not responding",
+            "Docker running",
+            "fail",
+            "Docker daemon not responding",
             fix="Start Docker Desktop or run 'sudo systemctl start docker'",
         )
 
@@ -467,18 +484,22 @@ class DoctorChecker:
         conn = self._conn_mgr.get_active_connection()
         if conn is None:
             return CheckResult(
-                "Kamiwaza connection", "warn", "No connection configured",
+                "Kamiwaza connection",
+                "warn",
+                "No connection configured",
                 fix="Run 'kz-ext login <url>' to connect",
             )
         token = self._conn_mgr.get_token()
         if token is None:
             return CheckResult(
-                "Kamiwaza connection", "warn",
+                "Kamiwaza connection",
+                "warn",
                 f"Connection '{conn.name}' has no token",
                 fix=f"Run 'kz-ext login {conn.url}' to re-authenticate",
             )
         # Try health endpoints — platform may expose different ones
         import requests
+
         for path in ("/auth/ping", "/auth/health", "/health"):
             try:
                 resp = requests.get(
@@ -488,11 +509,14 @@ class DoctorChecker:
                     verify=conn.verify_ssl,
                 )
                 if resp.ok:
-                    return CheckResult("Kamiwaza connection", "pass", f"{conn.name} ({conn.url})")
+                    return CheckResult(
+                        "Kamiwaza connection", "pass", f"{conn.name} ({conn.url})"
+                    )
             except requests.ConnectionError:
                 # Server unreachable — no point trying more paths on same host
                 return CheckResult(
-                    "Kamiwaza connection", "warn",
+                    "Kamiwaza connection",
+                    "warn",
                     f"{conn.name}: unreachable ({conn.url})",
                     fix="Check network connectivity or VPN",
                 )
@@ -501,7 +525,8 @@ class DoctorChecker:
 
         # All endpoints responded but none returned 200
         return CheckResult(
-            "Kamiwaza connection", "warn",
+            "Kamiwaza connection",
+            "warn",
             f"{conn.name}: no health endpoint found",
             fix="Server is reachable but health check failed",
         )
@@ -548,7 +573,8 @@ class DoctorChecker:
         connection = self._conn_mgr.get_active_connection()
         if connection is None:
             return CheckResult(
-                name, "warn",
+                name,
+                "warn",
                 "No Kamiwaza connection configured; cluster readiness probe skipped",
                 fix="Run 'kz-ext login <url>' to connect, then re-run doctor",
             )
@@ -561,9 +587,11 @@ class DoctorChecker:
         # reinstall the platform" (review re-review PR #84 H1). Skip with
         # a transparent warn instead.
         from kamiwaza_extensions.platform_compat import is_local_connection
+
         if not is_local_connection(connection.url):
             return CheckResult(
-                name, "warn",
+                name,
+                "warn",
                 f"Connection '{connection.name}' is remote ({connection.url}); "
                 "local kubectl context cannot be verified to target the same cluster — "
                 "probe skipped",
@@ -578,7 +606,8 @@ class DoctorChecker:
         kubectl_check = self._kubectl_available()
         if not kubectl_check:
             return CheckResult(
-                name, "warn",
+                name,
+                "warn",
                 "kubectl not available; cluster readiness probe skipped",
                 fix="Install kubectl and configure access to the target cluster",
             )
@@ -594,13 +623,15 @@ class DoctorChecker:
             # broken cluster.
             if _is_kubectl_not_found_error(crd_err):
                 return CheckResult(
-                    name, "fail",
+                    name,
+                    "fail",
                     f"Extension CRD '{EXTENSION_CRD}' not installed on cluster",
                     fix=f"Install or upgrade the kamiwaza platform on this cluster: {crd_err}",
                     exit_code=not_ready,
                 )
             return CheckResult(
-                name, "warn",
+                name,
+                "warn",
                 f"Could not query cluster for CRD: {crd_err}",
                 fix=(
                     "Verify your kubeconfig is valid and points at the "
@@ -620,13 +651,15 @@ class DoctorChecker:
             err_msg = deploy_payload if isinstance(deploy_payload, str) else ""
             if _is_kubectl_not_found_error(err_msg):
                 return CheckResult(
-                    name, "fail",
+                    name,
+                    "fail",
                     f"extension-operator Deployment not found in '{OPERATOR_NAMESPACE}'",
                     fix="Re-run the platform installer on this cluster",
                     exit_code=not_ready,
                 )
             return CheckResult(
-                name, "warn",
+                name,
+                "warn",
                 f"Could not query cluster for extension-operator Deployment: {err_msg}",
                 fix=(
                     "Verify your kubeconfig is valid and points at the "
@@ -662,7 +695,8 @@ class DoctorChecker:
         if backoff_msg:
             expected = ", ".join(OPERATOR_COMPATIBLE_TAGS)
             return CheckResult(
-                name, "fail",
+                name,
+                "fail",
                 f"extension-operator pod is in ImagePullBackOff: {backoff_msg}",
                 fix=(
                     f"Operator image '{image_ref}' cannot be pulled. "
@@ -683,7 +717,8 @@ class DoctorChecker:
         )
         if not available or (observed_gen is not None and observed_gen != spec_gen):
             return CheckResult(
-                name, "fail",
+                name,
+                "fail",
                 "extension-operator Deployment is not Available",
                 fix=(
                     "Operator is not ready to reconcile extensions. "
@@ -701,14 +736,16 @@ class DoctorChecker:
         # warning (review re-review PR #84 H1).
         if image_tag and is_digest_ref(image_tag):
             return CheckResult(
-                name, "pass",
+                name,
+                "pass",
                 f"CRD installed, extension-operator Available "
                 f"(digest-pinned: {image_tag[:19]}…)",
             )
         if not is_compatible_tag(image_tag):
             expected = ", ".join(OPERATOR_COMPATIBLE_TAGS)
             return CheckResult(
-                name, "warn",
+                name,
+                "warn",
                 f"extension-operator running '{image_tag}' (Available)",
                 fix=(
                     f"Tag '{image_tag}' is not in this CLI's compatible set "
@@ -717,7 +754,8 @@ class DoctorChecker:
             )
 
         return CheckResult(
-            name, "pass",
+            name,
+            "pass",
             f"CRD installed, extension-operator Available ({image_tag})",
         )
 
@@ -726,7 +764,9 @@ class DoctorChecker:
         try:
             result = subprocess.run(
                 ["kubectl", "version", "--client=true", "-o", "json"],
-                capture_output=True, text=True, timeout=10,
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             return result.returncode == 0
         except (FileNotFoundError, subprocess.TimeoutExpired):
@@ -737,7 +777,9 @@ class DoctorChecker:
         try:
             result = subprocess.run(
                 ["kubectl", "get", *args],
-                capture_output=True, text=True, timeout=15,
+                capture_output=True,
+                text=True,
+                timeout=15,
             )
             return result.returncode, (result.stderr.strip() or result.stdout.strip())
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
@@ -748,12 +790,18 @@ class DoctorChecker:
         try:
             result = subprocess.run(
                 ["kubectl", "get", *args, "-o", "json"],
-                capture_output=True, text=True, timeout=15,
+                capture_output=True,
+                text=True,
+                timeout=15,
             )
             if result.returncode != 0:
                 return result.returncode, result.stderr.strip()
             return 0, json.loads(result.stdout)
-        except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        except (
+            FileNotFoundError,
+            subprocess.TimeoutExpired,
+            json.JSONDecodeError,
+        ) as exc:
             return 1, str(exc)
 
     @staticmethod
@@ -767,12 +815,19 @@ class DoctorChecker:
         try:
             result = subprocess.run(
                 [
-                    "kubectl", "get", "pods",
-                    "-n", OPERATOR_NAMESPACE,
-                    "-l", f"app.kubernetes.io/name={OPERATOR_DEPLOYMENT}",
-                    "-o", "json",
+                    "kubectl",
+                    "get",
+                    "pods",
+                    "-n",
+                    OPERATOR_NAMESPACE,
+                    "-l",
+                    f"app.kubernetes.io/name={OPERATOR_DEPLOYMENT}",
+                    "-o",
+                    "json",
                 ],
-                capture_output=True, text=True, timeout=15,
+                capture_output=True,
+                text=True,
+                timeout=15,
             )
             if result.returncode != 0:
                 return None
@@ -840,15 +895,21 @@ class DoctorChecker:
             spec = SpecifierSet(specifier_str)
             ver = Version(__version__)
             if ver in spec:
-                return CheckResult("CLI version compatibility", "pass", f"{__version__} matches {specifier_str}")
+                return CheckResult(
+                    "CLI version compatibility",
+                    "pass",
+                    f"{__version__} matches {specifier_str}",
+                )
             return CheckResult(
-                "CLI version compatibility", "fail",
+                "CLI version compatibility",
+                "fail",
                 f"{__version__} does not match {specifier_str}",
                 fix=f"Install a compatible version: pip install 'kamiwaza-sdk{specifier_str}'",
             )
         except (InvalidSpecifier, InvalidVersion) as exc:
             return CheckResult(
-                "CLI version compatibility", "warn",
+                "CLI version compatibility",
+                "warn",
                 f"Could not parse kz_ext_version: {exc}",
             )
 
@@ -877,15 +938,28 @@ class DoctorChecker:
             declared_req = req
             break
         if declared_req is None:
+            # ENG-3901 / F-003: include the CLI version in the fix hint so a
+            # developer with a stale ``kz-ext`` install can spot the version
+            # skew. Without this, ``compat_range`` is read from the bundle
+            # baked into the installed wheel — which may differ from what
+            # develop says is current — and the suggested pin sounds
+            # authoritative even when the CLI itself is out of date.
             return CheckResult(
-                "Runtime lib (Python)", "warn",
+                "Runtime lib (Python)",
+                "warn",
                 "kamiwaza-extensions-lib not found in requirements.txt",
-                fix=f"Add 'kamiwaza-extensions-lib{compat_range}' to requirements.txt",
+                fix=(
+                    f"Add 'kamiwaza-extensions-lib{compat_range}' to "
+                    f"requirements.txt (range from kz-ext {__version__}; "
+                    "if this looks stale, upgrade kz-ext first: "
+                    "pip install --upgrade kamiwaza-sdk)"
+                ),
             )
         declared_spec = str(declared_req.specifier) or ""
         if not compat_range:
             return CheckResult(
-                "Runtime lib (Python)", "pass",
+                "Runtime lib (Python)",
+                "pass",
                 f"kamiwaza-extensions-lib{declared_spec} matches any (no compat range bundled)",
             )
         try:
@@ -893,7 +967,8 @@ class DoctorChecker:
         except InvalidSpecifier:
             # Bundle range malformed — fail open with the declared spec passing.
             return CheckResult(
-                "Runtime lib (Python)", "pass",
+                "Runtime lib (Python)",
+                "pass",
                 f"kamiwaza-extensions-lib{declared_spec} (compat range unparseable, skipping check)",
             )
         # PR-86 M6: range-vs-range overlap. ``declared_req.specifier`` is a
@@ -904,13 +979,24 @@ class DoctorChecker:
             declared_req.specifier, supported
         )
         if out_of_range_reason is not None:
+            # ENG-3901 / F-003: the compat range is read from the bundle baked
+            # into THIS kz-ext install. If the CLI is stale, the bundle is
+            # too — and our "Update to ..." suggestion would point at the
+            # wrong window. Surfacing the CLI version in the hint lets
+            # developers spot the skew themselves.
             return CheckResult(
-                "Runtime lib (Python)", "warn",
+                "Runtime lib (Python)",
+                "warn",
                 f"kamiwaza-extensions-lib{declared_spec} is outside CLI compatibility range {compat_range} ({out_of_range_reason})",
-                fix=f"Update to 'kamiwaza-extensions-lib{compat_range}'",
+                fix=(
+                    f"Update to 'kamiwaza-extensions-lib{compat_range}' "
+                    f"(range from kz-ext {__version__}; if this looks stale, "
+                    "upgrade kz-ext first: pip install --upgrade kamiwaza-sdk)"
+                ),
             )
         return CheckResult(
-            "Runtime lib (Python)", "pass",
+            "Runtime lib (Python)",
+            "pass",
             f"kamiwaza-extensions-lib{declared_spec} matches {compat_range}",
         )
 
@@ -927,13 +1013,15 @@ class DoctorChecker:
             deps = {**data.get("dependencies", {}), **data.get("devDependencies", {})}
         except (json.JSONDecodeError, FileNotFoundError):
             return CheckResult(
-                "Runtime lib (TypeScript)", "warn",
+                "Runtime lib (TypeScript)",
+                "warn",
                 "package.json could not be parsed",
             )
         declared = deps.get("@kamiwaza-ai/extensions-lib")
         if declared is None:
             return CheckResult(
-                "Runtime lib (TypeScript)", "warn",
+                "Runtime lib (TypeScript)",
+                "warn",
                 "@kamiwaza-ai/extensions-lib not found in package.json",
                 fix=f'Add "@kamiwaza-ai/extensions-lib": "{compat_range or "^0.4.0"}" to package.json dependencies',
             )
@@ -959,12 +1047,14 @@ class DoctorChecker:
                 )
                 if reason is not None:
                     return CheckResult(
-                        "Runtime lib (TypeScript)", "warn",
+                        "Runtime lib (TypeScript)",
+                        "warn",
                         f"@kamiwaza-ai/extensions-lib {declared} is outside CLI compatibility range {compat_range} ({reason})",
                         fix=f'Update to "@kamiwaza-ai/extensions-lib": "{compat_range}"',
                     )
         return CheckResult(
-            "Runtime lib (TypeScript)", "pass",
+            "Runtime lib (TypeScript)",
+            "pass",
             f"@kamiwaza-ai/extensions-lib {declared} matches {compat_range or 'any'}",
         )
 
@@ -986,10 +1076,13 @@ class DoctorChecker:
         if spec is None:
             return results  # No override configured — skip
 
-        results.append(CheckResult(
-            "SDK override config", "pass",
-            f"Loaded from .kz-ext/local.yaml (sdk_repo: {spec.sdk_repo})",
-        ))
+        results.append(
+            CheckResult(
+                "SDK override config",
+                "pass",
+                f"Loaded from .kz-ext/local.yaml (sdk_repo: {spec.sdk_repo})",
+            )
+        )
 
         validation = validate_sdk_override(spec)
 
@@ -997,37 +1090,53 @@ class DoctorChecker:
         if spec.sdk_repo.is_dir():
             results.append(CheckResult("SDK repo exists", "pass", str(spec.sdk_repo)))
         else:
-            results.append(CheckResult(
-                "SDK repo exists", "fail", f"Not found: {spec.sdk_repo}",
-                fix="Check path in .kz-ext/local.yaml",
-            ))
+            results.append(
+                CheckResult(
+                    "SDK repo exists",
+                    "fail",
+                    f"Not found: {spec.sdk_repo}",
+                    fix="Check path in .kz-ext/local.yaml",
+                )
+            )
             return results  # Can't check further
 
         # Python lib
         if spec.python:
             if spec.python_lib_path.is_dir():
-                results.append(CheckResult(
-                    "SDK Python lib", "pass",
-                    "kamiwaza_extensions_lib/ found",
-                ))
+                results.append(
+                    CheckResult(
+                        "SDK Python lib",
+                        "pass",
+                        "kamiwaza_extensions_lib/ found",
+                    )
+                )
             else:
-                results.append(CheckResult(
-                    "SDK Python lib", "fail",
-                    "kamiwaza_extensions_lib/ not found in SDK repo",
-                ))
+                results.append(
+                    CheckResult(
+                        "SDK Python lib",
+                        "fail",
+                        "kamiwaza_extensions_lib/ not found in SDK repo",
+                    )
+                )
 
         # TypeScript lib
         if spec.typescript:
             if spec.typescript_lib_path.is_dir():
-                results.append(CheckResult(
-                    "SDK TypeScript lib", "pass",
-                    "kamiwaza-ai-extensions-lib/ found",
-                ))
+                results.append(
+                    CheckResult(
+                        "SDK TypeScript lib",
+                        "pass",
+                        "kamiwaza-ai-extensions-lib/ found",
+                    )
+                )
             else:
-                results.append(CheckResult(
-                    "SDK TypeScript lib", "fail",
-                    "kamiwaza-ai-extensions-lib/ not found in SDK repo",
-                ))
+                results.append(
+                    CheckResult(
+                        "SDK TypeScript lib",
+                        "fail",
+                        "kamiwaza-ai-extensions-lib/ not found in SDK repo",
+                    )
+                )
 
             # dist/ check
             if spec.typescript_lib_path.is_dir():
@@ -1035,21 +1144,31 @@ class DoctorChecker:
                     # Check staleness via validation warnings
                     stale = any("stale" in w for w in validation.warnings)
                     if stale:
-                        results.append(CheckResult(
-                            "SDK TypeScript dist/", "warn",
-                            "dist/ exists but may be stale (src/ is newer)",
-                            fix=f"cd {spec.typescript_lib_path} && npm run build",
-                        ))
+                        results.append(
+                            CheckResult(
+                                "SDK TypeScript dist/",
+                                "warn",
+                                "dist/ exists but may be stale (src/ is newer)",
+                                fix=f"cd {spec.typescript_lib_path} && npm run build",
+                            )
+                        )
                     else:
-                        results.append(CheckResult(
-                            "SDK TypeScript dist/", "pass", "Built and up to date",
-                        ))
+                        results.append(
+                            CheckResult(
+                                "SDK TypeScript dist/",
+                                "pass",
+                                "Built and up to date",
+                            )
+                        )
                 else:
-                    results.append(CheckResult(
-                        "SDK TypeScript dist/", "warn",
-                        "dist/ not found — will be built on first run",
-                        fix=f"cd {spec.typescript_lib_path} && npm install && npm run build",
-                    ))
+                    results.append(
+                        CheckResult(
+                            "SDK TypeScript dist/",
+                            "warn",
+                            "dist/ not found — will be built on first run",
+                            fix=f"cd {spec.typescript_lib_path} && npm install && npm run build",
+                        )
+                    )
 
         # Template contract check
         ext_dir = cwd
@@ -1075,23 +1194,32 @@ class DoctorChecker:
             try:
                 with pkg_file.open() as f:
                     data = json.load(f)
-                deps = {**data.get("dependencies", {}), **data.get("devDependencies", {})}
+                deps = {
+                    **data.get("dependencies", {}),
+                    **data.get("devDependencies", {}),
+                }
                 if "@kamiwaza-ai/extensions-lib" not in deps:
                     contract_ok = False
             except (json.JSONDecodeError, FileNotFoundError):
                 pass
 
         if contract_ok:
-            results.append(CheckResult(
-                "SDK override contract", "pass",
-                "requirements.txt and package.json reference runtime libs",
-            ))
+            results.append(
+                CheckResult(
+                    "SDK override contract",
+                    "pass",
+                    "requirements.txt and package.json reference runtime libs",
+                )
+            )
         else:
-            results.append(CheckResult(
-                "SDK override contract", "warn",
-                "Non-standard install — SDK override may need manual configuration",
-                fix="Ensure requirements.txt has kamiwaza-extensions-lib and "
+            results.append(
+                CheckResult(
+                    "SDK override contract",
+                    "warn",
+                    "Non-standard install — SDK override may need manual configuration",
+                    fix="Ensure requirements.txt has kamiwaza-extensions-lib and "
                     "package.json has @kamiwaza-ai/extensions-lib",
-            ))
+                )
+            )
 
         return results

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -20,10 +20,18 @@ from kamiwaza_sdk.schemas.extensions import (
 from kamiwaza_extensions.connections import ConnectionInfo
 
 # CRD annotation keys — name-spaced under kamiwaza.ai (§4.2.9 / §4.7).
-ANNOTATION_DEPLOYER = "kamiwaza.ai/deployer"
-ANNOTATION_BUILD_HOST = "kamiwaza.ai/build-host"
-ANNOTATION_REVISION = "kamiwaza.ai/revision"
-ANNOTATION_DEPLOYED_AT = "kamiwaza.ai/deployed-at"
+# Annotation namespace is ``kamiwaza.io/*``, NOT ``kamiwaza.ai/*``. The
+# platform's annotation persister filters incoming Extension CR annotations
+# to the ``kamiwaza.io/*`` namespace; ``kamiwaza.ai/*`` annotations are
+# silently dropped on the platform side, leaving ``kz-ext status`` unable
+# to surface "Last deployed by..." and similar observability fields.
+# (ENG-3901 dry-run finding F-010 — tactical SDK-side workaround until the
+# platform broadens its allow-list. The ``.ai`` namespace was chosen
+# originally for SDK-team-set annotations but is unsupported in practice.)
+ANNOTATION_DEPLOYER = "kamiwaza.io/deployer"
+ANNOTATION_BUILD_HOST = "kamiwaza.io/build-host"
+ANNOTATION_REVISION = "kamiwaza.io/revision"
+ANNOTATION_DEPLOYED_AT = "kamiwaza.io/deployed-at"
 
 
 def _compose_resources_to_k8s(resources: Dict[str, str]) -> Dict[str, str]:
@@ -61,9 +69,15 @@ class PayloadBuilder:
         revision: Optional[str] = None,
     ) -> CreateExtension:
         ext_type = self._resolve_type(metadata)
-        app_path = f"/runtime/apps/{dev_name}" if ext_type == "app" else f"/runtime/{ext_type}s/{dev_name}"
+        app_path = (
+            f"/runtime/apps/{dev_name}"
+            if ext_type == "app"
+            else f"/runtime/{ext_type}s/{dev_name}"
+        )
         services = self._build_services(
-            transformed_compose, app_path=app_path, verify_ssl=connection.verify_ssl,
+            transformed_compose,
+            app_path=app_path,
+            verify_ssl=connection.verify_ssl,
         )
         origin = connection.url.removesuffix("/api")
         tls_reject = "0" if not connection.verify_ssl else "1"
@@ -104,10 +118,10 @@ class PayloadBuilder:
     ) -> Dict[str, str]:
         """Build the CRD-metadata annotations attached on every dev deploy.
 
-        - ``kamiwaza.ai/deployer``     — email of the deploying user
-        - ``kamiwaza.ai/build-host``   — local hostname of the developer machine
-        - ``kamiwaza.ai/revision``     — revision tag (image tag suffix)
-        - ``kamiwaza.ai/deployed-at``  — ISO-8601 UTC timestamp of the deploy
+        - ``kamiwaza.io/deployer``     — email of the deploying user
+        - ``kamiwaza.io/build-host``   — local hostname of the developer machine
+        - ``kamiwaza.io/revision``     — revision tag (image tag suffix)
+        - ``kamiwaza.io/deployed-at``  — ISO-8601 UTC timestamp of the deploy
 
         Empty values are dropped so consumers can ``in``-check without
         seeing meaningless empty strings.
@@ -146,7 +160,9 @@ class PayloadBuilder:
     # ------------------------------------------------------------------
 
     def _build_services(
-        self, transformed: Dict[str, Any], app_path: str = "",
+        self,
+        transformed: Dict[str, Any],
+        app_path: str = "",
         verify_ssl: bool = True,
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
@@ -170,7 +186,7 @@ class PayloadBuilder:
             env = self._parse_env(svc.get("environment", []))
             resources = self._parse_resources(svc)
 
-            is_primary = (svc_name == primary_name)
+            is_primary = svc_name == primary_name
 
             # Inject platform env vars
             if is_primary and app_path:
@@ -205,9 +221,13 @@ class PayloadBuilder:
             proto = "TCP"
             if "/" in s:
                 s, proto_str = s.rsplit("/", 1)
-                proto = proto_str.upper() if proto_str.upper() in ("TCP", "UDP") else "TCP"
+                proto = (
+                    proto_str.upper() if proto_str.upper() in ("TCP", "UDP") else "TCP"
+                )
             try:
-                result.append(ExtensionPort(container_port=int(s), protocol=proto, name="http"))
+                result.append(
+                    ExtensionPort(container_port=int(s), protocol=proto, name="http")
+                )
             except (ValueError, TypeError):
                 continue
         return result
@@ -237,7 +257,9 @@ class PayloadBuilder:
 
     @staticmethod
     def _default_health_check(
-        svc_name: str, svc: Dict[str, Any], ports: List[ExtensionPort],
+        svc_name: str,
+        svc: Dict[str, Any],
+        ports: List[ExtensionPort],
     ) -> Optional[Dict[str, Any]]:
         """Generate a default health check based on service type."""
         if not ports:

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -78,6 +78,7 @@ class PayloadBuilder:
             transformed_compose,
             app_path=app_path,
             verify_ssl=connection.verify_ssl,
+            extension_type=ext_type,
         )
         origin = connection.url.removesuffix("/api")
         tls_reject = "0" if not connection.verify_ssl else "1"
@@ -164,6 +165,7 @@ class PayloadBuilder:
         transformed: Dict[str, Any],
         app_path: str = "",
         verify_ssl: bool = True,
+        extension_type: str = "app",
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
         specs: List[ExtensionServiceSpec] = []
@@ -194,7 +196,13 @@ class PayloadBuilder:
             if not verify_ssl:
                 env.append({"name": "KAMIWAZA_VERIFY_SSL", "value": "false"})
 
-            health_check = self._default_health_check(svc_name, svc, ports)
+            health_check = self._default_health_check(
+                svc_name,
+                svc,
+                ports,
+                extension_type=extension_type,
+                is_primary=is_primary,
+            )
 
             spec_kwargs: Dict[str, Any] = dict(
                 name=svc_name,
@@ -260,8 +268,25 @@ class PayloadBuilder:
         svc_name: str,
         svc: Dict[str, Any],
         ports: List[ExtensionPort],
+        *,
+        extension_type: str = "app",
+        is_primary: bool = False,
     ) -> Optional[Dict[str, Any]]:
-        """Generate a default health check based on service type."""
+        """Generate a default health check based on service type.
+
+        Path-selection rules (ENG-3901 / F-013):
+
+        - Frontend (Next.js) services use a node-based exec probe that
+          resolves the basePath env var dynamically.
+        - Backend services in app-type extensions probe ``/health`` —
+          the scaffolded FastAPI backend ships an explicit /health route.
+        - Primary services in **service** and **tool** extensions probe
+          ``/`` — those scaffolds ship a minimal stub (``python -m
+          http.server`` for service, FastMCP for tool) that doesn't
+          declare /health. Probing /health on those stubs returns 404
+          and the K8s startup probe fails the pod into restart loops.
+          Probing ``/`` works because both stubs respond to it.
+        """
         if not ports:
             return None
         port = ports[0].container_port
@@ -287,18 +312,24 @@ class PayloadBuilder:
                 "startPeriod": 300,
                 "timeoutSeconds": 5,
             }
+        # service / tool primary stubs don't expose /health; probe / instead.
+        # Generic non-primary "frontend"-named services keep / for the same
+        # reason (they typically serve at root). Backends in app-type
+        # extensions ship a real /health route so they keep that path.
+        if (
+            extension_type in ("service", "tool") and is_primary
+        ) or svc_name == "frontend":
+            path = "/"
         else:
-            # Generic frontends usually serve "/" even when they lack a
-            # dedicated /health endpoint; backend-style services still use /health.
-            path = "/" if svc_name == "frontend" else "/health"
-            return {
-                "httpGet": {"path": path, "port": port},
-                "initialDelaySeconds": 10,
-                "periodSeconds": 10,
-                "failureThreshold": 3,
-                "startPeriod": 5,
-                "timeoutSeconds": 5,
-            }
+            path = "/health"
+        return {
+            "httpGet": {"path": path, "port": port},
+            "initialDelaySeconds": 10,
+            "periodSeconds": 10,
+            "failureThreshold": 3,
+            "startPeriod": 5,
+            "timeoutSeconds": 5,
+        }
 
     @staticmethod
     def _parse_resources(svc: Dict[str, Any]) -> Optional[ResourceSpec]:

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -19,14 +19,13 @@ from kamiwaza_sdk.schemas.extensions import (
 
 from kamiwaza_extensions.connections import ConnectionInfo
 
-# CRD annotation keys — name-spaced under kamiwaza.ai (§4.2.9 / §4.7).
-# Annotation namespace is ``kamiwaza.io/*``, NOT ``kamiwaza.ai/*``. The
-# platform's annotation persister filters incoming Extension CR annotations
+# CRD annotation keys — namespace is ``kamiwaza.io/*`` (NOT ``kamiwaza.ai/*``).
+# The platform's annotation persister filters incoming Extension CR annotations
 # to the ``kamiwaza.io/*`` namespace; ``kamiwaza.ai/*`` annotations are
 # silently dropped on the platform side, leaving ``kz-ext status`` unable
 # to surface "Last deployed by..." and similar observability fields.
 # (ENG-3901 dry-run finding F-010 — tactical SDK-side workaround until the
-# platform broadens its allow-list. The ``.ai`` namespace was chosen
+# platform broadens its allow-list. The ``.ai`` namespace was tried
 # originally for SDK-team-set annotations but is unsupported in practice.)
 ANNOTATION_DEPLOYER = "kamiwaza.io/deployer"
 ANNOTATION_BUILD_HOST = "kamiwaza.io/build-host"
@@ -286,6 +285,15 @@ class PayloadBuilder:
           declare /health. Probing /health on those stubs returns 404
           and the K8s startup probe fails the pod into restart loops.
           Probing ``/`` works because both stubs respond to it.
+
+        Precedence note: the Node-frontend probe (when its detection
+        hits — service name ``frontend`` AND Node-like hints in env)
+        wins over the per-type tool/service rules below. That's the
+        right call because a Node Next.js frontend needs a node probe
+        regardless of extension shape. Realistic conflict only arises
+        if a tool extension's primary is named ``frontend`` AND carries
+        ``NEXT_PUBLIC_*`` env keys — vanishingly rare in practice
+        (the tool template names its primary ``tool``).
         """
         if not ports:
             return None

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -312,13 +312,22 @@ class PayloadBuilder:
                 "startPeriod": 300,
                 "timeoutSeconds": 5,
             }
-        # service / tool primary stubs don't expose /health; probe / instead.
-        # Generic non-primary "frontend"-named services keep / for the same
-        # reason (they typically serve at root). Backends in app-type
-        # extensions ship a real /health route so they keep that path.
-        if (
-            extension_type in ("service", "tool") and is_primary
-        ) or svc_name == "frontend":
+        # Path-selection rules (see docstring). Tool primary probes /sse —
+        # the FastMCP SSE endpoint — even though the response body streams
+        # past the K8s 5s probe timeout. The platform's CR API currently
+        # rejects ``tcpSocket`` and ``exec`` healthCheck shapes with an
+        # opaque 500, leaving httpGet as the only path. /sse is preferable
+        # to /health (404 under FastMCP) — the headers come back 200 even
+        # if the probe times out reading the body, which keeps the pod
+        # restart-loop from firing. Net result: pod runs and serves
+        # requests, but K8s may take longer to mark it Ready. The proper
+        # fix is to teach the platform API to accept tcpSocket/exec
+        # probes (tracked separately).
+        if extension_type == "service" and is_primary:
+            path = "/"
+        elif extension_type == "tool" and is_primary:
+            path = "/sse"
+        elif svc_name == "frontend":
             path = "/"
         else:
             path = "/health"

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -637,10 +637,17 @@ _PYTHON_OVERLAY = (
     "# --- SDK override: install local Python runtime lib ---\n"
     "USER root\n"
     "COPY --from=sdk kamiwaza_extensions_lib /tmp/kamiwaza_extensions_lib\n"
-    'RUN SITE=$(python -c "import kamiwaza_extensions_lib as m, os;'
-    ' print(os.path.dirname(m.__file__))")'
-    ' && rm -rf "$SITE"'
-    ' && cp -r /tmp/kamiwaza_extensions_lib "$SITE"'
+    # Resolve the site-packages dir via ``sysconfig`` rather than by
+    # importing ``kamiwaza_extensions_lib``. The pre-install strip
+    # (above) removed the lib from requirements.txt, so it's NOT
+    # installed via pip — importing it would crash here. ``purelib``
+    # is the canonical pure-Python site-packages path for the current
+    # interpreter and is always resolvable regardless of what's
+    # installed. (ENG-3901 / F-002 round-3.)
+    'RUN PURELIB=$(python -c "import sysconfig; print(sysconfig.get_paths()[\\"purelib\\"])")'
+    ' && mkdir -p "$PURELIB"'
+    ' && rm -rf "$PURELIB/kamiwaza_extensions_lib"'
+    ' && cp -r /tmp/kamiwaza_extensions_lib "$PURELIB/"'
     " && rm -rf /tmp/kamiwaza_extensions_lib\n"
     "{restore_user_block}"
 )

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -148,9 +148,7 @@ def validate_sdk_override(spec: SdkOverrideSpec) -> ValidationResult:
         return result
 
     if spec.python and not spec.python_lib_path.is_dir():
-        result.errors.append(
-            f"Python runtime lib not found: {spec.python_lib_path}"
-        )
+        result.errors.append(f"Python runtime lib not found: {spec.python_lib_path}")
 
     if spec.typescript:
         if not spec.typescript_lib_path.is_dir():
@@ -331,7 +329,9 @@ def _detect_build_service_runtime(
     stage_bases = _read_dockerfile_stage_bases(dockerfile)
     if not stage_bases:
         return detect_service_runtime(
-            svc_name, svc_config, extension_dir=extension_dir,
+            svc_name,
+            svc_config,
+            extension_dir=extension_dir,
         )
 
     final_base = _image_basename(stage_bases[-1])
@@ -348,7 +348,9 @@ def _detect_build_service_runtime(
         return "static"
 
     return detect_service_runtime(
-        svc_name, svc_config, extension_dir=extension_dir,
+        svc_name,
+        svc_config,
+        extension_dir=extension_dir,
     )
 
 
@@ -398,10 +400,10 @@ def _read_dockerfile_startup(dockerfile: Path) -> Optional[DockerStartup]:
         stripped = line.strip()
         if stripped.startswith("ENTRYPOINT "):
             startup.entrypoint = _parse_docker_command(
-                stripped[len("ENTRYPOINT "):].strip()
+                stripped[len("ENTRYPOINT ") :].strip()
             )
         elif stripped.startswith("CMD "):
-            startup.cmd = _parse_docker_command(stripped[len("CMD "):].strip())
+            startup.cmd = _parse_docker_command(stripped[len("CMD ") :].strip())
 
     if not startup.entrypoint and not startup.cmd:
         return None
@@ -440,9 +442,7 @@ def _read_dockerfile_stage_bases(dockerfile: Optional[Path]) -> List[str]:
     if not stages:
         return []
 
-    alias_map = {
-        alias: index for index, (_base, alias) in enumerate(stages) if alias
-    }
+    alias_map = {alias: index for index, (_base, alias) in enumerate(stages) if alias}
 
     def resolve_stage_base(index: int, seen: Optional[set[str]] = None) -> str:
         base_ref = stages[index][0]
@@ -477,6 +477,58 @@ def _startup_argv(
     return fallback
 
 
+def generate_local_build_dockerfile_patches(
+    spec: SdkOverrideSpec,
+    compose_data: dict,
+    extension_dir: Path,
+) -> Dict[str, str]:
+    """Per-service patched Dockerfile content for the ``dev local`` build phase.
+
+    Returns ``{service_name: patched_dockerfile_source}`` for every backend
+    (Python) and frontend (TypeScript/Node) service whose Dockerfile
+    contains a recognizable install line. The caller is responsible for
+    plumbing each value into a compose override (via
+    ``build.dockerfile`` pointing at a temp file).
+
+    Required because the runtime overlay (``generate_compose_override``)
+    can only kick in once the image exists. When the scaffold's
+    runtime-lib pin is not yet published on the language's package
+    registry (PyPI / npm), the build's install step fails before any
+    runtime overlay runs, leaving the developer with a hard build error
+    and no path forward. The strip step inserted here makes each install
+    succeed without the pin; the runtime overlay then surfaces the local
+    source.
+
+    Returns an empty dict when no service has a recognizable install line
+    (e.g. a poetry-based custom Dockerfile, or a Node image that bakes
+    deps differently — those users are responsible for their own
+    runtime-lib install).
+    """
+    patches: Dict[str, str] = {}
+    for svc_name, svc_config in compose_data.get("services", {}).items():
+        if "build" not in svc_config:
+            continue
+        svc_runtime = detect_service_runtime(
+            svc_name, svc_config, extension_dir=extension_dir
+        )
+        if svc_runtime == "backend" and spec.python:
+            pattern = _PYTHON_PIP_INSTALL_PATTERN
+            strip_steps = _PYTHON_PRE_INSTALL_STRIP
+        elif svc_runtime == "frontend" and spec.typescript:
+            pattern = _TS_NPM_INSTALL_PATTERN
+            strip_steps = _TS_PRE_INSTALL_STRIP
+        else:
+            continue
+        df_path = _resolve_dockerfile(svc_config["build"], extension_dir)
+        if df_path is None or not df_path.exists():
+            continue
+        original = df_path.read_text()
+        patched = _insert_before_install_pattern(original, strip_steps, pattern)
+        if patched != original:
+            patches[svc_name] = patched
+    return patches
+
+
 def generate_compose_override(
     spec: SdkOverrideSpec,
     compose_data: dict,
@@ -503,7 +555,9 @@ def generate_compose_override(
             continue
 
         svc_type = detect_service_runtime(
-            svc_name, svc_config, extension_dir=extension_dir,
+            svc_name,
+            svc_config,
+            extension_dir=extension_dir,
         )
         svc_override: dict = {}
 
@@ -515,30 +569,30 @@ def generate_compose_override(
                 startup = _read_dockerfile_startup(df)
 
         if svc_type == "backend" and spec.python:
-            svc_override["volumes"] = [{
-                "type": "bind",
-                "source": str(spec.sdk_repo),
-                "target": "/sdk",
-                "read_only": True,
-            }]
-            exec_cmd = shlex.join(
-                _startup_argv(startup, _DEFAULT_BACKEND_STARTUP)
-            )
+            svc_override["volumes"] = [
+                {
+                    "type": "bind",
+                    "source": str(spec.sdk_repo),
+                    "target": "/sdk",
+                    "read_only": True,
+                }
+            ]
+            exec_cmd = shlex.join(_startup_argv(startup, _DEFAULT_BACKEND_STARTUP))
             svc_override["entrypoint"] = ["/bin/sh", "-c"]
             svc_override["command"] = [
                 _escape_compose_shell_vars(_PYTHON_LIB_COPY) + f" && exec {exec_cmd}"
             ]
 
         elif svc_type == "frontend" and spec.typescript:
-            svc_override["volumes"] = [{
-                "type": "bind",
-                "source": str(spec.sdk_repo),
-                "target": "/sdk",
-                "read_only": True,
-            }]
-            exec_cmd = shlex.join(
-                _startup_argv(startup, _DEFAULT_FRONTEND_STARTUP)
-            )
+            svc_override["volumes"] = [
+                {
+                    "type": "bind",
+                    "source": str(spec.sdk_repo),
+                    "target": "/sdk",
+                    "read_only": True,
+                }
+            ]
+            exec_cmd = shlex.join(_startup_argv(startup, _DEFAULT_FRONTEND_STARTUP))
             svc_override["entrypoint"] = ["/bin/sh", "-c"]
             svc_override["command"] = [
                 _escape_compose_shell_vars(_TS_LIB_INSTALL) + f" && exec {exec_cmd}"
@@ -563,6 +617,7 @@ class BuildOverride:
     overlay_steps: str  # Dockerfile lines appended/inserted into the original
     additional_build_contexts: Dict[str, str]
     insert_before_build: bool = False  # Insert before npm/next build line
+    pre_install_steps: str = ""  # Inserted before RUN pip install -r requirements.txt
 
 
 _PYTHON_OVERLAY = (
@@ -574,6 +629,66 @@ _PYTHON_OVERLAY = (
     ' && rm -rf "$SITE"'
     ' && cp -r /tmp/kamiwaza_extensions_lib "$SITE"'
     " && rm -rf /tmp/kamiwaza_extensions_lib\n"
+    "{restore_user_block}"
+)
+
+# Pattern that locates the standard scaffolded backend's pip install line so
+# the pre-install strip step can be inserted before it.
+_PYTHON_PIP_INSTALL_PATTERN = re.compile(
+    # ``\b-r`` would not match because ``-`` is non-word and the preceding
+    # space is also non-word, so the boundary doesn't apply. Use a literal
+    # space instead. Trailing ``\b`` is fine — boundary between ``t`` and
+    # newline / whitespace.
+    r"^\s*RUN\s+.*\bpip\s+install\b.*\s-r\s+requirements\.txt\b",
+    re.IGNORECASE,
+)
+
+# Pattern locating the frontend scaffold's npm install (``npm install`` or
+# ``npm ci``). Matched per-line; ``RUN npm install`` and ``RUN npm ci`` are
+# both accepted, optionally with flags before/after.
+_TS_NPM_INSTALL_PATTERN = re.compile(
+    r"^\s*RUN\s+.*\bnpm\s+(install|ci)\b", re.IGNORECASE
+)
+
+# Drops the ``kamiwaza-extensions-lib`` pin from requirements.txt before pip
+# install runs. The post-install ``_PYTHON_OVERLAY`` will copy the local
+# source into site-packages, so removing the pin avoids a hard failure when
+# the declared range isn't published yet (PR #89 dry-run finding F-002).
+# Word-boundary check on the package name so prefix-aliases like
+# ``kamiwaza-extensions-lib-extras`` are NOT stripped.
+_PYTHON_PRE_INSTALL_STRIP = (
+    "# --- SDK override: strip kamiwaza-extensions-lib from requirements.txt ---\n"
+    "# The post-install overlay below copies the local runtime-lib source into\n"
+    "# site-packages, so the PyPI install is redundant and would fail whenever\n"
+    "# the pinned version is not yet published. See sdk_override.py docs.\n"
+    "USER root\n"
+    "RUN sed -i -E '/^[[:space:]]*kamiwaza-extensions-lib($|[^A-Za-z0-9_-])/d'"
+    " requirements.txt\n"
+    "{restore_user_block}"
+)
+
+# Drops ``@kamiwaza-ai/extensions-lib`` from the three dependency maps in
+# package.json before ``npm install`` runs. The post-install ``_TS_OVERLAY``
+# (or local-mode bind-mount + npm install) ships the runtime lib via
+# ``npm pack``; removing the dep avoids a hard ETARGET failure when the
+# declared version range isn't on the npm registry yet (mirror of
+# ``_PYTHON_PRE_INSTALL_STRIP`` for the TS side).
+#
+# Implementation note: package.json is JSON, so a sed-line-strip would
+# leave dangling commas. Use ``node -e`` (always present in the frontend
+# image) to parse → mutate → write a structurally valid manifest.
+_TS_PRE_INSTALL_STRIP = (
+    "# --- SDK override: strip @kamiwaza-ai/extensions-lib from package.json ---\n"
+    "# The post-install overlay below installs the local runtime-lib source\n"
+    "# via ``npm pack``, so the registry install is redundant and would fail\n"
+    "# whenever the pinned version is not yet published.\n"
+    "USER root\n"
+    'RUN node -e "'
+    "const fs=require('fs');"
+    "const p=JSON.parse(fs.readFileSync('package.json','utf8'));"
+    "for(const k of ['dependencies','devDependencies','peerDependencies'])"
+    "{if(p[k])delete p[k]['@kamiwaza-ai/extensions-lib'];}"
+    "fs.writeFileSync('package.json', JSON.stringify(p,null,2)+'\\n');\"\n"
     "{restore_user_block}"
 )
 
@@ -614,23 +729,30 @@ def generate_build_overrides(
             continue
 
         svc_type = _detect_build_service_runtime(
-            svc_name, svc_config, extension_dir=extension_dir,
+            svc_name,
+            svc_config,
+            extension_dir=extension_dir,
         )
 
         if svc_type == "backend" and spec.python:
-            overrides.append(BuildOverride(
-                service_name=svc_name,
-                overlay_steps=_PYTHON_OVERLAY,
-                additional_build_contexts={"sdk": str(spec.sdk_repo)},
-            ))
+            overrides.append(
+                BuildOverride(
+                    service_name=svc_name,
+                    overlay_steps=_PYTHON_OVERLAY,
+                    additional_build_contexts={"sdk": str(spec.sdk_repo)},
+                    pre_install_steps=_PYTHON_PRE_INSTALL_STRIP,
+                )
+            )
 
         elif svc_type == "frontend" and spec.typescript:
-            overrides.append(BuildOverride(
-                service_name=svc_name,
-                overlay_steps=_TS_OVERLAY,
-                additional_build_contexts={"sdk": str(spec.sdk_repo)},
-                insert_before_build=True,
-            ))
+            overrides.append(
+                BuildOverride(
+                    service_name=svc_name,
+                    overlay_steps=_TS_OVERLAY,
+                    additional_build_contexts={"sdk": str(spec.sdk_repo)},
+                    insert_before_build=True,
+                )
+            )
 
     return overrides
 
@@ -638,10 +760,20 @@ def generate_build_overrides(
 def apply_build_overlay(dockerfile_content: str, overlay: BuildOverride) -> str:
     """Apply a build overlay to Dockerfile content.
 
-    If ``overlay.insert_before_build`` is True, scans for a ``RUN npm run build``
-    (or similar) line and inserts the overlay before it. Otherwise appends.
+    Two insertion points, applied in order:
+
+    1. ``pre_install_steps`` (Python backend) — inserted immediately before
+       the first ``RUN ... pip install -r requirements.txt`` line, so the
+       runtime-lib pin can be stripped before the install runs. No-op when
+       the Dockerfile has no matching pip-install line.
+    2. ``overlay_steps`` — inserted before a frontend build line when
+       ``insert_before_build`` is True; appended at end otherwise.
     """
-    lines = dockerfile_content.splitlines(keepends=True)
+    content = dockerfile_content
+    if overlay.pre_install_steps:
+        content = _insert_before_pip_install(content, overlay.pre_install_steps)
+
+    lines = content.splitlines(keepends=True)
     insert_idx = None
 
     if overlay.insert_before_build:
@@ -666,7 +798,54 @@ def apply_build_overlay(dockerfile_content: str, overlay: BuildOverride) -> str:
         )
 
     # No build line found or not insert_before_build — append at end
-    return dockerfile_content.rstrip() + "\n\n" + overlay_steps
+    return content.rstrip() + "\n\n" + overlay_steps
+
+
+def _insert_before_pip_install(dockerfile_content: str, pre_steps: str) -> str:
+    """Backend-specific shim around ``_insert_before_install_pattern``."""
+    return _insert_before_install_pattern(
+        dockerfile_content,
+        pre_steps,
+        _PYTHON_PIP_INSTALL_PATTERN,
+    )
+
+
+def _insert_before_install_pattern(
+    dockerfile_content: str,
+    pre_steps: str,
+    pattern: "re.Pattern[str]",
+) -> str:
+    """Insert ``pre_steps`` immediately before the first line matching
+    ``pattern`` (e.g. ``RUN pip install -r requirements.txt`` or
+    ``RUN npm install``). Returns the content unchanged when no such line
+    is present — the user's Dockerfile is then responsible for runtime-lib
+    install on its own, and the post-install overlay (if any) still
+    appends as before."""
+    lines = dockerfile_content.splitlines(keepends=True)
+    insert_idx = None
+    for i, line in enumerate(lines):
+        if pattern.match(line):
+            insert_idx = i
+            break
+    if insert_idx is None:
+        return dockerfile_content
+    pre_steps_resolved = pre_steps.replace(
+        "{restore_user_block}",
+        _restore_user_block(_find_active_user(lines[:insert_idx])),
+    )
+    # Ensure the inserted block starts on its own line and doesn't fuse with
+    # the preceding directive.
+    leading = (
+        "" if not lines[:insert_idx] or lines[insert_idx - 1].endswith("\n") else "\n"
+    )
+    trailing = "" if pre_steps_resolved.endswith("\n") else "\n"
+    return (
+        "".join(lines[:insert_idx])
+        + leading
+        + pre_steps_resolved
+        + trailing
+        + "".join(lines[insert_idx:])
+    )
 
 
 def _find_active_user(lines: List[str]) -> Optional[str]:
@@ -675,7 +854,7 @@ def _find_active_user(lines: List[str]) -> Optional[str]:
     for line in lines:
         stripped = line.strip()
         if stripped.startswith("USER "):
-            user = stripped[len("USER "):].strip()
+            user = stripped[len("USER ") :].strip()
             if user:
                 active_user = user
     return active_user

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -682,8 +682,9 @@ _PYTHON_PRE_INSTALL_STRIP = (
     "# site-packages, so the PyPI install is redundant and would fail whenever\n"
     "# the pinned version is not yet published. See sdk_override.py docs.\n"
     "USER root\n"
-    "RUN sed -i -E '/^[[:space:]]*kamiwaza-extensions-lib($|[^A-Za-z0-9_-])/d'"
-    " requirements.txt\n"
+    "RUN if [ -f requirements.txt ]; then"
+    " sed -i -E '/^[[:space:]]*kamiwaza-extensions-lib($|[^A-Za-z0-9_-])/d'"
+    " requirements.txt; fi\n"
     "{restore_user_block}"
 )
 
@@ -701,14 +702,23 @@ _TS_PRE_INSTALL_STRIP = (
     "# --- SDK override: strip @kamiwaza-ai/extensions-lib from package.json ---\n"
     "# The post-install overlay below installs the local runtime-lib source\n"
     "# via ``npm pack``, so the registry install is redundant and would fail\n"
-    "# whenever the pinned version is not yet published.\n"
+    "# whenever the pinned version is not yet published. Covers all five\n"
+    "# dependency-map keys plus ``overrides`` / ``resolutions`` so a pin in\n"
+    "# any of them won't survive the strip. Guarded with a file-exists check\n"
+    "# so non-canonical Dockerfile layouts (no package.json at WORKDIR) fail\n"
+    "# open instead of breaking the build.\n"
     "USER root\n"
-    'RUN node -e "'
+    'RUN if [ -f package.json ]; then node -e "'
     "const fs=require('fs');"
     "const p=JSON.parse(fs.readFileSync('package.json','utf8'));"
-    "for(const k of ['dependencies','devDependencies','peerDependencies'])"
-    "{if(p[k])delete p[k]['@kamiwaza-ai/extensions-lib'];}"
-    "fs.writeFileSync('package.json', JSON.stringify(p,null,2)+'\\n');\"\n"
+    "const N='@kamiwaza-ai/extensions-lib';"
+    "for(const k of ['dependencies','devDependencies','peerDependencies',"
+    "'optionalDependencies','bundleDependencies','bundledDependencies',"
+    "'overrides','resolutions'])"
+    "{if(p[k]&&typeof p[k]==='object'&&!Array.isArray(p[k]))delete p[k][N];"
+    " else if(Array.isArray(p[k]))p[k]=p[k].filter(x=>x!==N);}"
+    "fs.writeFileSync('package.json', JSON.stringify(p,null,2)+'\\n');\";"
+    " fi\n"
     "{restore_user_block}"
 )
 

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -521,7 +521,14 @@ def generate_local_build_dockerfile_patches(
     for svc_name, svc_config in compose_data.get("services", {}).items():
         if "build" not in svc_config:
             continue
-        svc_runtime = detect_service_runtime(
+        # Use the multi-stage-aware classifier (mirrors the cluster-deploy
+        # ``generate_build_overrides`` path) so a multi-stage
+        # ``FROM node … AS builder; FROM nginx:alpine`` frontend still
+        # receives the TS strip — its final base is ``nginx`` (which
+        # ``detect_service_runtime`` would tag as ``static``) but its
+        # builder stage is the one running ``npm ci`` against the
+        # unpublished pin (PR #91 round-3 reviewer H2 / Codex).
+        svc_runtime = _detect_build_service_runtime(
             svc_name, svc_config, extension_dir=extension_dir
         )
         if svc_runtime == "backend" and spec.python:
@@ -538,6 +545,16 @@ def generate_local_build_dockerfile_patches(
         original = df_path.read_text()
         patched = _insert_before_install_pattern(original, strip_steps, pattern)
         if patched != original:
+            # Mirror the cluster-deploy ``apply_build_overlay`` behavior:
+            # if the matched install line uses ``npm ci``, rewrite it to
+            # ``npm install`` so the package.json/lockfile divergence the
+            # strip creates doesn't abort the build (PR #91 round-3 H1 /
+            # Codex P2 — applies to local-dev path too, not just cluster
+            # deploy).
+            if pattern is _TS_NPM_INSTALL_PATTERN:
+                patched = _TS_NPM_CI_LINE_PATTERN.sub(
+                    r"\1npm install", patched
+                )
             patches[svc_name] = patched
     return patches
 

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -670,6 +670,19 @@ _TS_NPM_INSTALL_PATTERN = re.compile(
     r"^\s*RUN\s+.*\bnpm\s+(install|ci)\b", re.IGNORECASE
 )
 
+# Rewrites ``RUN ... npm ci ...`` to ``RUN ... npm install ...`` line-by-line.
+# Required because the TS pre-install strip mutates ``package.json`` while
+# leaving ``package-lock.json`` unchanged. ``npm ci`` enforces strict
+# package.json ↔ lockfile parity and aborts on any divergence; ``npm install``
+# consults the lockfile but tolerates mismatches and re-resolves. Local-build
+# overrides already break strict lockfile reproducibility (we swap in a
+# local source-built tarball at install time via ``_TS_OVERLAY``), so
+# accepting looser install semantics is consistent and necessary
+# (Codex P2 review on PR #91).
+_TS_NPM_CI_LINE_PATTERN = re.compile(
+    r"^(\s*RUN\s+.*\b)npm\s+ci\b", re.IGNORECASE | re.MULTILINE
+)
+
 # Drops the ``kamiwaza-extensions-lib`` pin from requirements.txt before pip
 # install runs. The post-install ``_PYTHON_OVERLAY`` will copy the local
 # source into site-packages, so removing the pin avoids a hard failure when
@@ -821,6 +834,14 @@ def apply_build_overlay(dockerfile_content: str, overlay: BuildOverride) -> str:
             )
             if new_content is not content:
                 content = new_content
+                # If the matched install line uses ``npm ci``, rewrite to
+                # ``npm install`` so the lockfile mismatch the strip step
+                # creates doesn't abort the build (Codex P2 review on
+                # PR #91). Safe even when no ``npm ci`` line is present.
+                if pattern is _TS_NPM_INSTALL_PATTERN:
+                    content = _TS_NPM_CI_LINE_PATTERN.sub(
+                        r"\1npm install", content
+                    )
                 break
 
     lines = content.splitlines(keepends=True)

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -688,12 +688,15 @@ _PYTHON_PRE_INSTALL_STRIP = (
     "{restore_user_block}"
 )
 
-# Drops ``@kamiwaza-ai/extensions-lib`` from the three dependency maps in
-# package.json before ``npm install`` runs. The post-install ``_TS_OVERLAY``
-# (or local-mode bind-mount + npm install) ships the runtime lib via
-# ``npm pack``; removing the dep avoids a hard ETARGET failure when the
-# declared version range isn't on the npm registry yet (mirror of
-# ``_PYTHON_PRE_INSTALL_STRIP`` for the TS side).
+# Drops ``@kamiwaza-ai/extensions-lib`` from every npm dependency-map
+# field (the three documented dep maps + ``optionalDependencies``,
+# ``bundleDependencies`` / ``bundledDependencies``, ``overrides``,
+# ``resolutions``) in package.json before ``npm install`` runs. The
+# post-install ``_TS_OVERLAY`` (or local-mode bind-mount + npm install)
+# ships the runtime lib via ``npm pack``; removing the dep avoids a
+# hard ETARGET failure when the declared version range isn't on the
+# npm registry yet (mirror of ``_PYTHON_PRE_INSTALL_STRIP`` for the TS
+# side).
 #
 # Implementation note: package.json is JSON, so a sed-line-strip would
 # leave dangling commas. Use ``node -e`` (always present in the frontend
@@ -846,15 +849,6 @@ def apply_build_overlay(dockerfile_content: str, overlay: BuildOverride) -> str:
 
     # No build line found or not insert_before_build — append at end
     return content.rstrip() + "\n\n" + overlay_steps
-
-
-def _insert_before_pip_install(dockerfile_content: str, pre_steps: str) -> str:
-    """Backend-specific shim around ``_insert_before_install_pattern``."""
-    return _insert_before_install_pattern(
-        dockerfile_content,
-        pre_steps,
-        _PYTHON_PIP_INSTALL_PATTERN,
-    )
 
 
 def _insert_before_install_pattern(

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -159,18 +159,31 @@ def validate_sdk_override(spec: SdkOverrideSpec) -> ValidationResult:
             result.warnings.append(
                 f"TypeScript dist/ missing — run: cd {spec.typescript_lib_path} && npm run build"
             )
-        else:
-            # Check staleness: is dist/ older than src/?
-            src_dir = spec.typescript_lib_path / "src"
-            if src_dir.is_dir():
-                dist_mtime = _newest_mtime(spec.typescript_dist_path)
-                src_mtime = _newest_mtime(src_dir)
-                if src_mtime > dist_mtime:
-                    result.warnings.append(
-                        "TypeScript dist/ may be stale (src/ is newer) — consider rebuilding"
-                    )
+        elif is_typescript_dist_stale(spec):
+            result.warnings.append(
+                "TypeScript dist/ is stale (src/ is newer) — will rebuild before bind-mount"
+            )
 
     return result
+
+
+def is_typescript_dist_stale(spec: SdkOverrideSpec) -> bool:
+    """Return True when ``dist/`` exists but is older than ``src/``.
+
+    Used as a trigger for ``build_typescript_lib`` in the ``dev local`` /
+    ``dev`` flows. Treats stale-dist the same as missing-dist: if the
+    developer asked us to bind-mount their local SDK, they want fresh
+    artifacts — anything else turns into a baffling "module not found"
+    at the consumer (e.g. dropped subpath exports between releases —
+    PR #87 → ``dist/local-dev-auth/`` was added to ``package.json``
+    but the dist/ wasn't rebuilt before merge).
+    """
+    if not spec.typescript_dist_path.is_dir():
+        return False
+    src_dir = spec.typescript_lib_path / "src"
+    if not src_dir.is_dir():
+        return False
+    return _newest_mtime(src_dir) > _newest_mtime(spec.typescript_dist_path)
 
 
 def _newest_mtime(directory: Path) -> float:

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -764,6 +764,13 @@ def generate_build_overrides(
                     overlay_steps=_TS_OVERLAY,
                     additional_build_contexts={"sdk": str(spec.sdk_repo)},
                     insert_before_build=True,
+                    # Mirror the backend's pre-install strip: drop
+                    # ``@kamiwaza-ai/extensions-lib`` from package.json
+                    # before ``npm install`` runs, otherwise the build
+                    # ETARGET-fails when the pinned version isn't on the
+                    # npm registry yet (ENG-3901 / F-002 round-2 — cluster
+                    # deploy hit the same wall as dev local).
+                    pre_install_steps=_TS_PRE_INSTALL_STRIP,
                 )
             )
 
@@ -775,16 +782,26 @@ def apply_build_overlay(dockerfile_content: str, overlay: BuildOverride) -> str:
 
     Two insertion points, applied in order:
 
-    1. ``pre_install_steps`` (Python backend) — inserted immediately before
-       the first ``RUN ... pip install -r requirements.txt`` line, so the
-       runtime-lib pin can be stripped before the install runs. No-op when
-       the Dockerfile has no matching pip-install line.
+    1. ``pre_install_steps`` — inserted immediately before the first
+       ``RUN ... pip install -r requirements.txt`` (Python) or
+       ``RUN npm install`` (TypeScript) line, so the runtime-lib pin can
+       be stripped before the install runs. No-op when the Dockerfile
+       has no matching install line.
     2. ``overlay_steps`` — inserted before a frontend build line when
        ``insert_before_build`` is True; appended at end otherwise.
     """
     content = dockerfile_content
     if overlay.pre_install_steps:
-        content = _insert_before_pip_install(content, overlay.pre_install_steps)
+        # Try Python pattern first, fall through to TS — the
+        # pre_install_steps content is language-specific but the
+        # insertion logic just needs to find the right line.
+        for pattern in (_PYTHON_PIP_INSTALL_PATTERN, _TS_NPM_INSTALL_PATTERN):
+            new_content = _insert_before_install_pattern(
+                content, overlay.pre_install_steps, pattern
+            )
+            if new_content is not content:
+                content = new_content
+                break
 
     lines = content.splitlines(keepends=True)
     insert_idx = None

--- a/kamiwaza_extensions/sdk_override.py
+++ b/kamiwaza_extensions/sdk_override.py
@@ -8,7 +8,7 @@ import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 from rich.console import Console
@@ -648,6 +648,16 @@ class BuildOverride:
     additional_build_contexts: Dict[str, str]
     insert_before_build: bool = False  # Insert before npm/next build line
     pre_install_steps: str = ""  # Inserted before RUN pip install -r requirements.txt
+    # Which install pattern ``apply_build_overlay`` should match for the
+    # ``pre_install_steps`` insert: "python" → ``RUN pip install -r
+    # requirements.txt``, "typescript" → ``RUN npm install`` / ``RUN npm
+    # ci``. None preserves the legacy "try both, Python first" behavior
+    # for callers that don't set it (Codex P2 review on PR #91 round-4 —
+    # without explicit language tagging, a frontend Dockerfile that also
+    # runs ``pip install`` for build tooling would have the TS strip
+    # inserted before the pip line, which is a no-op there because
+    # ``package.json`` hasn't been copied yet).
+    language: Optional[str] = None
 
 
 _PYTHON_OVERLAY = (
@@ -804,6 +814,7 @@ def generate_build_overrides(
                     overlay_steps=_PYTHON_OVERLAY,
                     additional_build_contexts={"sdk": str(spec.sdk_repo)},
                     pre_install_steps=_PYTHON_PRE_INSTALL_STRIP,
+                    language="python",
                 )
             )
 
@@ -821,6 +832,7 @@ def generate_build_overrides(
                     # npm registry yet (ENG-3901 / F-002 round-2 — cluster
                     # deploy hit the same wall as dev local).
                     pre_install_steps=_TS_PRE_INSTALL_STRIP,
+                    language="typescript",
                 )
             )
 
@@ -842,10 +854,22 @@ def apply_build_overlay(dockerfile_content: str, overlay: BuildOverride) -> str:
     """
     content = dockerfile_content
     if overlay.pre_install_steps:
-        # Try Python pattern first, fall through to TS — the
-        # pre_install_steps content is language-specific but the
-        # insertion logic just needs to find the right line.
-        for pattern in (_PYTHON_PIP_INSTALL_PATTERN, _TS_NPM_INSTALL_PATTERN):
+        # Pick the install pattern based on the overlay's declared
+        # language. A frontend Dockerfile that also runs ``pip install``
+        # for build tooling would otherwise have the TS strip inserted
+        # before the pip line (no-op, because package.json hasn't been
+        # copied yet) and the actual ``npm install`` would still hit the
+        # unstripped pin (Codex P2 review on PR #91 round-4).
+        if overlay.language == "python":
+            patterns: Tuple["re.Pattern[str]", ...] = (_PYTHON_PIP_INSTALL_PATTERN,)
+        elif overlay.language == "typescript":
+            patterns = (_TS_NPM_INSTALL_PATTERN,)
+        else:
+            # Legacy fallback for callers that don't declare a language —
+            # try Python first, fall through to TS. Same behavior as
+            # before round-4.
+            patterns = (_PYTHON_PIP_INSTALL_PATTERN, _TS_NPM_INSTALL_PATTERN)
+        for pattern in patterns:
             new_content = _insert_before_install_pattern(
                 content, overlay.pre_install_steps, pattern
             )

--- a/kamiwaza_extensions/templates/tool/src/server.py
+++ b/kamiwaza_extensions/templates/tool/src/server.py
@@ -2,7 +2,12 @@
 
 from mcp.server.fastmcp import FastMCP
 
-mcp = FastMCP("{{name}}")
+# host/port are FastMCP constructor kwargs, not run() arguments. The default
+# ``host="127.0.0.1"`` only listens on the loopback interface — unreachable
+# from outside the container — so we must override with ``0.0.0.0`` here.
+# (Earlier scaffolds passed host/port to ``run()`` which is a TypeError on
+# the current FastMCP API; ENG-3901 dry-run F-014.)
+mcp = FastMCP("{{name}}", host="0.0.0.0", port=8000)
 
 
 @mcp.tool()
@@ -12,4 +17,4 @@ def hello(name: str = "world") -> str:
 
 
 if __name__ == "__main__":
-    mcp.run(transport="sse", host="0.0.0.0", port=8000)
+    mcp.run(transport="sse")

--- a/tests/e2e/scenarios/runbooks/s1-user-facing-app-with-forced-login.yaml
+++ b/tests/e2e/scenarios/runbooks/s1-user-facing-app-with-forced-login.yaml
@@ -11,7 +11,7 @@ prd_ref: "PRD §EDX-E2E-1 / Appendix A Scenario 1"
 
 steps:
   - name: scaffold_app
-    description: "kz-ext create --shape app generates an `app` scaffold with USE_AUTH=true and the forced-login middleware wired into frontend/src/middleware.ts."
+    description: "kz-ext create --type app generates an `app` scaffold with USE_AUTH=true and the forced-login middleware wired into frontend/src/middleware.ts."
   - name: dev_local_with_auth_bridge
     description: "kz-ext dev local --auth boots backend+frontend; the local-dev auth middleware bridges browser → kamiwaza identity (cookies + ForwardAuth-equivalent headers)."
   - name: assert_unauthenticated_redirects_to_login

--- a/tests/e2e/scenarios/runbooks/s2-workroom-manager-launch.yaml
+++ b/tests/e2e/scenarios/runbooks/s2-workroom-manager-launch.yaml
@@ -13,7 +13,7 @@ notes: |
 
 steps:
   - name: scaffold_app
-    description: "kz-ext create --shape app; deploy via kz-ext dev to staging."
+    description: "kz-ext create --type app; deploy via kz-ext dev to staging."
   - name: assert_workroom_scoped_identity_headers
     description: "Stub a Workroom Manager-style invocation that injects X-Workroom-Id; assert the backend resolves the workroom-scoped identity (UAC-9c)."
   - name: assert_global_workroom_sentinel_handling

--- a/tests/e2e/scenarios/runbooks/s3-operator-deployable-connector.yaml
+++ b/tests/e2e/scenarios/runbooks/s3-operator-deployable-connector.yaml
@@ -10,10 +10,10 @@ uacs:
 prd_ref: "PRD §EDX-E2E-1 / Appendix A Scenario 3"
 
 steps:
-  - name: scaffold_service_shape
-    description: "kz-ext create --shape service generates a connector scaffold (no frontend); template manifest includes service-specific files."
+  - name: scaffold_service
+    description: "kz-ext create --type service generates a connector scaffold (no frontend); template manifest includes service-specific files."
   - name: validate_connector_contract
-    description: "kz-ext validate passes; the Extension CR declares the service correctly (no app-shape leakage)."
+    description: "kz-ext validate passes; the Extension CR declares the service correctly (no app-type leakage)."
   - name: deploy_with_operator_credentials
     description: "Operator (not end-user) deploys the connector via kz-ext dev; OperatorImagePin keeps the operator on a known-published tag."
   - name: invoke_with_authenticated_user_identity

--- a/tests/e2e/scenarios/runbooks/s4-data-type-conversion-tool-via-kaizen.yaml
+++ b/tests/e2e/scenarios/runbooks/s4-data-type-conversion-tool-via-kaizen.yaml
@@ -7,8 +7,8 @@ uacs:
 prd_ref: "PRD §EDX-E2E-1 / Appendix A Scenario 4"
 
 steps:
-  - name: scaffold_tool_shape
-    description: "kz-ext create --shape tool produces a tool scaffold with MCP server registration + tool manifest."
+  - name: scaffold_tool
+    description: "kz-ext create --type tool produces a tool scaffold with MCP server registration + tool manifest."
   - name: implement_minimal_conversion
     description: "Implement a trivial data-type conversion (e.g. CSV → JSON) inside the tool body. No platform plumbing required."
   - name: deploy_and_register_with_kaizen

--- a/tests/e2e/scenarios/runbooks/s5-data-enrichment-context-graph.yaml
+++ b/tests/e2e/scenarios/runbooks/s5-data-enrichment-context-graph.yaml
@@ -14,7 +14,7 @@ notes: |
 
 steps:
   - name: scaffold_enrichment_app
-    description: "kz-ext create --shape app for an enrichment workflow; declare the data-boundary (workroom + file context graph) in the extension config."
+    description: "kz-ext create --type app for an enrichment workflow; declare the data-boundary (workroom + file context graph) in the extension config."
   - name: deploy_to_cluster
     description: "kz-ext dev deploys; cluster_extension_readiness probe green."
   - name: invoke_with_in_boundary_file

--- a/tests/unit/extensions/test_cli_polish_bundle.py
+++ b/tests/unit/extensions/test_cli_polish_bundle.py
@@ -26,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 # when the cwd is non-empty (TS-M2-43, TS-M2-44).
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.extension_regression
 class TestCreateIntoNamedSubdir:
     @pytest.fixture
@@ -84,6 +85,7 @@ class TestCreateIntoNamedSubdir:
 # work for one release.
 # ---------------------------------------------------------------------------
 
+
 class TestPublishProfileListSubcommand:
     def test_list_as_first_argument_routes_to_list(self, tmp_path, monkeypatch, capsys):
         from kamiwaza_extensions.commands import config as config_cmd
@@ -124,9 +126,9 @@ DEV_GUIDE_PATH = REPO_ROOT / "docs" / "extensions" / "developer-guide.md"
 class TestDeveloperGuide:
     @pytest.fixture(scope="class")
     def text(self) -> str:
-        assert DEV_GUIDE_PATH.exists(), (
-            f"Expected developer guide at {DEV_GUIDE_PATH.relative_to(REPO_ROOT)}"
-        )
+        assert (
+            DEV_GUIDE_PATH.exists()
+        ), f"Expected developer guide at {DEV_GUIDE_PATH.relative_to(REPO_ROOT)}"
         return DEV_GUIDE_PATH.read_text()
 
     def test_has_what_runs_where_section(self, text):
@@ -151,3 +153,84 @@ class TestDeveloperGuide:
             "Developer Guide must mention .ai/extensions/ (P7 §4.8) as the "
             "author-facing AI-context entry point."
         )
+
+
+# ---------------------------------------------------------------------------
+# F-005 / F-007: kz-ext create next-steps banner suggests the right
+# follow-up command for the extension type and warns about the auto-
+# assigned host port. (ENG-3901 dry-run findings.)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBanner:
+    """The banner printed after ``kz-ext create`` is the very first
+    instruction a developer reads. F-005: for app-type extensions the
+    suggested follow-up is ``kz-ext dev local --auth`` (without ``--auth``
+    they hit the platform login UI by surprise). F-007: the banner must
+    call out the auto-assigned host port so the developer doesn't open
+    localhost:3000 by instinct (which is the platform UI on a sibling
+    install)."""
+
+    @pytest.fixture
+    def banner_lines(self):
+        from io import StringIO
+
+        from rich.console import Console
+
+        from kamiwaza_extensions.commands import create as create_cmd
+
+        def render(type_: str, name: str = "x") -> list[str]:
+            buf = StringIO()
+            captured = Console(file=buf, force_terminal=False, no_color=True, width=120)
+            # Patch the module's console (banner output) and the
+            # Scaffolder.create that run_create calls into. The
+            # Scaffolder is imported lazily inside run_create, so the
+            # patch target is its module path.
+            with (
+                patch.object(create_cmd, "console", captured),
+                patch(
+                    "kamiwaza_extensions.scaffolder.Scaffolder.create",
+                    lambda self, **kw: None,
+                ),
+            ):
+                create_cmd.run_create(type_=type_, name=name)
+            return buf.getvalue().splitlines()
+
+        return render
+
+    def test_app_type_suggests_dev_local_with_auth(self, banner_lines):
+        lines = banner_lines("app")
+        joined = "\n".join(lines)
+        assert (
+            "kz-ext dev local --auth" in joined
+        ), f"app banner should suggest --auth (F-005); got:\n{joined}"
+
+    def test_tool_type_suggests_plain_dev_local(self, banner_lines):
+        lines = banner_lines("tool")
+        joined = "\n".join(lines)
+        assert "kz-ext dev local" in joined
+        # Tools have no Next.js layer, so --auth doesn't apply.
+        assert (
+            "kz-ext dev local --auth" not in joined
+        ), f"tool banner must NOT suggest --auth; got:\n{joined}"
+
+    def test_service_type_suggests_plain_dev_local(self, banner_lines):
+        lines = banner_lines("service")
+        joined = "\n".join(lines)
+        assert "kz-ext dev local" in joined
+        assert (
+            "kz-ext dev local --auth" not in joined
+        ), f"service banner must NOT suggest --auth; got:\n{joined}"
+
+    def test_banner_warns_about_auto_assigned_host_port(self, banner_lines):
+        """F-007: developers instinctively go to localhost:3000 (which is
+        the platform UI on a sibling install) instead of the auto-assigned
+        port the scaffold actually binds. The banner must tell them to
+        watch the kz-ext dev local output for the real URL."""
+        for type_ in ("app", "tool", "service"):
+            lines = banner_lines(type_)
+            joined = "\n".join(lines).lower()
+            assert "auto-assigned" in joined or "host port" in joined, (
+                f"{type_} banner must mention the auto-assigned host port "
+                f"(F-007); got:\n{joined}"
+            )

--- a/tests/unit/extensions/test_compatibility_bundle.py
+++ b/tests/unit/extensions/test_compatibility_bundle.py
@@ -21,10 +21,10 @@ import pytest
 
 from kamiwaza_extensions.doctor import DoctorChecker
 
-
 # ---------------------------------------------------------------------------
 # TS-M2-37: bundle is shipped with the package and is well-formed.
 # ---------------------------------------------------------------------------
+
 
 class TestCompatibilityBundleResource:
     """The bundle is imported as a package resource so it works whether the
@@ -65,25 +65,24 @@ class TestCompatibilityBundleResource:
         packaging drift."""
         from pathlib import Path
 
-        pyproject_path = (
-            Path(__file__).resolve().parents[3] / "pyproject.toml"
-        )
+        pyproject_path = Path(__file__).resolve().parents[3] / "pyproject.toml"
         text = pyproject_path.read_text()
         # Find the package-data section for kamiwaza_extensions and verify
         # compatibility.json is listed. We do a coarse string check (no full
         # TOML parse) to keep this independent of the toml stdlib version.
         kw_line = next(
             (
-                line for line in text.splitlines()
+                line
+                for line in text.splitlines()
                 if line.lstrip().startswith("kamiwaza_extensions ")
                 and "=" in line
                 and "templates" in line  # disambiguate from the "lib" entry
             ),
             None,
         )
-        assert kw_line is not None, (
-            "kamiwaza_extensions package-data entry not found in pyproject.toml"
-        )
+        assert (
+            kw_line is not None
+        ), "kamiwaza_extensions package-data entry not found in pyproject.toml"
         assert "compatibility.json" in kw_line, (
             f"compatibility.json missing from kamiwaza_extensions package-data:\n"
             f"  {kw_line}\n"
@@ -97,7 +96,9 @@ class TestCompatibilityBundleResource:
         # commas) for AND between bounds — a comma here makes
         # ``npm install`` fail to parse the spec. The earlier loose
         # "non-empty string" check let the bug ship.
-        ts_range = bundle["runtime_lib_compat"]["typescript"]["@kamiwaza-ai/extensions-lib"]
+        ts_range = bundle["runtime_lib_compat"]["typescript"][
+            "@kamiwaza-ai/extensions-lib"
+        ]
         assert isinstance(ts_range, str) and len(ts_range) > 0
         assert "," not in ts_range, (
             f"TS runtime-lib range {ts_range!r} uses comma syntax — npm semver "
@@ -123,6 +124,7 @@ class TestCompatibilityBundleResource:
 # ---------------------------------------------------------------------------
 # TS-M2-38: Python runtime-lib version probe + warn on out-of-range.
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.extension_regression
 class TestPythonRuntimeLibCheck:
@@ -152,6 +154,36 @@ class TestPythonRuntimeLibCheck:
         req.write_text("fastapi>=0.100\n")
         result = checker._check_python_runtime_lib(req)
         assert result.status == "warn"
+
+    def test_missing_runtime_lib_hint_mentions_cli_version(self, checker, tmp_path):
+        """ENG-3901 / F-003: a developer hitting the "kamiwaza-extensions-lib
+        not found" hint may have a stale ``kz-ext`` install whose bundled
+        compat range is no longer accurate. The fix hint must surface the
+        CLI version and tell them to upgrade kz-ext if it looks stale,
+        not just mechanically apply whatever the (possibly stale) range says."""
+        from kamiwaza_extensions import __version__
+
+        req = tmp_path / "requirements.txt"
+        req.write_text("fastapi>=0.100\n")
+        result = checker._check_python_runtime_lib(req)
+        assert result.fix is not None
+        assert (
+            __version__ in result.fix
+        ), f"hint should include kz-ext version {__version__}; got: {result.fix}"
+        assert "upgrade" in result.fix.lower()
+
+    def test_out_of_range_hint_mentions_cli_version(self, checker, tmp_path):
+        """Same as above but for the out-of-range path: the suggested
+        update target is computed from this CLI's bundled range; the
+        developer needs to know whether to trust it."""
+        from kamiwaza_extensions import __version__
+
+        req = tmp_path / "requirements.txt"
+        req.write_text("kamiwaza-extensions-lib==0.1.0\n")
+        result = checker._check_python_runtime_lib(req)
+        assert result.fix is not None
+        assert __version__ in result.fix
+        assert "upgrade" in result.fix.lower()
 
     def test_prefix_alias_does_not_falsely_match(self, checker, tmp_path):
         """PR-86 H7 — `kamiwaza-extensions-lib-extras` must NOT match the
@@ -194,10 +226,10 @@ class TestPythonRuntimeLibCheck:
     @pytest.mark.parametrize(
         "spec",
         [
-            "kamiwaza-extensions-lib>=0.4",        # bare lower, unbounded above
-            "kamiwaza-extensions-lib~=0.4",        # ~=0.4 = >=0.4,<1.0 (admits 0.5+)
-            "kamiwaza-extensions-lib>0.4",         # strict lower, no upper
-            "kamiwaza-extensions-lib>=0.4,<0.6",   # upper above supported's 0.5
+            "kamiwaza-extensions-lib>=0.4",  # bare lower, unbounded above
+            "kamiwaza-extensions-lib~=0.4",  # ~=0.4 = >=0.4,<1.0 (admits 0.5+)
+            "kamiwaza-extensions-lib>0.4",  # strict lower, no upper
+            "kamiwaza-extensions-lib>=0.4,<0.6",  # upper above supported's 0.5
         ],
     )
     def test_open_ended_or_too_wide_specs_warn(self, checker, tmp_path, spec):
@@ -225,7 +257,7 @@ class TestPythonRuntimeLibCheck:
             ("kamiwaza-extensions-lib~=0.3.0", "warn"),  # >=0.3.0,<0.4 — below floor
             ("kamiwaza-extensions-lib~=0.2.0", "warn"),  # >=0.2.0,<0.3 — below floor
             # X.Y form expands to <(X+1), still warns: admits 0.5+.
-            ("kamiwaza-extensions-lib~=0.4",   "warn"),  # >=0.4,<1.0 — too wide
+            ("kamiwaza-extensions-lib~=0.4", "warn"),  # >=0.4,<1.0 — too wide
         ],
     )
     def test_tilde_eq_upper_bound_derived(self, checker, tmp_path, spec, expected):
@@ -271,6 +303,7 @@ class TestPythonRuntimeLibCheck:
 # TS-M2-39: TypeScript runtime-lib version probe + warn on out-of-range.
 # ---------------------------------------------------------------------------
 
+
 class TestTypeScriptRuntimeLibCheck:
     @pytest.fixture
     def checker(self, tmp_path):
@@ -278,17 +311,25 @@ class TestTypeScriptRuntimeLibCheck:
 
     def test_in_range_dependency_passes(self, checker, tmp_path):
         pkg = tmp_path / "package.json"
-        pkg.write_text(json.dumps({
-            "dependencies": {"@kamiwaza-ai/extensions-lib": "^0.4.0"},
-        }))
+        pkg.write_text(
+            json.dumps(
+                {
+                    "dependencies": {"@kamiwaza-ai/extensions-lib": "^0.4.0"},
+                }
+            )
+        )
         result = checker._check_ts_runtime_lib(pkg)
         assert result.status == "pass"
 
     def test_out_of_range_dependency_warns(self, checker, tmp_path):
         pkg = tmp_path / "package.json"
-        pkg.write_text(json.dumps({
-            "dependencies": {"@kamiwaza-ai/extensions-lib": "0.1.5"},
-        }))
+        pkg.write_text(
+            json.dumps(
+                {
+                    "dependencies": {"@kamiwaza-ai/extensions-lib": "0.1.5"},
+                }
+            )
+        )
         result = checker._check_ts_runtime_lib(pkg)
         assert result.status == "warn"
 
@@ -301,20 +342,28 @@ class TestTypeScriptRuntimeLibCheck:
     @pytest.mark.parametrize(
         "spec,expected",
         [
-            (">=0.4", "warn"),         # bare lower, unbounded above
-            (">0.4", "warn"),          # strict lower, no upper
-            (">=0.4,<0.6", "warn"),    # upper above supported's 0.5
-            ("*", "warn"),             # any-version
-            ("^0.2.0", "warn"),        # caret 0.2 below supported floor
-            ("^0.3.0", "warn"),        # caret 0.3 below supported floor (PR #87 round-6 codex P2)
-            ("~0.3.0", "warn"),        # tilde 0.3 below supported floor
-            ("^0.4.0", "pass"),        # caret 0.4.0 = >=0.4.0,<0.5.0 ⊂ supported (ENG-4318 release)
-            ("~0.4.0", "pass"),        # tilde 0.4.0 = >=0.4.0,<0.5.0 ⊂ supported
-            ("0.3.5", "warn"),         # exact pin below supported floor
-            ("0.4.0", "pass"),         # exact pin in window
+            (">=0.4", "warn"),  # bare lower, unbounded above
+            (">0.4", "warn"),  # strict lower, no upper
+            (">=0.4,<0.6", "warn"),  # upper above supported's 0.5
+            ("*", "warn"),  # any-version
+            ("^0.2.0", "warn"),  # caret 0.2 below supported floor
+            (
+                "^0.3.0",
+                "warn",
+            ),  # caret 0.3 below supported floor (PR #87 round-6 codex P2)
+            ("~0.3.0", "warn"),  # tilde 0.3 below supported floor
+            (
+                "^0.4.0",
+                "pass",
+            ),  # caret 0.4.0 = >=0.4.0,<0.5.0 ⊂ supported (ENG-4318 release)
+            ("~0.4.0", "pass"),  # tilde 0.4.0 = >=0.4.0,<0.5.0 ⊂ supported
+            ("0.3.5", "warn"),  # exact pin below supported floor
+            ("0.4.0", "pass"),  # exact pin in window
         ],
     )
-    def test_full_containment_check_for_npm_specs(self, checker, tmp_path, spec, expected):
+    def test_full_containment_check_for_npm_specs(
+        self, checker, tmp_path, spec, expected
+    ):
         """Round-4 H3 — TS check uses full-containment (was: lower-only
         probe). Open-ended specs (no upper, or upper above the supported
         ceiling) warn. Caret/tilde/exact specs that are fully contained
@@ -327,9 +376,13 @@ class TestTypeScriptRuntimeLibCheck:
         features and to stay on the supported window).
         """
         pkg = tmp_path / "package.json"
-        pkg.write_text(json.dumps({
-            "dependencies": {"@kamiwaza-ai/extensions-lib": spec},
-        }))
+        pkg.write_text(
+            json.dumps(
+                {
+                    "dependencies": {"@kamiwaza-ai/extensions-lib": spec},
+                }
+            )
+        )
         result = checker._check_ts_runtime_lib(pkg)
         assert result.status == expected, (
             f"declared {spec!r} expected={expected} actual={result.status} "
@@ -356,9 +409,13 @@ class TestTypeScriptRuntimeLibCheck:
             "treats this as invalid syntax."
         )
         pkg = tmp_path / "package.json"
-        pkg.write_text(json.dumps({
-            "dependencies": {"@kamiwaza-ai/extensions-lib": rendered_value},
-        }))
+        pkg.write_text(
+            json.dumps(
+                {
+                    "dependencies": {"@kamiwaza-ai/extensions-lib": rendered_value},
+                }
+            )
+        )
         result = checker._check_ts_runtime_lib(pkg)
         assert result.status == "pass", (
             f"fresh scaffold TS pin {rendered_value!r} fails compat check; "
@@ -372,20 +429,29 @@ class TestTypeScriptRuntimeLibCheck:
 # detected (e.g. a Go-only extension).
 # ---------------------------------------------------------------------------
 
+
 class TestNeitherRuntimeLibPresent:
     @pytest.fixture
     def checker(self, tmp_path):
         return DoctorChecker(config_dir=tmp_path / ".kamiwaza")
 
-    def test_runtime_lib_check_skipped_when_no_files(self, checker, tmp_path, monkeypatch):
+    def test_runtime_lib_check_skipped_when_no_files(
+        self, checker, tmp_path, monkeypatch
+    ):
         # No requirements.txt, no package.json — a Go reference, say.
         # The bundle-aware check should produce zero results, not phantom
         # warnings.
         metadata = tmp_path / "kamiwaza.json"
-        metadata.write_text(json.dumps({
-            "name": "go-ext", "version": "0.1.0", "type": "tool",
-            "kz_ext_version": ">=0.11.0",
-        }))
+        metadata.write_text(
+            json.dumps(
+                {
+                    "name": "go-ext",
+                    "version": "0.1.0",
+                    "type": "tool",
+                    "kz_ext_version": ">=0.11.0",
+                }
+            )
+        )
         monkeypatch.chdir(tmp_path)
         results = checker._check_extension_context()
         # _check_cli_version always runs; runtime-lib checks should be absent.

--- a/tests/unit/extensions/test_dev_local.py
+++ b/tests/unit/extensions/test_dev_local.py
@@ -1054,6 +1054,129 @@ class TestHasBarePorts:
         assert runner._has_bare_ports(compose) is True
 
 
+@pytest.mark.unit
+class TestPollAndPrintUrls:
+    """The foreground URL-poll daemon thread (ENG-3901 / F-008) drives
+    ``docker compose port`` until every bare-port spec resolves and prints
+    each one. This test class exercises termination semantics, multi-port
+    keying (PR #91 Codex P3 / Claude High), and the threading.Event
+    stop-signal wiring (PR #91 round-2 review High).
+    """
+
+    def _runner(self):
+        from kamiwaza_extensions.dev_local import DevLocalRunner
+
+        return DevLocalRunner.__new__(DevLocalRunner)
+
+    def test_stop_event_set_immediately_returns_fast(self, monkeypatch):
+        """The runner's ``finally`` block sets the stop event before
+        unlinking compose override temp files. The polling thread must
+        wake from its initial 2s wait and exit promptly so the cleanup
+        doesn't race the next ``docker compose port`` call against
+        already-deleted ``-f`` paths."""
+        import threading
+        import time as _time
+
+        runner = self._runner()
+        compose = {"services": {"frontend": {"ports": ["3000"]}}}
+        stop = threading.Event()
+        stop.set()
+
+        # Track whether _docker_compose_port was ever called — it must
+        # not be (the thread should exit during the initial wait).
+        port_calls: list = []
+        monkeypatch.setattr(
+            runner,
+            "_docker_compose_port",
+            lambda *a, **kw: port_calls.append((a, kw)) or 12345,
+        )
+
+        t0 = _time.monotonic()
+        runner._poll_and_print_urls(
+            compose, ["docker", "compose"], "/tmp/x", stop_event=stop
+        )
+        elapsed = _time.monotonic() - t0
+        assert elapsed < 0.5, f"poll didn't fast-exit: {elapsed:.2f}s"
+        assert port_calls == []
+
+    def test_multi_port_service_prints_every_url_and_terminates(self, monkeypatch):
+        """A frontend exposing both 3000 (Next.js) and 4173 (HMR) should
+        get TWO URLs printed, not one — and the loop must terminate as
+        soon as both are resolved, not spin to the 60s deadline."""
+        import threading
+        from kamiwaza_extensions import dev_local
+
+        runner = self._runner()
+        compose = {"services": {"frontend": {"ports": ["3000", "4173"]}}}
+        stop = threading.Event()
+
+        # Skip the 2s initial wait so the test runs fast.
+        monkeypatch.setattr(
+            "kamiwaza_extensions.dev_local.threading.Event.wait",
+            lambda self, _t=None: False,
+        )
+        # Resolve both ports immediately on the first iteration.
+        port_results = {3000: 32001, 4173: 32002}
+        monkeypatch.setattr(
+            runner,
+            "_docker_compose_port",
+            lambda svc, port, **kw: port_results.get(port),
+        )
+
+        printed: list = []
+        monkeypatch.setattr(
+            dev_local.console, "print", lambda *a, **kw: printed.append(a)
+        )
+
+        runner._poll_and_print_urls(
+            compose, ["docker", "compose"], "/tmp/x", stop_event=stop
+        )
+        # Both URLs printed exactly once each.
+        urls = " ".join(str(args) for args in printed)
+        assert "32001" in urls and "32002" in urls
+        assert urls.count("frontend:") == 2
+
+    def test_duplicate_bare_port_specs_do_not_spin_loop(self, monkeypatch):
+        """A duplicate bare-port spec like ``ports: ["3000", "3000"]``
+        is technically illegal compose but valid YAML. Without dedupe,
+        the completion check stayed permanently true (printed has one
+        unique key, services_with_bare_ports has two duplicates) and
+        the loop spun until the 60s deadline. With dedupe it terminates
+        the moment the single URL is resolved (PR #91 round-3 / Claude
+        review)."""
+        import threading
+        from kamiwaza_extensions import dev_local
+
+        runner = self._runner()
+        compose = {"services": {"frontend": {"ports": ["3000", "3000"]}}}
+        stop = threading.Event()
+
+        monkeypatch.setattr(
+            "kamiwaza_extensions.dev_local.threading.Event.wait",
+            lambda self, _t=None: False,
+        )
+        sleeps: list = []
+        monkeypatch.setattr(
+            "kamiwaza_extensions.dev_local.time.sleep",
+            lambda s: sleeps.append(s),
+        )
+        monkeypatch.setattr(
+            runner, "_docker_compose_port", lambda svc, port, **kw: 32001
+        )
+        monkeypatch.setattr(dev_local.console, "print", lambda *a, **kw: None)
+
+        runner._poll_and_print_urls(
+            compose, ["docker", "compose"], "/tmp/x", stop_event=stop
+        )
+        # Loop terminated after one iteration because dedupe collapsed
+        # the two specs to one. Without dedupe it would have hit the
+        # 1.5s sleep (or wait) and re-iterated.
+        assert sleeps == [], (
+            "loop should not have slept once duplicates were collapsed; "
+            f"got sleeps={sleeps}"
+        )
+
+
 class TestPrintUrlsBarePort:
     """ENG-3889 P2 + review PR #84 Critical #3 — bare-port URL discovery
     must work in both pre-up and post-up modes. The pre-up mode runs

--- a/tests/unit/extensions/test_dev_local.py
+++ b/tests/unit/extensions/test_dev_local.py
@@ -4,7 +4,7 @@ Extension detection and compose file discovery tests moved to
 test_extension_detector.py (shared ExtensionDetector module).
 """
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -30,7 +30,9 @@ class TestEnvOverlay:
         # can build ``${base}/auth/login`` correctly. Previous round-2
         # behavior stripped ``/api`` here, breaking login redirects
         # under ``--auth`` (codex P2).
-        conn = ConnectionInfo(name="test", url="https://example.com/api", active=True, created_at=0.0)
+        conn = ConnectionInfo(
+            name="test", url="https://example.com/api", active=True, created_at=0.0
+        )
         overlay = build_env_overlay(conn, "my-app")
         assert overlay["KAMIWAZA_API_URL"] == "https://example.com/api"
         assert overlay["KAMIWAZA_PUBLIC_API_URL"] == "https://example.com/api"
@@ -38,7 +40,9 @@ class TestEnvOverlay:
         assert overlay["KAMIWAZA_APP_NAME"] == "my-app"
 
     def test_overlay_without_api_in_url(self):
-        conn = ConnectionInfo(name="test", url="https://example.com", active=True, created_at=0.0)
+        conn = ConnectionInfo(
+            name="test", url="https://example.com", active=True, created_at=0.0
+        )
         overlay = build_env_overlay(conn, "my-app")
         assert overlay["KAMIWAZA_PUBLIC_API_URL"] == "https://example.com"
 
@@ -50,10 +54,15 @@ class TestEnvOverlay:
         demand and that helper has its own mid-path-safe regression
         coverage in ``test_url.py``."""
         conn = ConnectionInfo(
-            name="test", url="https://example.com/api-gateway/api", active=True, created_at=0.0
+            name="test",
+            url="https://example.com/api-gateway/api",
+            active=True,
+            created_at=0.0,
         )
         overlay = build_env_overlay(conn, "my-app")
-        assert overlay["KAMIWAZA_PUBLIC_API_URL"] == "https://example.com/api-gateway/api"
+        assert (
+            overlay["KAMIWAZA_PUBLIC_API_URL"] == "https://example.com/api-gateway/api"
+        )
 
     def test_auth_false_preserves_current_behaviour(self):
         # TS-5 — auth=False is the existing path; no gate, no bearer, USE_AUTH=false
@@ -105,10 +114,7 @@ class TestEnvOverlay:
         overlay = build_env_overlay(conn, "my-app", auth=True, bridge=bridge)
         # Container-side: rewritten so backend can reach the host.
         assert overlay["KAMIWAZA_API_URL"] == "http://host.docker.internal:8000/api"
-        assert (
-            overlay["KAMIWAZA_ENDPOINT"]
-            == "http://host.docker.internal:8000/api/v1"
-        )
+        assert overlay["KAMIWAZA_ENDPOINT"] == "http://host.docker.internal:8000/api/v1"
         # Browser-side: NEVER rewritten — host.docker.internal isn't
         # resolvable from the developer's browser. Round-10: keeps the
         # ``/api`` suffix so session.py's login/logout URLs are correct.
@@ -143,7 +149,9 @@ class TestEnvOverlay:
         # name or /auth/login-url + /auth/logout redirect to a host the
         # browser cannot resolve.
         bridge = BridgeContext(
-            bearer_token="t", user_id="user-1", expires_at=None,
+            bearer_token="t",
+            user_id="user-1",
+            expires_at=None,
         )
         for original_url in [
             "http://localhost:8000/api",
@@ -158,7 +166,10 @@ class TestEnvOverlay:
                 created_at=0.0,
             )
             overlay = build_env_overlay(
-                conn, "my-app", auth=True, bridge=bridge,
+                conn,
+                "my-app",
+                auth=True,
+                bridge=bridge,
             )
             # Container-side IS rewritten
             assert "host.docker.internal" in overlay["KAMIWAZA_API_URL"], (
@@ -192,10 +203,12 @@ class TestBuildComposeExtraHosts:
     def test_non_loopback_returns_empty_without_auth(self, monkeypatch):
         # TS-10 — auth=False (default)
         import socket as _socket
+
         # Round-11 (codex GH High): resolver switched from gethostbyname
         # (IPv4-only) to getaddrinfo (dual-stack); patch the new target.
         monkeypatch.setattr(
-            _socket, "getaddrinfo",
+            _socket,
+            "getaddrinfo",
             lambda *a, **kw: [(0, 0, 0, "", ("1.2.3.4", 0))],
         )
         conn = ConnectionInfo(
@@ -233,10 +246,12 @@ class TestBuildComposeExtraHosts:
         # host.docker.internal:host-gateway. Harmless on non-loopback
         # connections and keeps the contract consistent.
         import socket as _socket
+
         # Round-11 (codex GH High): resolver switched from gethostbyname
         # (IPv4-only) to getaddrinfo (dual-stack); patch the new target.
         monkeypatch.setattr(
-            _socket, "getaddrinfo",
+            _socket,
+            "getaddrinfo",
             lambda *a, **kw: [(0, 0, 0, "", ("1.2.3.4", 0))],
         )
         conn = ConnectionInfo(
@@ -289,7 +304,10 @@ class TestPublicApiUrlConsistency:
         ]
         for url in cases:
             conn = ConnectionInfo(
-                name="t", url=url, active=True, created_at=0.0,
+                name="t",
+                url=url,
+                active=True,
+                created_at=0.0,
             )
             overlay = build_env_overlay(conn, "my-app")
             base = overlay["KAMIWAZA_PUBLIC_API_URL"]
@@ -365,6 +383,7 @@ class TestRunnerEnvPassthroughOverlay:
         )
 
         from kamiwaza_extensions import sdk_override as sdk_override_mod
+
         monkeypatch.setattr(
             dev_local_mod,
             "detect_compose_command",
@@ -419,12 +438,12 @@ class TestRunnerEnvPassthroughOverlay:
                 f"service {svc!r} environment must be a mapping (round-10 "
                 f"review Comprehensive H — list form interpolates `$`)"
             )
-            assert env_map.get("KZ_EXT_DEV_LOCAL_AUTH") == "1", (
-                f"service {svc!r} missing KZ_EXT_DEV_LOCAL_AUTH"
-            )
-            assert env_map.get("KAMIWAZA_BEARER_TOKEN") == "bearer-xyz", (
-                f"service {svc!r} missing KAMIWAZA_BEARER_TOKEN"
-            )
+            assert (
+                env_map.get("KZ_EXT_DEV_LOCAL_AUTH") == "1"
+            ), f"service {svc!r} missing KZ_EXT_DEV_LOCAL_AUTH"
+            assert (
+                env_map.get("KAMIWAZA_BEARER_TOKEN") == "bearer-xyz"
+            ), f"service {svc!r} missing KAMIWAZA_BEARER_TOKEN"
 
         # Round-3 review High #8 — assert the overlay path is present in
         # the compose argv. Generating the overlay but not referencing
@@ -435,9 +454,9 @@ class TestRunnerEnvPassthroughOverlay:
         auth_env_paths = [
             arg for arg in cmd if isinstance(arg, str) and "kz-auth-env-" in arg
         ]
-        assert auth_env_paths, (
-            f"auth-env overlay not wired into compose argv. cmd={cmd!r}"
-        )
+        assert (
+            auth_env_paths
+        ), f"auth-env overlay not wired into compose argv. cmd={cmd!r}"
         # And the preceding `-f` flag is what makes compose actually pick
         # the overlay up — assert the flag-arg pairing is correct.
         idx = cmd.index(auth_env_paths[0])
@@ -492,6 +511,7 @@ class TestRunnerEnvPassthroughOverlay:
         )
 
         from kamiwaza_extensions import sdk_override as sdk_override_mod
+
         monkeypatch.setattr(
             dev_local_mod,
             "detect_compose_command",
@@ -552,6 +572,7 @@ class TestRunnerEnvPassthroughOverlay:
         )
 
         from kamiwaza_extensions import sdk_override as sdk_override_mod
+
         monkeypatch.setattr(
             dev_local_mod,
             "detect_compose_command",
@@ -611,10 +632,10 @@ class TestRunnerAuthExtensionTypeGate:
         self, tmp_path, monkeypatch, metadata, expected_type_in_message
     ):
         import yaml as _yaml
-        from kamiwaza_extensions_lib.local_dev import LocalDevAuthError
 
         from kamiwaza_extensions import dev_local as dev_local_mod
         from kamiwaza_extensions.dev_local import DevLocalRunner
+        from kamiwaza_extensions_lib.local_dev import LocalDevAuthError
 
         compose_data = {"services": {"server": {"build": "."}}}
         compose_path = tmp_path / "docker-compose.yml"
@@ -646,17 +667,13 @@ class TestRunnerAuthExtensionTypeGate:
             prepare_called.append(True)
             raise AssertionError("prepare_bridge_context should not run")
 
-        monkeypatch.setattr(
-            dev_local_mod, "prepare_bridge_context", fail_if_called
-        )
+        monkeypatch.setattr(dev_local_mod, "prepare_bridge_context", fail_if_called)
 
         with pytest.raises(LocalDevAuthError, match="only supported for `app`"):
             runner.run(detach=False, auth=True)
         assert not prepare_called
 
-    def test_runner_accepts_auth_for_app_extension_type(
-        self, tmp_path, monkeypatch
-    ):
+    def test_runner_accepts_auth_for_app_extension_type(self, tmp_path, monkeypatch):
         """Sanity check: app-type passes the gate (bridge prep is then
         invoked normally)."""
         import yaml as _yaml
@@ -688,6 +705,7 @@ class TestRunnerAuthExtensionTypeGate:
         )
 
         from kamiwaza_extensions import sdk_override as sdk_override_mod
+
         monkeypatch.setattr(
             dev_local_mod,
             "detect_compose_command",
@@ -703,7 +721,9 @@ class TestRunnerAuthExtensionTypeGate:
             dev_local_mod,
             "prepare_bridge_context",
             lambda connection_manager: BridgeContext(
-                bearer_token="b", user_id="u", expires_at=None,
+                bearer_token="b",
+                user_id="u",
+                expires_at=None,
             ),
         )
         runner._run_subprocess = MagicMock(return_value=0)
@@ -735,7 +755,6 @@ class TestComposeDetection:
         with patch("subprocess.run", side_effect=FileNotFoundError()):
             with pytest.raises(FileNotFoundError, match="Docker Compose not found"):
                 detect_compose_command()
-
 
 
 @pytest.mark.unit
@@ -850,9 +869,7 @@ class TestIsPortAvailable:
         finally:
             sock.close()
 
-    def test_v6_disabled_runtime_does_not_falsely_report_port_taken(
-        self, monkeypatch
-    ):
+    def test_v6_disabled_runtime_does_not_falsely_report_port_taken(self, monkeypatch):
         """PR #87 round-12 review (codex M1) — ``socket.has_ipv6`` is
         a build-time flag, not a runtime capability. On Linux hosts
         with ``net.ipv6.conf.all.disable_ipv6=1`` (hardened servers,
@@ -995,6 +1012,49 @@ class TestApplyPortRemaps:
 
 
 @pytest.mark.unit
+@pytest.mark.unit
+class TestHasBarePorts:
+    """Foreground-mode URL polling (ENG-3901 / F-008) only fires when
+    there's at least one bare-port spec to resolve. Mapped specs already
+    have a known host port, and services without ports don't need URLs."""
+
+    def _runner(self):
+        from kamiwaza_extensions.dev_local import DevLocalRunner
+
+        return DevLocalRunner.__new__(DevLocalRunner)
+
+    def test_returns_true_when_a_service_has_a_bare_port(self):
+        runner = self._runner()
+        compose = {"services": {"frontend": {"ports": ["3000"]}}}
+        assert runner._has_bare_ports(compose) is True
+
+    def test_returns_false_when_all_ports_are_mapped(self):
+        runner = self._runner()
+        compose = {"services": {"frontend": {"ports": ["3000:3000"]}}}
+        assert runner._has_bare_ports(compose) is False
+
+    def test_returns_false_when_no_services_have_ports(self):
+        runner = self._runner()
+        compose = {"services": {"backend": {"image": "redis:7"}}}
+        assert runner._has_bare_ports(compose) is False
+
+    def test_returns_false_for_empty_compose(self):
+        runner = self._runner()
+        assert runner._has_bare_ports(None) is False
+        assert runner._has_bare_ports({}) is False
+        assert runner._has_bare_ports({"services": {}}) is False
+
+    def test_returns_true_when_one_service_is_mapped_and_another_is_bare(self):
+        runner = self._runner()
+        compose = {
+            "services": {
+                "backend": {"ports": ["8000:8000"]},
+                "frontend": {"ports": ["3000"]},
+            }
+        }
+        assert runner._has_bare_ports(compose) is True
+
+
 class TestPrintUrlsBarePort:
     """ENG-3889 P2 + review PR #84 Critical #3 — bare-port URL discovery
     must work in both pre-up and post-up modes. The pre-up mode runs
@@ -1029,7 +1089,12 @@ class TestPrintUrlsBarePort:
         called = {"docker_compose_port": False}
         monkeypatch.setattr(
             "kamiwaza_extensions.dev_local.DevLocalRunner._docker_compose_port",
-            staticmethod(lambda svc, port, compose_cmd=None, cwd=None: called.__setitem__("docker_compose_port", True) or None),
+            staticmethod(
+                lambda svc, port, compose_cmd=None, cwd=None: called.__setitem__(
+                    "docker_compose_port", True
+                )
+                or None
+            ),
         )
 
         runner._print_urls(compose, {}, post_up=False)
@@ -1049,7 +1114,11 @@ class TestPrintUrlsBarePort:
         # Simulate Docker having assigned host port 49152 to container port 3000.
         monkeypatch.setattr(
             "kamiwaza_extensions.dev_local.DevLocalRunner._docker_compose_port",
-            staticmethod(lambda svc, port, compose_cmd=None, cwd=None: 49152 if svc == "frontend" and port == 3000 else None),
+            staticmethod(
+                lambda svc, port, compose_cmd=None, cwd=None: (
+                    49152 if svc == "frontend" and port == 3000 else None
+                )
+            ),
         )
 
         runner._print_urls(compose, {}, post_up=True)
@@ -1107,7 +1176,9 @@ class TestDockerComposePortV1Compat:
 
         monkeypatch.setattr("subprocess.run", fake_run)
         host = DevLocalRunner._docker_compose_port(
-            "frontend", 3000, compose_cmd=["docker-compose"],
+            "frontend",
+            3000,
+            compose_cmd=["docker-compose"],
         )
         assert host == 49152
         assert captured == [["docker-compose", "port", "frontend", "3000"]]
@@ -1123,7 +1194,9 @@ class TestDockerComposePortV1Compat:
 
         monkeypatch.setattr("subprocess.run", fake_run)
         host = DevLocalRunner._docker_compose_port(
-            "frontend", 3000, compose_cmd=["docker", "compose"],
+            "frontend",
+            3000,
+            compose_cmd=["docker", "compose"],
         )
         assert host == 49152
         assert captured == [["docker", "compose", "port", "frontend", "3000"]]
@@ -1165,13 +1238,18 @@ class TestDockerComposePortV1Compat:
         monkeypatch.setattr("subprocess.run", fake_run)
 
         compose_prefix = [
-            "docker", "compose",
-            "-f", "/tmp/kz-ports-abc.yml",
-            "-f", "/tmp/kz-sdk-xyz.yml",
-            "--project-directory", "/Users/dev/my-app",
+            "docker",
+            "compose",
+            "-f",
+            "/tmp/kz-ports-abc.yml",
+            "-f",
+            "/tmp/kz-sdk-xyz.yml",
+            "--project-directory",
+            "/Users/dev/my-app",
         ]
         host = DevLocalRunner._docker_compose_port(
-            "frontend", 3000,
+            "frontend",
+            3000,
             compose_cmd=compose_prefix,
             cwd="/Users/dev/my-app",
         )
@@ -1179,6 +1257,9 @@ class TestDockerComposePortV1Compat:
         # Project-identifier args + `port` + service + container port —
         # matches the same project that `compose up` was invoked against.
         assert captured["cmd"] == [
-            *compose_prefix, "port", "frontend", "3000",
+            *compose_prefix,
+            "port",
+            "frontend",
+            "3000",
         ]
         assert captured["cwd"] == "/Users/dev/my-app"

--- a/tests/unit/extensions/test_dev_local.py
+++ b/tests/unit/extensions/test_dev_local.py
@@ -1012,7 +1012,6 @@ class TestApplyPortRemaps:
 
 
 @pytest.mark.unit
-@pytest.mark.unit
 class TestHasBarePorts:
     """Foreground-mode URL polling (ENG-3901 / F-008) only fires when
     there's at least one bare-port spec to resolve. Mapped specs already

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -63,11 +63,15 @@ class TestReadWrite:
         # reading the same file must drop unknowns rather than crash.
         path = state_path(tmp_path)
         path.parent.mkdir()
-        path.write_text(json.dumps({
-            "last_dev_name": "hello-dev-x",
-            "last_successful_step": "apply",
-            "future_field": "ignored",
-        }))
+        path.write_text(
+            json.dumps(
+                {
+                    "last_dev_name": "hello-dev-x",
+                    "last_successful_step": "apply",
+                    "future_field": "ignored",
+                }
+            )
+        )
         out = read_state(tmp_path)
         assert out is not None
         assert out.last_dev_name == "hello-dev-x"
@@ -79,17 +83,24 @@ class TestMarkStep:
     def test_invalid_step_raises(self, tmp_path):
         with pytest.raises(ValueError, match="Unknown dev step"):
             mark_step(
-                tmp_path, "wrong",
-                revision="x", dev_name="y", cluster="c",
-                extension_name="e", deployer="d",
+                tmp_path,
+                "wrong",
+                revision="x",
+                dev_name="y",
+                cluster="c",
+                extension_name="e",
+                deployer="d",
             )
 
     def test_records_step_and_metadata(self, tmp_path):
         s = mark_step(
-            tmp_path, "build",
-            revision="1.0.0-dev-abc", dev_name="hello-dev-b1",
+            tmp_path,
+            "build",
+            revision="1.0.0-dev-abc",
+            dev_name="hello-dev-b1",
             cluster="https://k.test/api",
-            extension_name="hello", deployer="jonathan@kamiwaza.ai",
+            extension_name="hello",
+            deployer="jonathan@kamiwaza.ai",
         )
         assert s.last_successful_step == "build"
         assert s.last_revision == "1.0.0-dev-abc"
@@ -101,9 +112,13 @@ class TestMarkStep:
     def test_progresses_step_in_order(self, tmp_path):
         for step in STEPS:
             mark_step(
-                tmp_path, step,
-                revision="x", dev_name="y", cluster="c",
-                extension_name="e", deployer="d",
+                tmp_path,
+                step,
+                revision="x",
+                dev_name="y",
+                cluster="c",
+                extension_name="e",
+                deployer="d",
             )
         out = read_state(tmp_path)
         assert out is not None
@@ -147,7 +162,6 @@ class TestResumeMessage:
         assert msg is not None
         assert "push" in msg
         assert "2026-04-28" in msg
-
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +280,9 @@ class TestIsResumableStableId:
     def test_stable_revision_id_strips_epoch_for_clean_sha(self):
         from kamiwaza_extensions.commands.dev import _stable_revision_id
 
-        assert _stable_revision_id("1.0.0-dev-abc1234.1714000000") == "1.0.0-dev-abc1234"
+        assert (
+            _stable_revision_id("1.0.0-dev-abc1234.1714000000") == "1.0.0-dev-abc1234"
+        )
         assert _stable_revision_id("0.12.1-dev-deadbeef.1") == "0.12.1-dev-deadbeef"
         # Custom revision (no .epoch suffix) — return as-is.
         assert _stable_revision_id("rev-1") == "rev-1"
@@ -301,21 +317,29 @@ class TestIsResumableSdkOverride:
         s = self._state()
         # Same revision + same cluster — would normally resume — but
         # sdk_repo is set, so skip.
-        assert _is_resumable(
-            s, "1.0.0-dev-abc1234.1714999999",
-            "https://cluster.test/api",
-            sdk_repo="/Users/dev/kamiwaza-sdk",
-        ) is False
+        assert (
+            _is_resumable(
+                s,
+                "1.0.0-dev-abc1234.1714999999",
+                "https://cluster.test/api",
+                sdk_repo="/Users/dev/kamiwaza-sdk",
+            )
+            is False
+        )
 
     def test_sdk_repo_none_allows_resume(self):
         from kamiwaza_extensions.commands.dev import _is_resumable
 
         s = self._state()
-        assert _is_resumable(
-            s, "1.0.0-dev-abc1234.1714999999",
-            "https://cluster.test/api",
-            sdk_repo=None,
-        ) is True
+        assert (
+            _is_resumable(
+                s,
+                "1.0.0-dev-abc1234.1714999999",
+                "https://cluster.test/api",
+                sdk_repo=None,
+            )
+            is True
+        )
 
     def test_sdk_repo_default_argument_omitted(self):
         # Back-compat: callers that don't pass sdk_repo (legacy unit tests,
@@ -324,10 +348,14 @@ class TestIsResumableSdkOverride:
         from kamiwaza_extensions.commands.dev import _is_resumable
 
         s = self._state()
-        assert _is_resumable(
-            s, "1.0.0-dev-abc1234.1714999999",
-            "https://cluster.test/api",
-        ) is True
+        assert (
+            _is_resumable(
+                s,
+                "1.0.0-dev-abc1234.1714999999",
+                "https://cluster.test/api",
+            )
+            is True
+        )
 
 
 @pytest.mark.unit
@@ -362,26 +390,32 @@ class TestIsResumableServiceFilterAndRegistry:
         from kamiwaza_extensions.commands.dev import _is_resumable
 
         prior = self._state(last_service="backend")
-        assert _is_resumable(
-            prior,
-            rev_tag="1.0.0-dev-abc1234.1714999999",
-            connection_url="https://cluster.test/api",
-            registry="registry.test",
-            service=None,
-        ) is False
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry.test",
+                service=None,
+            )
+            is False
+        )
 
     def test_same_service_filter_resumes(self):
         # `--service backend` → fail → `--service backend` again is fine.
         from kamiwaza_extensions.commands.dev import _is_resumable
 
         prior = self._state(last_service="backend")
-        assert _is_resumable(
-            prior,
-            rev_tag="1.0.0-dev-abc1234.1714999999",
-            connection_url="https://cluster.test/api",
-            registry="registry.test",
-            service="backend",
-        ) is True
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry.test",
+                service="backend",
+            )
+            is True
+        )
 
     def test_different_service_filter_invalidates_resume(self):
         # `--service backend` → fail → `--service frontend` —
@@ -389,13 +423,16 @@ class TestIsResumableServiceFilterAndRegistry:
         from kamiwaza_extensions.commands.dev import _is_resumable
 
         prior = self._state(last_service="backend")
-        assert _is_resumable(
-            prior,
-            rev_tag="1.0.0-dev-abc1234.1714999999",
-            connection_url="https://cluster.test/api",
-            registry="registry.test",
-            service="frontend",
-        ) is False
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry.test",
+                service="frontend",
+            )
+            is False
+        )
 
     def test_sdk_repo_change_invalidates_resume(self):
         # Prior run had no sdk-repo override; new run does → SDK code
@@ -403,26 +440,32 @@ class TestIsResumableServiceFilterAndRegistry:
         from kamiwaza_extensions.commands.dev import _is_resumable
 
         prior = self._state(last_sdk_repo=None)
-        assert _is_resumable(
-            prior,
-            rev_tag="1.0.0-dev-abc1234.1714999999",
-            connection_url="https://cluster.test/api",
-            registry="registry.test",
-            sdk_repo="/Users/dev/kamiwaza-sdk",
-        ) is False
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry.test",
+                sdk_repo="/Users/dev/kamiwaza-sdk",
+            )
+            is False
+        )
 
     def test_sdk_repo_consistent_resumes(self):
         # Same sdk-repo path on both runs — resume is safe.
         from kamiwaza_extensions.commands.dev import _is_resumable
 
         prior = self._state(last_sdk_repo="/Users/dev/kamiwaza-sdk")
-        assert _is_resumable(
-            prior,
-            rev_tag="1.0.0-dev-abc1234.1714999999",
-            connection_url="https://cluster.test/api",
-            registry="registry.test",
-            sdk_repo="/Users/dev/kamiwaza-sdk",
-        ) is True
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry.test",
+                sdk_repo="/Users/dev/kamiwaza-sdk",
+            )
+            is True
+        )
 
     def test_registry_change_invalidates_resume(self):
         # KAMIWAZA_REGISTRY=registry-a → fail →
@@ -431,12 +474,15 @@ class TestIsResumableServiceFilterAndRegistry:
         from kamiwaza_extensions.commands.dev import _is_resumable
 
         prior = self._state(last_registry="registry-a")
-        assert _is_resumable(
-            prior,
-            rev_tag="1.0.0-dev-abc1234.1714999999",
-            connection_url="https://cluster.test/api",
-            registry="registry-b",
-        ) is False
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry-b",
+            )
+            is False
+        )
 
     def test_legacy_state_without_resume_inputs_invalidates_when_current_set(self):
         # An older dev-state file (pre-H1) doesn't carry service /
@@ -448,15 +494,20 @@ class TestIsResumableServiceFilterAndRegistry:
         from kamiwaza_extensions.commands.dev import _is_resumable
 
         prior = self._state(
-            last_service=None, last_sdk_repo=None, last_registry="",
+            last_service=None,
+            last_sdk_repo=None,
+            last_registry="",
         )
-        assert _is_resumable(
-            prior,
-            rev_tag="1.0.0-dev-abc1234.1714999999",
-            connection_url="https://cluster.test/api",
-            registry="registry.test",
-            service="backend",
-        ) is False
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry.test",
+                service="backend",
+            )
+            is False
+        )
 
 
 @pytest.mark.unit
@@ -476,9 +527,9 @@ class TestBuildPatchKwargsCarriesAnnotations:
         from kamiwaza_extensions.commands.dev import _build_patch_kwargs
 
         annotations = {
-            "kamiwaza.ai/deployer": "alice@example.com",
-            "kamiwaza.ai/revision": "1.0.0-dev-abc",
-            "kamiwaza.ai/deployed-at": "2026-04-29T10:00:00+00:00",
+            "kamiwaza.io/deployer": "alice@example.com",
+            "kamiwaza.io/revision": "1.0.0-dev-abc",
+            "kamiwaza.io/deployed-at": "2026-04-29T10:00:00+00:00",
         }
         kwargs = _build_patch_kwargs(
             patch_services=["svc-a"],

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -316,10 +316,13 @@ class TestHealthChecks:
             "port": 8000,
         }, f"service-type primary must probe / not /health; got {health_check['httpGet']!r}"
 
-    def test_tool_type_primary_uses_root_probe(self, builder, connection):
-        """ENG-3901 / F-013: same fix for tool-type. The tool template
-        ships an MCP server that may or may not declare /health depending
-        on developer implementation; / is the always-safe default."""
+    def test_tool_type_primary_probes_sse(self, builder, connection):
+        """ENG-3901 / F-013 (final): tool primary probes ``/sse`` — the
+        FastMCP SSE endpoint. ``/`` 404s (FastMCP doesn't mount root) and
+        ``/health`` doesn't exist on the stub. The platform API rejects
+        ``tcpSocket`` and ``exec`` probe shapes with opaque 500s, so
+        httpGet ``/sse`` is the only viable choice today even though the
+        K8s probe may time out reading the streamed response body."""
         metadata = {"name": "my-tool", "version": "1.0.0", "type": "tool"}
         transformed = {
             "services": {
@@ -333,7 +336,9 @@ class TestHealthChecks:
         tool = payload.services[0]
         health_check = tool.model_dump()["healthCheck"]
         assert tool.primary is True
-        assert health_check["httpGet"] == {"path": "/", "port": 8080}
+        assert health_check["httpGet"] == {"path": "/sse", "port": 8080}
+        assert "tcpSocket" not in health_check
+        assert "exec" not in health_check
 
     def test_app_type_backend_keeps_health_probe(self, builder, connection):
         """Regression guard: F-013's fix is scoped to service/tool primary.

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -104,10 +104,17 @@ class TestAnnotations:
     """ENG-3887 / §4.2.9 — DeployedImageAnnotation on the CRD payload."""
 
     def test_annotations_present_when_deployer_and_revision_supplied(
-        self, builder, metadata, transformed_compose, connection,
+        self,
+        builder,
+        metadata,
+        transformed_compose,
+        connection,
     ):
         payload = builder.build(
-            metadata, transformed_compose, connection, "my-app-dev-abc",
+            metadata,
+            transformed_compose,
+            connection,
+            "my-app-dev-abc",
             deployer="jonathan@kamiwaza.ai",
             revision="1.0.0-dev-a1b2c3d.1714000000",
         )
@@ -121,12 +128,19 @@ class TestAnnotations:
         assert annotations[ANNOTATION_DEPLOYED_AT].endswith("+00:00")
 
     def test_no_annotations_when_neither_supplied(
-        self, builder, metadata, transformed_compose, connection,
+        self,
+        builder,
+        metadata,
+        transformed_compose,
+        connection,
     ):
         # If we have nothing meaningful to attach, don't carry an empty dict
         # — but `deployed-at` is always present, since "when" is always known.
         payload = builder.build(
-            metadata, transformed_compose, connection, "my-app-dev-abc",
+            metadata,
+            transformed_compose,
+            connection,
+            "my-app-dev-abc",
         )
         annotations = (payload.model_extra or {}).get("annotations")
         # build_annotations always sets `deployed-at`, so the key exists even
@@ -276,3 +290,69 @@ class TestHealthChecks:
         assert backend.primary is True
         assert health_check["httpGet"] == {"path": "/health", "port": 8000}
         assert "exec" not in health_check
+
+    def test_service_type_primary_uses_root_probe(self, builder, connection):
+        """ENG-3901 / F-013: the service template ships a stub
+        (``python -m http.server``) that returns 404 for /health. The
+        K8s startup probe loops the pod into restarts. Service-type
+        primary services must probe ``/`` instead — the stub answers it,
+        and developers who add real /health code can override at the
+        compose level."""
+        metadata = {"name": "my-svc", "version": "1.0.0", "type": "service"}
+        transformed = {
+            "services": {
+                "service": {
+                    "image": "registry.test/my-svc:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        svc = payload.services[0]
+        health_check = svc.model_dump()["healthCheck"]
+        assert svc.primary is True
+        assert health_check["httpGet"] == {
+            "path": "/",
+            "port": 8000,
+        }, f"service-type primary must probe / not /health; got {health_check['httpGet']!r}"
+
+    def test_tool_type_primary_uses_root_probe(self, builder, connection):
+        """ENG-3901 / F-013: same fix for tool-type. The tool template
+        ships an MCP server that may or may not declare /health depending
+        on developer implementation; / is the always-safe default."""
+        metadata = {"name": "my-tool", "version": "1.0.0", "type": "tool"}
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8080"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        health_check = tool.model_dump()["healthCheck"]
+        assert tool.primary is True
+        assert health_check["httpGet"] == {"path": "/", "port": 8080}
+
+    def test_app_type_backend_keeps_health_probe(self, builder, connection):
+        """Regression guard: F-013's fix is scoped to service/tool primary.
+        The app-type backend (non-primary in app extensions, ships a real
+        FastAPI /health route) must still probe /health."""
+        metadata = {"name": "my-app", "version": "1.0.0", "type": "app"}
+        transformed = {
+            "services": {
+                "frontend": {
+                    "image": "registry.test/my-app-frontend:1.0.0",
+                    "ports": ["3000"],
+                },
+                "backend": {
+                    "image": "registry.test/my-app-backend:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        backend = next(s for s in payload.services if s.name == "backend")
+        health_check = backend.model_dump()["healthCheck"]
+        assert health_check["httpGet"] == {"path": "/health", "port": 8000}

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -14,7 +14,6 @@ from kamiwaza_extensions.sdk_override import (
     validate_sdk_override,
 )
 
-
 # ------------------------------------------------------------------
 # SdkOverrideSpec
 # ------------------------------------------------------------------
@@ -26,7 +25,10 @@ class TestSdkOverrideSpec:
         spec = SdkOverrideSpec(sdk_repo=tmp_path)
         assert spec.python_lib_path == tmp_path / "kamiwaza_extensions_lib"
         assert spec.typescript_lib_path == tmp_path / "kamiwaza-ai-extensions-lib"
-        assert spec.typescript_dist_path == tmp_path / "kamiwaza-ai-extensions-lib" / "dist"
+        assert (
+            spec.typescript_dist_path
+            == tmp_path / "kamiwaza-ai-extensions-lib" / "dist"
+        )
 
     def test_defaults(self, tmp_path):
         spec = SdkOverrideSpec(sdk_repo=tmp_path)
@@ -57,9 +59,7 @@ class TestResolveSdkOverride:
         # Create config with different path
         config_dir = tmp_path / ".kz-ext"
         config_dir.mkdir()
-        (config_dir / "local.yaml").write_text(
-            yaml.dump({"sdk_repo": "/other/path"})
-        )
+        (config_dir / "local.yaml").write_text(yaml.dump({"sdk_repo": "/other/path"}))
         spec = resolve_sdk_override(str(tmp_path), extension_path=tmp_path)
         assert spec is not None
         assert spec.sdk_repo == tmp_path  # CLI wins
@@ -67,9 +67,7 @@ class TestResolveSdkOverride:
     def test_config_file(self, tmp_path):
         config_dir = tmp_path / ".kz-ext"
         config_dir.mkdir()
-        (config_dir / "local.yaml").write_text(
-            yaml.dump({"sdk_repo": str(tmp_path)})
-        )
+        (config_dir / "local.yaml").write_text(yaml.dump({"sdk_repo": str(tmp_path)}))
         spec = resolve_sdk_override(None, extension_path=tmp_path)
         assert spec is not None
         assert spec.sdk_repo == tmp_path
@@ -78,11 +76,13 @@ class TestResolveSdkOverride:
         config_dir = tmp_path / ".kz-ext"
         config_dir.mkdir()
         (config_dir / "local.yaml").write_text(
-            yaml.dump({
-                "sdk_repo": str(tmp_path),
-                "runtime_libs": {"python": "local", "typescript": "published"},
-                "build_typescript": True,
-            })
+            yaml.dump(
+                {
+                    "sdk_repo": str(tmp_path),
+                    "runtime_libs": {"python": "local", "typescript": "published"},
+                    "build_typescript": True,
+                }
+            )
         )
         spec = resolve_sdk_override(None, extension_path=tmp_path)
         assert spec is not None
@@ -104,9 +104,7 @@ class TestResolveSdkOverride:
     def test_config_without_sdk_repo_returns_none(self, tmp_path):
         config_dir = tmp_path / ".kz-ext"
         config_dir.mkdir()
-        (config_dir / "local.yaml").write_text(
-            yaml.dump({"build_typescript": True})
-        )
+        (config_dir / "local.yaml").write_text(yaml.dump({"build_typescript": True}))
         spec = resolve_sdk_override(None, extension_path=tmp_path)
         assert spec is None
 
@@ -288,7 +286,10 @@ class TestGenerateComposeOverride:
         spec = self._make_spec(tmp_path)
         compose = {
             "services": {
-                "frontend": {"build": {"context": "./frontend"}, "ports": ["3000:3000"]},
+                "frontend": {
+                    "build": {"context": "./frontend"},
+                    "ports": ["3000:3000"],
+                },
                 "backend": {"build": {"context": "./backend"}, "ports": ["8000:8000"]},
             }
         }
@@ -296,8 +297,14 @@ class TestGenerateComposeOverride:
         services = override["services"]
 
         # Backend reads CMD from Dockerfile
-        assert 'export PYTHONPATH="/sdk$${PYTHONPATH:+:$$PYTHONPATH}"' in services["backend"]["command"][0]
-        assert "exec uvicorn app.main:app --host 0.0.0.0" in services["backend"]["command"][0]
+        assert (
+            'export PYTHONPATH="/sdk$${PYTHONPATH:+:$$PYTHONPATH}"'
+            in services["backend"]["command"][0]
+        )
+        assert (
+            "exec uvicorn app.main:app --host 0.0.0.0"
+            in services["backend"]["command"][0]
+        )
 
         # Frontend reads ENTRYPOINT from Dockerfile
         assert "npm pack" in services["frontend"]["command"][0]
@@ -316,7 +323,10 @@ class TestGenerateComposeOverride:
         spec = self._make_spec(tmp_path, python=False)
         compose = {
             "services": {
-                "frontend": {"build": {"context": "./frontend"}, "ports": ["3000:3000"]},
+                "frontend": {
+                    "build": {"context": "./frontend"},
+                    "ports": ["3000:3000"],
+                },
             }
         }
 
@@ -366,7 +376,10 @@ class TestGenerateComposeOverride:
         }
         override = generate_compose_override(spec, compose)
         services = override["services"]
-        assert 'export PYTHONPATH="/sdk$${PYTHONPATH:+:$$PYTHONPATH}"' in services["backend"]["command"][0]
+        assert (
+            'export PYTHONPATH="/sdk$${PYTHONPATH:+:$$PYTHONPATH}"'
+            in services["backend"]["command"][0]
+        )
         assert "frontend" not in services
 
     def test_typescript_only(self, tmp_path):
@@ -628,7 +641,7 @@ class TestGenerateBuildOverrides:
 @pytest.mark.unit
 class TestApplyBuildOverlay:
     def test_appends_when_no_build_line(self):
-        dockerfile = "FROM node:20\nCOPY . .\nENTRYPOINT [\"node\", \"start.mjs\"]\n"
+        dockerfile = 'FROM node:20\nCOPY . .\nENTRYPOINT ["node", "start.mjs"]\n'
         overlay = BuildOverride(
             service_name="frontend",
             overlay_steps="# overlay\nRUN echo hello\n",
@@ -639,7 +652,7 @@ class TestApplyBuildOverlay:
         assert result.endswith("RUN echo hello\n")
 
     def test_inserts_before_npm_run_build(self):
-        dockerfile = "FROM node:20\nCOPY . .\nRUN npm run build\nCMD [\"npm\", \"start\"]\n"
+        dockerfile = 'FROM node:20\nCOPY . .\nRUN npm run build\nCMD ["npm", "start"]\n'
         overlay = BuildOverride(
             service_name="frontend",
             overlay_steps="# SDK override\nRUN echo injected\n",
@@ -648,12 +661,8 @@ class TestApplyBuildOverlay:
         )
         result = apply_build_overlay(dockerfile, overlay)
         lines = result.splitlines()
-        build_idx = next(
-            i for i, line in enumerate(lines) if "npm run build" in line
-        )
-        inject_idx = next(
-            i for i, line in enumerate(lines) if "echo injected" in line
-        )
+        build_idx = next(i for i, line in enumerate(lines) if "npm run build" in line)
+        inject_idx = next(i for i, line in enumerate(lines) if "echo injected" in line)
         assert inject_idx < build_idx
 
     def test_inserts_before_next_build(self):
@@ -707,6 +716,239 @@ class TestApplyBuildOverlay:
 
 
 # ------------------------------------------------------------------
+# pre_install_steps — strip kamiwaza-extensions-lib before pip install
+# (PR #89 dry-run finding F-002)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPreInstallStripOverlay:
+    """The Python overlay must strip the runtime-lib pin from
+    requirements.txt *before* the scaffold's pip-install step runs, so the
+    docker build doesn't fail when the pinned version isn't on PyPI yet.
+    The post-install overlay then drops local source into site-packages.
+
+    Regression: previously the overlay only appended; pip install would
+    fail before the appended COPY/cp could replace site-packages."""
+
+    SCAFFOLD_DOCKERFILE = (
+        "FROM python:3.10-slim\n"
+        "RUN groupadd -r -g 1001 appuser && useradd -r -u 1001 -g appuser -d /app appuser\n"
+        "WORKDIR /app\n"
+        "COPY requirements.txt .\n"
+        "RUN pip install --no-cache-dir -r requirements.txt\n"
+        "COPY . .\n"
+        "USER 1001\n"
+        'CMD ["uvicorn", "app.main:app"]\n'
+    )
+
+    def test_backend_override_carries_pre_install_steps(self, tmp_path):
+        """``generate_build_overrides`` must wire the strip step onto every
+        Python backend override so ``--sdk-repo`` works against a scaffold
+        whose runtime-lib pin isn't installable from PyPI."""
+        from kamiwaza_extensions.sdk_override import _PYTHON_PRE_INSTALL_STRIP
+
+        spec = SdkOverrideSpec(sdk_repo=tmp_path)
+        compose = {
+            "services": {"backend": {"build": "./backend", "ports": ["8000:8000"]}}
+        }
+        overrides = generate_build_overrides(spec, compose)
+        assert len(overrides) == 1
+        assert overrides[0].pre_install_steps == _PYTHON_PRE_INSTALL_STRIP
+
+    def test_strip_step_inserted_before_pip_install(self):
+        overlay = BuildOverride(
+            service_name="backend",
+            overlay_steps="# post-install\nRUN echo post\n",
+            additional_build_contexts={"sdk": "/tmp/sdk"},
+            pre_install_steps=(
+                "# strip\nUSER root\nRUN sed -i '/x/d' requirements.txt\n"
+                "{restore_user_block}"
+            ),
+        )
+        result = apply_build_overlay(self.SCAFFOLD_DOCKERFILE, overlay)
+        # Strip must appear in the output and BEFORE the pip install line.
+        assert "# strip" in result
+        assert result.index("# strip") < result.index("pip install")
+        # Post-install overlay still appended.
+        assert result.index("pip install") < result.index("# post-install")
+
+    def test_strip_step_uses_root_then_restores_active_user(self):
+        """The strip overlay must drop into root and restore the user that
+        was active before it. In the scaffold's Dockerfile the pip-install
+        runs as root (no USER set yet), so no restore is needed."""
+        overlay = BuildOverride(
+            service_name="backend",
+            overlay_steps="",
+            additional_build_contexts={"sdk": "/tmp/sdk"},
+            pre_install_steps=("USER root\nRUN echo strip\n{restore_user_block}"),
+        )
+        result = apply_build_overlay(self.SCAFFOLD_DOCKERFILE, overlay)
+        # USER root is set explicitly in the strip block; nothing to restore
+        # because the scaffold has no USER directive before pip install.
+        strip_section, _, _ = result.partition("RUN pip install")
+        assert "USER root" in strip_section
+        # The trailing USER 1001 in the original Dockerfile is untouched.
+        assert result.rstrip().endswith('CMD ["uvicorn", "app.main:app"]')
+
+    def test_strip_step_restores_non_root_user_when_pip_install_runs_as_appuser(self):
+        """A Dockerfile that switches to a non-root user before pip install
+        must have that user restored after the strip block — otherwise the
+        pip install would unexpectedly run as root."""
+        df = (
+            "FROM python:3.10-slim\nRUN useradd -m appuser\nWORKDIR /app\n"
+            "COPY requirements.txt .\nUSER appuser\n"
+            "RUN pip install -r requirements.txt\n"
+        )
+        overlay = BuildOverride(
+            service_name="backend",
+            overlay_steps="",
+            additional_build_contexts={"sdk": "/tmp/sdk"},
+            pre_install_steps=("USER root\nRUN echo strip\n{restore_user_block}"),
+        )
+        result = apply_build_overlay(df, overlay)
+        # The strip's USER root block must be followed by USER appuser
+        # before the pip install line.
+        strip_section, _, after = result.partition("RUN pip install")
+        assert "USER root" in strip_section
+        assert "RUN echo strip" in strip_section
+        assert "USER appuser" in strip_section
+        # The order is: USER appuser (original) -> USER root + strip ->
+        # USER appuser (restore) -> RUN pip install.
+        last_user_before_install = strip_section.rstrip().splitlines()[-1]
+        assert last_user_before_install.strip() == "USER appuser"
+
+    def test_strip_step_is_a_no_op_when_no_pip_install_line(self):
+        """Custom Dockerfile (e.g. poetry-based) without
+        ``RUN ... pip install -r requirements.txt`` should be left alone by
+        the strip step — the post-install overlay still appends as before."""
+        df = "FROM python:3.10-slim\nRUN poetry install\n"
+        overlay = BuildOverride(
+            service_name="backend",
+            overlay_steps="# post-install\nRUN echo post\n",
+            additional_build_contexts={"sdk": "/tmp/sdk"},
+            pre_install_steps=("USER root\nRUN echo strip\n{restore_user_block}"),
+        )
+        result = apply_build_overlay(df, overlay)
+        assert "RUN echo strip" not in result
+        assert result.endswith("# post-install\nRUN echo post\n")
+
+    def test_generate_local_build_dockerfile_patches_handles_backend_and_frontend(
+        self, tmp_path
+    ):
+        """``dev local`` failure path on freshly-scaffolded extensions:
+        BOTH the Python backend (pip install) and the TS frontend
+        (npm install) blow up before the runtime overlay can rescue
+        them when their respective runtime-lib pins aren't published.
+        ``generate_local_build_dockerfile_patches`` must produce a
+        patched Dockerfile per service so the build phase succeeds."""
+        from kamiwaza_extensions.sdk_override import (
+            generate_local_build_dockerfile_patches,
+        )
+
+        ext = tmp_path / "ext"
+        ext.mkdir()
+        backend = ext / "backend"
+        backend.mkdir()
+        (backend / "Dockerfile").write_text(
+            "FROM python:3.10-slim\nWORKDIR /app\nCOPY requirements.txt .\n"
+            "RUN pip install --no-cache-dir -r requirements.txt\nCOPY . .\n"
+        )
+        (backend / "requirements.txt").write_text(
+            "fastapi>=0.100.0\nkamiwaza-extensions-lib>=0.4,<0.5\n"
+        )
+
+        frontend = ext / "frontend"
+        frontend.mkdir()
+        (frontend / "Dockerfile").write_text(
+            "FROM node:20-alpine\nWORKDIR /app\nCOPY package.json .\n"
+            "RUN npm install\nCOPY . .\n"
+        )
+        (frontend / "package.json").write_text(
+            '{"dependencies": {"@kamiwaza-ai/extensions-lib": ">=0.4 <0.5"}}'
+        )
+
+        spec = SdkOverrideSpec(sdk_repo=tmp_path / "sdk")
+        compose = {
+            "services": {
+                "backend": {"build": "./backend", "ports": ["8000:8000"]},
+                "frontend": {"build": "./frontend", "ports": ["3000:3000"]},
+            }
+        }
+        patches = generate_local_build_dockerfile_patches(spec, compose, ext)
+
+        assert set(patches.keys()) == {"backend", "frontend"}
+        assert "kamiwaza-extensions-lib" in patches["backend"]
+        # Backend patch: sed strip is inserted before pip install.
+        assert patches["backend"].index("sed -i") < patches["backend"].index(
+            "pip install"
+        )
+        # Frontend patch: node-based JSON strip is inserted before npm install.
+        assert "@kamiwaza-ai/extensions-lib" in patches["frontend"]
+        assert patches["frontend"].index("node -e") < patches["frontend"].index(
+            "npm install"
+        )
+
+    def test_generate_local_build_dockerfile_patches_skips_when_no_install_line(
+        self, tmp_path
+    ):
+        """Custom Dockerfile (e.g. poetry-based) without a recognizable
+        install line is left out of the patch dict — the user's Dockerfile
+        owns its own runtime-lib install."""
+        from kamiwaza_extensions.sdk_override import (
+            generate_local_build_dockerfile_patches,
+        )
+
+        ext = tmp_path / "ext"
+        ext.mkdir()
+        backend = ext / "backend"
+        backend.mkdir()
+        (backend / "Dockerfile").write_text(
+            "FROM python:3.10-slim\nRUN poetry install\n"
+        )
+
+        spec = SdkOverrideSpec(sdk_repo=tmp_path / "sdk")
+        compose = {
+            "services": {"backend": {"build": "./backend", "ports": ["8000:8000"]}}
+        }
+        assert generate_local_build_dockerfile_patches(spec, compose, ext) == {}
+
+    def test_strip_regex_matches_real_pin_forms_and_skips_prefix_aliases(self):
+        """Sanity-check the embedded sed pattern against realistic
+        requirements.txt content: every pin form for the runtime lib should
+        be removed; siblings whose name *starts with* the lib name (e.g.
+        ``kamiwaza-extensions-lib-extras``) and unrelated lines stay."""
+        import re
+
+        # Mirror of the sed pattern used in _PYTHON_PRE_INSTALL_STRIP, but
+        # rewritten as a Python regex (POSIX [[:space:]] -> \s).
+        pattern = re.compile(
+            r"^\s*kamiwaza-extensions-lib($|[^A-Za-z0-9_-])", re.MULTILINE
+        )
+        requirements = (
+            "fastapi>=0.100.0\n"
+            "kamiwaza-extensions-lib>=0.4,<0.5\n"
+            "kamiwaza-extensions-lib==0.1.0\n"
+            "kamiwaza-extensions-lib\n"
+            "  kamiwaza-extensions-lib>=0.4\n"
+            "kamiwaza-extensions-lib[extras]>=0.4\n"
+            "kamiwaza-extensions-lib-extras>=0.1\n"
+            "# kamiwaza-extensions-lib>=0.4 (commented)\n"
+        )
+        kept = [line for line in requirements.splitlines() if not pattern.match(line)]
+        assert "fastapi>=0.100.0" in kept
+        assert (
+            "kamiwaza-extensions-lib-extras>=0.1" in kept
+        ), "prefix-alias must NOT be stripped"
+        assert "# kamiwaza-extensions-lib>=0.4 (commented)" in kept
+        # Every form of the actual runtime-lib pin is gone.
+        assert not any("kamiwaza-extensions-lib>=0.4,<0.5" in k for k in kept)
+        assert not any("kamiwaza-extensions-lib==0.1.0" in k for k in kept)
+        assert not any(k.strip() == "kamiwaza-extensions-lib" for k in kept)
+        assert not any("kamiwaza-extensions-lib[extras]" in k for k in kept)
+
+
+# ------------------------------------------------------------------
 # validate_sdk_override — path safety
 # ------------------------------------------------------------------
 
@@ -731,14 +973,16 @@ class TestValidatePathSafety:
 class TestDoctorSdkChecks:
     def test_no_config_returns_empty(self, tmp_path, monkeypatch):
         from kamiwaza_extensions.doctor import DoctorChecker
+
         monkeypatch.chdir(tmp_path)
         checker = DoctorChecker()
         results = checker._check_sdk_override()
         assert results == []
 
     def test_valid_config_returns_checks(self, tmp_path, monkeypatch):
-        from kamiwaza_extensions.doctor import DoctorChecker
         import time
+
+        from kamiwaza_extensions.doctor import DoctorChecker
 
         # Set up SDK repo structure
         (tmp_path / "kamiwaza_extensions_lib").mkdir()
@@ -756,6 +1000,7 @@ class TestDoctorSdkChecks:
         (ext_dir / "kamiwaza.json").write_text('{"name": "test", "version": "0.1.0"}')
         (ext_dir / ".kz-ext").mkdir()
         import yaml
+
         (ext_dir / ".kz-ext" / "local.yaml").write_text(
             yaml.dump({"sdk_repo": str(tmp_path)})
         )

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -526,6 +526,28 @@ class TestGenerateBuildOverrides:
         assert "COPY --from=sdk" in overrides[0].overlay_steps
         assert "USER root" in overrides[0].overlay_steps
 
+    def test_python_overlay_resolves_site_packages_without_importing_runtime_lib(
+        self, tmp_path
+    ):
+        """ENG-3901 / F-002 round-3: the post-install overlay must resolve
+        the site-packages dir via ``sysconfig`` rather than by importing
+        ``kamiwaza_extensions_lib``. The pre-install strip removes the lib
+        from requirements.txt so the import would crash here. Use
+        ``sysconfig.get_paths()['purelib']`` which is always resolvable
+        regardless of what's installed."""
+        spec = self._make_spec(tmp_path)
+        compose = {"services": {"backend": {"build": ".", "ports": ["8000:8000"]}}}
+        overlay = generate_build_overrides(spec, compose)[0].overlay_steps
+        # Must NOT import the lib (would fail post-strip).
+        assert "import kamiwaza_extensions_lib" not in overlay, (
+            f"overlay still resolves site-packages by importing the lib — "
+            f"this crashes when the pre-install strip removes the pin. "
+            f"overlay: {overlay!r}"
+        )
+        # MUST use sysconfig.get_paths()['purelib'].
+        assert "sysconfig" in overlay
+        assert "purelib" in overlay
+
     def test_empty_services(self, tmp_path):
         spec = self._make_spec(tmp_path)
         assert generate_build_overrides(spec, {"services": {}}) == []

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -818,6 +818,68 @@ class TestPreInstallStripOverlay:
         assert "# ts-strip" in result
         assert result.index("# ts-strip") < result.index("RUN npm install")
 
+    def test_apply_build_overlay_rewrites_npm_ci_to_npm_install(self):
+        """ENG-3901 / round-3 (Codex P2): when a frontend Dockerfile uses
+        ``RUN npm ci`` (which the install pattern matches), the strip
+        step mutates package.json and leaves package-lock.json out of
+        sync. ``npm ci`` enforces strict parity and would error. The
+        overlay applier must rewrite the line to ``npm install`` so the
+        install proceeds and re-resolves with the mutated package.json.
+        Local-build overrides already break strict reproducibility (we
+        swap in a local source tarball) so looser semantics is consistent."""
+        ts_dockerfile = (
+            "FROM node:20-alpine\nWORKDIR /app\n"
+            "COPY package.json package-lock.json ./\n"
+            "RUN npm ci --no-audit\n"
+            "COPY . .\n"
+            "RUN npm run build\n"
+            'CMD ["node", "/app/start.mjs"]\n'
+        )
+        overlay = BuildOverride(
+            service_name="frontend",
+            overlay_steps="# post-install\nRUN echo post\n",
+            additional_build_contexts={"sdk": "/tmp/sdk"},
+            insert_before_build=True,
+            pre_install_steps=(
+                "# ts-strip\nUSER root\nRUN node -e 'strip'\n{restore_user_block}"
+            ),
+        )
+        result = apply_build_overlay(ts_dockerfile, overlay)
+        # The strip is inserted before the install line, AND the install
+        # line itself is rewritten to ``npm install`` (preserving flags).
+        assert "RUN npm ci" not in result, (
+            "npm ci must be rewritten to npm install to tolerate the "
+            "lockfile mismatch the strip creates"
+        )
+        assert "RUN npm install --no-audit" in result, (
+            "npm install rewrite must preserve trailing flags from the "
+            f"original line; got result:\n{result}"
+        )
+
+    def test_apply_build_overlay_leaves_npm_install_unchanged(self):
+        """Sanity: the npm ci → npm install rewrite must NOT mangle a
+        Dockerfile that already uses ``npm install`` (e.g. by accidentally
+        matching ``ci`` inside another flag like ``--ci-mode``)."""
+        ts_dockerfile = (
+            "FROM node:20-alpine\nWORKDIR /app\n"
+            "COPY package.json ./\n"
+            "RUN npm install --legacy-peer-deps\n"
+            "COPY . .\nRUN npm run build\n"
+        )
+        overlay = BuildOverride(
+            service_name="frontend",
+            overlay_steps="",
+            additional_build_contexts={"sdk": "/tmp/sdk"},
+            insert_before_build=True,
+            pre_install_steps=(
+                "# ts-strip\nUSER root\nRUN node -e 'strip'\n{restore_user_block}"
+            ),
+        )
+        result = apply_build_overlay(ts_dockerfile, overlay)
+        assert "RUN npm install --legacy-peer-deps" in result
+        # Only one install line in the patched output.
+        assert result.count("RUN npm install") == 1
+
     def test_strip_step_inserted_before_pip_install(self):
         overlay = BuildOverride(
             service_name="backend",

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -889,6 +889,59 @@ class TestPreInstallStripOverlay:
             "npm install"
         )
 
+    def test_is_typescript_dist_stale_detects_src_newer_than_dist(self, tmp_path):
+        """``--sdk-repo`` must auto-rebuild when src/ has changes that
+        haven't reached dist/. Without this, a ``git pull`` that adds a
+        new subpath export silently produces a "Module not found" at the
+        consumer (PR #87 / F-006: ``dist/local-dev-auth/`` declared in
+        package.json but never built before merge)."""
+        import time
+
+        from kamiwaza_extensions.sdk_override import is_typescript_dist_stale
+
+        ts_lib = tmp_path / "kamiwaza-ai-extensions-lib"
+        ts_lib.mkdir()
+        (ts_lib / "dist").mkdir()
+        (ts_lib / "src").mkdir()
+        (ts_lib / "dist" / "index.js").write_text("//")
+        time.sleep(0.05)
+        (ts_lib / "src" / "index.ts").write_text("// newer")
+
+        spec = SdkOverrideSpec(sdk_repo=tmp_path)
+        assert is_typescript_dist_stale(spec) is True
+
+    def test_is_typescript_dist_stale_returns_false_when_dist_is_fresh(self, tmp_path):
+        import time
+
+        from kamiwaza_extensions.sdk_override import is_typescript_dist_stale
+
+        ts_lib = tmp_path / "kamiwaza-ai-extensions-lib"
+        ts_lib.mkdir()
+        (ts_lib / "src").mkdir()
+        (ts_lib / "dist").mkdir()
+        (ts_lib / "src" / "index.ts").write_text("//")
+        time.sleep(0.05)
+        (ts_lib / "dist" / "index.js").write_text("// newer")
+
+        spec = SdkOverrideSpec(sdk_repo=tmp_path)
+        assert is_typescript_dist_stale(spec) is False
+
+    def test_is_typescript_dist_stale_returns_false_when_dist_is_missing(
+        self, tmp_path
+    ):
+        """Missing dist/ is a different signal — handled separately by the
+        caller. ``is_typescript_dist_stale`` only answers the comparison
+        question when both src/ and dist/ exist."""
+        from kamiwaza_extensions.sdk_override import is_typescript_dist_stale
+
+        ts_lib = tmp_path / "kamiwaza-ai-extensions-lib"
+        ts_lib.mkdir()
+        (ts_lib / "src").mkdir()
+        (ts_lib / "src" / "index.ts").write_text("//")
+
+        spec = SdkOverrideSpec(sdk_repo=tmp_path)
+        assert is_typescript_dist_stale(spec) is False
+
     def test_generate_local_build_dockerfile_patches_skips_when_no_install_line(
         self, tmp_path
     ):

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -880,6 +880,70 @@ class TestPreInstallStripOverlay:
         # Only one install line in the patched output.
         assert result.count("RUN npm install") == 1
 
+    def test_apply_build_overlay_routes_strip_by_language(self):
+        """ENG-3901 / round-4 (Codex P2): a frontend Dockerfile that
+        ALSO runs ``pip install`` for build tooling must have the TS
+        strip inserted before ``RUN npm install``, NOT before the pip
+        line. Without the language tag, the legacy "try both, Python
+        first" fallback would no-op the strip there because
+        ``package.json`` isn't yet copied — and the unstripped npm
+        install would then ETARGET on the unpublished pin."""
+        mixed_dockerfile = (
+            "FROM node:20-alpine\nWORKDIR /app\n"
+            # Python tooling first (e.g. for asset pipelines)
+            "RUN apk add python3 py3-pip\n"
+            "COPY tooling-requirements.txt .\n"
+            "RUN pip install -r requirements.txt\n"
+            # Then the actual TS install
+            "COPY package.json package-lock.json ./\n"
+            "RUN npm install\n"
+            "COPY . .\nRUN npm run build\n"
+        )
+        overlay = BuildOverride(
+            service_name="frontend",
+            overlay_steps="",
+            additional_build_contexts={"sdk": "/tmp/sdk"},
+            insert_before_build=True,
+            pre_install_steps=(
+                "# ts-strip\nUSER root\nRUN node -e 'strip'\n{restore_user_block}"
+            ),
+            language="typescript",
+        )
+        result = apply_build_overlay(mixed_dockerfile, overlay)
+        # The strip must land before npm install, NOT before pip install.
+        assert result.index("# ts-strip") > result.index("pip install"), (
+            "TS strip must NOT be inserted before the pip line; the strip "
+            f"would no-op there. Got result:\n{result}"
+        )
+        assert result.index("# ts-strip") < result.index("RUN npm install")
+
+    def test_apply_build_overlay_python_language_skips_npm_pattern(self):
+        """Inverse: a Python overlay must use the pip pattern only —
+        even if the Dockerfile happens to have a later npm install
+        line, the Python strip targets requirements.txt and would
+        no-op there too."""
+        mixed_dockerfile = (
+            "FROM python:3.10-slim\nWORKDIR /app\n"
+            "COPY package.json ./\n"
+            "RUN npm install -g some-tool\n"
+            "COPY requirements.txt .\n"
+            "RUN pip install -r requirements.txt\n"
+        )
+        overlay = BuildOverride(
+            service_name="backend",
+            overlay_steps="",
+            additional_build_contexts={"sdk": "/tmp/sdk"},
+            pre_install_steps=(
+                "# py-strip\nUSER root\nRUN sed -i '/x/d' requirements.txt\n"
+                "{restore_user_block}"
+            ),
+            language="python",
+        )
+        result = apply_build_overlay(mixed_dockerfile, overlay)
+        # Strip lands before pip install, not before npm install.
+        assert result.index("# py-strip") > result.index("RUN npm install")
+        assert result.index("# py-strip") < result.index("pip install")
+
     def test_strip_step_inserted_before_pip_install(self):
         overlay = BuildOverride(
             service_name="backend",

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -756,6 +756,46 @@ class TestPreInstallStripOverlay:
         assert len(overrides) == 1
         assert overrides[0].pre_install_steps == _PYTHON_PRE_INSTALL_STRIP
 
+    def test_frontend_override_carries_ts_pre_install_steps(self, tmp_path):
+        """``generate_build_overrides`` (cluster deploy path) must also wire
+        the TS strip step onto every frontend override. Round-2 of F-002:
+        the cluster-deploy build hits the same npm ETARGET as ``dev local``
+        when ``@kamiwaza-ai/extensions-lib`` isn't published, but the dev
+        local fix only landed in ``generate_local_build_dockerfile_patches``
+        — leaving ``kz-ext dev`` broken."""
+        from kamiwaza_extensions.sdk_override import _TS_PRE_INSTALL_STRIP
+
+        spec = SdkOverrideSpec(sdk_repo=tmp_path)
+        compose = {
+            "services": {"frontend": {"build": "./frontend", "ports": ["3000:3000"]}}
+        }
+        overrides = generate_build_overrides(spec, compose)
+        assert len(overrides) == 1
+        assert overrides[0].pre_install_steps == _TS_PRE_INSTALL_STRIP
+
+    def test_apply_build_overlay_inserts_ts_strip_before_npm_install(self):
+        """The overlay applier must locate ``RUN npm install`` (not just
+        ``pip install``) when the pre_install_steps target the frontend."""
+        ts_dockerfile = (
+            "FROM node:20-alpine\nWORKDIR /app\n"
+            "COPY package.json package-lock.json* ./\n"
+            "RUN npm install\nCOPY . .\n"
+            "RUN npm run build\n"
+            'CMD ["node", "/app/start.mjs"]\n'
+        )
+        overlay = BuildOverride(
+            service_name="frontend",
+            overlay_steps="# post-install\nRUN echo post\n",
+            additional_build_contexts={"sdk": "/tmp/sdk"},
+            insert_before_build=True,
+            pre_install_steps=(
+                "# ts-strip\nUSER root\nRUN node -e 'strip'\n{restore_user_block}"
+            ),
+        )
+        result = apply_build_overlay(ts_dockerfile, overlay)
+        assert "# ts-strip" in result
+        assert result.index("# ts-strip") < result.index("RUN npm install")
+
     def test_strip_step_inserted_before_pip_install(self):
         overlay = BuildOverride(
             service_name="backend",

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -1064,6 +1064,172 @@ class TestPreInstallStripOverlay:
 
 
 # ------------------------------------------------------------------
+# Pre-install strip steps (PR #91 round-2 review hardening): file-exists
+# guard fails open when the canonical filename is missing, and the TS
+# strip covers every npm dep-map key plus overrides/resolutions.
+# ------------------------------------------------------------------
+
+
+def _extract_run_command(template: str) -> str:
+    """Pull the ``RUN ...`` body out of one of the strip templates.
+
+    The templates contain a ``USER root\\n`` line, then a ``RUN <body>\\n``,
+    then a trailing ``{restore_user_block}`` placeholder. This helper
+    returns just ``<body>`` so a test can hand it to ``bash -c``.
+    """
+    lines = template.splitlines()
+    run_idx = next(i for i, ln in enumerate(lines) if ln.startswith("RUN "))
+    return lines[run_idx][len("RUN ") :]
+
+
+@pytest.mark.unit
+class TestPreInstallStripExecution:
+    """Behavioral coverage for the file-exists guards and the expanded
+    TS strip key set added in the round-2 review of PR #91."""
+
+    def test_python_strip_is_no_op_when_requirements_txt_missing(self, tmp_path):
+        """ENG-3901 / round-2: ``[ -f requirements.txt ]`` guard fails open
+        on non-canonical Dockerfile layouts."""
+        import shutil
+        import subprocess
+
+        from kamiwaza_extensions.sdk_override import _PYTHON_PRE_INSTALL_STRIP
+
+        if not shutil.which("bash"):
+            pytest.skip("bash not available")
+
+        cmd = _extract_run_command(_PYTHON_PRE_INSTALL_STRIP)
+        result = subprocess.run(
+            ["bash", "-c", cmd],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        # No file created, no stderr noise.
+        assert list(tmp_path.iterdir()) == []
+        assert result.stderr == ""
+
+    def test_python_strip_removes_pin_when_requirements_txt_present(self, tmp_path):
+        import shutil
+        import subprocess
+
+        from kamiwaza_extensions.sdk_override import _PYTHON_PRE_INSTALL_STRIP
+
+        if not shutil.which("bash"):
+            pytest.skip("bash not available")
+        # GNU sed is required for ``-i`` without a backup arg + POSIX
+        # character classes. macOS ships BSD sed, so install gnu-sed
+        # locally would be needed; the Dockerfile only runs in Linux
+        # build contexts so we gate to GNU sed only.
+        sed_path = shutil.which("sed")
+        if not sed_path:
+            pytest.skip("sed not available")
+        sed_help = subprocess.run(
+            [sed_path, "--version"], capture_output=True, text=True
+        )
+        if "GNU sed" not in sed_help.stdout:
+            pytest.skip("strip requires GNU sed; this host has BSD sed")
+
+        (tmp_path / "requirements.txt").write_text(
+            "fastapi>=0.100.0\n"
+            "kamiwaza-extensions-lib>=0.4,<0.5\n"
+            "kamiwaza-extensions-lib-extras>=0.1\n"
+        )
+        cmd = _extract_run_command(_PYTHON_PRE_INSTALL_STRIP)
+        result = subprocess.run(
+            ["bash", "-c", cmd],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        kept = (tmp_path / "requirements.txt").read_text()
+        assert "fastapi>=0.100.0" in kept
+        assert "kamiwaza-extensions-lib-extras>=0.1" in kept
+        assert "kamiwaza-extensions-lib>=0.4,<0.5" not in kept
+
+    def test_ts_strip_is_no_op_when_package_json_missing(self, tmp_path):
+        """ENG-3901 / round-2: ``[ -f package.json ]`` guard fails open
+        on non-canonical Dockerfile layouts."""
+        import shutil
+        import subprocess
+
+        from kamiwaza_extensions.sdk_override import _TS_PRE_INSTALL_STRIP
+
+        if not shutil.which("bash") or not shutil.which("node"):
+            pytest.skip("bash + node required")
+
+        cmd = _extract_run_command(_TS_PRE_INSTALL_STRIP)
+        result = subprocess.run(
+            ["bash", "-c", cmd],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert list(tmp_path.iterdir()) == []
+        assert result.stderr == ""
+
+    def test_ts_strip_removes_lib_from_every_dep_map_key(self, tmp_path):
+        """ENG-3901 / round-2: ``optionalDependencies``,
+        ``bundleDependencies`` / ``bundledDependencies``, ``overrides``,
+        and ``resolutions`` are all covered alongside the three
+        documented dep maps. Both object and array forms handled."""
+        import json as _json
+        import shutil
+        import subprocess
+
+        from kamiwaza_extensions.sdk_override import _TS_PRE_INSTALL_STRIP
+
+        if not shutil.which("bash") or not shutil.which("node"):
+            pytest.skip("bash + node required")
+
+        package = {
+            "name": "stripper-fixture",
+            "version": "0.0.0",
+            "dependencies": {
+                "@kamiwaza-ai/extensions-lib": "^0.4.0",
+                "react": "^18.0.0",
+            },
+            "devDependencies": {"@kamiwaza-ai/extensions-lib": "^0.4.0"},
+            "peerDependencies": {"@kamiwaza-ai/extensions-lib": "^0.4.0"},
+            "optionalDependencies": {"@kamiwaza-ai/extensions-lib": "^0.4.0"},
+            "bundleDependencies": ["@kamiwaza-ai/extensions-lib", "react"],
+            "bundledDependencies": ["@kamiwaza-ai/extensions-lib"],
+            "overrides": {"@kamiwaza-ai/extensions-lib": "0.4.0"},
+            "resolutions": {"@kamiwaza-ai/extensions-lib": "0.4.0"},
+        }
+        (tmp_path / "package.json").write_text(_json.dumps(package, indent=2))
+
+        cmd = _extract_run_command(_TS_PRE_INSTALL_STRIP)
+        result = subprocess.run(
+            ["bash", "-c", cmd],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        out = _json.loads((tmp_path / "package.json").read_text())
+        for k in (
+            "dependencies",
+            "devDependencies",
+            "peerDependencies",
+            "optionalDependencies",
+            "overrides",
+            "resolutions",
+        ):
+            assert "@kamiwaza-ai/extensions-lib" not in out[k], (
+                f"{k!r} still contains the lib"
+            )
+        assert "@kamiwaza-ai/extensions-lib" not in out["bundleDependencies"]
+        assert "@kamiwaza-ai/extensions-lib" not in out["bundledDependencies"]
+        # Unrelated entries survive.
+        assert out["dependencies"]["react"] == "^18.0.0"
+        assert "react" in out["bundleDependencies"]
+
+
+# ------------------------------------------------------------------
 # validate_sdk_override — path safety
 # ------------------------------------------------------------------
 

--- a/tests/unit/extensions/test_sdk_override.py
+++ b/tests/unit/extensions/test_sdk_override.py
@@ -1090,6 +1090,61 @@ class TestPreInstallStripOverlay:
         }
         assert generate_local_build_dockerfile_patches(spec, compose, ext) == {}
 
+    def test_local_build_patches_multistage_node_to_nginx_frontend(self, tmp_path):
+        """ENG-3901 / round-3 reviewer H2 (Codex): the dev-local path must
+        emit the TS strip for a multi-stage ``FROM node ... AS build;
+        FROM nginx:alpine`` frontend, not just the cluster-deploy path.
+        Final-stage classification ('static' for nginx) misses these;
+        ``_detect_build_service_runtime`` correctly identifies the
+        upstream Node builder stage. Without this, ``kz-ext dev local
+        --sdk-repo`` against a multi-stage frontend would hard-fail at
+        ``npm ci`` against the unpublished pin."""
+        from kamiwaza_extensions.sdk_override import (
+            _TS_PRE_INSTALL_STRIP,
+            generate_local_build_dockerfile_patches,
+        )
+
+        ext = tmp_path / "ext"
+        ext.mkdir()
+        web = ext / "web"
+        web.mkdir()
+        (web / "Dockerfile").write_text(
+            "FROM node:20 AS build\n"
+            "WORKDIR /app\n"
+            "COPY package.json package-lock.json ./\n"
+            "RUN npm ci\n"
+            "COPY . .\n"
+            "RUN npm run build\n"
+            "FROM nginx:alpine\n"
+            "COPY --from=build /app/dist /usr/share/nginx/html\n"
+        )
+
+        spec = SdkOverrideSpec(
+            sdk_repo=tmp_path, python=False, typescript=True
+        )
+        compose = {
+            "services": {
+                "frontend": {"build": {"context": "./web"}, "ports": ["8080:80"]}
+            }
+        }
+        patches = generate_local_build_dockerfile_patches(spec, compose, ext)
+        assert "frontend" in patches, (
+            "multi-stage Node→nginx frontend was not patched — final-stage "
+            "classifier misclassified it as 'static'"
+        )
+        assert "# --- SDK override: strip @kamiwaza-ai/extensions-lib" in (
+            patches["frontend"]
+        )
+        # ``RUN npm ci`` was rewritten to ``RUN npm install`` so the
+        # package.json/lockfile divergence the strip creates doesn't abort
+        # the build — same handling as the cluster-deploy path
+        # (``apply_build_overlay``).
+        assert "RUN npm ci" not in patches["frontend"], (
+            "npm ci must be rewritten to npm install in the local-dev path "
+            "too, not just the cluster-deploy path"
+        )
+        assert "RUN npm install" in patches["frontend"]
+
     def test_strip_regex_matches_real_pin_forms_and_skips_prefix_aliases(self):
         """Sanity-check the embedded sed pattern against realistic
         requirements.txt content: every pin form for the runtime lib should

--- a/tests/unit/extensions/test_status_cmd.py
+++ b/tests/unit/extensions/test_status_cmd.py
@@ -30,10 +30,16 @@ def _mock_extension(annotations: dict | None = None):
         "type": "app",
         "version": "1.0.0",
         "phase": "Running",
-        "endpoints": ExtensionEndpoints(external="https://cluster.test/runtime/apps/myapp"),
+        "endpoints": ExtensionEndpoints(
+            external="https://cluster.test/runtime/apps/myapp"
+        ),
         "services": [
-            ExtensionServiceStatus(name="backend", ready=True, replicas=1, available_replicas=1),
-            ExtensionServiceStatus(name="frontend", ready=True, replicas=1, available_replicas=1),
+            ExtensionServiceStatus(
+                name="backend", ready=True, replicas=1, available_replicas=1
+            ),
+            ExtensionServiceStatus(
+                name="frontend", ready=True, replicas=1, available_replicas=1
+            ),
         ],
     }
     if annotations is not None:
@@ -43,7 +49,9 @@ def _mock_extension(annotations: dict | None = None):
 
 @patch("kamiwaza_sdk.KamiwazaClient")
 @patch("kamiwaza_extensions.connections.ConnectionManager")
-def test_status_with_name_hits_extensions_endpoint_not_status(mock_conn_cls, mock_client_cls):
+def test_status_with_name_hits_extensions_endpoint_not_status(
+    mock_conn_cls, mock_client_cls
+):
     """ENG-3887 P10: must call get_extension (/extensions/{name}), not the
     /status sibling that returns 404 on every cluster currently deployed."""
     mock_conn = MagicMock()
@@ -70,7 +78,10 @@ def test_status_with_name_hits_extensions_endpoint_not_status(mock_conn_cls, moc
 @patch("kamiwaza_sdk.KamiwazaClient")
 @patch("kamiwaza_extensions.connections.ConnectionManager")
 def test_status_surfaces_deployer_annotation(mock_conn_cls, mock_client_cls):
-    """ENG-3887 §4.2.9: surface `kamiwaza.ai/deployer` from CRD annotations."""
+    """ENG-3887 §4.2.9: surface `kamiwaza.io/deployer` from CRD annotations.
+
+    Namespace is ``kamiwaza.io/*`` per ENG-3901 / F-010 — the platform's
+    annotation filter only persists ``kamiwaza.io/*`` keys."""
     mock_conn = MagicMock()
     mock_conn.get_active_connection.return_value = MagicMock(
         url="https://cluster.test/api", verify_ssl=True
@@ -81,9 +92,9 @@ def test_status_surfaces_deployer_annotation(mock_conn_cls, mock_client_cls):
     mock_client = MagicMock()
     mock_client.extensions.get_extension.return_value = _mock_extension(
         annotations={
-            "kamiwaza.ai/deployer": "jonathan@kamiwaza.ai",
-            "kamiwaza.ai/revision": "1.0.0-dev-abc.123",
-            "kamiwaza.ai/deployed-at": "2026-04-28T20:00:00+00:00",
+            "kamiwaza.io/deployer": "jonathan@kamiwaza.ai",
+            "kamiwaza.io/revision": "1.0.0-dev-abc.123",
+            "kamiwaza.io/deployed-at": "2026-04-28T20:00:00+00:00",
         },
     )
     mock_client_cls.return_value = mock_client
@@ -121,7 +132,6 @@ def test_status_not_found(mock_conn_cls, mock_client_cls):
     assert "not found" in result.output.lower()
 
 
-
 # ---------------------------------------------------------------------------
 # Review re-review PR #84 H2: cluster-mismatch fallback in name resolution
 # ---------------------------------------------------------------------------
@@ -132,7 +142,10 @@ def test_status_not_found(mock_conn_cls, mock_client_cls):
 @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
 @patch("kamiwaza_extensions.dev_state.read_state")
 def test_status_falls_back_to_jwt_when_dev_state_cluster_mismatches(
-    mock_read_state, mock_detector_cls, mock_conn_cls, mock_client_cls,
+    mock_read_state,
+    mock_detector_cls,
+    mock_conn_cls,
+    mock_client_cls,
 ):
     """H2: after `kz-ext login` to a different cluster, `status` must NOT
     use the saved dev_name from the prior cluster — querying the new
@@ -144,7 +157,8 @@ def test_status_falls_back_to_jwt_when_dev_state_cluster_mismatches(
     # Active connection is now cluster B.
     mock_conn = MagicMock()
     mock_conn.get_active_connection.return_value = MagicMock(
-        url="https://cluster-b.test/api", verify_ssl=True,
+        url="https://cluster-b.test/api",
+        verify_ssl=True,
     )
     mock_conn.get_token.return_value = MagicMock(
         access_token="header.eyJzdWIiOiJ1c2VyLWIifQ.sig",
@@ -155,7 +169,9 @@ def test_status_falls_back_to_jwt_when_dev_state_cluster_mismatches(
 
     mock_detector = MagicMock()
     mock_detector.detect.return_value = SimpleNamespace(
-        path="/tmp/x", name="my-app", version="1.0.0",
+        path="/tmp/x",
+        name="my-app",
+        version="1.0.0",
     )
     mock_detector_cls.return_value = mock_detector
 
@@ -171,8 +187,11 @@ def test_status_falls_back_to_jwt_when_dev_state_cluster_mismatches(
 
     mock_client = MagicMock()
     ext = MagicMock(
-        name="my-app-dev-jwt", phase="Running",
-        endpoints=MagicMock(external=None), services=[], model_extra={},
+        name="my-app-dev-jwt",
+        phase="Running",
+        endpoints=MagicMock(external=None),
+        services=[],
+        model_extra={},
     )
     ext.annotations = {}
     mock_client.extensions.get_extension.return_value = ext
@@ -182,9 +201,9 @@ def test_status_falls_back_to_jwt_when_dev_state_cluster_mismatches(
 
     assert result.exit_code == 0
     called_with = mock_client.extensions.get_extension.call_args[0][0]
-    assert called_with != "my-app-dev-old123", (
-        f"status used cluster-A dev_name {called_with!r} despite cluster-B connection"
-    )
+    assert (
+        called_with != "my-app-dev-old123"
+    ), f"status used cluster-A dev_name {called_with!r} despite cluster-B connection"
     assert called_with.startswith("my-app-dev-")
     assert len(called_with.split("-")[-1]) == 6
 
@@ -194,14 +213,18 @@ def test_status_falls_back_to_jwt_when_dev_state_cluster_mismatches(
 @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
 @patch("kamiwaza_extensions.dev_state.read_state")
 def test_status_uses_dev_state_name_when_cluster_matches(
-    mock_read_state, mock_detector_cls, mock_conn_cls, mock_client_cls,
+    mock_read_state,
+    mock_detector_cls,
+    mock_conn_cls,
+    mock_client_cls,
 ):
     """Sanity check the H2 fix doesn't break the happy path."""
     from kamiwaza_extensions.dev_state import DevState
 
     mock_conn = MagicMock()
     mock_conn.get_active_connection.return_value = MagicMock(
-        url="https://cluster.test/api", verify_ssl=True,
+        url="https://cluster.test/api",
+        verify_ssl=True,
     )
     mock_conn.get_token.return_value = MagicMock(
         access_token="header.eyJzdWIiOiAidXNlci1hbGljZSIsICJlbWFpbCI6ICJhbGljZUBleGFtcGxlLmNvbSJ9.sig",
@@ -212,7 +235,9 @@ def test_status_uses_dev_state_name_when_cluster_matches(
 
     mock_detector = MagicMock()
     mock_detector.detect.return_value = SimpleNamespace(
-        path="/tmp/x", name="my-app", version="1.0.0",
+        path="/tmp/x",
+        name="my-app",
+        version="1.0.0",
     )
     mock_detector_cls.return_value = mock_detector
 
@@ -227,8 +252,11 @@ def test_status_uses_dev_state_name_when_cluster_matches(
 
     mock_client = MagicMock()
     ext = MagicMock(
-        name="my-app-dev-saved", phase="Running",
-        endpoints=MagicMock(external=None), services=[], model_extra={},
+        name="my-app-dev-saved",
+        phase="Running",
+        endpoints=MagicMock(external=None),
+        services=[],
+        model_extra={},
     )
     ext.annotations = {}
     mock_client.extensions.get_extension.return_value = ext
@@ -238,7 +266,6 @@ def test_status_uses_dev_state_name_when_cluster_matches(
     assert result.exit_code == 0
     called_with = mock_client.extensions.get_extension.call_args[0][0]
     assert called_with == "my-app-dev-saved"
-
 
 
 # ---------------------------------------------------------------------------
@@ -251,7 +278,10 @@ def test_status_uses_dev_state_name_when_cluster_matches(
 @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
 @patch("kamiwaza_extensions.dev_state.read_state")
 def test_status_falls_back_to_jwt_when_deployer_mismatches(
-    mock_read_state, mock_detector_cls, mock_conn_cls, mock_client_cls,
+    mock_read_state,
+    mock_detector_cls,
+    mock_conn_cls,
+    mock_client_cls,
 ):
     """Same cluster, but a *different user* is now logged in. Without
     the deployer guard, `kz-ext status` would query for user A's
@@ -262,7 +292,8 @@ def test_status_falls_back_to_jwt_when_deployer_mismatches(
 
     mock_conn = MagicMock()
     mock_conn.get_active_connection.return_value = MagicMock(
-        url="https://cluster.test/api", verify_ssl=True,
+        url="https://cluster.test/api",
+        verify_ssl=True,
     )
     # JWT carrying email=bob@example.com — different from state.deployer.
     mock_conn.get_token.return_value = MagicMock(
@@ -271,26 +302,32 @@ def test_status_falls_back_to_jwt_when_deployer_mismatches(
     mock_conn_cls.return_value = mock_conn
 
     from types import SimpleNamespace
+
     mock_detector = MagicMock()
     mock_detector.detect.return_value = SimpleNamespace(
-        path="/tmp/x", name="my-app", version="1.0.0",
+        path="/tmp/x",
+        name="my-app",
+        version="1.0.0",
     )
     mock_detector_cls.return_value = mock_detector
 
     # Saved state from user A, same cluster as the active connection.
     mock_read_state.return_value = DevState(
-        last_dev_name="my-app-dev-userA1",     # alice's deployment
+        last_dev_name="my-app-dev-userA1",  # alice's deployment
         last_revision="rev-1",
-        cluster="https://cluster.test/api",     # matches active connection
+        cluster="https://cluster.test/api",  # matches active connection
         extension_name="my-app",
-        deployer="alice@example.com",           # ≠ bob's JWT
+        deployer="alice@example.com",  # ≠ bob's JWT
         last_successful_step="poll",
     )
 
     mock_client = MagicMock()
     ext = MagicMock(
-        name="my-app-dev-userB", phase="Running",
-        endpoints=MagicMock(external=None), services=[], model_extra={},
+        name="my-app-dev-userB",
+        phase="Running",
+        endpoints=MagicMock(external=None),
+        services=[],
+        model_extra={},
     )
     ext.annotations = {}
     mock_client.extensions.get_extension.return_value = ext
@@ -301,13 +338,12 @@ def test_status_falls_back_to_jwt_when_deployer_mismatches(
     assert result.exit_code == 0
     called_with = mock_client.extensions.get_extension.call_args[0][0]
     # Crucially NOT alice's saved name.
-    assert called_with != "my-app-dev-userA1", (
-        f"status surfaced alice's deployment {called_with!r} to bob"
-    )
+    assert (
+        called_with != "my-app-dev-userA1"
+    ), f"status surfaced alice's deployment {called_with!r} to bob"
     # Bob gets his own JWT-derived name.
     assert called_with.startswith("my-app-dev-")
     assert len(called_with.split("-")[-1]) == 6
-
 
 
 # ---------------------------------------------------------------------------
@@ -320,7 +356,10 @@ def test_status_falls_back_to_jwt_when_deployer_mismatches(
 @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
 @patch("kamiwaza_extensions.dev_state.read_state")
 def test_status_email_match_is_case_insensitive(
-    mock_read_state, mock_detector_cls, mock_conn_cls, mock_client_cls,
+    mock_read_state,
+    mock_detector_cls,
+    mock_conn_cls,
+    mock_client_cls,
 ):
     """Some IdPs vary email casing across token refreshes (`Alice@Example.com`
     one minute, `alice@example.com` the next). The deployer match should
@@ -329,7 +368,8 @@ def test_status_email_match_is_case_insensitive(
 
     mock_conn = MagicMock()
     mock_conn.get_active_connection.return_value = MagicMock(
-        url="https://cluster.test/api", verify_ssl=True,
+        url="https://cluster.test/api",
+        verify_ssl=True,
     )
     # JWT carries `Alice@Example.COM` (mixed case).
     mock_conn.get_token.return_value = MagicMock(
@@ -338,9 +378,12 @@ def test_status_email_match_is_case_insensitive(
     mock_conn_cls.return_value = mock_conn
 
     from types import SimpleNamespace
+
     mock_detector = MagicMock()
     mock_detector.detect.return_value = SimpleNamespace(
-        path="/tmp/x", name="my-app", version="1.0.0",
+        path="/tmp/x",
+        name="my-app",
+        version="1.0.0",
     )
     mock_detector_cls.return_value = mock_detector
 
@@ -350,14 +393,17 @@ def test_status_email_match_is_case_insensitive(
         last_revision="1.0.0-dev-abc.1",
         cluster="https://cluster.test/api",
         extension_name="my-app",
-        deployer="alice@example.com",          # ≠ JWT casing
+        deployer="alice@example.com",  # ≠ JWT casing
         last_successful_step="poll",
     )
 
     mock_client = MagicMock()
     ext = MagicMock(
-        name="my-app-dev-saved", phase="Running",
-        endpoints=MagicMock(external=None), services=[], model_extra={},
+        name="my-app-dev-saved",
+        phase="Running",
+        endpoints=MagicMock(external=None),
+        services=[],
+        model_extra={},
     )
     ext.annotations = {}
     mock_client.extensions.get_extension.return_value = ext

--- a/tests/unit/extensions/test_template_manifest.py
+++ b/tests/unit/extensions/test_template_manifest.py
@@ -38,6 +38,7 @@ def template_root() -> Path:
 # entries and no version-ordering surprises.
 # ---------------------------------------------------------------------------
 
+
 class TestRegistryShape:
     def test_manifests_cover_all_three_shapes(self):
         assert set(MANIFESTS.keys()) == {"app", "tool", "service"}
@@ -63,9 +64,9 @@ class TestRegistryShape:
     def test_strategies_are_valid(self, shape: str):
         valid = {"overwrite", "preserve_if_modified", "merge"}
         for f in MANIFESTS[shape].files:
-            assert f.strategy in valid, (
-                f"{shape}/{f.relative_path}: invalid strategy {f.strategy!r}"
-            )
+            assert (
+                f.strategy in valid
+            ), f"{shape}/{f.relative_path}: invalid strategy {f.strategy!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -74,14 +75,13 @@ class TestRegistryShape:
 # without a manifest entry trips this.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.extension_regression
 @pytest.mark.parametrize("shape", ["app", "tool", "service"])
 def test_every_template_file_is_classified(shape: str, template_root: Path):
     shape_dir = template_root / shape
     on_disk = sorted(
-        str(p.relative_to(shape_dir))
-        for p in shape_dir.rglob("*")
-        if p.is_file()
+        str(p.relative_to(shape_dir)) for p in shape_dir.rglob("*") if p.is_file()
     )
     classified = {f.relative_path for f in MANIFESTS[shape].files} | set(
         AUTHOR_OWNED_DENYLIST.get(shape, ())
@@ -101,10 +101,47 @@ def test_every_template_file_is_classified(shape: str, template_root: Path):
 # Migration entries are well-formed.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.parametrize("shape", ["app", "tool", "service"])
 def test_migrations_have_distinct_old_paths(shape: str):
     olds = [m.old_path for m in MANIFESTS[shape].migrations]
     assert len(olds) == len(set(olds)), (
         f"Duplicate migration old_path entries in {shape}: "
         f"{[p for p in olds if olds.count(p) > 1]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tool template's FastMCP server uses the right API shape (ENG-3901 / F-014).
+# ---------------------------------------------------------------------------
+
+
+def test_tool_template_fastmcp_run_does_not_pass_host_or_port_kwargs(template_root):
+    """ENG-3901 / F-014: ``FastMCP.run()`` accepts only ``transport`` and
+    ``mount_path`` — NOT ``host`` or ``port``. Earlier tool template
+    invoked ``mcp.run(transport="sse", host="0.0.0.0", port=8000)`` which
+    is a TypeError on the current ``mcp>=1.0`` / ``fastmcp>=0.1`` API.
+    Pod CrashLoopBackOff'd on every fresh tool deploy until host/port
+    moved into the ``FastMCP(...)`` constructor."""
+    import re
+
+    server_py = (template_root / "tool" / "src" / "server.py").read_text()
+    run_args = server_py.split("mcp.run(")[1].split(")")[0]
+    # Must not pass host/port to .run() — word-boundary match so
+    # ``transport="sse"`` doesn't false-positive against the substring
+    # "port=".
+    assert not re.search(r"\bhost\s*=", run_args), (
+        f"tool template still passes host=... to FastMCP.run() — that's a "
+        f"TypeError on the current API. host/port belong on the FastMCP() "
+        f"constructor. run args: {run_args!r}"
+    )
+    assert not re.search(
+        r"\bport\s*=", run_args
+    ), f"tool template still passes port=... to FastMCP.run(). run args: {run_args!r}"
+    # Must bind on 0.0.0.0 somewhere (otherwise loopback-only — unreachable
+    # from outside the container).
+    assert "0.0.0.0" in server_py, (
+        "tool template must bind the FastMCP server on 0.0.0.0 (default "
+        "127.0.0.1 only listens on loopback, unreachable from outside the "
+        "container)"
     )


### PR DESCRIPTION
## Summary

Drove the ENG-3901 D210/M3 dry run end-to-end across all 5 Appendix A scenarios and fixed every finding the SDK can fix on its own. Platform-side follow-ons tracked separately in Linear.

**Test posture:** 1286 unit/contract passing, 8 skipped (5 are S1–S5 drivers awaiting `KAMIWAZA_STAGING_URL`), 0 regressions.

## Findings landed (10)

| # | Severity | Fix |
|---|---|---|
| F-002 (×3) | P0 | `kz-ext dev` — strip `kamiwaza-extensions-lib` / `@kamiwaza-ai/extensions-lib` from `requirements.txt` / `package.json` before pip/npm; resolve site-packages via `sysconfig.purelib` rather than importing the lib; cluster-deploy path also handles frontend strip. Unblocks every freshly-scaffolded extension's first build until F-001 publish lands. |
| F-003 | P3 | Doctor's "runtime lib not found" / "out of range" hints now include the running kz-ext version + a `pip install --upgrade kamiwaza-sdk` suggestion so a stale install doesn't silently mislead. |
| F-005 | P3 | `kz-ext create` next-steps banner suggests `kz-ext dev local --auth` for `--type app`, plain `dev local` for tool/service. |
| F-006 | P2 | `kz-ext dev local --sdk-repo` auto-rebuilds the TS dist when src/ is newer (not just when missing). Earlier "consider rebuilding" warning is now an automatic action. |
| F-007 | P2 | Create banner mentions the auto-assigned host port pattern; combined with F-008 the localhost:3000 footgun is mostly defused. |
| F-008 | P2 | Foreground `kz-ext dev local` now spawns a daemon polling thread that prints the resolved frontend / backend URL once compose binds the host port. Detach mode unchanged. |
| F-009 | P0 | `--auth` bridge defaults `X-Workroom-Id` to the global-workroom sentinel (`ffff…ffff`) instead of `claims.sub`. Earlier default silently 403'd every backend → platform call (workroom-membership filter rejected the synthesized fake workroom). |
| F-010 | P1 | SDK rename of CRD annotations from `kamiwaza.ai/*` to `kamiwaza.io/*` so the platform's persister filter accepts them. `kz-ext status`'s "Last deployed by..." surface now works. |
| F-013 | P0 / P1 | Service-type primary K8s probe uses `/`; tool-type primary uses `/sse` (FastMCP). Earlier `/health` probe 404'd against both stubs and pods CrashLoopBackOff'd. Tool probe is best-effort pending ENG-4389 (platform rejects `tcpSocket`/`exec` probes). |
| F-014 | P0 | Tool template's `src/server.py` rewritten for `mcp>=1.0` API: `host`/`port` go to `FastMCP(...)` constructor, not `mcp.run()`. Earlier scaffold raised `TypeError` on first start. |

## Findings tracked in Linear

| Issue | Severity | Note |
|---|---|---|
| [ENG-4383](https://linear.app/kamiwaza/issue/ENG-4383) | High | Platform extension-operator doesn't inject `KAMIWAZA_*` env vars on `kz-ext dev` deployments → silent breaks of logout, /api/models, /auth/login-url. |
| [ENG-4387](https://linear.app/kamiwaza/issue/ENG-4387) | Urgent | Publish `kamiwaza-extensions-lib==0.4.0` to PyPI + `@kamiwaza-ai/extensions-lib >=0.4` to npm — needed before any external developer can run `kz-ext dev local` / `kz-ext dev` without `--sdk-repo`. |
| [ENG-4388](https://linear.app/kamiwaza/issue/ENG-4388) | Medium | Platform broaden Extension CR annotation allowlist to accept `kamiwaza.ai/*` (SDK already worked around with `.io` rename). |
| [ENG-4389](https://linear.app/kamiwaza/issue/ENG-4389) | High | Platform Extension CR API rejects `tcpSocket` and `exec` healthCheck shapes with opaque 500 even though the CRD allows them. Affects tool-type probe quality. |

## Scenario sign-off summary

| Scenario | Sign-off actor | Status |
|---|---|---|
| S1 — User-facing app with forced login | Preston McGowan | drove automatable parts (scaffold → dev local with auth bridge → cluster deploy → unauth gateway gating); browser auth + chat invocation deferred to Preston UAT |
| S2 — App launched from Workroom Manager | SDK team | **PASS** (14/14 probe assertions) |
| S3 — Operator-deployable connector | Preston McGowan | drove deploy + gateway gating; scaffold has no developer connector code to exercise authenticated invocation |
| S4 — Data-type conversion tool via Kaizen | Preston McGowan | drove deploy + FastMCP server; Kaizen invocation deferred to Preston UAT |
| S5 — Data enrichment / boundary enforcement | SDK team | **PASS** (17/17 probe assertions) |

Sign-off `.md` artifacts (rendered programmatically during the dry-run) are intentionally NOT committed in this PR — they're for actor sign-off and will land separately.

## Test plan

- [x] `pytest -m "not integration and not live and not e2e"` — 1286 passed, 8 skipped, 0 regressions
- [x] `pytest -m extension_regression` — all 12 inventory items still green
- [x] End-to-end against the dry-run cluster: app-type deploy reaches Running, gateway 401s unauth, identity headers reach backend; service-type deploy reaches Running with F-013 fix; tool-type deploy creates CR + runs FastMCP server with F-013 round-2 + F-014 fixes
- [x] Probe scripts (`/tmp/eng-3901-dry-run/{s2,s5}-probe.py`) exercise UAC-9c / UAC-9d at the runtime-lib level
- [ ] Preston UAT — S1, S3, S4 manual sign-off (post-PR-merge, against staging)
- [ ] Re-run after ENG-4387 publishes runtime libs — confirm external-developer path works without `--sdk-repo`

## Files of note

- `kamiwaza_extensions/sdk_override.py` — F-002 (×3), F-006 plumbing
- `kamiwaza_extensions/dev_local.py` — F-006 trigger, F-008 polling thread
- `kamiwaza_extensions/payload_builder.py` — F-010 namespace, F-013 probe-path threading
- `kamiwaza_extensions/commands/{create,status}.py` — F-005, F-007 banner; F-010 read sites
- `kamiwaza_extensions/doctor.py` — F-003 hint
- `kamiwaza_extensions/templates/tool/src/server.py` — F-014
- `kamiwaza-ai-extensions-lib/src/local-dev-auth/index.ts` — F-009 bridge default

🤖 Generated with [Claude Code](https://claude.com/claude-code)