### PR TITLE
feat(extensions): --digest flag on kz-ext publish for digest-pinned catalog refs (ENG-4370)

### DIFF
--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -345,6 +345,16 @@ def publish(
             "idempotent CI re-publishes; --force overrides."
         ),
     ),
+    digest: Optional[str] = typer.Option(
+        None,
+        "--digest",
+        help=(
+            "Pin the catalog entry to a specific manifest digest "
+            "(sha256:<64-hex>). Catalog refs become 'image:tag@sha256:...' "
+            "for immutable identity. Requires exactly one buildable "
+            "service in compose; omit to auto-resolve per-service digests."
+        ),
+    ),
 ) -> None:
     """Publish extension to catalog."""
     from kamiwaza_extensions.commands.publish import run_publish
@@ -356,6 +366,7 @@ def publish(
         no_push=no_push,
         verbose=_state.verbose,
         revision=revision,
+        digest=digest,
     )
 
 

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -81,6 +81,7 @@ def run_publish(
     no_push: bool = False,
     verbose: bool = False,
     revision: Optional[str] = None,
+    digest: Optional[str] = None,
 ) -> None:
     """Build, push, and publish extension to catalog."""
     from kamiwaza_extensions.catalog_publisher import (
@@ -93,7 +94,11 @@ def run_publish(
     from kamiwaza_extensions.exit_codes import ExitCode
     from kamiwaza_extensions.extension_detector import ExtensionDetector
     from kamiwaza_extensions.image_builder import ImageBuilder, ImageBuildError
-    from kamiwaza_extensions.image_pusher import ImagePusher, ImagePushError
+    from kamiwaza_extensions.image_pusher import (
+        ImagePushError,
+        ImagePusher,
+        validate_digest,
+    )
     from kamiwaza_extensions.profile_manager import ProfileManager
     from kamiwaza_extensions.registry_builder import RegistryBuilder
     from kamiwaza_extensions.validators.compose import ComposeValidator
@@ -111,6 +116,16 @@ def run_publish(
             console.print(f"[red]Error:[/red] {exc}")
             raise typer.Exit(code=int(ExitCode.VALIDATION)) from exc
 
+    # Same fail-fast intent for --digest: reject malformed input before any
+    # build/push side effects. Format guard only — buildable-count check
+    # happens after compose data is loaded.
+    if digest is not None:
+        try:
+            validate_digest(digest)
+        except ValueError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(code=int(ExitCode.VALIDATION)) from exc
+
     # 1. Detect extension
     detector = ExtensionDetector()
     info = detector.detect()
@@ -118,6 +133,23 @@ def run_publish(
     if info.compose_data is None:
         console.print("[red]Error:[/red] No docker-compose.yml found.")
         raise typer.Exit(code=1)
+
+    # ENG-4370: --digest pins identity for one image. Multi-image extensions
+    # must rely on auto-resolve (the per-service push digest), so reject the
+    # ambiguous case before doing any work.
+    if digest is not None:
+        buildable_services = [
+            name for name, svc in (info.compose_data.get("services") or {}).items()
+            if "build" in svc
+        ]
+        if len(buildable_services) != 1:
+            found = ", ".join(buildable_services) if buildable_services else "none"
+            console.print(
+                f"[red]Error:[/red] --digest requires exactly one buildable "
+                f"service in docker-compose.yml; found {len(buildable_services)} "
+                f"({found}). Omit --digest to auto-resolve per-service digests."
+            )
+            raise typer.Exit(code=int(ExitCode.VALIDATION))
 
     version = info.version
     ext_type = _infer_extension_type(info.metadata)
@@ -301,6 +333,23 @@ def run_publish(
     elif no_push:
         console.print("  [dim]Skipping push (--no-push)[/dim]")
 
+    # 6.5 Resolve digests for buildable images (ENG-4370). Catalog refs
+    # are pinned `image:tag@sha256:...` so they're immutable regardless
+    # of tag mutability. Pass-through external/prebuilt-internal refs
+    # (postgres, etc.) keep whatever pinning their source repo applied.
+    digest_map: Dict[str, str] = {}
+    if image_refs:
+        if digest is not None:
+            # Buildable-count validation above guarantees a single ref.
+            digest_map[image_refs[0]] = digest
+        else:
+            try:
+                for ref in image_refs:
+                    digest_map[ref] = ImagePusher.resolve_digest(ref)
+            except ImagePushError as exc:
+                console.print(f"\n[red]Error:[/red] {exc}")
+                raise typer.Exit(code=1) from exc
+
     # 7. Build catalog entry
     reg_builder = RegistryBuilder()
     entry = reg_builder.build_entry(
@@ -310,6 +359,7 @@ def run_publish(
         version=version,
         stage=stage,
         revision=revision,
+        digest_map=digest_map or None,
     )
 
     # 8. Publish to catalog

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -110,10 +110,6 @@ def _auto_resolve_digests(
     --no-push``): pre-PR behavior was tag-only with no docker dependency,
     so a resolve failure becomes a warning and the ref is omitted from
     the result rather than aborting the publish.
-
-    For the partial shape ``--no-push`` without ``--no-build``, a
-    ``manifest unknown`` registry error is rewrapped with an actionable
-    hint (push first, or pass ``--digest``).
     """
     from kamiwaza_extensions.image_pusher import ImagePushError, ImagePusher
 
@@ -129,13 +125,7 @@ def _auto_resolve_digests(
                     "this ref"
                 )
                 continue
-            if no_push and "manifest unknown" in str(exc).lower():
-                console.print(
-                    f"\n[red]Error:[/red] registry has no image at "
-                    f"{ref}. Push it first or pass --digest explicitly."
-                )
-            else:
-                console.print(f"\n[red]Error:[/red] {exc}")
+            console.print(f"\n[red]Error:[/red] {exc}")
             raise typer.Exit(code=1) from exc
     return digest_map
 
@@ -417,6 +407,19 @@ def run_publish(
         image_refs = _collect_image_refs(
             info.compose_data, info.name, image_tag, registry
         )
+
+    # 5.5 Preflight: digest resolution post-push needs `docker buildx
+    # imagetools`. If buildx is missing on this host, fail before mutating
+    # the registry rather than push-then-fail-on-resolve. Only required
+    # when push will happen and there's at least one published service to
+    # pin (the catalog-only-republish path soft-falls in
+    # `_auto_resolve_digests` and doesn't need this guard).
+    if not no_push and buildable_services:
+        try:
+            ImagePusher.check_buildx_available()
+        except ImagePushError as exc:
+            console.print(f"\n[red]Error:[/red] {exc}")
+            raise typer.Exit(code=1) from exc
 
     # 6. Push images (same stage-aware tag)
     if not no_push and image_refs:

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -72,6 +72,74 @@ def _collect_image_refs(
     return refs
 
 
+def _verify_supplied_digest(ref: str, supplied: str) -> None:
+    """Resolve *ref* in the registry and abort if it disagrees with *supplied*.
+
+    Catches CI typos, stale digests, and the TOCTOU window where a
+    parallel run re-pointed the tag between our push and our publish.
+    Caller must guarantee the image was just pushed (i.e. ``no_push`` is
+    False) — otherwise the registry isn't authoritative for what we
+    intended to publish.
+    """
+    from kamiwaza_extensions.exit_codes import ExitCode
+    from kamiwaza_extensions.image_pusher import ImagePushError, ImagePusher
+
+    try:
+        actual = ImagePusher.resolve_digest(ref)
+    except ImagePushError as exc:
+        console.print(f"\n[red]Error:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+    if actual != supplied:
+        console.print(
+            f"\n[red]Error:[/red] supplied --digest does not match "
+            f"the registry manifest for {ref}.\n"
+            f"  supplied: {supplied}\n"
+            f"  registry: {actual}\n"
+            "Re-run with the correct digest, or omit --digest to "
+            "auto-resolve."
+        )
+        raise typer.Exit(code=int(ExitCode.VALIDATION))
+
+
+def _auto_resolve_digests(
+    refs: List[str], *, no_build: bool, no_push: bool,
+) -> Dict[str, str]:
+    """Resolve registry digests for each *ref* and return ``{ref: digest}``.
+
+    Soft-fails for the catalog-only-republish shape (``--no-build
+    --no-push``): pre-PR behavior was tag-only with no docker dependency,
+    so a resolve failure becomes a warning and the ref is omitted from
+    the result rather than aborting the publish.
+
+    For the partial shape ``--no-push`` without ``--no-build``, a
+    ``manifest unknown`` registry error is rewrapped with an actionable
+    hint (push first, or pass ``--digest``).
+    """
+    from kamiwaza_extensions.image_pusher import ImagePushError, ImagePusher
+
+    digest_map: Dict[str, str] = {}
+    for ref in refs:
+        try:
+            digest_map[ref] = ImagePusher.resolve_digest(ref)
+        except ImagePushError as exc:
+            if no_build and no_push:
+                console.print(
+                    f"  [yellow]warn[/yellow] could not resolve digest "
+                    f"for {ref}: {exc} — catalog will use tag-only for "
+                    "this ref"
+                )
+                continue
+            if no_push and "manifest unknown" in str(exc).lower():
+                console.print(
+                    f"\n[red]Error:[/red] registry has no image at "
+                    f"{ref}. Push it first or pass --digest explicitly."
+                )
+            else:
+                console.print(f"\n[red]Error:[/red] {exc}")
+            raise typer.Exit(code=1) from exc
+    return digest_map
+
+
 def run_publish(
     *,
     stage: str,
@@ -123,7 +191,11 @@ def run_publish(
         try:
             validate_digest(digest)
         except ValueError as exc:
-            console.print(f"[red]Error:[/red] {exc}")
+            # The exception text contains the user-supplied digest verbatim;
+            # rich console treats `[…]` as markup, so disable interpretation
+            # to avoid silent stripping or a markup-injection vector.
+            console.print("[red]Error:[/red] ", end="")
+            console.print(str(exc), markup=False)
             raise typer.Exit(code=int(ExitCode.VALIDATION)) from exc
 
     # 1. Detect extension
@@ -156,9 +228,9 @@ def run_publish(
         )
         raise typer.Exit(code=int(ExitCode.VALIDATION))
 
-    # ENG-4370 H1: auto-resolve queries the registry post-build. Built-but-
-    # not-pushed leaves the registry stale (or empty), so the resolved
-    # digest would either error or silently pin the *previous* push.
+    # Auto-resolve queries the registry post-build. Built-but-not-pushed
+    # leaves the registry stale (or empty), so the resolved digest would
+    # either error or silently pin the *previous* push.
     # Force the user to either push, skip the build, or supply --digest.
     # Skipped under: dry-run (no build/push happens), and external-only
     # extensions (no buildable services means no hazard).
@@ -271,13 +343,15 @@ def run_publish(
 
         # Dry-run preview reflects an explicit --digest; auto-resolve
         # is skipped because a dry-run shouldn't talk to the registry.
+        # Mirrors the live path's published_refs derivation: pin against
+        # the buildable_services-derived ref so a profiled helper that
+        # appears first in dict order can't redirect the user's digest.
         dry_digest_map: Dict[str, str] = {}
-        if digest is not None:
-            dry_refs = _collect_image_refs(
-                info.compose_data, info.name, image_tag, registry
+        if digest is not None and buildable_services:
+            dry_canonical_ref = (
+                f"{registry}/{info.name}-{buildable_services[0]}:{image_tag}"
             )
-            if dry_refs:
-                dry_digest_map[dry_refs[0]] = digest
+            dry_digest_map[dry_canonical_ref] = digest
 
         # Run merge check so dry-run detects version conflicts
         reg_builder = RegistryBuilder()
@@ -370,75 +444,27 @@ def run_publish(
     elif no_push:
         console.print("  [dim]Skipping push (--no-push)[/dim]")
 
-    # 6.5 Resolve digests for published buildable images (ENG-4370). Catalog
-    # refs are pinned `image:tag@sha256:...` so they're immutable regardless
-    # of tag mutability. Pass-through external/prebuilt-internal refs
-    # (postgres, etc.) keep whatever pinning their source repo applied.
-    #
-    # Iterate over `published_refs` derived from `buildable_services` (which
-    # already excludes profile-only services) instead of `image_refs`.
-    # `image_refs` reflects what ImageBuilder built and ImagePusher pushed,
-    # which can include profiled helpers — those won't appear in the
-    # transformed catalog compose, so resolving / pinning their digest is at
-    # best wasted work and at worst (with --digest) misdirects the user's
-    # supplied digest at the wrong ref.
+    # Catalog refs are pinned `image:tag@sha256:...` so they're immutable
+    # regardless of tag mutability. published_refs is derived from
+    # buildable_services (which excludes profile-only services per
+    # ComposeTransformer's filter), so a profiled helper appearing first
+    # in image_refs cannot misdirect the digest map. Pass-through external
+    # refs keep whatever pinning their source repo applied.
     published_refs: List[str] = [
         f"{registry}/{info.name}-{name}:{image_tag}" for name in buildable_services
     ]
     digest_map: Dict[str, str] = {}
     if published_refs:
         if digest is not None:
-            # Buildable-count validation above guarantees a single ref.
+            # Single-buildable invariant guaranteed by validation above.
             ref = published_refs[0]
             digest_map[ref] = digest
-            # H2: when push happened, verify the supplied digest matches
-            # the registry's manifest. Catches CI typos, stale digests,
-            # and the TOCTOU window where a parallel run re-pointed the
-            # tag between our push and our publish.
             if not no_push:
-                try:
-                    actual = ImagePusher.resolve_digest(ref)
-                except ImagePushError as exc:
-                    console.print(f"\n[red]Error:[/red] {exc}")
-                    raise typer.Exit(code=1) from exc
-                if actual != digest:
-                    console.print(
-                        f"\n[red]Error:[/red] supplied --digest does not match "
-                        f"the registry manifest for {ref}.\n"
-                        f"  supplied: {digest}\n"
-                        f"  registry: {actual}\n"
-                        "Re-run with the correct digest, or omit --digest to "
-                        "auto-resolve."
-                    )
-                    raise typer.Exit(code=int(ExitCode.VALIDATION))
+                _verify_supplied_digest(ref, digest)
         else:
-            for ref in published_refs:
-                try:
-                    digest_map[ref] = ImagePusher.resolve_digest(ref)
-                except ImagePushError as exc:
-                    # H3 (Codex re-review): under --no-build --no-push the
-                    # caller is doing a catalog-only republish; pre-PR
-                    # behavior was tag-only with no docker dependency.
-                    # Soft-fail to preserve that: warn, leave this ref out
-                    # of digest_map → catalog gets tag-only for it.
-                    if no_build and no_push:
-                        console.print(
-                            f"  [yellow]warn[/yellow] could not resolve "
-                            f"digest for {ref}: {exc} — catalog will use "
-                            "tag-only for this ref"
-                        )
-                        continue
-                    # M4: actionable hint for partial-republish flows
-                    # where the tag isn't in the registry yet.
-                    if no_push and "manifest unknown" in str(exc).lower():
-                        console.print(
-                            f"\n[red]Error:[/red] registry has no image at "
-                            f"{ref}. Push it first or pass --digest "
-                            "explicitly."
-                        )
-                    else:
-                        console.print(f"\n[red]Error:[/red] {exc}")
-                    raise typer.Exit(code=1) from exc
+            digest_map = _auto_resolve_digests(
+                published_refs, no_build=no_build, no_push=no_push,
+            )
 
     # 7. Build catalog entry
     reg_builder = RegistryBuilder()

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -155,7 +155,10 @@ def run_publish(
     # not-pushed leaves the registry stale (or empty), so the resolved
     # digest would either error or silently pin the *previous* push.
     # Force the user to either push, skip the build, or supply --digest.
-    if not no_build and no_push and digest is None:
+    # Dry-run is exempt: that branch returns before build/push/auto-resolve,
+    # so no hazard exists — preview the catalog without forcing the user
+    # to add ceremony flags.
+    if not dry_run and not no_build and no_push and digest is None:
         console.print(
             "[red]Error:[/red] --no-push without --no-build cannot pin a "
             "catalog digest — the just-built image is only in your local "

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -151,6 +151,19 @@ def run_publish(
             )
             raise typer.Exit(code=int(ExitCode.VALIDATION))
 
+    # ENG-4370 H1: auto-resolve queries the registry post-build. Built-but-
+    # not-pushed leaves the registry stale (or empty), so the resolved
+    # digest would either error or silently pin the *previous* push.
+    # Force the user to either push, skip the build, or supply --digest.
+    if not no_build and no_push and digest is None:
+        console.print(
+            "[red]Error:[/red] --no-push without --no-build cannot pin a "
+            "catalog digest — the just-built image is only in your local "
+            "daemon. Push first, pass --no-build to publish-only against "
+            "the existing registry tag, or supply --digest explicitly."
+        )
+        raise typer.Exit(code=int(ExitCode.VALIDATION))
+
     version = info.version
     ext_type = _infer_extension_type(info.metadata)
 
@@ -352,14 +365,44 @@ def run_publish(
     if image_refs:
         if digest is not None:
             # Buildable-count validation above guarantees a single ref.
-            digest_map[image_refs[0]] = digest
+            ref = image_refs[0]
+            digest_map[ref] = digest
+            # H2: when push happened, verify the supplied digest matches
+            # the registry's manifest. Catches CI typos, stale digests,
+            # and the TOCTOU window where a parallel run re-pointed the
+            # tag between our push and our publish.
+            if not no_push:
+                try:
+                    actual = ImagePusher.resolve_digest(ref)
+                except ImagePushError as exc:
+                    console.print(f"\n[red]Error:[/red] {exc}")
+                    raise typer.Exit(code=1) from exc
+                if actual != digest:
+                    console.print(
+                        f"\n[red]Error:[/red] supplied --digest does not match "
+                        f"the registry manifest for {ref}.\n"
+                        f"  supplied: {digest}\n"
+                        f"  registry: {actual}\n"
+                        "Re-run with the correct digest, or omit --digest to "
+                        "auto-resolve."
+                    )
+                    raise typer.Exit(code=int(ExitCode.VALIDATION))
         else:
-            try:
-                for ref in image_refs:
+            for ref in image_refs:
+                try:
                     digest_map[ref] = ImagePusher.resolve_digest(ref)
-            except ImagePushError as exc:
-                console.print(f"\n[red]Error:[/red] {exc}")
-                raise typer.Exit(code=1) from exc
+                except ImagePushError as exc:
+                    # M4: actionable hint for the catalog-only-republish
+                    # case where the tag isn't in the registry yet.
+                    if no_push and "manifest unknown" in str(exc).lower():
+                        console.print(
+                            f"\n[red]Error:[/red] registry has no image at "
+                            f"{ref}. Push it first or pass --digest "
+                            "explicitly."
+                        )
+                    else:
+                        console.print(f"\n[red]Error:[/red] {exc}")
+                    raise typer.Exit(code=1) from exc
 
     # 7. Build catalog entry
     reg_builder = RegistryBuilder()
@@ -410,5 +453,10 @@ def run_publish(
         f"Published [bold]{info.name}[/bold] v{version} to {profile.catalog_bucket}"
     )
     if image_refs:
-        console.print(f"  Images:  {', '.join(image_refs)}")
+        # Show what was actually pinned in the catalog, not the bare tag.
+        pinned = [
+            f"{r}@{digest_map[r]}" if r in digest_map else r
+            for r in image_refs
+        ]
+        console.print(f"  Images:  {', '.join(pinned)}")
     console.print(f"  Catalog: {result.catalog_file}")

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -243,6 +243,16 @@ def run_publish(
         )
         console.print(f"  Would push to:         {registry}/")
 
+        # Dry-run preview reflects an explicit --digest; auto-resolve
+        # is skipped because a dry-run shouldn't talk to the registry.
+        dry_digest_map: Dict[str, str] = {}
+        if digest is not None:
+            dry_refs = _collect_image_refs(
+                info.compose_data, info.name, image_tag, registry
+            )
+            if dry_refs:
+                dry_digest_map[dry_refs[0]] = digest
+
         # Run merge check so dry-run detects version conflicts
         reg_builder = RegistryBuilder()
         entry = reg_builder.build_entry(
@@ -252,6 +262,7 @@ def run_publish(
             version=version,
             stage=stage,
             revision=revision,
+            digest_map=dry_digest_map or None,
         )
         try:
             publisher = CatalogPublisher(profile, extension_dir=info.path)

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -134,31 +134,41 @@ def run_publish(
         console.print("[red]Error:[/red] No docker-compose.yml found.")
         raise typer.Exit(code=1)
 
+    # Buildable services that will actually be published. Mirrors
+    # ComposeTransformer's `profiles:` filter — services with a profiles
+    # key are local-only and stripped before catalog construction, so
+    # they don't count for buildable-count or hazard checks.
+    buildable_services = [
+        name
+        for name, svc in (info.compose_data.get("services") or {}).items()
+        if "build" in svc and not svc.get("profiles")
+    ]
+
     # ENG-4370: --digest pins identity for one image. Multi-image extensions
     # must rely on auto-resolve (the per-service push digest), so reject the
     # ambiguous case before doing any work.
-    if digest is not None:
-        buildable_services = [
-            name for name, svc in (info.compose_data.get("services") or {}).items()
-            if "build" in svc
-        ]
-        if len(buildable_services) != 1:
-            found = ", ".join(buildable_services) if buildable_services else "none"
-            console.print(
-                f"[red]Error:[/red] --digest requires exactly one buildable "
-                f"service in docker-compose.yml; found {len(buildable_services)} "
-                f"({found}). Omit --digest to auto-resolve per-service digests."
-            )
-            raise typer.Exit(code=int(ExitCode.VALIDATION))
+    if digest is not None and len(buildable_services) != 1:
+        found = ", ".join(buildable_services) if buildable_services else "none"
+        console.print(
+            f"[red]Error:[/red] --digest requires exactly one buildable "
+            f"service in docker-compose.yml; found {len(buildable_services)} "
+            f"({found}). Omit --digest to auto-resolve per-service digests."
+        )
+        raise typer.Exit(code=int(ExitCode.VALIDATION))
 
     # ENG-4370 H1: auto-resolve queries the registry post-build. Built-but-
     # not-pushed leaves the registry stale (or empty), so the resolved
     # digest would either error or silently pin the *previous* push.
     # Force the user to either push, skip the build, or supply --digest.
-    # Dry-run is exempt: that branch returns before build/push/auto-resolve,
-    # so no hazard exists — preview the catalog without forcing the user
-    # to add ceremony flags.
-    if not dry_run and not no_build and no_push and digest is None:
+    # Skipped under: dry-run (no build/push happens), and external-only
+    # extensions (no buildable services means no hazard).
+    if (
+        not dry_run
+        and not no_build
+        and no_push
+        and digest is None
+        and buildable_services
+    ):
         console.print(
             "[red]Error:[/red] --no-push without --no-build cannot pin a "
             "catalog digest — the just-built image is only in your local "
@@ -395,8 +405,20 @@ def run_publish(
                 try:
                     digest_map[ref] = ImagePusher.resolve_digest(ref)
                 except ImagePushError as exc:
-                    # M4: actionable hint for the catalog-only-republish
-                    # case where the tag isn't in the registry yet.
+                    # H3 (Codex re-review): under --no-build --no-push the
+                    # caller is doing a catalog-only republish; pre-PR
+                    # behavior was tag-only with no docker dependency.
+                    # Soft-fail to preserve that: warn, leave this ref out
+                    # of digest_map → catalog gets tag-only for it.
+                    if no_build and no_push:
+                        console.print(
+                            f"  [yellow]warn[/yellow] could not resolve "
+                            f"digest for {ref}: {exc} — catalog will use "
+                            "tag-only for this ref"
+                        )
+                        continue
+                    # M4: actionable hint for partial-republish flows
+                    # where the tag isn't in the registry yet.
                     if no_push and "manifest unknown" in str(exc).lower():
                         console.print(
                             f"\n[red]Error:[/red] registry has no image at "

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -370,15 +370,26 @@ def run_publish(
     elif no_push:
         console.print("  [dim]Skipping push (--no-push)[/dim]")
 
-    # 6.5 Resolve digests for buildable images (ENG-4370). Catalog refs
-    # are pinned `image:tag@sha256:...` so they're immutable regardless
+    # 6.5 Resolve digests for published buildable images (ENG-4370). Catalog
+    # refs are pinned `image:tag@sha256:...` so they're immutable regardless
     # of tag mutability. Pass-through external/prebuilt-internal refs
     # (postgres, etc.) keep whatever pinning their source repo applied.
+    #
+    # Iterate over `published_refs` derived from `buildable_services` (which
+    # already excludes profile-only services) instead of `image_refs`.
+    # `image_refs` reflects what ImageBuilder built and ImagePusher pushed,
+    # which can include profiled helpers — those won't appear in the
+    # transformed catalog compose, so resolving / pinning their digest is at
+    # best wasted work and at worst (with --digest) misdirects the user's
+    # supplied digest at the wrong ref.
+    published_refs: List[str] = [
+        f"{registry}/{info.name}-{name}:{image_tag}" for name in buildable_services
+    ]
     digest_map: Dict[str, str] = {}
-    if image_refs:
+    if published_refs:
         if digest is not None:
             # Buildable-count validation above guarantees a single ref.
-            ref = image_refs[0]
+            ref = published_refs[0]
             digest_map[ref] = digest
             # H2: when push happened, verify the supplied digest matches
             # the registry's manifest. Catches CI typos, stale digests,
@@ -401,7 +412,7 @@ def run_publish(
                     )
                     raise typer.Exit(code=int(ExitCode.VALIDATION))
         else:
-            for ref in image_refs:
+            for ref in published_refs:
                 try:
                     digest_map[ref] = ImagePusher.resolve_digest(ref)
                 except ImagePushError as exc:
@@ -477,11 +488,12 @@ def run_publish(
     console.print(
         f"Published [bold]{info.name}[/bold] v{version} to {profile.catalog_bucket}"
     )
-    if image_refs:
-        # Show what was actually pinned in the catalog, not the bare tag.
+    if published_refs:
+        # Show what's actually in the catalog (post-profile-filter), pinned
+        # where digest_map carries an entry.
         pinned = [
             f"{r}@{digest_map[r]}" if r in digest_map else r
-            for r in image_refs
+            for r in published_refs
         ]
         console.print(f"  Images:  {', '.join(pinned)}")
     console.print(f"  Catalog: {result.catalog_file}")

--- a/kamiwaza_extensions/image_pusher.py
+++ b/kamiwaza_extensions/image_pusher.py
@@ -19,10 +19,16 @@ DIGEST_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
 
 
 def validate_digest(digest: str) -> None:
-    """Raise ``ValueError`` if *digest* is not a ``sha256:<64-hex>`` string."""
+    """Raise ``ValueError`` if *digest* is not a ``sha256:<64-hex>`` string.
+
+    Phrasing avoids square brackets in the message — rich console markup
+    treats ``[a-f0-9]`` as a (broken) tag and silently strips it from
+    user-facing output.
+    """
     if not DIGEST_PATTERN.match(digest):
         raise ValueError(
-            f"Invalid digest '{digest}': must match ^sha256:[a-f0-9]{{64}}$"
+            f"Invalid digest '{digest}': must be 'sha256:' followed by "
+            "64 lowercase hex characters"
         )
 
 

--- a/kamiwaza_extensions/image_pusher.py
+++ b/kamiwaza_extensions/image_pusher.py
@@ -150,7 +150,16 @@ class ImagePusher:
             raise ImagePushError(
                 f"Could not parse imagetools output for {image_ref}: {exc}"
             ) from exc
-        digest = manifest.get("digest", "")
+        # Guard against valid-but-unexpected JSON shapes (lists, scalars).
+        # `imagetools inspect --format '{{json .Manifest}}'` returns an OCI
+        # Descriptor object, but a registry/buildx quirk could surface
+        # something else; bare .get() would raise AttributeError.
+        if not isinstance(manifest, dict):
+            raise ImagePushError(
+                f"Unexpected imagetools output for {image_ref}: "
+                f"expected an object, got {type(manifest).__name__}"
+            )
+        digest = manifest.get("digest")
         if not isinstance(digest, str) or not DIGEST_PATTERN.match(digest):
             raise ImagePushError(
                 f"Unexpected digest field for {image_ref}: {digest!r}"

--- a/kamiwaza_extensions/image_pusher.py
+++ b/kamiwaza_extensions/image_pusher.py
@@ -92,21 +92,28 @@ class ImagePusher:
     def resolve_digest(image_ref: str) -> str:
         """Return the manifest digest for *image_ref* from the registry.
 
-        Uses ``docker buildx imagetools inspect`` to read the digest
-        without pulling the image. The ref must already exist in the
-        registry — call after ``push`` for the just-built image, or
-        against any pre-existing tag.
+        Uses ``docker buildx imagetools inspect`` with a JSON template
+        so that an OCI manifest list (multi-arch) returns its index
+        digest and a single-platform manifest returns its own digest —
+        matching what ``image:tag@sha256:...`` resolves to at pull
+        time. The ref must already exist in the registry; call after
+        ``push`` for the just-built image, or against any pre-existing
+        tag.
 
-        Returns a ``sha256:<64-hex>`` string.
+        Note: ``{{.Manifest.Digest}}`` does not work — that template
+        path hits the type's Stringer and dumps a human-readable
+        manifest. The JSON form is the canonical extraction.
 
         Raises:
-            ImagePushError: When ``docker`` is not installed, the
-                inspect command fails, or the returned digest does not
-                match the expected grammar.
+            ImagePushError: When ``docker`` is missing, the inspect
+                command fails, the JSON cannot be parsed, or the
+                returned digest does not match the expected grammar.
         """
+        import json as _json
+
         cmd = [
             "docker", "buildx", "imagetools", "inspect", image_ref,
-            "--format", "{{.Manifest.Digest}}",
+            "--format", "{{json .Manifest}}",
         ]
         try:
             result = subprocess.run(
@@ -123,10 +130,16 @@ class ImagePusher:
             raise ImagePushError(
                 f"Digest resolution failed for {image_ref}: {result.stderr.strip()}"
             )
-        digest = result.stdout.strip()
-        if not DIGEST_PATTERN.match(digest):
+        try:
+            manifest = _json.loads(result.stdout)
+        except _json.JSONDecodeError as exc:
             raise ImagePushError(
-                f"Unexpected digest output for {image_ref}: {digest!r}"
+                f"Could not parse imagetools output for {image_ref}: {exc}"
+            ) from exc
+        digest = manifest.get("digest", "")
+        if not isinstance(digest, str) or not DIGEST_PATTERN.match(digest):
+            raise ImagePushError(
+                f"Unexpected digest field for {image_ref}: {digest!r}"
             )
         return digest
 

--- a/kamiwaza_extensions/image_pusher.py
+++ b/kamiwaza_extensions/image_pusher.py
@@ -99,6 +99,42 @@ class ImagePusher:
             ) from exc
 
     @staticmethod
+    def check_buildx_available() -> None:
+        """Verify ``docker buildx imagetools`` is usable on PATH.
+
+        Run before push when a downstream ``resolve_digest`` call will
+        be required, so a missing buildx plugin fails the publish *before*
+        the registry is mutated rather than after. Modern docker (Desktop,
+        docker-ce 20.10+) bundles buildx; this guards against older or
+        minimal installations where the plugin is absent.
+
+        Raises:
+            ImagePushError: When ``docker`` is not installed or the
+                ``buildx imagetools`` subcommand isn't recognized.
+        """
+        try:
+            result = subprocess.run(
+                ["docker", "buildx", "imagetools", "--help"],
+                capture_output=True,
+                timeout=5,
+            )
+        except FileNotFoundError as exc:
+            raise ImagePushError(
+                "docker not found — required for digest pinning. "
+                "Install Docker (with buildx) before publishing."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise ImagePushError(
+                "docker buildx availability check timed out after 5s"
+            ) from exc
+        if result.returncode != 0:
+            raise ImagePushError(
+                "docker buildx imagetools is not available — required "
+                "for digest pinning. Modern docker (20.10+) bundles "
+                "buildx; older installs may need the plugin added."
+            )
+
+    @staticmethod
     def resolve_digest(image_ref: str) -> str:
         """Return the manifest digest for *image_ref* from the registry.
 

--- a/kamiwaza_extensions/image_pusher.py
+++ b/kamiwaza_extensions/image_pusher.py
@@ -93,6 +93,10 @@ class ImagePusher:
             raise ImagePushError(
                 f"{cli} not found. Install Docker/Podman or ensure '{cli}' is on PATH."
             )
+        except subprocess.TimeoutExpired as exc:
+            raise ImagePushError(
+                f"Registry login to {registry} timed out after 30s"
+            ) from exc
 
     @staticmethod
     def resolve_digest(image_ref: str) -> str:
@@ -131,6 +135,10 @@ class ImagePusher:
         except FileNotFoundError as exc:
             raise ImagePushError(
                 "docker not found. Install Docker (with buildx) to resolve image digests."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise ImagePushError(
+                f"Digest resolution for {image_ref} timed out after 60s"
             ) from exc
         if result.returncode != 0:
             raise ImagePushError(
@@ -173,3 +181,7 @@ class ImagePusher:
             raise ImagePushError(
                 f"{cli} not found. Install Docker/Podman or ensure '{cli}' is on PATH."
             )
+        except subprocess.TimeoutExpired as exc:
+            raise ImagePushError(
+                f"Push timed out after 600s for {image_ref}"
+            ) from exc

--- a/kamiwaza_extensions/image_pusher.py
+++ b/kamiwaza_extensions/image_pusher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from typing import List, Optional
@@ -9,6 +10,20 @@ from typing import List, Optional
 from rich.console import Console
 
 console = Console(stderr=True)
+
+
+# OCI image digest grammar: sha256: followed by 64 lowercase hex chars.
+# Used both for validating user-supplied --digest input and for sanity-
+# checking the output of `docker buildx imagetools inspect`.
+DIGEST_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
+
+
+def validate_digest(digest: str) -> None:
+    """Raise ``ValueError`` if *digest* is not a ``sha256:<64-hex>`` string."""
+    if not DIGEST_PATTERN.match(digest):
+        raise ValueError(
+            f"Invalid digest '{digest}': must match ^sha256:[a-f0-9]{{64}}$"
+        )
 
 
 class ImagePushError(RuntimeError):
@@ -72,6 +87,48 @@ class ImagePusher:
             raise ImagePushError(
                 f"{cli} not found. Install Docker/Podman or ensure '{cli}' is on PATH."
             )
+
+    @staticmethod
+    def resolve_digest(image_ref: str) -> str:
+        """Return the manifest digest for *image_ref* from the registry.
+
+        Uses ``docker buildx imagetools inspect`` to read the digest
+        without pulling the image. The ref must already exist in the
+        registry — call after ``push`` for the just-built image, or
+        against any pre-existing tag.
+
+        Returns a ``sha256:<64-hex>`` string.
+
+        Raises:
+            ImagePushError: When ``docker`` is not installed, the
+                inspect command fails, or the returned digest does not
+                match the expected grammar.
+        """
+        cmd = [
+            "docker", "buildx", "imagetools", "inspect", image_ref,
+            "--format", "{{.Manifest.Digest}}",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except FileNotFoundError as exc:
+            raise ImagePushError(
+                "docker not found. Install Docker (with buildx) to resolve image digests."
+            ) from exc
+        if result.returncode != 0:
+            raise ImagePushError(
+                f"Digest resolution failed for {image_ref}: {result.stderr.strip()}"
+            )
+        digest = result.stdout.strip()
+        if not DIGEST_PATTERN.match(digest):
+            raise ImagePushError(
+                f"Unexpected digest output for {image_ref}: {digest!r}"
+            )
+        return digest
 
     @staticmethod
     def _push(image_ref: str, *, use_podman: bool = False, verbose: bool = False) -> None:

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -253,7 +253,11 @@ class RegistryBuilder:
         with the *registry* prefix (legacy behaviour).
 
         Refs of the form ``image:tag@sha256:<digest>`` keep the digest;
-        only the tag portion is rewritten.
+        only the tag portion is rewritten. Digest-only refs of the form
+        ``image@sha256:<digest>`` (no tag) are left untouched — the
+        repo-path char class excludes ``@`` so the regex can't capture
+        ``@sha256`` as part of the service name and treat the hex as a
+        tag.
         """
         suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
         new_tag = f"{version}{suffix}"
@@ -263,7 +267,7 @@ class RegistryBuilder:
             escaped_ext = re.escape(extension_name)
             # Only match: registry/extension-name-service:tag[@sha256:...]
             pattern = re.compile(
-                rf"(image:\s*){escaped_reg}/({escaped_ext}-[^:\s]+)"
+                rf"(image:\s*){escaped_reg}/({escaped_ext}-[^:\s@]+)"
                 rf":([^\s@]+)(@sha256:[a-f0-9]{{64}})?"
             )
             return pattern.sub(
@@ -272,7 +276,7 @@ class RegistryBuilder:
 
         # Fallback: match any image with the registry prefix
         pattern = re.compile(
-            rf"(image:\s*){escaped_reg}(/[^:\s]+):([^\s@]+)(@sha256:[a-f0-9]{{64}})?"
+            rf"(image:\s*){escaped_reg}(/[^:\s@]+):([^\s@]+)(@sha256:[a-f0-9]{{64}})?"
         )
         return pattern.sub(rf"\g<1>{registry}\2:{new_tag}\g<4>", compose_yml)
 

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -103,6 +103,12 @@ class RegistryBuilder:
             # ref that's redundantly listed in `extra_docker_images`
             # collapses against its already-pinned compose copy during
             # dedup, instead of leaking an unpinned duplicate.
+            #
+            # Match is exact-string against the post-stage-suffix ref
+            # (e.g. `<reg>/<ext>-<svc>:<version>-dev`); a pre-suffix
+            # entry like `<reg>/<ext>-<svc>:<version>` won't collapse.
+            # Author the entry to match what compose carries after
+            # transform.
             if digest_map:
                 extra_images = [
                     f"{img}@{digest_map[img]}"

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -240,6 +240,9 @@ class RegistryBuilder:
 
         If *extension_name* is empty, falls back to matching all images
         with the *registry* prefix (legacy behaviour).
+
+        Refs of the form ``image:tag@sha256:<digest>`` keep the digest;
+        only the tag portion is rewritten.
         """
         suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
         new_tag = f"{version}{suffix}"
@@ -247,17 +250,20 @@ class RegistryBuilder:
 
         if extension_name:
             escaped_ext = re.escape(extension_name)
-            # Only match: registry/extension-name-service:tag
+            # Only match: registry/extension-name-service:tag[@sha256:...]
             pattern = re.compile(
-                rf"(image:\s*){escaped_reg}/({escaped_ext}-[^:\s]+):([^\s]+)"
+                rf"(image:\s*){escaped_reg}/({escaped_ext}-[^:\s]+)"
+                rf":([^\s@]+)(@sha256:[a-f0-9]{{64}})?"
             )
-            return pattern.sub(rf"\g<1>{registry}/\2:{new_tag}", compose_yml)
+            return pattern.sub(
+                rf"\g<1>{registry}/\2:{new_tag}\g<4>", compose_yml,
+            )
 
         # Fallback: match any image with the registry prefix
         pattern = re.compile(
-            rf"(image:\s*){escaped_reg}(/[^:\s]+):([^\s]+)"
+            rf"(image:\s*){escaped_reg}(/[^:\s]+):([^\s@]+)(@sha256:[a-f0-9]{{64}})?"
         )
-        return pattern.sub(rf"\g<1>{registry}\2:{new_tag}", compose_yml)
+        return pattern.sub(rf"\g<1>{registry}\2:{new_tag}\g<4>", compose_yml)
 
     def extract_docker_images(
         self, compose_data_or_yml: Any,

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -9,6 +9,7 @@ with version-constraint-aware conflict resolution.
 
 from __future__ import annotations
 
+import copy
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -57,6 +58,7 @@ class RegistryBuilder:
         version: str,
         stage: str = "prod",
         revision: Optional[str] = None,
+        digest_map: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Generate a catalog entry dict from *metadata* and *transformed_compose*.
 
@@ -77,10 +79,21 @@ class RegistryBuilder:
             revision: Optional revision identifier. When provided, included
                 as a top-level ``revision`` field on the entry; consumed by
                 ``CatalogDedupGuard`` to make CI re-publishes idempotent.
+            digest_map: Optional mapping of rewritten image ref
+                (``"<registry>/<ext>-<svc>:<tag>"``) to its OCI manifest
+                digest (``"sha256:..."``). When provided, matching service
+                ``image`` fields in the rendered ``compose_yml`` and the
+                ``docker_images`` list are rewritten to ``ref@digest`` for
+                immutable identity (ENG-4370). Refs not in the map (e.g.
+                pass-through external/postgres images, prebuilt-internal
+                images) are left untouched.
 
         Returns:
             A dict matching the Kamiwaza catalog entry schema.
         """
+        if digest_map:
+            transformed_compose = _apply_digests(transformed_compose, digest_map)
+
         compose_yml = yaml.dump(transformed_compose, default_flow_style=False)
         docker_images = self.extract_docker_images(transformed_compose)
 
@@ -362,6 +375,25 @@ class RegistryBuilder:
 # ------------------------------------------------------------------
 # Module-level helpers
 # ------------------------------------------------------------------
+
+
+def _apply_digests(
+    compose: Dict[str, Any], digest_map: Dict[str, str],
+) -> Dict[str, Any]:
+    """Return a deep copy of *compose* with image refs digest-pinned.
+
+    For each ``services[*].image`` whose value matches a key in
+    *digest_map* and does not already carry a ``@`` digest suffix,
+    rewrite the value to ``"<image>@<digest>"``. Other refs (external
+    pass-through, prebuilt-internal, already-digest-pinned) are left
+    untouched. Caller's *compose* dict is not mutated.
+    """
+    result = copy.deepcopy(compose)
+    for svc in (result.get("services") or {}).values():
+        img = svc.get("image")
+        if img and "@" not in img and img in digest_map:
+            svc["image"] = f"{img}@{digest_map[img]}"
+    return result
 
 
 def _normalize_preview_image(path: str) -> str:

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -99,6 +99,17 @@ class RegistryBuilder:
 
         extra_images = metadata.get("extra_docker_images") or []
         if extra_images:
+            # Apply the same digest-pinning rule to extras so a service
+            # ref that's redundantly listed in `extra_docker_images`
+            # collapses against its already-pinned compose copy during
+            # dedup, instead of leaking an unpinned duplicate.
+            if digest_map:
+                extra_images = [
+                    f"{img}@{digest_map[img]}"
+                    if img in digest_map and "@" not in img
+                    else img
+                    for img in extra_images
+                ]
             docker_images = list(dict.fromkeys(docker_images + extra_images))
 
         entry: Dict[str, Any] = {

--- a/tests/unit/extensions/test_image_pusher.py
+++ b/tests/unit/extensions/test_image_pusher.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kamiwaza_extensions.image_pusher import ImagePusher, ImagePushError
+from kamiwaza_extensions.image_pusher import (
+    ImagePusher,
+    ImagePushError,
+    validate_digest,
+)
 
 
 @pytest.fixture
@@ -84,3 +88,78 @@ class TestPushOrchestration:
         pusher.push(["reg/app:v1"], registry="reg", token="tok", insecure=False)
         mock_login.assert_called_once_with("reg", "tok", use_podman=False)
         mock_push.assert_called_once_with("reg/app:v1", use_podman=False, verbose=False)
+
+
+# ENG-4370 — digest-pinning catalog references
+
+
+_VALID_DIGEST = "sha256:" + "a" * 64
+
+
+class TestValidateDigest:
+    @pytest.mark.parametrize(
+        "good",
+        [
+            "sha256:" + "0" * 64,
+            "sha256:" + "f" * 64,
+            "sha256:" + "abcdef0123456789" * 4,
+        ],
+    )
+    def test_accepts_well_formed(self, good):
+        validate_digest(good)  # no raise
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "abc",
+            "sha512:" + "a" * 64,                    # wrong algorithm
+            "sha256:" + "a" * 63,                    # too short
+            "sha256:" + "a" * 65,                    # too long
+            "sha256:" + "A" * 64,                    # uppercase hex
+            "sha256:" + "g" * 64,                    # non-hex char
+            "sha256:" + "a" * 32 + " " + "a" * 31,   # embedded space
+            "Sha256:" + "a" * 64,                    # uppercase prefix
+        ],
+    )
+    def test_rejects_malformed(self, bad):
+        with pytest.raises(ValueError, match="Invalid digest"):
+            validate_digest(bad)
+
+
+class TestResolveDigest:
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_returns_digest_from_imagetools(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=_VALID_DIGEST + "\n", stderr=""
+        )
+        digest = ImagePusher.resolve_digest("reg.test/app:v1")
+        assert digest == _VALID_DIGEST
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:4] == ["docker", "buildx", "imagetools", "inspect"]
+        assert "reg.test/app:v1" in cmd
+        assert "{{.Manifest.Digest}}" in cmd
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_inspect_failure_raises(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="manifest unknown"
+        )
+        with pytest.raises(ImagePushError, match="Digest resolution failed"):
+            ImagePusher.resolve_digest("reg.test/app:v1")
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_unexpected_output_raises(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="not-a-digest\n", stderr=""
+        )
+        with pytest.raises(ImagePushError, match="Unexpected digest output"):
+            ImagePusher.resolve_digest("reg.test/app:v1")
+
+    @patch(
+        "kamiwaza_extensions.image_pusher.subprocess.run",
+        side_effect=FileNotFoundError(),
+    )
+    def test_missing_docker_raises(self, _mock_run):
+        with pytest.raises(ImagePushError, match="docker not found"):
+            ImagePusher.resolve_digest("reg.test/app:v1")

--- a/tests/unit/extensions/test_image_pusher.py
+++ b/tests/unit/extensions/test_image_pusher.py
@@ -151,6 +151,16 @@ class TestResolveDigest:
             ImagePusher.resolve_digest("reg.test/app:v1")
 
     @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_non_dict_json_raises(self, mock_run):
+        # Valid JSON but not a dict — bare .get would AttributeError
+        # without an isinstance guard.
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="[]", stderr=""
+        )
+        with pytest.raises(ImagePushError, match="expected an object"):
+            ImagePusher.resolve_digest("reg.test/app:v1")
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
     def test_invalid_json_raises(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="not-json-at-all", stderr=""
@@ -187,8 +197,8 @@ class TestResolveDigest:
         side_effect=__import__("subprocess").TimeoutExpired(cmd="docker", timeout=60),
     )
     def test_timeout_raises_image_push_error(self, _mock_run):
-        # M1 (re-review): wedged registry must surface as ImagePushError,
-        # not an unhandled TimeoutExpired.
+        # Wedged registry must surface as ImagePushError, not an
+        # unhandled TimeoutExpired.
         with pytest.raises(ImagePushError, match="timed out"):
             ImagePusher.resolve_digest("reg.test/app:v1")
 

--- a/tests/unit/extensions/test_image_pusher.py
+++ b/tests/unit/extensions/test_image_pusher.py
@@ -203,6 +203,41 @@ class TestResolveDigest:
             ImagePusher.resolve_digest("reg.test/app:v1")
 
 
+class TestCheckBuildxAvailable:
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_passes_when_buildx_present(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        ImagePusher.check_buildx_available()  # no raise
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["docker", "buildx", "imagetools", "--help"]
+
+    @patch(
+        "kamiwaza_extensions.image_pusher.subprocess.run",
+        side_effect=FileNotFoundError(),
+    )
+    def test_raises_when_docker_missing(self, _mock_run):
+        with pytest.raises(ImagePushError, match="docker not found"):
+            ImagePusher.check_buildx_available()
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_raises_when_buildx_subcommand_missing(self, mock_run):
+        # docker is present but buildx plugin isn't — docker exits non-zero
+        # with stderr like "docker: 'buildx' is not a docker command".
+        mock_run.return_value = MagicMock(
+            returncode=1, stderr=b"docker: 'buildx' is not a docker command."
+        )
+        with pytest.raises(ImagePushError, match="buildx imagetools is not available"):
+            ImagePusher.check_buildx_available()
+
+    @patch(
+        "kamiwaza_extensions.image_pusher.subprocess.run",
+        side_effect=__import__("subprocess").TimeoutExpired(cmd="docker", timeout=5),
+    )
+    def test_raises_on_timeout(self, _mock_run):
+        with pytest.raises(ImagePushError, match="availability check timed out"):
+            ImagePusher.check_buildx_available()
+
+
 class TestPushTimeout:
     @patch(
         "kamiwaza_extensions.image_pusher.subprocess.run",

--- a/tests/unit/extensions/test_image_pusher.py
+++ b/tests/unit/extensions/test_image_pusher.py
@@ -131,14 +131,16 @@ class TestResolveDigest:
     @patch("kamiwaza_extensions.image_pusher.subprocess.run")
     def test_returns_digest_from_imagetools(self, mock_run):
         mock_run.return_value = MagicMock(
-            returncode=0, stdout=_VALID_DIGEST + "\n", stderr=""
+            returncode=0,
+            stdout='{"digest":"' + _VALID_DIGEST + '","mediaType":"application/vnd.oci.image.index.v1+json"}',
+            stderr="",
         )
         digest = ImagePusher.resolve_digest("reg.test/app:v1")
         assert digest == _VALID_DIGEST
         cmd = mock_run.call_args[0][0]
         assert cmd[:4] == ["docker", "buildx", "imagetools", "inspect"]
         assert "reg.test/app:v1" in cmd
-        assert "{{.Manifest.Digest}}" in cmd
+        assert "{{json .Manifest}}" in cmd
 
     @patch("kamiwaza_extensions.image_pusher.subprocess.run")
     def test_inspect_failure_raises(self, mock_run):
@@ -149,11 +151,27 @@ class TestResolveDigest:
             ImagePusher.resolve_digest("reg.test/app:v1")
 
     @patch("kamiwaza_extensions.image_pusher.subprocess.run")
-    def test_unexpected_output_raises(self, mock_run):
+    def test_invalid_json_raises(self, mock_run):
         mock_run.return_value = MagicMock(
-            returncode=0, stdout="not-a-digest\n", stderr=""
+            returncode=0, stdout="not-json-at-all", stderr=""
         )
-        with pytest.raises(ImagePushError, match="Unexpected digest output"):
+        with pytest.raises(ImagePushError, match="parse imagetools output"):
+            ImagePusher.resolve_digest("reg.test/app:v1")
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_missing_digest_field_raises(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout='{"mediaType":"foo"}', stderr=""
+        )
+        with pytest.raises(ImagePushError, match="Unexpected digest field"):
+            ImagePusher.resolve_digest("reg.test/app:v1")
+
+    @patch("kamiwaza_extensions.image_pusher.subprocess.run")
+    def test_malformed_digest_field_raises(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout='{"digest":"not-a-digest"}', stderr=""
+        )
+        with pytest.raises(ImagePushError, match="Unexpected digest field"):
             ImagePusher.resolve_digest("reg.test/app:v1")
 
     @patch(

--- a/tests/unit/extensions/test_image_pusher.py
+++ b/tests/unit/extensions/test_image_pusher.py
@@ -181,3 +181,31 @@ class TestResolveDigest:
     def test_missing_docker_raises(self, _mock_run):
         with pytest.raises(ImagePushError, match="docker not found"):
             ImagePusher.resolve_digest("reg.test/app:v1")
+
+    @patch(
+        "kamiwaza_extensions.image_pusher.subprocess.run",
+        side_effect=__import__("subprocess").TimeoutExpired(cmd="docker", timeout=60),
+    )
+    def test_timeout_raises_image_push_error(self, _mock_run):
+        # M1 (re-review): wedged registry must surface as ImagePushError,
+        # not an unhandled TimeoutExpired.
+        with pytest.raises(ImagePushError, match="timed out"):
+            ImagePusher.resolve_digest("reg.test/app:v1")
+
+
+class TestPushTimeout:
+    @patch(
+        "kamiwaza_extensions.image_pusher.subprocess.run",
+        side_effect=__import__("subprocess").TimeoutExpired(cmd="docker", timeout=600),
+    )
+    def test_push_timeout_raises_image_push_error(self, _mock_run, pusher):
+        with pytest.raises(ImagePushError, match="Push timed out"):
+            pusher._push("reg.test/app:v1")
+
+    @patch(
+        "kamiwaza_extensions.image_pusher.subprocess.run",
+        side_effect=__import__("subprocess").TimeoutExpired(cmd="docker", timeout=30),
+    )
+    def test_login_timeout_raises_image_push_error(self, _mock_run, pusher):
+        with pytest.raises(ImagePushError, match="login.*timed out"):
+            pusher._login_registry("reg.test", "tok")

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -439,7 +439,12 @@ class TestNoBuildNoPush:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        run_publish(stage="dev", no_push=True)
+        # H1: --no-push without --no-build (or --digest) is rejected
+        # because we can't pin a digest for an image that's only local.
+        # This test exercises the build+push-skipped path via --digest.
+        run_publish(
+            stage="dev", no_push=True, digest="sha256:" + "a" * 64,
+        )
 
         # Build happens
         mock_image_builder.build.assert_called_once()
@@ -686,45 +691,10 @@ class TestPublishDigest:
             "ghcr.io/my-org/my-app-frontend:1.0.0-dev": _DIGEST_FRONTEND,
         }
 
-    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
-    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
-    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
-    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
-    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
-    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
-    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
-    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
-    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
-    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
-    def test_explicit_digest_skips_resolver(
-        self, mock_detector_cls, mock_meta_validator_cls,
-        mock_compose_validator_cls, mock_transformer_cls,
-        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
-        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
-        tmp_path,
-    ):
-        wired = _wire_publish_mocks(
-            detector_cls=mock_detector_cls,
-            meta_validator_cls=mock_meta_validator_cls,
-            compose_validator_cls=mock_compose_validator_cls,
-            transformer_cls=mock_transformer_cls,
-            profile_mgr_cls=mock_profile_mgr_cls,
-            builder_cls=mock_builder_cls,
-            pusher_cls=mock_pusher_cls,
-            reg_builder_cls=mock_reg_builder_cls,
-            publisher_cls=mock_publisher_cls,
-            tmp_path=tmp_path,
-        )
-
-        from kamiwaza_extensions.commands.publish import run_publish
-
-        run_publish(stage="dev", digest=_DIGEST_USER_SUPPLIED)
-
-        mock_resolve.assert_not_called()
-        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
-        assert kwargs["digest_map"] == {
-            "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
-        }
+    # Note: previous test_explicit_digest_skips_resolver was removed —
+    # H2 changed the contract so explicit --digest with push DOES call
+    # resolve_digest for verification. See test_explicit_digest_with_
+    # push_verifies_against_registry below.
 
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
     @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
@@ -783,14 +753,47 @@ class TestPublishDigest:
     @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
     @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
-    def test_no_push_still_resolves_digest(
+    def test_built_no_push_without_digest_errors(
         self, mock_detector_cls, mock_meta_validator_cls,
         mock_compose_validator_cls, mock_transformer_cls,
         mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        mock_resolve.return_value = _DIGEST_BACKEND
+        # H1: building locally and skipping push leaves the registry
+        # stale relative to the local image; auto-resolve would pin to
+        # the wrong digest. The CLI must reject this combination.
+        info = _make_extension_info(tmp_path)
+        mock_detector_cls.return_value.detect.return_value = info
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        with pytest.raises((SystemExit, ClickExit)):
+            run_publish(stage="dev", no_push=True)
+
+        # Should never have built or attempted to resolve.
+        mock_builder_cls.return_value.build.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_built_no_push_with_digest_skips_resolve(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # H1 escape hatch: explicit --digest lets the user opt out of
+        # auto-resolve, so build+no-push is allowed when --digest is set.
         wired = _wire_publish_mocks(
             detector_cls=mock_detector_cls,
             meta_validator_cls=mock_meta_validator_cls,
@@ -806,13 +809,143 @@ class TestPublishDigest:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        run_publish(stage="dev", no_push=True)
+        run_publish(stage="dev", no_push=True, digest=_DIGEST_USER_SUPPLIED)
 
-        # Push skipped, but resolve_digest still ran against existing tag.
+        # No push, no resolve (no_push=True), digest taken verbatim.
         wired["pusher"].push.assert_not_called()
-        mock_resolve.assert_called_once_with(
-            "ghcr.io/my-org/my-app-backend:1.0.0-dev"
+        mock_resolve.assert_not_called()
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        assert kwargs["digest_map"] == {
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
+        }
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_explicit_digest_with_push_verifies_against_registry(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # H2: when --digest is set and push happened, resolve_digest is
+        # called for integrity verification (not as the source of truth).
+        mock_resolve.return_value = _DIGEST_USER_SUPPLIED
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
         )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", digest=_DIGEST_USER_SUPPLIED)
+
+        mock_resolve.assert_called_once()
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        assert kwargs["digest_map"] == {
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
+        }
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_explicit_digest_mismatch_aborts(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # H2: registry returns a different digest from what user supplied
+        # → publish must abort before catalog is written.
+        mock_resolve.return_value = _DIGEST_BACKEND  # registry has this
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        with pytest.raises((SystemExit, ClickExit)):
+            run_publish(stage="dev", digest=_DIGEST_USER_SUPPLIED)  # not _DIGEST_BACKEND
+
+        # Catalog publish never happened.
+        wired["reg_builder"].build_entry.assert_not_called()
+        mock_publisher_cls.return_value.publish.assert_not_called()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_resolve_digest_failure_aborts_publish(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # Orchestration: if resolve_digest raises, run_publish exits 1
+        # and never writes the catalog.
+        from kamiwaza_extensions.image_pusher import ImagePushError
+
+        mock_resolve.side_effect = ImagePushError("manifest unknown")
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        with pytest.raises((SystemExit, ClickExit)):
+            run_publish(stage="dev")
+
+        wired["reg_builder"].build_entry.assert_not_called()
+        mock_publisher_cls.return_value.publish.assert_not_called()
 
     @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
     @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -439,9 +439,9 @@ class TestNoBuildNoPush:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        # H1: --no-push without --no-build (or --digest) is rejected
-        # because we can't pin a digest for an image that's only local.
-        # This test exercises the build+push-skipped path via --digest.
+        # --no-push without --no-build (or --digest) is rejected because
+        # we can't pin a digest for an image that's only local. This test
+        # exercises the build+push-skipped path via --digest.
         run_publish(
             stage="dev", no_push=True, digest="sha256:" + "a" * 64,
         )
@@ -778,7 +778,7 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # H1: building locally and skipping push leaves the registry
+        # Building locally and skipping push leaves the registry
         # stale relative to the local image; auto-resolve would pin to
         # the wrong digest. The CLI must reject this combination.
         info = _make_extension_info(tmp_path)
@@ -810,7 +810,7 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # Re-review HIGH 1: extensions whose compose has zero buildable
+        # Extensions whose compose has zero buildable
         # services (only external/prebuilt refs) must not trip H1 — there
         # is no local-only image to pin.
         compose = {
@@ -865,7 +865,7 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # Re-review HIGH 2: a buildable service with a `profiles:` key
+        # A buildable service with a `profiles:` key
         # is stripped by ComposeTransformer before publish, so it should
         # not count toward the buildable-count guard.
         compose = {
@@ -923,9 +923,9 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # P2 (local Codex): profiled service first in dict order must NOT
-        # redirect --digest pinning. The pinned ref must come from the
-        # filtered buildable_services list, not image_refs[0].
+        # Profiled service first in dict order must NOT redirect --digest
+        # pinning. The pinned ref must come from the filtered
+        # buildable_services list, not image_refs[0].
         compose = {
             "services": {
                 "dev-helper": {
@@ -993,10 +993,10 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # P2 sibling: auto-resolve must not call resolve_digest for
-        # profiled refs — they aren't published in the catalog so any
-        # pin would be silently dropped, and a profiled-only-in-registry
-        # ref might cause a needless network round-trip / failure.
+        # Auto-resolve must not call resolve_digest for profiled refs —
+        # they aren't published in the catalog so any pin would be
+        # silently dropped, and a profiled-only-in-registry ref might
+        # cause a needless network round-trip / failure.
         compose = {
             "services": {
                 "dev-helper": {
@@ -1059,10 +1059,9 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # Re-review HIGH 3 (option A): catalog-only republish softly
-        # falls back to tag-only when resolve_digest fails (e.g. no
-        # docker on host). Catalog publishes; the failed ref is absent
-        # from digest_map.
+        # Catalog-only republish softly falls back to tag-only when
+        # resolve_digest fails (e.g. no docker on host). Catalog
+        # publishes; the failed ref is absent from digest_map.
         from kamiwaza_extensions.image_pusher import ImagePushError
 
         mock_resolve.side_effect = ImagePushError("docker not found")
@@ -1106,7 +1105,7 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # F2: H1's stale-registry hazard does not apply under --dry-run
+        # The stale-registry hazard does not apply under --dry-run
         # (no build, no push, no auto-resolve happens). Preview should
         # complete without forcing the user to add --no-build or --digest.
         wired = _wire_publish_mocks(
@@ -1152,7 +1151,7 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # H1 escape hatch: explicit --digest lets the user opt out of
+        # Escape hatch: explicit --digest lets the user opt out of
         # auto-resolve, so build+no-push is allowed when --digest is set.
         wired = _wire_publish_mocks(
             detector_cls=mock_detector_cls,
@@ -1196,7 +1195,7 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # H2: when --digest is set and push happened, resolve_digest is
+        # When --digest is set and push happened, resolve_digest is
         # called for integrity verification (not as the source of truth).
         mock_resolve.return_value = _DIGEST_USER_SUPPLIED
         wired = _wire_publish_mocks(
@@ -1239,7 +1238,7 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # H2: registry returns a different digest from what user supplied
+        # Registry returns a different digest from what user supplied
         # → publish must abort before catalog is written.
         mock_resolve.return_value = _DIGEST_BACKEND  # registry has this
         wired = _wire_publish_mocks(
@@ -1542,3 +1541,69 @@ class TestPublishDigest:
             assert kwargs["digest_map"] == {
                 "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
             }
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_dry_run_digest_pins_canonical_when_profiled_helper_first(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, tmp_path,
+    ):
+        # Same dict-order trap as the live path, but inside the dry-run
+        # branch. Pre-fix: dry-run used `_collect_image_refs` (unfiltered),
+        # so a profiled helper appearing first would have pinned the
+        # user's digest against a local-only ref — mismatched against the
+        # canonical buildable ref that ComposeTransformer actually keeps.
+        compose = {
+            "services": {
+                "dev-helper": {
+                    "build": {"context": "./dev"},
+                    "image": "my-org/my-app-dev-helper:1.0.0",
+                    "profiles": ["dev"],   # FIRST in dict order
+                },
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "my-org/my-app-backend:1.0.0",
+                },
+            },
+        }
+        with patch(
+            "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest"
+        ) as mock_resolve:
+            wired = _wire_publish_mocks(
+                detector_cls=mock_detector_cls,
+                meta_validator_cls=mock_meta_validator_cls,
+                compose_validator_cls=mock_compose_validator_cls,
+                transformer_cls=mock_transformer_cls,
+                profile_mgr_cls=mock_profile_mgr_cls,
+                builder_cls=mock_builder_cls,
+                pusher_cls=mock_pusher_cls,
+                reg_builder_cls=mock_reg_builder_cls,
+                publisher_cls=mock_publisher_cls,
+                tmp_path=tmp_path,
+                compose_data=compose,
+            )
+            mock_publisher_cls.return_value.publish.return_value = (
+                _make_publish_result(dry_run=True)
+            )
+
+            from kamiwaza_extensions.commands.publish import run_publish
+
+            run_publish(stage="dev", dry_run=True, digest=_DIGEST_USER_SUPPLIED)
+
+            mock_resolve.assert_not_called()
+            kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+            # Dry-run preview pins against the canonical (non-profiled)
+            # ref, not against the dev-helper that appears first.
+            assert kwargs["digest_map"] == {
+                "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
+            }
+            assert "dev-helper" not in str(kwargs["digest_map"])

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -645,6 +645,147 @@ def _wire_publish_mocks(
 
 
 class TestPublishDigest:
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.check_buildx_available")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_buildx_preflight_aborts_before_push_when_unavailable(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls,
+        mock_resolve, mock_preflight, tmp_path,
+    ):
+        # Re-review HIGH 1: when buildx is missing, fail BEFORE push so
+        # the registry isn't mutated.
+        from kamiwaza_extensions.image_pusher import ImagePushError
+
+        mock_preflight.side_effect = ImagePushError(
+            "docker buildx imagetools is not available"
+        )
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        with pytest.raises((SystemExit, ClickExit)):
+            run_publish(stage="dev")
+
+        # Preflight ran; push and resolve never did.
+        mock_preflight.assert_called_once()
+        wired["pusher"].push.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.check_buildx_available")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_buildx_preflight_skipped_when_no_push(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls,
+        mock_resolve, mock_preflight, tmp_path,
+    ):
+        # The preflight only matters when push will happen. The catalog-
+        # only-republish path soft-falls in _auto_resolve_digests if buildx
+        # is missing, so don't gate it here.
+        mock_resolve.return_value = _DIGEST_BACKEND
+        _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", no_build=True, no_push=True)
+
+        mock_preflight.assert_not_called()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.check_buildx_available")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_buildx_preflight_skipped_when_no_buildable_services(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls,
+        mock_resolve, mock_preflight, tmp_path,
+    ):
+        # External-only extension (postgres etc.) — no resolve_digest
+        # call will happen, so no buildx needed.
+        compose = {
+            "services": {
+                "db": {"image": "postgres:15"},
+                "cache": {"image": "redis:7"},
+            },
+        }
+        _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data=compose,
+            image_refs=[],
+            transformed_services={
+                "db": {"image": "postgres:15"},
+                "cache": {"image": "redis:7"},
+            },
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        mock_preflight.assert_not_called()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.check_buildx_available")
     @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
     @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
     @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
@@ -659,8 +800,8 @@ class TestPublishDigest:
         self, mock_detector_cls, mock_meta_validator_cls,
         mock_compose_validator_cls, mock_transformer_cls,
         mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
-        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
-        tmp_path,
+        mock_reg_builder_cls, mock_publisher_cls,
+        mock_resolve, mock_preflight, tmp_path,
     ):
         mock_resolve.side_effect = lambda ref: (
             _DIGEST_BACKEND if "backend" in ref else _DIGEST_FRONTEND

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -620,9 +620,11 @@ def _wire_publish_mocks(
     transformer_cls.return_value = transformer
 
     image_builder = MagicMock()
-    image_builder.build.return_value = image_refs or [
-        "ghcr.io/my-org/my-app-backend:1.0.0-dev",
-    ]
+    # Use `is None` so callers can pass [] to mean "no buildable images".
+    image_builder.build.return_value = (
+        image_refs if image_refs is not None
+        else ["ghcr.io/my-org/my-app-backend:1.0.0-dev"]
+    )
     builder_cls.return_value = image_builder
 
     pusher_cls.return_value = MagicMock()
@@ -774,6 +776,166 @@ class TestPublishDigest:
         # Should never have built or attempted to resolve.
         mock_builder_cls.return_value.build.assert_not_called()
         mock_resolve.assert_not_called()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_external_only_extension_no_push_allowed(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # Re-review HIGH 1: extensions whose compose has zero buildable
+        # services (only external/prebuilt refs) must not trip H1 — there
+        # is no local-only image to pin.
+        compose = {
+            "services": {
+                "db": {"image": "postgres:15"},   # no `build:` key
+                "cache": {"image": "redis:7"},
+            },
+        }
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data=compose,
+            image_refs=[],  # nothing built
+            transformed_services={
+                "db": {"image": "postgres:15"},
+                "cache": {"image": "redis:7"},
+            },
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", no_push=True)
+
+        # H1 must NOT fire — build runs (and returns nothing), push is
+        # skipped, no digest resolution attempted, catalog publishes.
+        wired["pusher"].push.assert_not_called()
+        mock_resolve.assert_not_called()
+        wired["reg_builder"].build_entry.assert_called_once()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_digest_with_profiled_helper_allowed(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # Re-review HIGH 2: a buildable service with a `profiles:` key
+        # is stripped by ComposeTransformer before publish, so it should
+        # not count toward the buildable-count guard.
+        compose = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "my-org/my-app-backend:1.0.0",
+                },
+                "dev-helper": {
+                    "build": {"context": "./dev"},
+                    "image": "my-org/my-app-dev-helper:1.0.0",
+                    "profiles": ["dev"],   # local-only, stripped on publish
+                },
+            },
+        }
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data=compose,
+        )
+        mock_resolve.return_value = _DIGEST_USER_SUPPLIED
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        # Should NOT error on "found 2"; profiled service is excluded.
+        run_publish(stage="dev", digest=_DIGEST_USER_SUPPLIED)
+
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        assert kwargs["digest_map"] == {
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
+        }
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_no_build_no_push_resolve_failure_falls_back_to_tag_only(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # Re-review HIGH 3 (option A): catalog-only republish softly
+        # falls back to tag-only when resolve_digest fails (e.g. no
+        # docker on host). Catalog publishes; the failed ref is absent
+        # from digest_map.
+        from kamiwaza_extensions.image_pusher import ImagePushError
+
+        mock_resolve.side_effect = ImagePushError("docker not found")
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        # Must NOT raise — catalog still publishes with tag-only.
+        run_publish(stage="dev", no_build=True, no_push=True)
+
+        wired["reg_builder"].build_entry.assert_called_once()
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        # digest_map either None or empty — no entries for the failed ref.
+        assert not kwargs.get("digest_map")
 
     @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
     @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -665,6 +665,21 @@ class TestPublishDigest:
         mock_resolve.side_effect = lambda ref: (
             _DIGEST_BACKEND if "backend" in ref else _DIGEST_FRONTEND
         )
+        # Compose with two buildable services drives `published_refs`
+        # (which is now the source of truth for the auto-resolve loop,
+        # not `image_refs`).
+        compose = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "my-org/my-app-backend:1.0.0",
+                },
+                "frontend": {
+                    "build": {"context": "./frontend"},
+                    "image": "my-org/my-app-frontend:1.0.0",
+                },
+            },
+        }
         wired = _wire_publish_mocks(
             detector_cls=mock_detector_cls,
             meta_validator_cls=mock_meta_validator_cls,
@@ -676,6 +691,7 @@ class TestPublishDigest:
             reg_builder_cls=mock_reg_builder_cls,
             publisher_cls=mock_publisher_cls,
             tmp_path=tmp_path,
+            compose_data=compose,
             image_refs=[
                 "ghcr.io/my-org/my-app-backend:1.0.0-dev",
                 "ghcr.io/my-org/my-app-frontend:1.0.0-dev",
@@ -888,6 +904,142 @@ class TestPublishDigest:
         kwargs = wired["reg_builder"].build_entry.call_args.kwargs
         assert kwargs["digest_map"] == {
             "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
+        }
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_digest_pins_canonical_ref_when_profiled_helper_appears_first(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # P2 (local Codex): profiled service first in dict order must NOT
+        # redirect --digest pinning. The pinned ref must come from the
+        # filtered buildable_services list, not image_refs[0].
+        compose = {
+            "services": {
+                "dev-helper": {
+                    "build": {"context": "./dev"},
+                    "image": "my-org/my-app-dev-helper:1.0.0",
+                    "profiles": ["dev"],   # profiled — must NOT be pinned
+                },
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "my-org/my-app-backend:1.0.0",
+                },
+            },
+        }
+        # ImageBuilder builds both (it doesn't filter profiles). The
+        # profiled helper appears FIRST in image_refs.
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data=compose,
+            image_refs=[
+                "ghcr.io/my-org/my-app-dev-helper:1.0.0-dev",  # FIRST
+                "ghcr.io/my-org/my-app-backend:1.0.0-dev",
+            ],
+        )
+        mock_resolve.return_value = _DIGEST_USER_SUPPLIED  # H2 verify match
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", digest=_DIGEST_USER_SUPPLIED)
+
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        # Digest pinned against the canonical buildable ref (backend),
+        # NOT against the profiled helper's ref.
+        assert kwargs["digest_map"] == {
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
+        }
+        assert "dev-helper" not in str(kwargs["digest_map"])
+        # H2 verify also runs against the canonical ref.
+        mock_resolve.assert_called_once_with(
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev"
+        )
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_auto_resolve_skips_profiled_helper(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # P2 sibling: auto-resolve must not call resolve_digest for
+        # profiled refs — they aren't published in the catalog so any
+        # pin would be silently dropped, and a profiled-only-in-registry
+        # ref might cause a needless network round-trip / failure.
+        compose = {
+            "services": {
+                "dev-helper": {
+                    "build": {"context": "./dev"},
+                    "image": "my-org/my-app-dev-helper:1.0.0",
+                    "profiles": ["dev"],
+                },
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "my-org/my-app-backend:1.0.0",
+                },
+            },
+        }
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data=compose,
+            image_refs=[
+                "ghcr.io/my-org/my-app-dev-helper:1.0.0-dev",
+                "ghcr.io/my-org/my-app-backend:1.0.0-dev",
+            ],
+        )
+        mock_resolve.return_value = _DIGEST_BACKEND
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # resolve_digest invoked once, against the backend ref only.
+        mock_resolve.assert_called_once_with(
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev"
+        )
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        assert kwargs["digest_map"] == {
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_BACKEND,
         }
 
     @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -994,3 +994,58 @@ class TestPublishDigest:
             run_publish(stage="dev", dry_run=True)
 
             mock_resolve.assert_not_called()
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_dry_run_with_explicit_digest_passes_through(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, tmp_path,
+    ):
+        # Compose with one buildable backend (so --digest is valid).
+        compose = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "my-org/my-app-backend:1.0.0",
+                },
+            },
+        }
+        with patch(
+            "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest"
+        ) as mock_resolve:
+            wired = _wire_publish_mocks(
+                detector_cls=mock_detector_cls,
+                meta_validator_cls=mock_meta_validator_cls,
+                compose_validator_cls=mock_compose_validator_cls,
+                transformer_cls=mock_transformer_cls,
+                profile_mgr_cls=mock_profile_mgr_cls,
+                builder_cls=mock_builder_cls,
+                pusher_cls=mock_pusher_cls,
+                reg_builder_cls=mock_reg_builder_cls,
+                publisher_cls=mock_publisher_cls,
+                tmp_path=tmp_path,
+                compose_data=compose,
+            )
+            mock_publisher_cls.return_value.publish.return_value = (
+                _make_publish_result(dry_run=True)
+            )
+
+            from kamiwaza_extensions.commands.publish import run_publish
+
+            run_publish(stage="dev", dry_run=True, digest=_DIGEST_USER_SUPPLIED)
+
+            mock_resolve.assert_not_called()
+            kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+            # Dry-run preview pins the supplied digest on the buildable ref.
+            assert kwargs["digest_map"] == {
+                "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
+            }

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -785,6 +785,52 @@ class TestPublishDigest:
     @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
     @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_dry_run_no_push_without_digest_allowed(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # F2: H1's stale-registry hazard does not apply under --dry-run
+        # (no build, no push, no auto-resolve happens). Preview should
+        # complete without forcing the user to add --no-build or --digest.
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+        mock_publisher_cls.return_value.publish.return_value = (
+            _make_publish_result(dry_run=True)
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", dry_run=True, no_push=True)
+
+        # Dry-run completed: build_entry called, no resolver invocation.
+        wired["reg_builder"].build_entry.assert_called_once()
+        mock_resolve.assert_not_called()
+        wired["image_builder"].build.assert_not_called()
+        wired["pusher"].push.assert_not_called()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
     def test_built_no_push_with_digest_skips_resolve(
         self, mock_detector_cls, mock_meta_validator_cls,
         mock_compose_validator_cls, mock_transformer_cls,

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -560,3 +560,437 @@ class TestResolvePreviewImage:
 
         result = _resolve_preview_image({}, tmp_path)
         assert result is None
+
+
+# ------------------------------------------------------------------
+# ENG-4370 — --digest flag and auto-resolve digest pinning
+# ------------------------------------------------------------------
+
+
+_DIGEST_BACKEND = "sha256:" + "a" * 64
+_DIGEST_FRONTEND = "sha256:" + "b" * 64
+_DIGEST_USER_SUPPLIED = "sha256:" + "c" * 64
+
+
+def _multi_buildable_compose(name: str = "my-app", version: str = "1.0.0"):
+    return {
+        "services": {
+            "backend": {
+                "build": {"context": "./backend"},
+                "image": f"my-org/{name}-backend:{version}",
+            },
+            "frontend": {
+                "build": {"context": "./frontend"},
+                "image": f"my-org/{name}-frontend:{version}",
+            },
+            "db": {  # Pattern B: external pass-through
+                "image": "postgres:15",
+            },
+        },
+    }
+
+
+def _wire_publish_mocks(
+    *, detector_cls, meta_validator_cls, compose_validator_cls,
+    transformer_cls, profile_mgr_cls, builder_cls, pusher_cls,
+    reg_builder_cls, publisher_cls, tmp_path,
+    compose_data=None, image_refs=None, transformed_services=None,
+):
+    """Configure the standard chain of mocks used by the digest tests."""
+    info = _make_extension_info(tmp_path, compose_data=compose_data)
+    detector = MagicMock()
+    detector.detect.return_value = info
+    detector_cls.return_value = detector
+
+    meta_validator_cls.return_value.validate.return_value = _make_validation_result()
+    compose_validator_cls.return_value.validate.return_value = _make_validation_result()
+    profile_mgr_cls.return_value.resolve_profile.return_value = _make_profile()
+
+    transformer = MagicMock()
+    transformer.transform.return_value = {
+        "services": transformed_services or {
+            "backend": {"image": "ghcr.io/my-org/my-app-backend:1.0.0-dev"},
+        },
+    }
+    transformer_cls.return_value = transformer
+
+    image_builder = MagicMock()
+    image_builder.build.return_value = image_refs or [
+        "ghcr.io/my-org/my-app-backend:1.0.0-dev",
+    ]
+    builder_cls.return_value = image_builder
+
+    pusher_cls.return_value = MagicMock()
+
+    reg_builder = MagicMock()
+    reg_builder.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+    reg_builder_cls.return_value = reg_builder
+
+    publisher = MagicMock()
+    publisher.publish.return_value = _make_publish_result()
+    publisher_cls.return_value = publisher
+
+    return {
+        "reg_builder": reg_builder,
+        "image_builder": image_builder,
+        "pusher": pusher_cls.return_value,
+    }
+
+
+class TestPublishDigest:
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_auto_resolve_passes_digest_map_to_build_entry(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        mock_resolve.side_effect = lambda ref: (
+            _DIGEST_BACKEND if "backend" in ref else _DIGEST_FRONTEND
+        )
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            image_refs=[
+                "ghcr.io/my-org/my-app-backend:1.0.0-dev",
+                "ghcr.io/my-org/my-app-frontend:1.0.0-dev",
+            ],
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        assert mock_resolve.call_count == 2
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        assert kwargs["digest_map"] == {
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_BACKEND,
+            "ghcr.io/my-org/my-app-frontend:1.0.0-dev": _DIGEST_FRONTEND,
+        }
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_explicit_digest_skips_resolver(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", digest=_DIGEST_USER_SUPPLIED)
+
+        mock_resolve.assert_not_called()
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        assert kwargs["digest_map"] == {
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
+        }
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    def test_invalid_digest_format_exits_before_detect(
+        self, mock_meta_validator_cls, mock_compose_validator_cls,
+        mock_detector_cls, tmp_path,
+    ):
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        with pytest.raises((SystemExit, ClickExit)):
+            run_publish(stage="dev", digest="not-a-digest")
+
+        # Detection should NOT happen when format is bad — we fail fast.
+        mock_detector_cls.return_value.detect.assert_not_called()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_digest_with_multi_buildable_errors(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        info = _make_extension_info(
+            tmp_path, compose_data=_multi_buildable_compose(),
+        )
+        mock_detector_cls.return_value.detect.return_value = info
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        with pytest.raises((SystemExit, ClickExit)):
+            run_publish(stage="dev", digest=_DIGEST_USER_SUPPLIED)
+
+        # Should never have built or pushed.
+        mock_builder_cls.return_value.build.assert_not_called()
+        mock_pusher_cls.return_value.push.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_no_push_still_resolves_digest(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        mock_resolve.return_value = _DIGEST_BACKEND
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", no_push=True)
+
+        # Push skipped, but resolve_digest still ran against existing tag.
+        wired["pusher"].push.assert_not_called()
+        mock_resolve.assert_called_once_with(
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev"
+        )
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_no_build_no_push_resolves_digest_from_registry(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        mock_resolve.return_value = _DIGEST_BACKEND
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", no_build=True, no_push=True)
+
+        wired["image_builder"].build.assert_not_called()
+        wired["pusher"].push.assert_not_called()
+        # Image refs come from compose data; digest still resolved.
+        mock_resolve.assert_called_once()
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_revision_and_digest_orthogonal(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        mock_resolve.return_value = _DIGEST_BACKEND
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            image_refs=["ghcr.io/my-org/my-app-backend:abc1234"],
+            transformed_services={
+                "backend": {"image": "ghcr.io/my-org/my-app-backend:abc1234"},
+            },
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", revision="abc1234")
+
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        assert kwargs["revision"] == "abc1234"
+        assert kwargs["digest_map"] == {
+            "ghcr.io/my-org/my-app-backend:abc1234": _DIGEST_BACKEND,
+        }
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_pattern_b_external_image_not_in_digest_map(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
+        tmp_path,
+    ):
+        # Compose: one buildable backend + postgres pass-through.
+        compose = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "my-org/my-app-backend:1.0.0",
+                },
+                "db": {"image": "postgres:15"},
+            },
+        }
+        mock_resolve.return_value = _DIGEST_BACKEND
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data=compose,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        # Map only carries the buildable ref; postgres absent.
+        assert "postgres:15" not in kwargs["digest_map"]
+        assert all(
+            "postgres" not in ref for ref in kwargs["digest_map"]
+        )
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_dry_run_skips_digest_resolution(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, tmp_path,
+    ):
+        with patch(
+            "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest"
+        ) as mock_resolve:
+            wired = _wire_publish_mocks(
+                detector_cls=mock_detector_cls,
+                meta_validator_cls=mock_meta_validator_cls,
+                compose_validator_cls=mock_compose_validator_cls,
+                transformer_cls=mock_transformer_cls,
+                profile_mgr_cls=mock_profile_mgr_cls,
+                builder_cls=mock_builder_cls,
+                pusher_cls=mock_pusher_cls,
+                reg_builder_cls=mock_reg_builder_cls,
+                publisher_cls=mock_publisher_cls,
+                tmp_path=tmp_path,
+            )
+            wired["reg_builder"].build_entry.return_value = {
+                "name": "my-app", "version": "1.0.0",
+            }
+            mock_publisher_cls.return_value.publish.return_value = (
+                _make_publish_result(dry_run=True)
+            )
+
+            from kamiwaza_extensions.commands.publish import run_publish
+
+            run_publish(stage="dev", dry_run=True)
+
+            mock_resolve.assert_not_called()

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -344,6 +344,17 @@ class TestTransformImageTags:
         result = builder.transform_image_tags(yml, "kamiwazaai", "2.0.0", "stage")
         assert f"kamiwazaai/my-app:2.0.0-stage@{digest}" in result
 
+    def test_malformed_digest_suffix_passes_through_untouched(self, builder):
+        # M5: an `@sha256:short` (or any non-conforming suffix) doesn't
+        # match the optional digest group, so the regex matches up to
+        # the bad `@` and the broken tail passes through verbatim.
+        # Preserves rather than corrupts user input.
+        yml = "image: kamiwazaai/my-app-web:old@sha256:short"
+        result = builder.transform_image_tags(
+            yml, "kamiwazaai", "2.0.0", "prod", extension_name="my-app",
+        )
+        assert "kamiwazaai/my-app-web:2.0.0@sha256:short" in result
+
     def test_preserves_digest_on_some_siblings_only(self, builder):
         digest = "sha256:" + "c" * 64
         yml = (
@@ -783,6 +794,32 @@ class TestBuildEntryDigestPinning:
             compose["services"]["backend"]["image"]
             == "kamiwazaai/my-app-backend:1.0.0"
         )
+
+    def test_extra_docker_images_collision_pinned_and_deduped(self, builder):
+        # M1: when extra_docker_images repeats a buildable service ref,
+        # both copies must end up pinned identically so dedup collapses
+        # them. Otherwise the catalog leaks an unpinned duplicate.
+        compose = {
+            "services": {
+                "backend": {"image": "kamiwazaai/my-app-backend:1.0.0"},
+            },
+        }
+        meta = {
+            "name": "my-app",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            # Redundantly listed (same as the service image).
+            "extra_docker_images": ["kamiwazaai/my-app-backend:1.0.0"],
+        }
+        digest_map = {"kamiwazaai/my-app-backend:1.0.0": _DIGEST_A}
+        entry = builder.build_entry(
+            meta, compose, "kamiwazaai", "1.0.0", digest_map=digest_map,
+        )
+        # Single pinned entry — no unpinned duplicate.
+        assert entry["docker_images"] == [
+            f"kamiwazaai/my-app-backend:1.0.0@{_DIGEST_A}"
+        ]
 
     def test_revision_and_digest_are_orthogonal(self, builder, metadata):
         # Catalog ref carries both: <reg>/<ext>-<svc>:<revision>@<digest>.

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -643,3 +643,130 @@ class TestNormalizePreviewImage:
 
     def test_leading_slash(self):
         assert _normalize_preview_image("/screenshot.png") == "images/screenshot.png"
+
+
+# ------------------------------------------------------------------
+# ENG-4370 — digest pinning via build_entry(digest_map=...)
+# ------------------------------------------------------------------
+
+
+_DIGEST_A = "sha256:" + "a" * 64
+_DIGEST_B = "sha256:" + "b" * 64
+
+
+class TestBuildEntryDigestPinning:
+    def test_pinning_rewrites_compose_yml_and_docker_images(
+        self, builder, metadata, transformed_compose,
+    ):
+        digest_map = {
+            "kamiwazaai/my-app-frontend:1.0.0": _DIGEST_A,
+            "kamiwazaai/my-app-backend:1.0.0": _DIGEST_B,
+        }
+        entry = builder.build_entry(
+            metadata, transformed_compose, "kamiwazaai", "1.0.0",
+            digest_map=digest_map,
+        )
+
+        # docker_images carries `tag@digest` for buildable refs.
+        assert f"kamiwazaai/my-app-frontend:1.0.0@{_DIGEST_A}" in entry["docker_images"]
+        assert f"kamiwazaai/my-app-backend:1.0.0@{_DIGEST_B}" in entry["docker_images"]
+        # Pre-existing tag-only refs no longer present.
+        assert "kamiwazaai/my-app-frontend:1.0.0" not in entry["docker_images"]
+        assert "kamiwazaai/my-app-backend:1.0.0" not in entry["docker_images"]
+        # Pass-through external image left verbatim (Pattern B).
+        assert "postgres:15" in entry["docker_images"]
+
+        parsed = yaml.safe_load(entry["compose_yml"])
+        assert (
+            parsed["services"]["frontend"]["image"]
+            == f"kamiwazaai/my-app-frontend:1.0.0@{_DIGEST_A}"
+        )
+        assert (
+            parsed["services"]["backend"]["image"]
+            == f"kamiwazaai/my-app-backend:1.0.0@{_DIGEST_B}"
+        )
+        assert parsed["services"]["db"]["image"] == "postgres:15"
+
+    def test_omitted_digest_map_leaves_refs_unchanged(
+        self, builder, metadata, transformed_compose,
+    ):
+        entry = builder.build_entry(
+            metadata, transformed_compose, "kamiwazaai", "1.0.0",
+        )
+        assert "kamiwazaai/my-app-frontend:1.0.0" in entry["docker_images"]
+        assert all("@" not in img for img in entry["docker_images"])
+
+    def test_empty_digest_map_leaves_refs_unchanged(
+        self, builder, metadata, transformed_compose,
+    ):
+        entry = builder.build_entry(
+            metadata, transformed_compose, "kamiwazaai", "1.0.0",
+            digest_map={},
+        )
+        assert "kamiwazaai/my-app-frontend:1.0.0" in entry["docker_images"]
+        assert all("@" not in img for img in entry["docker_images"])
+
+    def test_partial_digest_map_only_pins_listed_refs(
+        self, builder, metadata, transformed_compose,
+    ):
+        # Only one of the two buildable refs in the map. The other is
+        # left as tag-only — verifies the map is the source of truth.
+        digest_map = {"kamiwazaai/my-app-frontend:1.0.0": _DIGEST_A}
+        entry = builder.build_entry(
+            metadata, transformed_compose, "kamiwazaai", "1.0.0",
+            digest_map=digest_map,
+        )
+        assert f"kamiwazaai/my-app-frontend:1.0.0@{_DIGEST_A}" in entry["docker_images"]
+        assert "kamiwazaai/my-app-backend:1.0.0" in entry["docker_images"]
+
+    def test_already_pinned_ref_not_double_pinned(self, builder, metadata):
+        compose = {
+            "services": {
+                "backend": {
+                    "image": f"kamiwazaai/my-app-backend:1.0.0@{_DIGEST_A}"
+                },
+            },
+        }
+        # Map keyed by the original (unpinned) ref. Because the compose
+        # value already contains '@', _apply_digests must skip it.
+        digest_map = {"kamiwazaai/my-app-backend:1.0.0": _DIGEST_B}
+        entry = builder.build_entry(
+            metadata, compose, "kamiwazaai", "1.0.0", digest_map=digest_map,
+        )
+        # Original digest preserved; no double `@`.
+        assert f"kamiwazaai/my-app-backend:1.0.0@{_DIGEST_A}" in entry["docker_images"]
+        assert _DIGEST_B not in entry["compose_yml"]
+
+    def test_does_not_mutate_caller_compose(self, builder, metadata):
+        compose = {
+            "services": {
+                "backend": {"image": "kamiwazaai/my-app-backend:1.0.0"},
+            },
+        }
+        digest_map = {"kamiwazaai/my-app-backend:1.0.0": _DIGEST_A}
+        builder.build_entry(metadata, compose, "kamiwazaai", "1.0.0", digest_map=digest_map)
+        assert (
+            compose["services"]["backend"]["image"]
+            == "kamiwazaai/my-app-backend:1.0.0"
+        )
+
+    def test_revision_and_digest_are_orthogonal(self, builder, metadata):
+        # Catalog ref carries both: <reg>/<ext>-<svc>:<revision>@<digest>.
+        compose = {
+            "services": {
+                "backend": {
+                    "image": "kamiwazaai/my-app-backend:abc1234",  # revision tag
+                },
+            },
+        }
+        digest_map = {"kamiwazaai/my-app-backend:abc1234": _DIGEST_A}
+        entry = builder.build_entry(
+            metadata, compose, "kamiwazaai", "1.0.0",
+            revision="abc1234",
+            digest_map=digest_map,
+        )
+        assert entry["revision"] == "abc1234"
+        assert (
+            f"kamiwazaai/my-app-backend:abc1234@{_DIGEST_A}"
+            in entry["docker_images"]
+        )

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -325,6 +325,40 @@ class TestTransformImageTags:
         result = builder.transform_image_tags(yml, "kamiwazaai", "2.0.0", "qa")
         assert "kamiwazaai/my-app:2.0.0-qa" in result
 
+    # ENG-4370: digest suffixes must survive tag rewriting.
+
+    def test_preserves_digest_suffix_extension_branch(self, builder):
+        digest = "sha256:" + "a" * 64
+        yml = f"image: kamiwazaai/my-app-web:old@{digest}"
+        result = builder.transform_image_tags(
+            yml, "kamiwazaai", "2.0.0", "prod", extension_name="my-app",
+        )
+        assert f"kamiwazaai/my-app-web:2.0.0@{digest}" in result
+        # Digest preserved, not stripped.
+        assert "kamiwazaai/my-app-web:2.0.0\n" not in result + "\n"
+        assert "kamiwazaai/my-app-web:2.0.0 " not in result + " "
+
+    def test_preserves_digest_suffix_fallback_branch(self, builder):
+        digest = "sha256:" + "b" * 64
+        yml = f"image: kamiwazaai/my-app:old@{digest}"
+        result = builder.transform_image_tags(yml, "kamiwazaai", "2.0.0", "stage")
+        assert f"kamiwazaai/my-app:2.0.0-stage@{digest}" in result
+
+    def test_preserves_digest_on_some_siblings_only(self, builder):
+        digest = "sha256:" + "c" * 64
+        yml = (
+            f"image: kamiwazaai/app-frontend:old@{digest}\n"
+            "image: kamiwazaai/app-backend:old\n"
+        )
+        result = builder.transform_image_tags(yml, "kamiwazaai", "3.0.0", "prod")
+        assert f"kamiwazaai/app-frontend:3.0.0@{digest}" in result
+        assert "kamiwazaai/app-backend:3.0.0" in result
+        # Backend has no `@` after rewrite.
+        backend_line = [
+            ln for ln in result.splitlines() if "app-backend" in ln
+        ][0]
+        assert "@" not in backend_line
+
 
 # ------------------------------------------------------------------
 # extract_docker_images

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -345,7 +345,7 @@ class TestTransformImageTags:
         assert f"kamiwazaai/my-app:2.0.0-stage@{digest}" in result
 
     def test_digest_only_ref_extension_branch_unchanged(self, builder):
-        # F1: image@sha256:<64> (no tag) must NOT be rewritten. Previous
+        # image@sha256:<64> (no tag) must NOT be rewritten. An earlier
         # regex captured `service@sha256` as the path and the hex as
         # the tag, producing `service@sha256:newtag` — corruption.
         digest = "sha256:" + "a" * 64
@@ -380,7 +380,7 @@ class TestTransformImageTags:
         assert ":3.0.0" not in frontend_line
 
     def test_malformed_digest_suffix_passes_through_untouched(self, builder):
-        # M5: an `@sha256:short` (or any non-conforming suffix) doesn't
+        # An `@sha256:short` (or any non-conforming suffix) doesn't
         # match the optional digest group, so the regex matches up to
         # the bad `@` and the broken tail passes through verbatim.
         # Preserves rather than corrupts user input.
@@ -831,7 +831,7 @@ class TestBuildEntryDigestPinning:
         )
 
     def test_extra_docker_images_collision_pinned_and_deduped(self, builder):
-        # M1: when extra_docker_images repeats a buildable service ref,
+        # When extra_docker_images repeats a buildable service ref,
         # both copies must end up pinned identically so dedup collapses
         # them. Otherwise the catalog leaks an unpinned duplicate.
         compose = {

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -344,6 +344,41 @@ class TestTransformImageTags:
         result = builder.transform_image_tags(yml, "kamiwazaai", "2.0.0", "stage")
         assert f"kamiwazaai/my-app:2.0.0-stage@{digest}" in result
 
+    def test_digest_only_ref_extension_branch_unchanged(self, builder):
+        # F1: image@sha256:<64> (no tag) must NOT be rewritten. Previous
+        # regex captured `service@sha256` as the path and the hex as
+        # the tag, producing `service@sha256:newtag` — corruption.
+        digest = "sha256:" + "a" * 64
+        yml = f"image: kamiwazaai/my-app-web@{digest}"
+        result = builder.transform_image_tags(
+            yml, "kamiwazaai", "2.0.0", "prod", extension_name="my-app",
+        )
+        # Verbatim — no rewrite.
+        assert result == yml
+
+    def test_digest_only_ref_fallback_branch_unchanged(self, builder):
+        digest = "sha256:" + "b" * 64
+        yml = f"image: kamiwazaai/my-app@{digest}"
+        result = builder.transform_image_tags(yml, "kamiwazaai", "2.0.0", "stage")
+        assert result == yml
+
+    def test_digest_only_and_tag_only_siblings(self, builder):
+        # Mixed compose: one ref pinned by digest only, one tagged.
+        # The tagged ref is rewritten; the digest-only ref passes through.
+        digest = "sha256:" + "c" * 64
+        yml = (
+            f"image: kamiwazaai/app-frontend@{digest}\n"
+            "image: kamiwazaai/app-backend:old\n"
+        )
+        result = builder.transform_image_tags(yml, "kamiwazaai", "3.0.0", "prod")
+        assert f"kamiwazaai/app-frontend@{digest}" in result
+        assert "kamiwazaai/app-backend:3.0.0" in result
+        # Frontend was not rewritten with a tag.
+        frontend_line = [
+            ln for ln in result.splitlines() if "app-frontend" in ln
+        ][0]
+        assert ":3.0.0" not in frontend_line
+
     def test_malformed_digest_suffix_passes_through_untouched(self, builder):
         # M5: an `@sha256:short` (or any non-conforming suffix) doesn't
         # match the optional digest group, so the regex matches up to


### PR DESCRIPTION
## Summary

Adds `--digest sha256:<64-hex>` to `kz-ext publish` and auto-resolves the digest from the registry when omitted, so catalog entries reference images as `image:tag@sha256:digest`. Buildable images only — pass-through external refs (postgres etc.) keep whatever pinning their source repo applied.

## Motivation

ENG-4369 versioning policy makes catalog identity digest-pinned so it survives tag mutability. CI auto-publish (ENG-3593) needs to record the exact image it just built. Pulling `image:tag@sha256:<d>` always returns the same content even if the tag is later re-pointed.

## Contract

- `--digest <sha256:...>` requires exactly one buildable service in compose; multi-buildable runs must rely on auto-resolve.
- When `--digest` is omitted, every buildable ref is resolved post-push via `docker buildx imagetools inspect`. With `--no-push`, the same call runs against the existing tag (the registry already has the image from a prior run).
- `--revision` and `--digest` are orthogonal: revision drives the tag and the `(name, semver, revision)` dedup guard; digest pins identity. Catalog can carry both — `<reg>/<ext>-<svc>:<rev>@sha256:<d>`.
- `RegistryBuilder.transform_image_tags()` now preserves an existing `@sha256:...` suffix when rewriting the tag (was silently dropping it).
- Dry-run skips digest resolution.

## Verification

- 1430 unit tests passing locally; 31 new across image_pusher, registry_builder, publish command.
- `uv run ruff check` clean on all changed files.

## Notes

- Consumer-side parsing of combined `repo:tag@digest` refs is ENG-4592 (blocking), tracked separately. Producer-side ships forward-compatible: older readers that ignore the digest portion will still see a valid `repo:tag`.
- `--revision` kept as-is. Its dedup guard is unique behavior `--digest` does not replace.
- Docs reference `--revision` in `docs/extensions/non-sdk-flow.md` and `docs/extensions/developer-guide.md`. Holding doc updates until ENG-3593 (CI auto-publish) lands so the recommended flow can be documented end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)