### PR TITLE
fix(extensions): kz-ext publish defaults to garden/v3 (ENG-4806)

### DIFF
--- a/kamiwaza_extensions/catalog_publisher.py
+++ b/kamiwaza_extensions/catalog_publisher.py
@@ -23,6 +23,9 @@ from kamiwaza_extensions.registry_builder import RegistryBuilder
 
 console = Console(stderr=True)
 
+DEFAULT_CATALOG_SCHEMA: int = 3
+SUPPORTED_CATALOG_SCHEMAS: frozenset[int] = frozenset({2, 3})
+
 # Revision grammar (Open Q #8 resolution): 1-64 chars, starts with
 # alphanumeric, allows lowercase letters, digits, hyphens, and dots.
 # Compatible with default revision_tagger output and plain Git SHAs.
@@ -154,7 +157,7 @@ class CatalogPublisher:
     def __init__(
         self,
         profile: PublishProfile,
-        catalog_schema: int = 3,
+        catalog_schema: int = DEFAULT_CATALOG_SCHEMA,
         extension_dir: Optional[Path] = None,
     ) -> None:
         """Initialize S3 client from profile credentials.
@@ -164,11 +167,18 @@ class CatalogPublisher:
             catalog_schema: Catalog schema version (determines the
                 ``garden/v{N}/`` path). Defaults to 3 (current schema for
                 K8s/v3 extensions). Pass ``2`` to publish to the legacy
-                ``garden/v2/`` catalog.
+                ``garden/v2/`` catalog. Must be in
+                ``SUPPORTED_CATALOG_SCHEMAS``; otherwise raises
+                ``ValueError``.
             extension_dir: Root directory of the extension project.  Used
                 for placing backup files.  Falls back to ``Path.cwd()`` if
                 not provided.
         """
+        if catalog_schema not in SUPPORTED_CATALOG_SCHEMAS:
+            raise ValueError(
+                f"Unsupported catalog_schema={catalog_schema!r}. "
+                f"Supported values: {sorted(SUPPORTED_CATALOG_SCHEMAS)}."
+            )
         try:
             import boto3
             from botocore.exceptions import ClientError

--- a/kamiwaza_extensions/catalog_publisher.py
+++ b/kamiwaza_extensions/catalog_publisher.py
@@ -154,14 +154,17 @@ class CatalogPublisher:
     def __init__(
         self,
         profile: PublishProfile,
-        repo_version: int = 2,
+        catalog_schema: int = 3,
         extension_dir: Optional[Path] = None,
     ) -> None:
         """Initialize S3 client from profile credentials.
 
         Args:
             profile: Publish profile with S3 endpoint and credentials.
-            repo_version: Catalog schema version (determines garden path).
+            catalog_schema: Catalog schema version (determines the
+                ``garden/v{N}/`` path). Defaults to 3 (current schema for
+                K8s/v3 extensions). Pass ``2`` to publish to the legacy
+                ``garden/v2/`` catalog.
             extension_dir: Root directory of the extension project.  Used
                 for placing backup files.  Falls back to ``Path.cwd()`` if
                 not provided.
@@ -180,15 +183,15 @@ class CatalogPublisher:
         self._ClientError = ClientError
 
         self._profile = profile
-        self._repo_version = repo_version
+        self._catalog_schema = catalog_schema
         self._extension_dir = extension_dir if extension_dir is not None else Path.cwd()
 
         # Build garden directory incorporating the optional catalog_prefix.
         prefix = profile.catalog_prefix.strip("/")
         if prefix:
-            self._garden_dir = f"{prefix}/garden/v{repo_version}/"
+            self._garden_dir = f"{prefix}/garden/v{catalog_schema}/"
         else:
-            self._garden_dir = f"garden/v{repo_version}/"
+            self._garden_dir = f"garden/v{catalog_schema}/"
 
         # Validate endpoint to prevent SSRF via env var override
         endpoint = profile.catalog_endpoint

--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -8,8 +8,21 @@ import typer
 from rich.console import Console
 
 from kamiwaza_extensions import __version__
+from kamiwaza_extensions.catalog_publisher import (
+    DEFAULT_CATALOG_SCHEMA,
+    SUPPORTED_CATALOG_SCHEMAS,
+)
 from kamiwaza_extensions.exit_codes import exit_code_for
 from kamiwaza_extensions_lib.errors import KamiwazaRuntimeError
+
+
+def _validate_catalog_schema(value: int) -> int:
+    """Typer callback: reject values outside ``SUPPORTED_CATALOG_SCHEMAS``."""
+    if value not in SUPPORTED_CATALOG_SCHEMAS:
+        raise typer.BadParameter(
+            f"must be one of {sorted(SUPPORTED_CATALOG_SCHEMAS)} (got {value})"
+        )
+    return value
 
 app = typer.Typer(
     name="kz-ext",
@@ -356,8 +369,9 @@ def publish(
         ),
     ),
     catalog_schema: int = typer.Option(
-        3,
+        DEFAULT_CATALOG_SCHEMA,
         "--catalog-schema",
+        callback=_validate_catalog_schema,
         help=(
             "Catalog schema version (garden/v{N}/ path). Defaults to 3 "
             "(K8s/v3 extensions). Pass 2 to publish to the legacy v2 catalog."

--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -355,6 +355,14 @@ def publish(
             "service in compose; omit to auto-resolve per-service digests."
         ),
     ),
+    catalog_schema: int = typer.Option(
+        3,
+        "--catalog-schema",
+        help=(
+            "Catalog schema version (garden/v{N}/ path). Defaults to 3 "
+            "(K8s/v3 extensions). Pass 2 to publish to the legacy v2 catalog."
+        ),
+    ),
 ) -> None:
     """Publish extension to catalog."""
     from kamiwaza_extensions.commands.publish import run_publish
@@ -367,6 +375,7 @@ def publish(
         verbose=_state.verbose,
         revision=revision,
         digest=digest,
+        catalog_schema=catalog_schema,
     )
 
 

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 import typer
 from rich.console import Console
 
+from kamiwaza_extensions.catalog_publisher import DEFAULT_CATALOG_SCHEMA
 from kamiwaza_extensions.extension_detector import infer_extension_type
 
 console = Console(stderr=True)
@@ -140,11 +141,10 @@ def run_publish(
     verbose: bool = False,
     revision: Optional[str] = None,
     digest: Optional[str] = None,
-    catalog_schema: Optional[int] = None,
+    catalog_schema: int = DEFAULT_CATALOG_SCHEMA,
 ) -> None:
     """Build, push, and publish extension to catalog."""
     from kamiwaza_extensions.catalog_publisher import (
-        DEFAULT_CATALOG_SCHEMA,
         CatalogDedupError,
         CatalogDedupGuard,
         CatalogPublishError,
@@ -163,9 +163,6 @@ def run_publish(
     from kamiwaza_extensions.registry_builder import RegistryBuilder
     from kamiwaza_extensions.validators.compose import ComposeValidator
     from kamiwaza_extensions.validators.metadata import MetadataValidator
-
-    if catalog_schema is None:
-        catalog_schema = DEFAULT_CATALOG_SCHEMA
 
     # 0. Fail fast on bad --revision before any side effects (build, push,
     # registry tag pollution). Previously this validated inside

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -140,10 +140,11 @@ def run_publish(
     verbose: bool = False,
     revision: Optional[str] = None,
     digest: Optional[str] = None,
-    catalog_schema: int = 3,
+    catalog_schema: Optional[int] = None,
 ) -> None:
     """Build, push, and publish extension to catalog."""
     from kamiwaza_extensions.catalog_publisher import (
+        DEFAULT_CATALOG_SCHEMA,
         CatalogDedupError,
         CatalogDedupGuard,
         CatalogPublishError,
@@ -162,6 +163,9 @@ def run_publish(
     from kamiwaza_extensions.registry_builder import RegistryBuilder
     from kamiwaza_extensions.validators.compose import ComposeValidator
     from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+    if catalog_schema is None:
+        catalog_schema = DEFAULT_CATALOG_SCHEMA
 
     # 0. Fail fast on bad --revision before any side effects (build, push,
     # registry tag pollution). Previously this validated inside

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -140,6 +140,7 @@ def run_publish(
     verbose: bool = False,
     revision: Optional[str] = None,
     digest: Optional[str] = None,
+    catalog_schema: int = 3,
 ) -> None:
     """Build, push, and publish extension to catalog."""
     from kamiwaza_extensions.catalog_publisher import (
@@ -355,7 +356,11 @@ def run_publish(
             digest_map=dry_digest_map or None,
         )
         try:
-            publisher = CatalogPublisher(profile, extension_dir=info.path)
+            publisher = CatalogPublisher(
+                profile,
+                catalog_schema=catalog_schema,
+                extension_dir=info.path,
+            )
             result = publisher.publish(
                 entry=entry,
                 extension_type=ext_type,
@@ -486,7 +491,11 @@ def run_publish(
     preview_image_path = _resolve_preview_image(info.metadata, info.path)
 
     try:
-        publisher = CatalogPublisher(profile, extension_dir=info.path)
+        publisher = CatalogPublisher(
+            profile,
+            catalog_schema=catalog_schema,
+            extension_dir=info.path,
+        )
         result = publisher.publish(
             entry=entry,
             extension_type=ext_type,

--- a/tests/unit/extensions/test_catalog_publisher.py
+++ b/tests/unit/extensions/test_catalog_publisher.py
@@ -452,6 +452,33 @@ class TestCatalogSchemaGardenPath:
 
 
 # ------------------------------------------------------------------
+# Catalog schema bounds check (fail fast on typos / unsupported values)
+# ------------------------------------------------------------------
+
+
+class TestCatalogSchemaValidation:
+    """``catalog_schema`` must be in ``SUPPORTED_CATALOG_SCHEMAS``."""
+
+    def test_zero_rejected(self):
+        from kamiwaza_extensions.catalog_publisher import CatalogPublisher
+
+        with pytest.raises(ValueError, match="Unsupported catalog_schema"):
+            CatalogPublisher(_make_profile(), catalog_schema=0)
+
+    def test_negative_rejected(self):
+        from kamiwaza_extensions.catalog_publisher import CatalogPublisher
+
+        with pytest.raises(ValueError, match="Unsupported catalog_schema"):
+            CatalogPublisher(_make_profile(), catalog_schema=-1)
+
+    def test_unknown_future_version_rejected(self):
+        from kamiwaza_extensions.catalog_publisher import CatalogPublisher
+
+        with pytest.raises(ValueError, match="Unsupported catalog_schema"):
+            CatalogPublisher(_make_profile(), catalog_schema=99)
+
+
+# ------------------------------------------------------------------
 # Preview image upload
 # ------------------------------------------------------------------
 

--- a/tests/unit/extensions/test_catalog_publisher.py
+++ b/tests/unit/extensions/test_catalog_publisher.py
@@ -410,6 +410,48 @@ class TestCredentialResolution:
 
 
 # ------------------------------------------------------------------
+# Catalog schema version → garden path
+# ------------------------------------------------------------------
+
+
+class TestCatalogSchemaGardenPath:
+    """``catalog_schema`` selects the ``garden/v{N}/`` path. Default is 3."""
+
+    @patch("boto3.Session")
+    def test_default_catalog_schema_is_v3(self, mock_session_cls):
+        from kamiwaza_extensions.catalog_publisher import CatalogPublisher
+
+        publisher = CatalogPublisher(_make_profile())
+
+        assert publisher._garden_dir == "garden/v3/"
+
+    @patch("boto3.Session")
+    def test_explicit_v2_uses_legacy_path(self, mock_session_cls):
+        from kamiwaza_extensions.catalog_publisher import CatalogPublisher
+
+        publisher = CatalogPublisher(_make_profile(), catalog_schema=2)
+
+        assert publisher._garden_dir == "garden/v2/"
+
+    @patch("boto3.Session")
+    def test_explicit_v3_matches_default(self, mock_session_cls):
+        from kamiwaza_extensions.catalog_publisher import CatalogPublisher
+
+        publisher = CatalogPublisher(_make_profile(), catalog_schema=3)
+
+        assert publisher._garden_dir == "garden/v3/"
+
+    @patch("boto3.Session")
+    def test_catalog_prefix_prepended_to_garden_path(self, mock_session_cls):
+        from kamiwaza_extensions.catalog_publisher import CatalogPublisher
+
+        profile = _make_profile(catalog_prefix="staging")
+        publisher = CatalogPublisher(profile, catalog_schema=3)
+
+        assert publisher._garden_dir == "staging/garden/v3/"
+
+
+# ------------------------------------------------------------------
 # Preview image upload
 # ------------------------------------------------------------------
 

--- a/tests/unit/extensions/test_catalog_publisher.py
+++ b/tests/unit/extensions/test_catalog_publisher.py
@@ -332,7 +332,6 @@ class TestLockReleaseOnError:
 
         # Lock succeeds, backup empty, download empty, then upload raises
         call_count = [0]
-        original_put = mock_s3.put_object
 
         def put_object_side_effect(**kwargs):
             call_count[0] += 1

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -64,7 +64,7 @@ def _make_publish_result(**overrides):
         version="1.0.0",
         action="insert",
         registry_url="ghcr.io/my-org",
-        catalog_file="garden/v2/apps.json",
+        catalog_file="garden/v3/apps.json",
         images_pushed=[],
         dry_run=False,
     )
@@ -254,6 +254,95 @@ class TestPublishDryRun:
         # Verify dry_run=True was passed
         call_kwargs = mock_publisher.publish.call_args[1]
         assert call_kwargs.get("dry_run") is True
+
+
+# ------------------------------------------------------------------
+# Catalog schema flag plumbing
+# ------------------------------------------------------------------
+
+
+class TestCatalogSchemaFlag:
+    """``--catalog-schema`` (a.k.a. ``catalog_schema``) selects garden/v{N}/.
+
+    Regression for ENG-4806: previously kz-ext silently published to v2
+    because run_publish never threaded the value to CatalogPublisher.
+    """
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_default_passes_catalog_schema_3(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path)
+        mock_meta_validator_cls.return_value.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value.validate.return_value = _make_validation_result()
+        mock_profile_mgr_cls.return_value.resolve_profile.return_value = _make_profile()
+        mock_transformer_cls.return_value.transform.return_value = {"services": {}}
+        mock_reg_builder_cls.return_value.build_entry.return_value = {
+            "name": "my-app", "version": "1.0.0",
+        }
+        mock_publisher_cls.return_value.publish.return_value = _make_publish_result(dry_run=True)
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", dry_run=True)
+
+        assert mock_publisher_cls.call_args.kwargs["catalog_schema"] == 3
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_explicit_v2_threaded_to_publisher(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path)
+        mock_meta_validator_cls.return_value.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value.validate.return_value = _make_validation_result()
+        mock_profile_mgr_cls.return_value.resolve_profile.return_value = _make_profile()
+        mock_transformer_cls.return_value.transform.return_value = {"services": {}}
+        mock_reg_builder_cls.return_value.build_entry.return_value = {
+            "name": "my-app", "version": "1.0.0",
+        }
+        mock_publisher_cls.return_value.publish.return_value = _make_publish_result(dry_run=True)
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", dry_run=True, catalog_schema=2)
+
+        assert mock_publisher_cls.call_args.kwargs["catalog_schema"] == 2
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -262,11 +262,7 @@ class TestPublishDryRun:
 
 
 class TestCatalogSchemaFlag:
-    """``--catalog-schema`` (a.k.a. ``catalog_schema``) selects garden/v{N}/.
-
-    Regression for ENG-4806: previously kz-ext silently published to v2
-    because run_publish never threaded the value to CatalogPublisher.
-    """
+    """``run_publish`` threads ``catalog_schema`` into ``CatalogPublisher``."""
 
     @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
     @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")


### PR DESCRIPTION
## Summary

`kz-ext publish` was hardcoded to write to `garden/v2/`, blocking the auto-publish CI in ENG-3593. Modern extensions (graphiti, omniparse, kaizen, …) live in `garden/v3/`, so kz-ext silently wrote to the wrong catalog and created orphan v2 entries.

- Default catalog schema flipped from `2` → `3` on `CatalogPublisher.__init__`.
- New `--catalog-schema INT` flag on `kz-ext publish` (default `3`); pass `2` to publish to the legacy v2 catalog.
- Threaded the value through `run_publish` into both `CatalogPublisher` call sites (dry-run + live). The bug had two halves — the wrong default *and* the missing plumbing — so both needed to be fixed for the override flag to do anything.

## Decisions

- **Renamed kwarg `repo_version` → `catalog_schema`.** `repo_version` was misleading — it doesn't refer to any repo, it's a catalog schema version. `CatalogPublisher` isn't exported from any `__init__.py` and has zero external importers (verified by grep across `~/kami/`), so this is a fully-internal rename.
- **Did NOT rename `build-registry.py`'s `--repo-version` flag.** Per the ticket, that's deferred — it's the externally-visible flag (CI workflows, `make publish-registry REPO_VERSION=N`) and the rename can land separately.

## Testing

Verified end-to-end against graphiti (`services/service-graphiti`, version `2.3.1`) using the dev R2 catalog:

- [x] `kz-ext publish --stage dev --no-build --no-push --dry-run --force` → \`Would publish to: garden/v3/apps.json (replace)\`
- [x] `kz-ext publish --stage dev --catalog-schema 2 --no-build --no-push --dry-run` → \`Would publish to: garden/v2/apps.json (insert)\` (entry doesn't exist in v2 catalog, confirming the override actually changes the read path too)
- [x] Round-trip parity with `make publish-registry STAGE=dev REPO_VERSION=3 DRY_RUN=1` — same \`garden/v3/\` path, same merge finding for \`service-graphiti 2.3.1\`
- [x] All 1084 extensions unit tests pass; new tests cover both the \`garden/v{N}/\` path resolution (default + explicit + prefix) and \`run_publish\`'s plumbing of \`catalog_schema\` into the publisher

Unblocks ENG-3593 (CI auto-publish to R2 on merge to develop).