### PR TITLE
fix: preserve kz-ext deployment overrides

### DIFF
--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -44,14 +44,66 @@ def _build_patch_kwargs(
        carry these or iterative dev silently runs against stale config.
     """
     kwargs: Dict[str, Any] = {"services": patch_services}
-    annotations = (payload.model_extra or {}).get("annotations")
+    extra = payload.model_extra or {}
+    annotations = extra.get("annotations")
     if annotations:
         kwargs["annotations"] = annotations
     # ``kamiwaza`` is a top-level field on CreateExtension; mirror it onto
     # the patch via ``extra="allow"`` so PATCH refreshes the persisted CR.
     if getattr(payload, "kamiwaza", None) is not None:
         kwargs["kamiwaza"] = payload.kamiwaza
+    # ``sandbox`` rides ``CreateExtension`` as an extra field
+    # (``extra="allow"``). Forward it on PATCH too: ``kz-ext dev`` uses
+    # PATCH after the first CREATE, and the operator needs the sandbox
+    # contract refreshed for sandbox RBAC reconciliation when a user
+    # toggles ``SANDBOX_BACKEND=kubernetes`` or changes
+    # namespace/whitelist/resources on a redeploy.
+    sandbox = extra.get("sandbox")
+    if sandbox:
+        kwargs["sandbox"] = sandbox
     return kwargs
+
+
+def _build_patch_service_specs(payload: Any) -> List[Any]:
+    """Build the per-service ``PatchServiceSpec`` list from a
+    ``CreateExtension`` payload, forwarding the new ``x-kamiwaza``
+    per-service overrides via ``extra="allow"``.
+
+    jxstanford PR #97 review H2: without forwarding ``healthCheck`` /
+    ``automountServiceAccountToken`` / ``containerSecurityContext`` on
+    PATCH, iterative ``kz-ext dev`` redeploys silently drop the very
+    overrides this PR added.
+    """
+    from kamiwaza_sdk.schemas.extensions import ImagePatch, PatchServiceSpec
+
+    patch_services: List[Any] = []
+    for svc in payload.services:
+        # Split tag after last '/' to avoid confusing registry port with tag
+        image = svc.image
+        slash_pos = image.rfind("/")
+        after_slash = image[slash_pos + 1:] if slash_pos >= 0 else image
+        if ":" in after_slash:
+            tag = after_slash.rsplit(":", 1)[1]
+        else:
+            tag = "latest"
+        spec = PatchServiceSpec(
+            name=svc.name,
+            image=ImagePatch(tag=tag),
+        )
+        if svc.env:
+            spec.env = svc.env
+        if svc.replicas is not None:
+            spec.replicas = svc.replicas
+        svc_extra = svc.model_extra or {}
+        for field in (
+            "healthCheck",
+            "automountServiceAccountToken",
+            "containerSecurityContext",
+        ):
+            if field in svc_extra and svc_extra[field] is not None:
+                setattr(spec, field, svc_extra[field])
+        patch_services.append(spec)
+    return patch_services
 
 
 # Match the default ``RevisionTagger.generate_tag`` format:
@@ -539,36 +591,16 @@ def run_dev_remote(
 
         # Deploy — PATCH if exists, POST if new
         from kamiwaza_sdk.exceptions import NotFoundError
-        from kamiwaza_sdk.schemas.extensions import (
-            ImagePatch,
-            PatchExtension,
-            PatchServiceSpec,
-        )
+        from kamiwaza_sdk.schemas.extensions import PatchExtension
 
         try:
             # Check if extension already exists
             client.extensions.get_extension(dev_name)
 
-            # Build patch from payload — extract image, env, replicas per service
-            patch_services = []
-            for svc in payload.services:
-                # Split tag after last '/' to avoid confusing registry port with tag
-                image = svc.image
-                slash_pos = image.rfind("/")
-                after_slash = image[slash_pos + 1:] if slash_pos >= 0 else image
-                if ":" in after_slash:
-                    tag = after_slash.rsplit(":", 1)[1]
-                else:
-                    tag = "latest"
-                spec = PatchServiceSpec(
-                    name=svc.name,
-                    image=ImagePatch(tag=tag),
-                )
-                if svc.env:
-                    spec.env = svc.env
-                if svc.replicas is not None:
-                    spec.replicas = svc.replicas
-                patch_services.append(spec)
+            # Build patch from payload — extract image, env, replicas
+            # plus the x-kamiwaza per-service overrides forwarded via
+            # ``extra="allow"`` (jxstanford PR #97 review H2).
+            patch_services = _build_patch_service_specs(payload)
             # Carries the deployer/revision/deployed-at annotations on
             # every PATCH so `kz-ext status` reflects the current
             # redeploy (review re-review PR #84 H1).

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -121,6 +121,9 @@ class PayloadBuilder:
                 verified=metadata.get("verified", False),
             ),
         )
+        sandbox = self._build_sandbox_spec(metadata, transformed_compose)
+        if sandbox:
+            kwargs["sandbox"] = sandbox
 
         annotations = self.build_annotations(deployer=deployer, revision=revision)
 
@@ -245,13 +248,15 @@ class PayloadBuilder:
                 env.append({"name": "KAMIWAZA_VERIFY_SSL", "value": "false"})
                 env.append({"name": "KAMIWAZA_TLS_REJECT_UNAUTHORIZED", "value": "0"})
 
-            health_check = self._default_health_check(
-                svc_name,
-                svc,
-                ports,
-                extension_type=extension_type,
-                is_primary=is_primary,
-            )
+            health_check = _service_extension_field(svc, "healthCheck")
+            if health_check is None:
+                health_check = self._default_health_check(
+                    svc_name,
+                    svc,
+                    ports,
+                    extension_type=extension_type,
+                    is_primary=is_primary,
+                )
 
             spec_kwargs: Dict[str, Any] = dict(
                 name=svc_name,
@@ -264,6 +269,14 @@ class PayloadBuilder:
             )
             if health_check:
                 spec_kwargs["healthCheck"] = health_check
+            automount = _service_extension_field(svc, "automountServiceAccountToken")
+            if automount is not None:
+                spec_kwargs["automountServiceAccountToken"] = automount
+            container_security_context = _service_extension_field(
+                svc, "containerSecurityContext"
+            )
+            if container_security_context is not None:
+                spec_kwargs["containerSecurityContext"] = container_security_context
 
             specs.append(ExtensionServiceSpec(**spec_kwargs))
 
@@ -418,6 +431,56 @@ class PayloadBuilder:
             return "app"
         return t
 
+    @staticmethod
+    def _build_sandbox_spec(
+        metadata: Dict[str, Any],
+        transformed: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        declared = metadata.get("sandbox")
+        if isinstance(declared, dict):
+            return declared
+
+        env_defaults = metadata.get("env_defaults") or {}
+        services = transformed.get("services") or {}
+        for svc_name, svc in services.items():
+            env = _service_env_map(svc)
+            if svc_name != "sandbox-controller" and "SANDBOX_BACKEND" not in env:
+                continue
+            if env.get("SANDBOX_BACKEND") != "kubernetes":
+                continue
+
+            spec: Dict[str, Any] = {
+                "enabled": True,
+                "service_name": svc_name,
+            }
+            namespace = env.get("SANDBOX_NAMESPACE")
+            if namespace:
+                spec["namespace"] = namespace
+
+            allowed_images = [
+                item.strip()
+                for item in env.get("SANDBOX_ALLOWED_IMAGE_PREFIXES", "").split(",")
+                if item.strip()
+            ]
+            if allowed_images:
+                spec["image_whitelist"] = allowed_images
+
+            resources = _sandbox_resources_from_env(env)
+            if resources:
+                spec["resources"] = resources
+
+            persistence = env.get("SANDBOX_PERSISTENCE") or env_defaults.get(
+                "SANDBOX_PERSISTENCE"
+            )
+            if isinstance(persistence, str):
+                spec["persistence"] = persistence.strip().lower() == "true"
+            elif isinstance(persistence, bool):
+                spec["persistence"] = persistence
+
+            return spec
+
+        return None
+
 
 def _should_use_node_frontend_probe(svc_name: str, svc: Dict[str, Any]) -> bool:
     """Use the Node-based probe only for likely Node/Next frontends.
@@ -467,3 +530,52 @@ def _should_use_node_frontend_probe(svc_name: str, svc: Dict[str, Any]) -> bool:
             return True
 
     return False
+
+
+def _service_extension_field(svc: Dict[str, Any], key: str) -> Optional[Any]:
+    """Read a service override from ``x-kamiwaza`` or a pre-flattened service."""
+    x_kamiwaza = svc.get("x-kamiwaza")
+    if isinstance(x_kamiwaza, dict) and key in x_kamiwaza:
+        return x_kamiwaza[key]
+    if key in svc:
+        return svc[key]
+    return None
+
+
+def _service_env_map(svc: Dict[str, Any]) -> Dict[str, str]:
+    env: Dict[str, str] = {}
+    raw = svc.get("environment") or {}
+    if isinstance(raw, dict):
+        for key, value in raw.items():
+            if value is not None:
+                env[str(key)] = str(value)
+        return env
+    if isinstance(raw, list):
+        for entry in raw:
+            if isinstance(entry, str) and "=" in entry:
+                key, value = entry.split("=", 1)
+                env[key] = value
+            elif isinstance(entry, dict):
+                for key, value in entry.items():
+                    if value is not None:
+                        env[str(key)] = str(value)
+    return env
+
+
+def _sandbox_resources_from_env(env: Dict[str, str]) -> Optional[Dict[str, Dict[str, str]]]:
+    resources: Dict[str, Dict[str, str]] = {}
+    requests: Dict[str, str] = {}
+    limits: Dict[str, str] = {}
+    if env.get("SANDBOX_RESOURCE_CPU_REQUEST"):
+        requests["cpu"] = env["SANDBOX_RESOURCE_CPU_REQUEST"]
+    if env.get("SANDBOX_RESOURCE_MEMORY_REQUEST"):
+        requests["memory"] = env["SANDBOX_RESOURCE_MEMORY_REQUEST"]
+    if env.get("SANDBOX_RESOURCE_CPU_LIMIT"):
+        limits["cpu"] = env["SANDBOX_RESOURCE_CPU_LIMIT"]
+    if env.get("SANDBOX_RESOURCE_MEMORY_LIMIT"):
+        limits["memory"] = env["SANDBOX_RESOURCE_MEMORY_LIMIT"]
+    if requests:
+        resources["requests"] = requests
+    if limits:
+        resources["limits"] = limits
+    return resources or None

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -249,7 +249,7 @@ class PayloadBuilder:
                 env.append({"name": "KAMIWAZA_TLS_REJECT_UNAUTHORIZED", "value": "0"})
 
             health_check = _service_extension_field(svc, "healthCheck")
-            if health_check is None:
+            if not health_check:
                 health_check = self._default_health_check(
                     svc_name,
                     svc,
@@ -442,10 +442,14 @@ class PayloadBuilder:
 
         env_defaults = metadata.get("env_defaults") or {}
         services = transformed.get("services") or {}
-        for svc_name, svc in services.items():
+        # Prefer the conventional `sandbox-controller` service; fall back to
+        # any other service that explicitly declares SANDBOX_BACKEND=kubernetes.
+        ordered = sorted(
+            services.items(),
+            key=lambda item: 0 if item[0] == "sandbox-controller" else 1,
+        )
+        for svc_name, svc in ordered:
             env = _service_env_map(svc)
-            if svc_name != "sandbox-controller" and "SANDBOX_BACKEND" not in env:
-                continue
             if env.get("SANDBOX_BACKEND") != "kubernetes":
                 continue
 
@@ -473,7 +477,12 @@ class PayloadBuilder:
                 "SANDBOX_PERSISTENCE"
             )
             if isinstance(persistence, str):
-                spec["persistence"] = persistence.strip().lower() == "true"
+                spec["persistence"] = persistence.strip().lower() in {
+                    "true",
+                    "1",
+                    "yes",
+                    "on",
+                }
             elif isinstance(persistence, bool):
                 spec["persistence"] = persistence
 
@@ -533,12 +542,10 @@ def _should_use_node_frontend_probe(svc_name: str, svc: Dict[str, Any]) -> bool:
 
 
 def _service_extension_field(svc: Dict[str, Any], key: str) -> Optional[Any]:
-    """Read a service override from ``x-kamiwaza`` or a pre-flattened service."""
+    """Read a service override from ``x-kamiwaza``."""
     x_kamiwaza = svc.get("x-kamiwaza")
     if isinstance(x_kamiwaza, dict) and key in x_kamiwaza:
         return x_kamiwaza[key]
-    if key in svc:
-        return svc[key]
     return None
 
 

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -225,6 +225,24 @@ class TestCleanup:
         assert "networks" not in result["services"]["api"]
         assert "networks" not in result
 
+    def test_preserves_x_kamiwaza_overrides(self, transformer):
+        compose = {
+            "services": {
+                "postgres": {
+                    "image": "postgres:15",
+                    "x-kamiwaza": {
+                        "containerSecurityContext": {"runAsNonRoot": False},
+                        "healthCheck": {"tcpSocket": {"port": 5432}},
+                    },
+                }
+            }
+        }
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["postgres"]["x-kamiwaza"] == {
+            "containerSecurityContext": {"runAsNonRoot": False},
+            "healthCheck": {"tcpSocket": {"port": 5432}},
+        }
+
 
 class TestFullTransform:
     def test_multi_service(self, transformer, multi_service_compose):

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -594,3 +594,131 @@ class TestBuildPatchKwargsCarriesAnnotations:
             payload=self._payload_with_annotations(None, kamiwaza=None),
         )
         assert "kamiwaza" not in kwargs
+
+    def test_carries_sandbox_spec_so_patch_refreshes_sandbox_contract(self):
+        """jxstanford PR #97 review H1: the existing CR persists from
+        the original CREATE. If the developer toggles
+        ``SANDBOX_BACKEND=kubernetes`` on or changes namespace/whitelist
+        on a redeploy, PATCH must carry the new ``sandbox`` block so
+        the operator can refresh sandbox RBAC. Without this carry-
+        forward, sandbox config edits silently no-op until the user
+        delete+recreates the extension."""
+        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
+
+        class _FakePayload:
+            model_extra = {
+                "sandbox": {
+                    "enabled": True,
+                    "service_name": "sandbox-controller",
+                    "namespace": "kamiwaza-sandboxes",
+                }
+            }
+            kamiwaza = None
+
+        kwargs = _build_patch_kwargs(
+            patch_services=["svc"], payload=_FakePayload()
+        )
+        assert kwargs["sandbox"] == {
+            "enabled": True,
+            "service_name": "sandbox-controller",
+            "namespace": "kamiwaza-sandboxes",
+        }
+
+    def test_omits_sandbox_when_payload_has_none(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
+
+        kwargs = _build_patch_kwargs(
+            patch_services=["svc"],
+            payload=self._payload_with_annotations(None),
+        )
+        assert "sandbox" not in kwargs
+
+    def test_patch_service_specs_forwards_x_kamiwaza_overrides(self):
+        """jxstanford PR #97 review H2: per-service overrides
+        (healthCheck, automountServiceAccountToken,
+        containerSecurityContext) must ride PATCH so the operator
+        refreshes them on existing CRs after iterative redeploys."""
+        from kamiwaza_sdk.schemas.extensions import ExtensionServiceSpec
+
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        class _FakePayload:
+            services = [
+                ExtensionServiceSpec(
+                    name="postgres",
+                    image="postgres:15",
+                    healthCheck={"tcpSocket": {"port": 5432}},
+                    containerSecurityContext={
+                        "runAsNonRoot": False,
+                        "runAsUser": 0,
+                    },
+                ),
+                ExtensionServiceSpec(
+                    name="sandbox-controller",
+                    image="reg/sc:dev",
+                    automountServiceAccountToken=True,
+                ),
+                ExtensionServiceSpec(name="frontend", image="reg/fe:dev"),
+            ]
+
+        specs = _build_patch_service_specs(_FakePayload())
+        by_name = {s.name: s for s in specs}
+
+        pg_extra = by_name["postgres"].model_extra or {}
+        assert pg_extra["healthCheck"] == {"tcpSocket": {"port": 5432}}
+        assert pg_extra["containerSecurityContext"] == {
+            "runAsNonRoot": False,
+            "runAsUser": 0,
+        }
+        assert "automountServiceAccountToken" not in pg_extra
+
+        sc_extra = by_name["sandbox-controller"].model_extra or {}
+        assert sc_extra["automountServiceAccountToken"] is True
+        assert "healthCheck" not in sc_extra
+        assert "containerSecurityContext" not in sc_extra
+
+        fe_extra = by_name["frontend"].model_extra or {}
+        assert "healthCheck" not in fe_extra
+        assert "automountServiceAccountToken" not in fe_extra
+        assert "containerSecurityContext" not in fe_extra
+
+    def test_patch_service_specs_preserves_automount_false(self):
+        """``automountServiceAccountToken=False`` is a meaningful
+        explicit setting (deny token mount). The ``is not None`` check
+        in the helper must preserve it, not skip it as falsy."""
+        from kamiwaza_sdk.schemas.extensions import ExtensionServiceSpec
+
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        class _FakePayload:
+            services = [
+                ExtensionServiceSpec(
+                    name="worker",
+                    image="reg/worker:dev",
+                    automountServiceAccountToken=False,
+                ),
+            ]
+
+        specs = _build_patch_service_specs(_FakePayload())
+        assert (specs[0].model_extra or {})["automountServiceAccountToken"] is False
+
+    def test_patchextension_accepts_sandbox_via_extra_allow(self):
+        """Sanity: PatchExtension must accept the sandbox kwarg via
+        ``extra="allow"``."""
+        from kamiwaza_sdk.schemas.extensions import PatchExtension, PatchServiceSpec
+
+        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
+
+        class _FakePayload:
+            model_extra = {"sandbox": {"enabled": True, "service_name": "sc"}}
+            kamiwaza = None
+
+        kwargs = _build_patch_kwargs(
+            patch_services=[PatchServiceSpec(name="x")],
+            payload=_FakePayload(),
+        )
+        patch = PatchExtension(**kwargs)
+        assert (patch.model_extra or {}).get("sandbox") == {
+            "enabled": True,
+            "service_name": "sc",
+        }

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -337,6 +337,78 @@ class TestEnvParsing:
         assert builder._parse_env({}) == []
 
 
+class TestServiceOverrides:
+    def test_x_kamiwaza_overrides_are_carried_into_service_spec(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "postgres": {
+                    "image": "postgres:15",
+                    "ports": ["5432"],
+                    "x-kamiwaza": {
+                        "containerSecurityContext": {
+                            "runAsNonRoot": False,
+                            "runAsUser": 0,
+                            "readOnlyRootFilesystem": False,
+                        },
+                        "healthCheck": {"tcpSocket": {"port": 5432}},
+                    },
+                },
+                "sandbox-controller": {
+                    "image": "reg/sandbox-controller:dev",
+                    "ports": ["8085"],
+                    "x-kamiwaza": {"automountServiceAccountToken": True},
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "my-app-dev-abc")
+        services = {svc.name: svc.model_dump() for svc in payload.services}
+
+        assert services["postgres"]["containerSecurityContext"] == {
+            "runAsNonRoot": False,
+            "runAsUser": 0,
+            "readOnlyRootFilesystem": False,
+        }
+        assert services["postgres"]["healthCheck"] == {"tcpSocket": {"port": 5432}}
+        assert services["sandbox-controller"]["automountServiceAccountToken"] is True
+
+    def test_kubernetes_sandbox_controller_emits_sandbox_spec(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "sandbox-controller": {
+                    "image": "reg/sandbox-controller:dev",
+                    "ports": ["8085"],
+                    "environment": {
+                        "SANDBOX_BACKEND": "kubernetes",
+                        "SANDBOX_NAMESPACE": "kamiwaza-sandboxes",
+                        "SANDBOX_ALLOWED_IMAGE_PREFIXES": "ghcr.io/openhands/,ghcr.io/acme/agent",
+                        "SANDBOX_RESOURCE_CPU_REQUEST": "50m",
+                        "SANDBOX_RESOURCE_CPU_LIMIT": "2",
+                        "SANDBOX_RESOURCE_MEMORY_REQUEST": "512Mi",
+                        "SANDBOX_RESOURCE_MEMORY_LIMIT": "4Gi",
+                    },
+                }
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "my-app-dev-abc")
+
+        assert (payload.model_extra or {})["sandbox"] == {
+            "enabled": True,
+            "service_name": "sandbox-controller",
+            "namespace": "kamiwaza-sandboxes",
+            "image_whitelist": ["ghcr.io/openhands/", "ghcr.io/acme/agent"],
+            "resources": {
+                "requests": {"cpu": "50m", "memory": "512Mi"},
+                "limits": {"cpu": "2", "memory": "4Gi"},
+            },
+        }
+
+
 class TestDevNaming:
     def test_format(self):
         name = PayloadBuilder.make_dev_name("my-app", user_id="user-123")

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -409,6 +409,101 @@ class TestServiceOverrides:
         }
 
 
+    def test_non_kubernetes_backend_emits_no_sandbox_spec(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "sandbox-controller": {
+                    "image": "reg/sandbox-controller:dev",
+                    "ports": ["8085"],
+                    "environment": {"SANDBOX_BACKEND": "docker"},
+                }
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "my-app-dev-abc")
+        assert "sandbox" not in (payload.model_extra or {})
+
+    def test_no_sandbox_backend_emits_no_sandbox_spec(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "worker": {"image": "reg/worker:dev", "ports": ["8000"]},
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "my-app-dev-abc")
+        assert "sandbox" not in (payload.model_extra or {})
+
+    def test_declared_metadata_sandbox_overrides_env_inference(
+        self, builder, connection
+    ):
+        meta = {
+            "name": "my-app",
+            "type": "app",
+            "version": "1.0.0",
+            "sandbox": {
+                "enabled": True,
+                "service_name": "explicit-controller",
+                "namespace": "explicit-ns",
+            },
+        }
+        transformed = {
+            "services": {
+                "sandbox-controller": {
+                    "image": "reg/sandbox-controller:dev",
+                    "ports": ["8085"],
+                    "environment": {
+                        "SANDBOX_BACKEND": "kubernetes",
+                        "SANDBOX_NAMESPACE": "inferred-ns",
+                    },
+                }
+            },
+        }
+        payload = builder.build(meta, transformed, connection, "my-app-dev-abc")
+        assert (payload.model_extra or {})["sandbox"] == {
+            "enabled": True,
+            "service_name": "explicit-controller",
+            "namespace": "explicit-ns",
+        }
+
+    def test_persistence_accepts_common_truthy_strings(
+        self, builder, metadata, connection
+    ):
+        for truthy in ("true", "1", "yes", "on", "TRUE"):
+            transformed = {
+                "services": {
+                    "sandbox-controller": {
+                        "image": "reg/sandbox-controller:dev",
+                        "ports": ["8085"],
+                        "environment": {
+                            "SANDBOX_BACKEND": "kubernetes",
+                            "SANDBOX_PERSISTENCE": truthy,
+                        },
+                    }
+                },
+            }
+            payload = builder.build(
+                metadata, transformed, connection, "my-app-dev-abc"
+            )
+            sandbox = (payload.model_extra or {})["sandbox"]
+            assert sandbox["persistence"] is True, f"failed for {truthy!r}"
+
+    def test_automount_false_is_preserved(self, builder, metadata, connection):
+        transformed = {
+            "services": {
+                "worker": {
+                    "image": "reg/worker:dev",
+                    "ports": ["8000"],
+                    "x-kamiwaza": {"automountServiceAccountToken": False},
+                }
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "my-app-dev-abc")
+        services = {svc.name: svc.model_dump() for svc in payload.services}
+        assert services["worker"]["automountServiceAccountToken"] is False
+
+
 class TestDevNaming:
     def test_format(self):
         name = PayloadBuilder.make_dev_name("my-app", user_id="user-123")


### PR DESCRIPTION
## Summary

- Preserve service-level `x-kamiwaza` deployment overrides when building `CreateExtension` payloads.
- Carry through `healthCheck`, `automountServiceAccountToken`, and `containerSecurityContext` into `ExtensionServiceSpec`.
- Emit an inferred top-level sandbox spec when compose configures `SANDBOX_BACKEND=kubernetes` for a sandbox controller.
- Add unit coverage for compose preservation, service override payload output, and Kubernetes sandbox spec inference.

## Why

Kaizen v3 conversion to kz-ext exposed two SDK payload gaps. The converted compose retained the right App Garden metadata, but the SDK deployment payload dropped service overrides and did not emit `spec.sandbox`. That caused Postgres to receive incompatible default security/probe behavior and prevented the sandbox controller from getting the sandbox RBAC contract it needs for Kubernetes backend mode.

Linear: ENG-4847, ENG-4848

## Validation

```text
uv run pytest tests/unit/extensions/test_payload_builder.py tests/unit/extensions/test_compose_transformer.py
72 passed in 0.91s
```