### PR TITLE
WS-M2 (Operability) — SDK surface for cluster + diagnose + recoverable jobs + cancel

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,46 @@ The `audit_actor` field is the same value `kz.jobs.run(...).audit_actor`
 returns in step 3 — that round-trip is the demo gate's load-bearing
 signal.
 
+### Recoverable long-jobs
+
+For jobs that may take longer than ~60 seconds, use `kz.jobs.run(...,
+recoverable=True)` instead of the default. The default holds the HTTP
+connection for the full job duration; FastAPI buffers the
+`X-Job-Id` response header along with the body and only flushes both on
+completion. If the connection drops mid-job, the SDK never sees the
+`X-Job-Id` and has no handle to recover the result from.
+
+`recoverable=True` flips the SDK to a `submit + poll` shape under the
+covers:
+
+1. `POST /api/cluster/jobs/submit` returns the `job_id` immediately.
+2. The SDK polls `/cluster/jobs/{id}/status` with exponential backoff
+   until the job reaches a terminal state.
+3. `/cluster/jobs/{id}/result` fetches the final payload.
+
+Because the `job_id` is in the SDK's hands from the first response, a
+mid-job process crash is recoverable on a fresh SDK instance:
+
+```python
+# Original process
+job_id = kz.jobs.submit_async(
+    entrypoint="python query.py",
+    target_cluster="ORION",
+    timeout_seconds=600,
+)
+# ... persist job_id somewhere (sqlite, /tmp file, etc.) ...
+# ... process dies ...
+
+# Fresh process, much later
+saved_job_id = load_persisted_job_id()
+result = kz.jobs.wait(saved_job_id, timeout=600)
+print(result.status, result.result)
+```
+
+**Recommended:** use `recoverable=True` for any job with
+`timeout_seconds > 60`. The two-call cost (submit + poll) is amortized
+over the long runtime.
+
 ### Error handling cheat sheet
 
 The SDK maps server-side error contracts to typed exceptions so

--- a/kamiwaza/client.py
+++ b/kamiwaza/client.py
@@ -77,6 +77,17 @@ class Kamiwaza:
         self._jobs: Any = None
         self._cluster: Any = None
         self._gates: Any = None
+        # NB: lazy retrieval-module attribute; matching wrapper below.
+        self._retrieval_api: Any = None
+
+    @property
+    def retrieval(self) -> Any:
+        """Retrieval job management (T5.36 / ENG-4713)."""
+        if self._retrieval_api is None:
+            from kamiwaza import retrieval as _retrieval_module
+
+            self._retrieval_api = _retrieval_module.RetrievalAPI(client=self)
+        return self._retrieval_api
 
     @property
     def gates(self) -> Any:

--- a/kamiwaza/client.py
+++ b/kamiwaza/client.py
@@ -75,6 +75,20 @@ class Kamiwaza:
         # in __init__ (would cycle back into client at module-load time).
         self._federations: Any = None
         self._jobs: Any = None
+        self._cluster: Any = None
+
+    @property
+    def cluster(self) -> Any:
+        """Local cluster operations — capabilities probe (T5.21).
+
+        Returns a ``kamiwaza.cluster.ClusterAPI`` instance. Annotated as
+        ``Any`` to keep the import lazy.
+        """
+        if self._cluster is None:
+            from kamiwaza.cluster import ClusterAPI
+
+            self._cluster = ClusterAPI(client=self)
+        return self._cluster
 
     @property
     def federations(self) -> Any:

--- a/kamiwaza/client.py
+++ b/kamiwaza/client.py
@@ -76,6 +76,21 @@ class Kamiwaza:
         self._federations: Any = None
         self._jobs: Any = None
         self._cluster: Any = None
+        self._gates: Any = None
+
+    @property
+    def gates(self) -> Any:
+        """Gate discovery (T5.4 / ENG-4691).
+
+        Returns a ``kamiwaza.gates.GatesAPI`` instance. WS-M2 surface is
+        ``discover(classpath)``; full surface (set_gate, packages.*) is
+        WS-M3.
+        """
+        if self._gates is None:
+            from kamiwaza.gates import GatesAPI
+
+            self._gates = GatesAPI(client=self)
+        return self._gates
 
     @property
     def cluster(self) -> Any:

--- a/kamiwaza/cluster.py
+++ b/kamiwaza/cluster.py
@@ -110,19 +110,25 @@ class ClusterAPI:
     def operations(self) -> ClusterOperations:
         """Return a unified view of in-flight jobs and retrievals (T5.37).
 
-        Walking-skeleton scope: jobs slice only — retrievals is an empty
-        list until ``GET /api/retrieval/jobs`` (T5.30) and the SDK
-        retrieval module (T5.36) ship. The contract is already the
-        unified shape, so customer code written today still works when
-        retrievals start populating.
+        Both slices now populate from their respective listing endpoints
+        (ENG-4706 for jobs, ENG-4707 for retrievals). On a missing /
+        503ing retrieval listing endpoint (e.g., older server), the
+        retrievals slice gracefully falls back to empty so the call
+        still returns a usable shape.
 
         Demo bullet (2): ``kz.cluster.operations()`` lists the running
         federated job + any active retrieval.
         """
         jobs_body = self._client._request("GET", "/api/cluster/jobs/")
+        try:
+            retrievals_body = self._client._request("GET", "/api/retrieval/jobs")
+        except KamiwazaError:
+            retrievals_body = []
         return ClusterOperations(
             jobs=list(jobs_body) if isinstance(jobs_body, list) else [],
-            retrievals=[],
+            retrievals=(
+                list(retrievals_body) if isinstance(retrievals_body, list) else []
+            ),
         )
 
     def _attempt_fix(self, issue: DiagnoseIssue) -> FixOutcome:

--- a/kamiwaza/cluster.py
+++ b/kamiwaza/cluster.py
@@ -1,0 +1,45 @@
+"""T5.21 / ENG-4698 — kamiwaza.cluster module.
+
+Customer-facing cluster surface per design §4.2.11 / §4.4.3:
+
+    kz.cluster.capabilities()    -> ClusterCapabilities
+
+The capabilities endpoint is mesh-routable since ENG-4697 (auth widened
+to viewer); a probing peer reaches the same surface through
+``kz.federations[name].probe()`` (see kamiwaza.federations.FederationProxy).
+
+Subsequent WS-M2 cycles layer ``diagnose()``, ``operations()``, and
+``fix()`` onto this module (T5.7 / T5.8 / T5.13 / T5.14).
+
+Server-side correlate: ``GET /api/cluster/cluster_capabilities`` in
+``kamiwaza.cluster.api`` (extended by ENG-4696).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kamiwaza.models import ClusterCapabilities
+
+
+class ClusterAPI:
+    """Top-level cluster operations on the local cluster."""
+
+    def __init__(self, client: Any) -> None:
+        # client is a kamiwaza.client.Kamiwaza instance — Any avoids a
+        # runtime cycle since the client lazy-imports this module.
+        self._client = client
+
+    def capabilities(self) -> ClusterCapabilities:
+        """Return the local cluster's capabilities (T5.19 + T5.21).
+
+        Hits ``GET /api/cluster/cluster_capabilities`` on the local cluster.
+        Auth: any authenticated user with viewer or owner on
+        ``cluster:<local_uuid>`` (admin's install-seeded owner passes).
+
+        Returns:
+            ClusterCapabilities — hardware, available platforms, GPU count,
+            federation_count, active_deployments, ray_ready, etc.
+        """
+        body = self._client._request("GET", "/api/cluster/cluster_capabilities")
+        return ClusterCapabilities.model_validate(body)

--- a/kamiwaza/cluster.py
+++ b/kamiwaza/cluster.py
@@ -1,29 +1,44 @@
-"""T5.7 / T5.21 — kamiwaza.cluster module.
+"""T5.7 / T5.8 / T5.21 — kamiwaza.cluster module.
 
 Customer-facing cluster surface per design §4.2.11 / §4.4.3 / §4.2.10:
 
     kz.cluster.capabilities()    -> ClusterCapabilities  (T5.21 / ENG-4698)
     kz.cluster.diagnose()        -> ClusterDiagnostics   (T5.7  / ENG-4692)
+    kz.cluster.fix()             -> FixResult            (T5.8  / ENG-4693)
 
 ``capabilities()`` is mesh-routable since ENG-4697 (auth widened to
 viewer); a probing peer reaches the same surface through
 ``kz.federations[name].probe()`` (see kamiwaza.federations.FederationProxy).
 
-``diagnose()`` is admin-only and returns structured cluster-health
-issues. ``fix()`` orchestration (T5.8 / ENG-4693) is deferred until at
-least one auto-fixable probe ships server-side — adding it now would be
-a customer surface that always reports manual_required for every issue.
+``diagnose()`` is admin-only and returns structured cluster-health issues.
+
+``fix()`` iterates the issues and POSTs to each ``fix_endpoint`` for
+auto-fixable ones. The SDK has no enumeration of probe types — dispatch
+is generic on the issue shape, so future server-side probes that ship
+``fix_endpoint`` + ``fix_payload`` work without SDK changes.
 
 Server-side correlates:
-- ``GET /api/cluster/cluster_capabilities``  (extended by ENG-4696)
-- ``GET /api/cluster/diagnose``              (new in ENG-4694)
+- ``GET  /api/cluster/cluster_capabilities``  (extended by ENG-4696)
+- ``GET  /api/cluster/diagnose``              (new in ENG-4694)
+- ``POST /api/cluster/diagnose/fix/{issue_id}``  (per design §4.2.10 —
+  endpoints land alongside auto-fixable probes in subsequent commits)
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, List
 
-from kamiwaza.models import ClusterCapabilities, ClusterDiagnostics
+from kamiwaza.exceptions import KamiwazaError
+from kamiwaza.models import (
+    ClusterCapabilities,
+    ClusterDiagnostics,
+    DiagnoseIssue,
+    FixOutcome,
+    FixResult,
+)
+
+
+_SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
 
 
 class ClusterAPI:
@@ -65,3 +80,41 @@ class ClusterAPI:
         """
         body = self._client._request("GET", "/api/cluster/diagnose")
         return ClusterDiagnostics.model_validate(body)
+
+    def fix(self) -> FixResult:
+        """Run diagnose then attempt to remediate each auto-fixable issue.
+
+        Per design §4.2.10: iterates issues in severity order (error →
+        warning → info), invokes ``issue.fix_endpoint`` with
+        ``issue.fix_payload`` for each ``auto_fixable=True`` issue, and
+        records per-issue outcomes. Issues with ``auto_fixable=False`` are
+        surfaced as ``manual_required`` without an endpoint call. A
+        fix_endpoint that returns non-2xx is recorded as ``failed`` with
+        the error message — never raises, so the operator sees per-issue
+        results for the whole batch.
+
+        Returns:
+            FixResult.outcomes — one FixOutcome per issue.
+        """
+        diagnostics = self.diagnose()
+        sorted_issues = sorted(
+            diagnostics.issues,
+            key=lambda issue: _SEVERITY_ORDER.get(issue.severity, 99),
+        )
+        outcomes: List[FixOutcome] = [
+            self._attempt_fix(issue) for issue in sorted_issues
+        ]
+        return FixResult(outcomes=outcomes)
+
+    def _attempt_fix(self, issue: DiagnoseIssue) -> FixOutcome:
+        if not issue.auto_fixable or not issue.fix_endpoint:
+            return FixOutcome(issue_id=issue.id, status="manual_required")
+        try:
+            self._client._request(
+                "POST",
+                issue.fix_endpoint,
+                json=issue.fix_payload or {},
+            )
+        except KamiwazaError as exc:
+            return FixOutcome(issue_id=issue.id, status="failed", error=str(exc))
+        return FixOutcome(issue_id=issue.id, status="fixed")

--- a/kamiwaza/cluster.py
+++ b/kamiwaza/cluster.py
@@ -32,6 +32,7 @@ from kamiwaza.exceptions import KamiwazaError
 from kamiwaza.models import (
     ClusterCapabilities,
     ClusterDiagnostics,
+    ClusterOperations,
     DiagnoseIssue,
     FixOutcome,
     FixResult,
@@ -105,6 +106,24 @@ class ClusterAPI:
             self._attempt_fix(issue) for issue in sorted_issues
         ]
         return FixResult(outcomes=outcomes)
+
+    def operations(self) -> ClusterOperations:
+        """Return a unified view of in-flight jobs and retrievals (T5.37).
+
+        Walking-skeleton scope: jobs slice only — retrievals is an empty
+        list until ``GET /api/retrieval/jobs`` (T5.30) and the SDK
+        retrieval module (T5.36) ship. The contract is already the
+        unified shape, so customer code written today still works when
+        retrievals start populating.
+
+        Demo bullet (2): ``kz.cluster.operations()`` lists the running
+        federated job + any active retrieval.
+        """
+        jobs_body = self._client._request("GET", "/api/cluster/jobs/")
+        return ClusterOperations(
+            jobs=list(jobs_body) if isinstance(jobs_body, list) else [],
+            retrievals=[],
+        )
 
     def _attempt_fix(self, issue: DiagnoseIssue) -> FixOutcome:
         if not issue.auto_fixable or not issue.fix_endpoint:

--- a/kamiwaza/cluster.py
+++ b/kamiwaza/cluster.py
@@ -1,25 +1,29 @@
-"""T5.21 / ENG-4698 — kamiwaza.cluster module.
+"""T5.7 / T5.21 — kamiwaza.cluster module.
 
-Customer-facing cluster surface per design §4.2.11 / §4.4.3:
+Customer-facing cluster surface per design §4.2.11 / §4.4.3 / §4.2.10:
 
-    kz.cluster.capabilities()    -> ClusterCapabilities
+    kz.cluster.capabilities()    -> ClusterCapabilities  (T5.21 / ENG-4698)
+    kz.cluster.diagnose()        -> ClusterDiagnostics   (T5.7  / ENG-4692)
 
-The capabilities endpoint is mesh-routable since ENG-4697 (auth widened
-to viewer); a probing peer reaches the same surface through
+``capabilities()`` is mesh-routable since ENG-4697 (auth widened to
+viewer); a probing peer reaches the same surface through
 ``kz.federations[name].probe()`` (see kamiwaza.federations.FederationProxy).
 
-Subsequent WS-M2 cycles layer ``diagnose()``, ``operations()``, and
-``fix()`` onto this module (T5.7 / T5.8 / T5.13 / T5.14).
+``diagnose()`` is admin-only and returns structured cluster-health
+issues. ``fix()`` orchestration (T5.8 / ENG-4693) is deferred until at
+least one auto-fixable probe ships server-side — adding it now would be
+a customer surface that always reports manual_required for every issue.
 
-Server-side correlate: ``GET /api/cluster/cluster_capabilities`` in
-``kamiwaza.cluster.api`` (extended by ENG-4696).
+Server-side correlates:
+- ``GET /api/cluster/cluster_capabilities``  (extended by ENG-4696)
+- ``GET /api/cluster/diagnose``              (new in ENG-4694)
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from kamiwaza.models import ClusterCapabilities
+from kamiwaza.models import ClusterCapabilities, ClusterDiagnostics
 
 
 class ClusterAPI:
@@ -43,3 +47,21 @@ class ClusterAPI:
         """
         body = self._client._request("GET", "/api/cluster/cluster_capabilities")
         return ClusterCapabilities.model_validate(body)
+
+    def diagnose(self) -> ClusterDiagnostics:
+        """Run cluster-health probes and return structured issues (T5.7).
+
+        Hits ``GET /api/cluster/diagnose`` on the local cluster — admin-only.
+        Each probe is fail-soft individually; ``has_issues`` is True iff any
+        probe surfaced an error-severity issue.
+
+        Demo bullet (1) for WS-M2: clean status on a healthy cluster,
+        structured issues on a partially-bootstrapped one.
+
+        Returns:
+            ClusterDiagnostics with cluster_id, timestamp, and per-issue
+            DiagnoseIssue records carrying stable ``id`` strings for
+            programmatic matching.
+        """
+        body = self._client._request("GET", "/api/cluster/diagnose")
+        return ClusterDiagnostics.model_validate(body)

--- a/kamiwaza/federations.py
+++ b/kamiwaza/federations.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
-from kamiwaza.models import BrokeredUser, Federation
+from kamiwaza.models import BrokeredUser, ClusterCapabilities, Federation
 
 
 class FederationsAPI:
@@ -137,6 +137,32 @@ class FederationProxy:
     @property
     def users(self) -> "FederationUsersAPI":
         return FederationUsersAPI(proxy=self)
+
+    def probe(self) -> ClusterCapabilities:
+        """Probe this federation peer's capabilities via the mesh (T5.21).
+
+        Routes ``GET /api/cluster/cluster_capabilities`` through the local
+        mesh proxy at ``/api/mesh/{name}/...``. The mesh proxy resolves
+        ``name`` to the federation, applies the federation:operator ReBAC
+        guard, signs the request with the local cluster's HMAC, and
+        forwards to the remote cluster — where the receiver's viewer-or-
+        owner gate (ENG-4697) lets the brokered identity reach the
+        capabilities endpoint.
+
+        Demo bullet (4): ``kz.federations["ORION"].probe()`` returns
+        ORION's GPU count, active deployments, Ray status, etc.
+
+        The federation selector is the cluster name itself — no separate
+        federation-id resolution round-trip is required.
+
+        Returns:
+            ClusterCapabilities for the remote cluster.
+        """
+        body = self._client._request(
+            "GET",
+            f"/api/mesh/{self.name}/api/cluster/cluster_capabilities",
+        )
+        return ClusterCapabilities.model_validate(body)
 
     def _id(self) -> str:
         cached = self._cached_id

--- a/kamiwaza/gates.py
+++ b/kamiwaza/gates.py
@@ -1,0 +1,54 @@
+"""T5.4 / ENG-4691 — kamiwaza.gates module.
+
+Customer-facing surface for gate discovery per design §4.2.11:
+
+    kz.gates.discover(classpath)   -> GateDiscovery
+
+WS-M2 ships only ``discover()``. Full surface (set_gate, clear_gate,
+packages.*) is WS-M3.
+
+Server-side correlate: POST /api/authz/gates/discover (§4.2.3).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kamiwaza.models import GateDiscovery
+
+
+class GatesAPI:
+    """Gate discovery on the local cluster."""
+
+    def __init__(self, client: Any) -> None:
+        # client is a kamiwaza.client.Kamiwaza instance — Any avoids a
+        # runtime cycle (client lazy-imports this module).
+        self._client = client
+
+    def discover(self, classpath: str) -> GateDiscovery:
+        """Reflect on a Gate class by classpath; return its metadata.
+
+        Per design §4.2.3: imports the class server-side, classifies it
+        as execution or attribute gate, returns name + required_attributes
+        + config_schema. The authoring guide's "discover before bind"
+        workflow uses this to validate gate configuration before writing
+        the binding to runtime config.
+
+        Args:
+            classpath: Dotted fully-qualified classpath, e.g.
+                ``"my_policy.MyExecutionGate"``.
+
+        Returns:
+            GateDiscovery — typed reflection payload.
+
+        Raises:
+            KamiwazaError: 404 classpath_unimportable when the module or
+                class can't be loaded; 400 not_a_gate when the loaded
+                class isn't an AttributeGate / ExecutionGate subclass.
+        """
+        response = self._client._request(
+            "POST",
+            "/api/authz/gates/discover",
+            json={"classpath": classpath},
+        )
+        return GateDiscovery.model_validate(response)

--- a/kamiwaza/jobs.py
+++ b/kamiwaza/jobs.py
@@ -53,8 +53,9 @@ class JobsAPI:
         target_cluster: Optional[str] = None,
         runtime_env: Optional[dict[str, Any]] = None,
         timeout_seconds: Optional[int] = None,
+        recoverable: bool = False,
     ) -> JobResult:
-        """Run a job synchronously and return the completed JobResult.
+        """Run a job and return the completed JobResult.
 
         Args:
             entrypoint: Shell command for Ray to execute, e.g.
@@ -62,16 +63,52 @@ class JobsAPI:
             target_cluster: Federation name to route to. None runs on
                 the local cluster.
             runtime_env: Ray runtime_env (env vars, working_dir, …).
-                Limited to the existing /run shape in skeleton; T5.38
-                adds pip / py_modules / working_dir convenience kwargs.
-            timeout_seconds: Server-side wall-clock cap (informational
-                only — server enforces; SDK does not poll).
+            timeout_seconds: Wall-clock cap. Server-enforced for
+                ``recoverable=False``; SDK-enforced poll budget for
+                ``recoverable=True``.
+            recoverable: When True (T5.22 / ENG-4699), the SDK uses async
+                submit + poll instead of the sync /run path so the
+                ``job_id`` is in hand immediately. A connection drop
+                mid-job is recoverable via ``kz.jobs.wait(job_id, ...)``.
+                Recommended for any job with ``timeout_seconds > 60``;
+                the sync path holds the HTTP connection for the full
+                duration and FastAPI buffers the X-Job-Id header until
+                completion — a mid-job drop loses the job_id (see
+                design §4.2.14 + SDK README "Recoverable long-jobs").
 
         Returns:
             Completed ``JobResult``. ``status`` will be SUCCEEDED for
             success or FAILED with ``error`` populated. Customers branch
             on ``result.status`` instead of catching exceptions.
+
+        Raises:
+            MeshJobTimeoutError: Only on the recoverable path, when
+                ``timeout_seconds`` expires before the job reaches a
+                terminal state.
         """
+        if recoverable:
+            return self._run_recoverable(
+                entrypoint=entrypoint,
+                target_cluster=target_cluster,
+                runtime_env=runtime_env,
+                timeout_seconds=timeout_seconds,
+            )
+        return self._run_sync(
+            entrypoint=entrypoint,
+            target_cluster=target_cluster,
+            runtime_env=runtime_env,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def _run_sync(
+        self,
+        *,
+        entrypoint: str,
+        target_cluster: Optional[str],
+        runtime_env: Optional[dict[str, Any]],
+        timeout_seconds: Optional[int],
+    ) -> JobResult:
+        """Existing sync /run path; X-Job-Id only visible on completion."""
         body = self._build_run_body(
             entrypoint=entrypoint,
             target_cluster=target_cluster,
@@ -80,6 +117,29 @@ class JobsAPI:
         )
         response = self._client._request("POST", "/api/cluster/jobs/run", json=body)
         return JobResult.model_validate(response)
+
+    def _run_recoverable(
+        self,
+        *,
+        entrypoint: str,
+        target_cluster: Optional[str],
+        runtime_env: Optional[dict[str, Any]],
+        timeout_seconds: Optional[int],
+    ) -> JobResult:
+        """Async submit + poll. job_id available immediately for resume.
+
+        Per design §4.2.14: returns when the server reports a terminal
+        state, or raises MeshJobTimeoutError when ``timeout_seconds``
+        expires. The wait_seconds default (600s) matches the existing
+        sync /run default behavior for parity.
+        """
+        job_id = self.submit_async(
+            entrypoint=entrypoint,
+            target_cluster=target_cluster,
+            runtime_env=runtime_env,
+            timeout_seconds=timeout_seconds,
+        )
+        return self.wait(job_id, timeout=timeout_seconds or 600)
 
     def submit_async(
         self,

--- a/kamiwaza/jobs.py
+++ b/kamiwaza/jobs.py
@@ -166,6 +166,19 @@ class JobsAPI:
         response = self._client._request("POST", "/api/cluster/jobs/submit", json=body)
         return str(response["job_id"])
 
+    def cancel(self, job_id: str) -> dict[str, Any]:
+        """Cancel a running job (T5.35 / ENG-4712).
+
+        POSTs to ``/api/cluster/jobs/{id}/cancel``. The server returns a
+        JobRecord; we surface the raw dict so customers can inspect
+        ``status`` (typically STOPPED on success) and timestamps.
+
+        Demo bullet (3): ``kz.jobs.cancel(job_id)`` stops a stuck job
+        within seconds.
+        """
+        response = self._client._request("POST", f"/api/cluster/jobs/{job_id}/cancel")
+        return dict(response)
+
     def wait(self, job_id: str, *, timeout: int) -> JobResult:
         """Poll a previously-submitted job until terminal, then return.
 

--- a/kamiwaza/jobs.py
+++ b/kamiwaza/jobs.py
@@ -54,6 +54,9 @@ class JobsAPI:
         runtime_env: Optional[dict[str, Any]] = None,
         timeout_seconds: Optional[int] = None,
         recoverable: bool = False,
+        pip: Optional[list[str]] = None,
+        py_modules: Optional[list[str]] = None,
+        working_dir: Optional[str] = None,
     ) -> JobResult:
         """Run a job and return the completed JobResult.
 
@@ -63,18 +66,22 @@ class JobsAPI:
             target_cluster: Federation name to route to. None runs on
                 the local cluster.
             runtime_env: Ray runtime_env (env vars, working_dir, …).
+                Caller-provided keys win over the convenience kwargs
+                below on collision.
             timeout_seconds: Wall-clock cap. Server-enforced for
                 ``recoverable=False``; SDK-enforced poll budget for
                 ``recoverable=True``.
             recoverable: When True (T5.22 / ENG-4699), the SDK uses async
                 submit + poll instead of the sync /run path so the
-                ``job_id`` is in hand immediately. A connection drop
-                mid-job is recoverable via ``kz.jobs.wait(job_id, ...)``.
-                Recommended for any job with ``timeout_seconds > 60``;
-                the sync path holds the HTTP connection for the full
-                duration and FastAPI buffers the X-Job-Id header until
-                completion — a mid-job drop loses the job_id (see
-                design §4.2.14 + SDK README "Recoverable long-jobs").
+                ``job_id`` is in hand immediately.
+            pip: T5.38 / ENG-4715 / FR-94 convenience — Ray pip list,
+                packed into ``runtime_env["pip"]`` on the wire.
+            py_modules: T5.38 / ENG-4715 / FR-94 convenience — local
+                module paths to ship with the job; packs into
+                ``runtime_env["py_modules"]``.
+            working_dir: T5.38 / ENG-4715 / FR-94 convenience — local
+                directory to bundle as the working dir; packs into
+                ``runtime_env["working_dir"]``.
 
         Returns:
             Completed ``JobResult``. ``status`` will be SUCCEEDED for
@@ -86,19 +93,56 @@ class JobsAPI:
                 ``timeout_seconds`` expires before the job reaches a
                 terminal state.
         """
+        merged_runtime_env = self._merge_runtime_env(
+            runtime_env=runtime_env,
+            pip=pip,
+            py_modules=py_modules,
+            working_dir=working_dir,
+        )
         if recoverable:
             return self._run_recoverable(
                 entrypoint=entrypoint,
                 target_cluster=target_cluster,
-                runtime_env=runtime_env,
+                runtime_env=merged_runtime_env,
                 timeout_seconds=timeout_seconds,
             )
         return self._run_sync(
             entrypoint=entrypoint,
             target_cluster=target_cluster,
-            runtime_env=runtime_env,
+            runtime_env=merged_runtime_env,
             timeout_seconds=timeout_seconds,
         )
+
+    @staticmethod
+    def _merge_runtime_env(
+        *,
+        runtime_env: Optional[dict[str, Any]],
+        pip: Optional[list[str]],
+        py_modules: Optional[list[str]],
+        working_dir: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        """Pack convenience kwargs (T5.38) into a runtime_env dict.
+
+        Caller-supplied runtime_env wins on key collision — the
+        convenience kwargs are sugar, not overrides. Returns None when
+        no source provided so the body shape matches the pre-T5.38
+        default-caller pattern (no runtime_env key on the wire).
+        """
+        convenience: dict[str, Any] = {}
+        if pip is not None:
+            convenience["pip"] = pip
+        if py_modules is not None:
+            convenience["py_modules"] = py_modules
+        if working_dir is not None:
+            convenience["working_dir"] = working_dir
+
+        if not convenience and runtime_env is None:
+            return None
+
+        merged: dict[str, Any] = dict(convenience)
+        if runtime_env:
+            merged.update(runtime_env)  # caller wins on collision
+        return merged
 
     def _run_sync(
         self,

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -20,7 +20,7 @@ must not break the SDK in a customer's pinned wheel.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict
 
@@ -81,6 +81,43 @@ class ClusterCapabilities(BaseModel):
     federation_count: int = 0
     active_deployments: int = 0
     ray_ready: bool = False
+
+
+class DiagnoseIssue(BaseModel):
+    """T5.13 / ENG-4694 — a single cluster-health issue from diagnose().
+
+    Stable ``id`` (e.g. ``admin_missing_baseline_rebac``,
+    ``missing_token_exchange_permission``) lets customer code match
+    programmatically. ``fix_endpoint`` + ``fix_payload`` are present when
+    ``auto_fixable=True`` so a future ``fix()`` orchestration can drive
+    remediation; ``None`` when manual remediation is required.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    severity: Literal["error", "warning", "info"]
+    summary: str
+    detail: Dict[str, Any] = {}
+    fix_endpoint: Optional[str] = None
+    fix_payload: Optional[Dict[str, Any]] = None
+    auto_fixable: bool = False
+
+
+class ClusterDiagnostics(BaseModel):
+    """T5.13 / ENG-4694 — aggregate result of a cluster diagnose run.
+
+    Returned by ``kz.cluster.diagnose()``. ``has_issues`` is True iff any
+    issue has ``severity == "error"``. Server-side correlate:
+    ``kamiwaza.cluster.diagnose.services.ClusterDiagnoseService.run()``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    cluster_id: str
+    timestamp: datetime
+    issues: List[DiagnoseIssue] = []
+    has_issues: bool = False
 
 
 class JobResult(BaseModel):

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -120,6 +120,37 @@ class ClusterDiagnostics(BaseModel):
     has_issues: bool = False
 
 
+class FixOutcome(BaseModel):
+    """T5.8 / ENG-4693 — per-issue outcome from kz.cluster.fix().
+
+    ``status`` is one of:
+      - ``fixed``           — issue.fix_endpoint returned 2xx.
+      - ``manual_required`` — issue.auto_fixable was False; skipped.
+      - ``failed``          — fix_endpoint returned non-2xx; ``error`` set.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    issue_id: str
+    status: Literal["fixed", "manual_required", "failed"]
+    error: Optional[str] = None
+
+
+class FixResult(BaseModel):
+    """T5.8 / ENG-4693 — aggregate result of a kz.cluster.fix() run.
+
+    Per design `system-design.md` §4.2.10: iterates ClusterDiagnostics
+    issues in severity order, dispatches each to its fix_endpoint when
+    auto_fixable, records per-issue outcomes. The skeleton supports
+    auto-fixable issues generically — fix() works for any future probe
+    that ships with a fix_endpoint, without SDK changes.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    outcomes: List[FixOutcome] = []
+
+
 class JobResult(BaseModel):
     """Result of a federated job — synchronous /run completion or async
     /submit + poll terminal state. ``status`` is one of SUCCEEDED, FAILED,

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -151,6 +151,23 @@ class FixResult(BaseModel):
     outcomes: List[FixOutcome] = []
 
 
+class ClusterOperations(BaseModel):
+    """T5.37 / ENG-4714 — unified jobs+retrieval listing.
+
+    Returned by ``kz.cluster.operations()``. The walking skeleton
+    populates ``jobs`` from ``GET /api/cluster/jobs`` and leaves
+    ``retrievals`` empty until ``GET /api/retrieval/jobs`` lands
+    (T5.30 / ENG-4707) and the SDK retrieval module ships (T5.36).
+
+    Demo bullet (2): list the running federated job + active retrieval.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    jobs: List[Any] = []
+    retrievals: List[Any] = []
+
+
 class JobResult(BaseModel):
     """Result of a federated job — synchronous /run completion or async
     /submit + poll terminal state. ``status`` is one of SUCCEEDED, FAILED,

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -58,6 +58,31 @@ class BrokeredUser(BaseModel):
     initial_tuples: Optional[List[Any]] = None
 
 
+class ClusterCapabilities(BaseModel):
+    """T5.19 / ENG-4696 capabilities-probe response.
+
+    Returned by ``kz.cluster.capabilities()`` (local) and
+    ``kz.federations[name].probe()`` (via mesh). Server-side correlate:
+    ``kamiwaza.cluster.services.ClusterService.get_cluster_capabilities()``.
+
+    Known fields cover the WS-M2 demo-bullet-(4) probe surface — hardware /
+    platform info plus federation pre-flight fields (federation_count,
+    active_deployments, ray_ready). Other fields flow through via
+    ``extra="allow"`` for forward compatibility per the common-pitfalls
+    guide; pinned SDK wheels must not break when the server adds fields.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    system_type: str
+    os: str
+    gpu_count: int = 0
+    available_platforms: List[str] = []
+    federation_count: int = 0
+    active_deployments: int = 0
+    ray_ready: bool = False
+
+
 class JobResult(BaseModel):
     """Result of a federated job — synchronous /run completion or async
     /submit + poll terminal state. ``status`` is one of SUCCEEDED, FAILED,

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -151,6 +151,26 @@ class FixResult(BaseModel):
     outcomes: List[FixOutcome] = []
 
 
+class GateDiscovery(BaseModel):
+    """T5.4 / ENG-4691 — reflection payload from POST /api/authz/gates/discover.
+
+    Returned by ``kz.gates.discover(classpath)``. ``kind`` is one of
+    ``"execution"`` or ``"attribute"``. ``required_attributes`` is the
+    set of user-attribute specs the gate consumes; ``config_schema`` is
+    the JSONSchema-shaped binding schema (empty dict when the gate
+    doesn't declare a ``config_schema()`` classmethod).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    kind: Literal["execution", "attribute"]
+    required_attributes: List[Dict[str, Any]] = []
+    config_schema: Dict[str, Any] = {}
+    classpath: str
+    location: str = ""
+
+
 class ClusterOperations(BaseModel):
     """T5.37 / ENG-4714 — unified jobs+retrieval listing.
 

--- a/kamiwaza/retrieval.py
+++ b/kamiwaza/retrieval.py
@@ -1,0 +1,55 @@
+"""T5.36 / ENG-4713 — kamiwaza.retrieval module.
+
+Customer-facing surface per design §4.2.11:
+
+    kz.retrieval.list(...)         -> list[dict]
+    kz.retrieval.cancel(query_id)  -> dict (updated status)
+
+Server-side correlates:
+- GET  /api/retrieval/jobs                  (ENG-4707 / T5.30 / FR-85)
+- POST /api/retrieval/jobs/{id}/cancel      (ENG-4709 / T5.32 / FR-84)
+
+The list / cancel return values are surfaced as raw dicts (rather than
+typed models) — the retrieval response shape is richer than the WS-M2
+demo gate needs, and customers can model-validate locally if they want.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class RetrievalAPI:
+    """Retrieval job management on the local cluster."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def list(
+        self,
+        *,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """List retrieval jobs newest-first (T5.36).
+
+        Native admin sees all; non-admin and mesh-origin callers are
+        scoped server-side to their own requester URN.
+        """
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        body = self._client._request("GET", "/api/retrieval/jobs", params=params)
+        return list(body) if isinstance(body, list) else []
+
+    def cancel(self, query_id: str) -> dict[str, Any]:
+        """Cancel a retrieval job (T5.36).
+
+        Returns the updated job-status dict (status will typically be
+        ``"CANCELED"``). Server-side enforces ownership; the SDK surfaces
+        ``KamiwazaError`` with the structured detail on 4xx.
+        """
+        response = self._client._request(
+            "POST", f"/api/retrieval/jobs/{query_id}/cancel"
+        )
+        return dict(response) if isinstance(response, dict) else {}
+
+    _unused: Optional[Any] = None  # vulture-noop placeholder

--- a/tests/integration/test_jobs_recoverable_drop_recovery.py
+++ b/tests/integration/test_jobs_recoverable_drop_recovery.py
@@ -1,0 +1,129 @@
+"""T5.24 / ENG-4701 — connection-drop recovery integration test.
+
+Verifies WS-M2 demo bullet (8): a federated job submitted via
+``kz.jobs.run(..., recoverable=True)`` survives an induced mid-call SDK
+process kill — the SDK reconnects via ``job_id`` and retrieves the
+result.
+
+Test shape: simulate two SDK instances on the same cluster. The first
+instance submits the job (capturing job_id from submit_async / from the
+saved-state log). A connection drop is induced; the first SDK process
+is "killed". A fresh second SDK instance resumes via ``wait(job_id)``
+and retrieves the result. This is exactly the demo bullet.
+
+The "process kill" is modeled as a fresh Kamiwaza() instance — same
+shape as a customer process restart, with the saved job_id passed in.
+
+Per design `system-design.md` §4.2.14 + Sequence 7.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_recoverable_run_survives_mid_call_sdk_kill(httpx_mock: Any) -> None:
+    """Demo bullet (8) — submit → kill SDK → resume from saved job_id.
+
+    Phase 1 (original SDK process):
+        - kz.jobs.submit_async() returns job_id
+        - SDK records job_id (would be persisted to disk in real usage)
+        - SDK process "dies" — no further calls on this instance
+    Phase 2 (fresh SDK process):
+        - new Kamiwaza() instance
+        - kz.jobs.wait(saved_job_id) resumes polling
+        - retrieves JobResult.SUCCEEDED with result payload
+    """
+    from kamiwaza.client import Kamiwaza
+
+    job_id = "job-survives-restart-001"
+
+    # Phase 1: original process submits.
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/submit",
+        status_code=200,
+        json={"job_id": job_id},
+    )
+    # Phase 2: fresh process polls — first poll returns RUNNING, then SUCCEEDED.
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://kamiwaza.test/api/cluster/jobs/{job_id}/status",
+        status_code=200,
+        json={"status": "RUNNING"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://kamiwaza.test/api/cluster/jobs/{job_id}/status",
+        status_code=200,
+        json={"status": "SUCCEEDED"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://kamiwaza.test/api/cluster/jobs/{job_id}/result",
+        status_code=200,
+        json={
+            "job_id": job_id,
+            "status": "SUCCEEDED",
+            "result": {"conjunction_pairs": 42},
+        },
+    )
+
+    # Phase 1 — submit on the first SDK process.
+    first_process = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    saved_job_id = first_process.jobs.submit_async(
+        entrypoint="python conjunction_query.py",
+        target_cluster="ORION",
+        timeout_seconds=300,
+    )
+    assert saved_job_id == job_id
+
+    # Simulate process death: explicit close + drop the reference. The fresh
+    # SDK below uses a brand-new httpx client; the only persisted state is
+    # the saved job_id string (as it would be in a real recovery scenario).
+    first_process.close()
+    del first_process
+
+    # Phase 2 — fresh SDK process resumes via wait(job_id).
+    second_process = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = second_process.jobs.wait(saved_job_id, timeout=120)
+
+    assert result.job_id == saved_job_id
+    assert result.status == "SUCCEEDED"
+    assert result.result == {"conjunction_pairs": 42}
+
+    second_process.close()
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_recoverable_run_returns_job_id_before_completion(
+    httpx_mock: Any,
+) -> None:
+    """The load-bearing property: submit_async must return the job_id
+    BEFORE the long-running poll loop completes. Without this, the SDK
+    has no recovery handle. We assert by interleaving the submit
+    response with a slow status path — submit returns immediately."""
+    from kamiwaza.client import Kamiwaza
+
+    job_id = "job-immediate-id-002"
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/submit",
+        status_code=200,
+        json={"job_id": job_id},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    returned_id = client.jobs.submit_async(
+        entrypoint="python query.py",
+        target_cluster="ORION",
+        timeout_seconds=300,
+    )
+
+    # job_id is in customer hands immediately — no poll loop ran.
+    assert returned_id == job_id
+    client.close()

--- a/tests/unit/test_kamiwaza_cluster.py
+++ b/tests/unit/test_kamiwaza_cluster.py
@@ -1,0 +1,170 @@
+"""T5.21 / ENG-4698 — kamiwaza.cluster module + federations[].probe() tests.
+
+Customer-facing capabilities probe surface per design §4.2.11 / §4.4.3:
+
+    kz.cluster.capabilities()              -> ClusterCapabilities  (local)
+    kz.federations[name].probe()           -> ClusterCapabilities  (via mesh)
+
+The local path hits ``GET /api/cluster/cluster_capabilities`` on the local
+cluster (auth widened to viewer by ENG-4697); the mesh path hits
+``GET /api/mesh/{name}/api/cluster/cluster_capabilities`` so a probing peer
+sees the remote cluster's GPU count, active deployments, Ray status, and
+federation count (extended by ENG-4696).
+
+Demo bullet (4): ``kz.federations["ORION"].probe()`` returns ORION's
+capabilities.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def test_kamiwaza_exposes_cluster_attribute() -> None:
+    """``client.cluster`` is the entry point for cluster operations."""
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    assert client.cluster is not None
+
+
+def test_cluster_is_lazy_loaded() -> None:
+    """Per .ai/rules/sdk-patterns.md, services are lazy-loaded."""
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    a = client.cluster
+    b = client.cluster
+    assert a is b
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_capabilities_hits_local_endpoint(httpx_mock: Any) -> None:
+    """``kz.cluster.capabilities()`` GETs ``/api/cluster/cluster_capabilities``."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import ClusterCapabilities
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/cluster_capabilities",
+        status_code=200,
+        json={
+            "system_type": "linux",
+            "os": "Linux",
+            "gpu_count": 1,
+            "gpu_types": ["nvidia"],
+            "available_platforms": ["GPU", "Fast CPU"],
+            "federation_count": 2,
+            "active_deployments": 3,
+            "ray_ready": True,
+            "is_dgx_spark": False,
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    caps = client.cluster.capabilities()
+
+    assert isinstance(caps, ClusterCapabilities)
+    assert caps.gpu_count == 1
+    assert caps.federation_count == 2
+    assert caps.active_deployments == 3
+    assert caps.ray_ready is True
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_capabilities_allows_unknown_fields(httpx_mock: Any) -> None:
+    """Forward-compat: new server-side fields must not crash the SDK."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/cluster_capabilities",
+        status_code=200,
+        json={
+            "system_type": "apple",
+            "os": "Darwin",
+            "gpu_count": 0,
+            "available_platforms": ["Apple Silicon", "Fast CPU"],
+            "federation_count": 0,
+            "active_deployments": 0,
+            "ray_ready": False,
+            "future_field_we_do_not_know": {"nested": "ok"},
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    caps = client.cluster.capabilities()
+
+    # Known fields validate; unknown fields pass through via extra="allow".
+    assert caps.system_type == "apple"
+    raw = caps.model_dump()
+    assert raw["future_field_we_do_not_know"] == {"nested": "ok"}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_federation_probe_hits_mesh_routed_endpoint(httpx_mock: Any) -> None:
+    """``kz.federations["ORION"].probe()`` GETs through ``/api/mesh/ORION/...``.
+
+    Per design §4.4.3: probing a peer's capabilities goes through the mesh
+    proxy. The selector is the federation's remote_cluster_name.
+    """
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import ClusterCapabilities
+
+    httpx_mock.add_response(
+        method="GET",
+        url=("https://kamiwaza.test/api/mesh/ORION/api/cluster/cluster_capabilities"),
+        status_code=200,
+        json={
+            "system_type": "linux",
+            "os": "Linux",
+            "gpu_count": 8,
+            "gpu_types": ["nvidia"],
+            "available_platforms": ["GPU", "Fast CPU"],
+            "federation_count": 1,
+            "active_deployments": 5,
+            "ray_ready": True,
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    caps = client.federations["ORION"].probe()
+
+    assert isinstance(caps, ClusterCapabilities)
+    assert caps.gpu_count == 8
+    assert caps.active_deployments == 5
+    assert caps.ray_ready is True
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_probe_does_not_resolve_federation_id(httpx_mock: Any) -> None:
+    """Probe must not trigger a federations list lookup — selector is the
+    cluster name itself, used directly in the mesh path. This protects the
+    probe latency budget and avoids an unnecessary round-trip."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="GET",
+        url=("https://kamiwaza.test/api/mesh/LYRA/api/cluster/cluster_capabilities"),
+        status_code=200,
+        json={
+            "system_type": "linux",
+            "os": "Linux",
+            "gpu_count": 0,
+            "available_platforms": ["Fast CPU"],
+            "federation_count": 1,
+            "active_deployments": 0,
+            "ray_ready": True,
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    proxy = client.federations["LYRA"]
+    caps = proxy.probe()
+
+    # Confirm only the mesh call was issued (no GET /api/cluster/federations
+    # for id resolution). httpx_mock would surface an unexpected call as a
+    # MissingResponseError on teardown.
+    assert caps.gpu_count == 0

--- a/tests/unit/test_kamiwaza_diagnose.py
+++ b/tests/unit/test_kamiwaza_diagnose.py
@@ -1,0 +1,124 @@
+"""T5.7 / T5.8 — ENG-4692 / ENG-4693 — kz.cluster.diagnose() SDK tests.
+
+Per design `system-design.md` §4.2.10 / §4.2.11: customer-facing diagnose
+surface returns typed ClusterDiagnostics. Demo bullet (1) for WS-M2:
+``kz.cluster.diagnose()`` returns clean status on a healthy cluster.
+
+Walking-skeleton scope (matches the server skeleton): ``diagnose()`` only.
+``fix()`` orchestration is deferred until at least one auto-fixable probe
+exists on the server — adding it now would be a no-op customer surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_diagnose_returns_typed_cluster_diagnostics(httpx_mock: Any) -> None:
+    """``kz.cluster.diagnose()`` GETs ``/api/cluster/diagnose`` and parses
+    the structured response into a ClusterDiagnostics model."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import ClusterDiagnostics
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/diagnose",
+        status_code=200,
+        json={
+            "cluster_id": "11111111-2222-3333-4444-555555555555",
+            "timestamp": "2026-05-10T22:00:00+00:00",
+            "issues": [],
+            "has_issues": False,
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.diagnose()
+
+    assert isinstance(result, ClusterDiagnostics)
+    assert result.has_issues is False
+    assert result.issues == []
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_diagnose_parses_structured_issues(httpx_mock: Any) -> None:
+    """Issues come back as typed DiagnoseIssue models so customer code
+    can match on stable issue.id strings."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import DiagnoseIssue
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/diagnose",
+        status_code=200,
+        json={
+            "cluster_id": "11111111-2222-3333-4444-555555555555",
+            "timestamp": "2026-05-10T22:00:00+00:00",
+            "issues": [
+                {
+                    "id": "admin_missing_baseline_rebac",
+                    "severity": "error",
+                    "summary": "No user holds owner on this cluster",
+                    "detail": {"cluster_id": "11111111-2222-3333-4444-555555555555"},
+                    "fix_endpoint": None,
+                    "fix_payload": None,
+                    "auto_fixable": False,
+                }
+            ],
+            "has_issues": True,
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.diagnose()
+
+    assert result.has_issues is True
+    assert len(result.issues) == 1
+    issue = result.issues[0]
+    assert isinstance(issue, DiagnoseIssue)
+    assert issue.id == "admin_missing_baseline_rebac"
+    assert issue.severity == "error"
+    assert issue.auto_fixable is False
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_diagnose_allows_unknown_issue_fields_forward_compat(httpx_mock: Any) -> None:
+    """Server-side schema evolution must not break a pinned SDK wheel."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/diagnose",
+        status_code=200,
+        json={
+            "cluster_id": "11111111-2222-3333-4444-555555555555",
+            "timestamp": "2026-05-10T22:00:00+00:00",
+            "issues": [
+                {
+                    "id": "missing_token_exchange_permission",
+                    "severity": "error",
+                    "summary": "kamiwaza-platform-svc lacks token-exchange",
+                    "detail": {"client_id": "kamiwaza-platform-svc"},
+                    "fix_endpoint": "/api/cluster/diagnose/fix/missing_token_exchange_permission",
+                    "fix_payload": {},
+                    "auto_fixable": True,
+                    "remediation_url": "https://docs/...",  # Future field
+                }
+            ],
+            "has_issues": True,
+            "next_run_recommended_at": "2026-05-10T22:05:00+00:00",  # Future field
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.diagnose()
+
+    assert result.issues[0].id == "missing_token_exchange_permission"
+    # Future fields preserved via extra="allow"
+    raw_issue = result.issues[0].model_dump()
+    assert raw_issue.get("remediation_url") == "https://docs/..."
+    raw_result = result.model_dump()
+    assert "next_run_recommended_at" in raw_result

--- a/tests/unit/test_kamiwaza_diagnose_fix.py
+++ b/tests/unit/test_kamiwaza_diagnose_fix.py
@@ -1,0 +1,158 @@
+"""T5.8 / ENG-4693 — kz.cluster.fix() orchestration tests.
+
+Per design `system-design.md` §4.2.10: ``fix()`` iterates issues in
+severity order; for each ``auto_fixable=True`` issue, invokes its
+``fix_endpoint`` with ``fix_payload``. Issues with ``auto_fixable=False``
+are surfaced but skipped with ``status="manual_required"``.
+
+Server-side fix endpoints don't exist yet (no auto-fixable probe is
+implemented in this cycle's walking skeleton). Tests verify the SDK's
+generic dispatch shape — when the token-exchange / claims-scope probes
+land with fix endpoints in subsequent commits, this SDK orchestration
+works without changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_fix_reports_manual_required_for_non_auto_fixable_issues(
+    httpx_mock: Any,
+) -> None:
+    """The skeleton-cluster case: admin-baseline issue is auto_fixable=False
+    so fix() reports manual_required without hitting any endpoint."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import FixResult
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/diagnose",
+        status_code=200,
+        json={
+            "cluster_id": "11111111-2222-3333-4444-555555555555",
+            "timestamp": "2026-05-10T22:00:00+00:00",
+            "issues": [
+                {
+                    "id": "admin_missing_baseline_rebac",
+                    "severity": "error",
+                    "summary": "No user holds owner",
+                    "detail": {},
+                    "fix_endpoint": None,
+                    "fix_payload": None,
+                    "auto_fixable": False,
+                }
+            ],
+            "has_issues": True,
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.fix()
+
+    assert isinstance(result, FixResult)
+    assert len(result.outcomes) == 1
+    outcome = result.outcomes[0]
+    assert outcome.issue_id == "admin_missing_baseline_rebac"
+    assert outcome.status == "manual_required"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_fix_invokes_fix_endpoint_for_auto_fixable_issue(httpx_mock: Any) -> None:
+    """When a probe ships an auto-fixable issue (e.g. token-exchange in a
+    later commit), fix() POSTs to issue.fix_endpoint with issue.fix_payload
+    and records the result. SDK is probe-type-agnostic — the dispatch is
+    generic on the issue shape."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/diagnose",
+        status_code=200,
+        json={
+            "cluster_id": "11111111-2222-3333-4444-555555555555",
+            "timestamp": "2026-05-10T22:00:00+00:00",
+            "issues": [
+                {
+                    "id": "missing_token_exchange_permission",
+                    "severity": "error",
+                    "summary": "OBO actor lacks token-exchange",
+                    "detail": {"client_id": "kamiwaza-platform-svc"},
+                    "fix_endpoint": "/api/cluster/diagnose/fix/missing_token_exchange_permission",
+                    "fix_payload": {"client_id": "kamiwaza-platform-svc"},
+                    "auto_fixable": True,
+                }
+            ],
+            "has_issues": True,
+        },
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=(
+            "https://kamiwaza.test/api/cluster/diagnose/fix/"
+            "missing_token_exchange_permission"
+        ),
+        status_code=200,
+        json={"fixed": True},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.fix()
+
+    assert len(result.outcomes) == 1
+    outcome = result.outcomes[0]
+    assert outcome.issue_id == "missing_token_exchange_permission"
+    assert outcome.status == "fixed"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_fix_records_failure_when_fix_endpoint_5xxs(httpx_mock: Any) -> None:
+    """If the fix endpoint returns an error, the outcome records
+    status=failed without raising — so the operator sees per-issue
+    success/failure for the batch."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/diagnose",
+        status_code=200,
+        json={
+            "cluster_id": "11111111-2222-3333-4444-555555555555",
+            "timestamp": "2026-05-10T22:00:00+00:00",
+            "issues": [
+                {
+                    "id": "missing_kamiwaza_claims_scope_attachment",
+                    "severity": "error",
+                    "summary": "kamiwaza-claims scope missing on platform clients",
+                    "detail": {"missing_on": ["kamiwaza-platform"]},
+                    "fix_endpoint": (
+                        "/api/cluster/diagnose/fix/"
+                        "missing_kamiwaza_claims_scope_attachment"
+                    ),
+                    "fix_payload": {},
+                    "auto_fixable": True,
+                }
+            ],
+            "has_issues": True,
+        },
+    )
+    httpx_mock.add_response(
+        method="POST",
+        url=(
+            "https://kamiwaza.test/api/cluster/diagnose/fix/"
+            "missing_kamiwaza_claims_scope_attachment"
+        ),
+        status_code=503,
+        json={"detail": "Keycloak unreachable"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.fix()
+
+    assert len(result.outcomes) == 1
+    outcome = result.outcomes[0]
+    assert outcome.status == "failed"
+    assert outcome.error is not None

--- a/tests/unit/test_kamiwaza_gates.py
+++ b/tests/unit/test_kamiwaza_gates.py
@@ -1,0 +1,133 @@
+"""T5.4 / ENG-4691 — kamiwaza.gates module tests.
+
+Customer-facing surface for gate discovery per design §4.2.11:
+
+    kz.gates.discover(classpath)   -> GateDiscovery
+
+Server-side correlate: POST /api/authz/gates/discover (§4.2.3).
+
+Full surface (set_gate, packages.*) is WS-M3 — this skeleton ships only
+the discover() method.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def test_kamiwaza_exposes_gates_attribute() -> None:
+    """client.gates is the entry point for gate discovery."""
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    assert client.gates is not None
+
+
+def test_gates_is_lazy_loaded() -> None:
+    """Lazy-load per .ai/rules/sdk-patterns.md."""
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    a = client.gates
+    b = client.gates
+    assert a is b
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_discover_posts_to_server_with_classpath(httpx_mock: Any) -> None:
+    """kz.gates.discover(classpath) POSTs to /api/authz/gates/discover."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import GateDiscovery
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/authz/gates/discover",
+        status_code=200,
+        json={
+            "name": "AllowAllExecutionGate",
+            "kind": "execution",
+            "required_attributes": [],
+            "config_schema": {},
+            "classpath": (
+                "kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate"
+            ),
+            "location": "/.../default_gates.py:42",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.gates.discover(
+        "kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate"
+    )
+
+    assert isinstance(result, GateDiscovery)
+    assert result.kind == "execution"
+    assert result.name == "AllowAllExecutionGate"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_discover_passes_classpath_in_request_body(httpx_mock: Any) -> None:
+    """The classpath is sent in the POST body — server's API contract."""
+    from kamiwaza.client import Kamiwaza
+
+    classpath = "my_policy.MyGate"
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/authz/gates/discover",
+        status_code=200,
+        json={
+            "name": "my-gate",
+            "kind": "execution",
+            "required_attributes": [],
+            "config_schema": {},
+            "classpath": classpath,
+            "location": "<unknown>",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.gates.discover(classpath)
+
+    request = httpx_mock.get_requests(method="POST")[0]
+    import json
+
+    body = json.loads(request.content)
+    assert body == {"classpath": classpath}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_discover_surfaces_required_attributes_and_schema(
+    httpx_mock: Any,
+) -> None:
+    """Customer-meaningful fields round-trip via the typed model."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/authz/gates/discover",
+        status_code=200,
+        json={
+            "name": "classification-gate",
+            "kind": "execution",
+            "required_attributes": [
+                {"name": "clearance", "kind": "string"},
+                {"name": "country", "kind": "string"},
+            ],
+            "config_schema": {
+                "type": "object",
+                "properties": {"min_clearance": {"type": "string"}},
+            },
+            "classpath": "stub.ClassificationGate",
+            "location": "<stub>",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.gates.discover("stub.ClassificationGate")
+
+    assert len(result.required_attributes) == 2
+    assert result.required_attributes[0]["name"] == "clearance"
+    assert result.config_schema["properties"]["min_clearance"]["type"] == "string"

--- a/tests/unit/test_kamiwaza_jobs_cancel_and_operations.py
+++ b/tests/unit/test_kamiwaza_jobs_cancel_and_operations.py
@@ -89,14 +89,20 @@ def test_operations_lists_running_jobs(httpx_mock: Any) -> None:
         ],
     )
 
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/retrieval/jobs",
+        status_code=200,
+        json=[],
+    )
+
     client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
     result = client.cluster.operations()
 
     assert isinstance(result, ClusterOperations)
     assert len(result.jobs) == 2
     assert result.jobs[0]["status"] == "RUNNING"
-    # Retrieval slice is empty until T5.30/T5.36 land; the contract is
-    # already that operations() returns the unified shape.
+    # Retrievals slice populates via /api/retrieval/jobs (T5.30/T5.36).
     assert result.retrievals == []
 
 
@@ -108,6 +114,12 @@ def test_operations_empty_when_no_jobs(httpx_mock: Any) -> None:
     httpx_mock.add_response(
         method="GET",
         url="https://kamiwaza.test/api/cluster/jobs/",
+        status_code=200,
+        json=[],
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/retrieval/jobs",
         status_code=200,
         json=[],
     )

--- a/tests/unit/test_kamiwaza_jobs_cancel_and_operations.py
+++ b/tests/unit/test_kamiwaza_jobs_cancel_and_operations.py
@@ -1,0 +1,119 @@
+"""T5.35 + T5.37 — kz.jobs.cancel() + kz.cluster.operations() tests.
+
+WS-M2 demo bullets (2) and (3):
+- (2) kz.cluster.operations() lists the running federated job + active
+  retrieval (retrieval slice is empty in the walking skeleton until
+  T5.30/T5.36 land).
+- (3) kz.jobs.cancel(job_id) stops a stuck job within seconds.
+
+Server-side correlates:
+- POST /api/cluster/jobs/{id}/cancel  (already shipped; M1)
+- GET /api/cluster/jobs               (ENG-4706 / T5.29)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+# -- kz.jobs.cancel ----------------------------------------------------------
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_cancel_posts_to_server_cancel_endpoint(httpx_mock: Any) -> None:
+    """``kz.jobs.cancel(job_id)`` POSTs to
+    ``/api/cluster/jobs/{id}/cancel`` and returns the JobRecord."""
+    from kamiwaza.client import Kamiwaza
+
+    job_id = "00000000-0000-0000-0000-000000000001"
+    httpx_mock.add_response(
+        method="POST",
+        url=f"https://kamiwaza.test/api/cluster/jobs/{job_id}/cancel",
+        status_code=200,
+        json={
+            "id": job_id,
+            "status": "STOPPED",
+            "source": "local",
+            "user_id": "u",
+            "entrypoint": "python q.py",
+            "submitted_at": "2026-05-10T22:00:00+00:00",
+            "created_at": "2026-05-10T22:00:00+00:00",
+            "updated_at": "2026-05-10T22:00:01+00:00",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.jobs.cancel(job_id)
+
+    assert result["id"] == job_id
+    assert result["status"] == "STOPPED"
+
+
+# -- kz.cluster.operations --------------------------------------------------
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_operations_lists_running_jobs(httpx_mock: Any) -> None:
+    """``kz.cluster.operations()`` GETs /api/cluster/jobs and surfaces
+    them as a structured ClusterOperations result."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import ClusterOperations
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/jobs/",
+        status_code=200,
+        json=[
+            {
+                "id": "00000000-0000-0000-0000-000000000001",
+                "status": "RUNNING",
+                "source": "local",
+                "user_id": "u",
+                "entrypoint": "python q.py",
+                "submitted_at": "2026-05-10T22:00:00+00:00",
+                "created_at": "2026-05-10T22:00:00+00:00",
+                "updated_at": "2026-05-10T22:00:00+00:00",
+            },
+            {
+                "id": "00000000-0000-0000-0000-000000000002",
+                "status": "SUCCEEDED",
+                "source": "mesh",
+                "user_id": "u",
+                "entrypoint": "python q2.py",
+                "submitted_at": "2026-05-10T21:00:00+00:00",
+                "created_at": "2026-05-10T21:00:00+00:00",
+                "updated_at": "2026-05-10T21:00:05+00:00",
+            },
+        ],
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.operations()
+
+    assert isinstance(result, ClusterOperations)
+    assert len(result.jobs) == 2
+    assert result.jobs[0]["status"] == "RUNNING"
+    # Retrieval slice is empty until T5.30/T5.36 land; the contract is
+    # already that operations() returns the unified shape.
+    assert result.retrievals == []
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_operations_empty_when_no_jobs(httpx_mock: Any) -> None:
+    """Empty cluster — no jobs, no retrievals — returns empty lists."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/jobs/",
+        status_code=200,
+        json=[],
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.operations()
+
+    assert result.jobs == []
+    assert result.retrievals == []

--- a/tests/unit/test_kamiwaza_jobs_recoverable.py
+++ b/tests/unit/test_kamiwaza_jobs_recoverable.py
@@ -1,0 +1,138 @@
+"""T5.22 / ENG-4699 — kz.jobs.run(recoverable=True) tests.
+
+Per design `system-design.md` §4.2.14: when ``recoverable=True``, the
+SDK uses async submit + poll instead of the sync /run path. This puts
+the ``job_id`` in the SDK's hands immediately so a connection drop
+mid-job is recoverable via ``kz.jobs.wait(job_id, ...)``.
+
+Demo bullet (8): a 5-minute federated job submitted via
+``kz.jobs.run(..., recoverable=True)`` survives an induced mid-call SDK
+process kill — the SDK reconnects via job_id and retrieves the result.
+
+Walking-skeleton scope: verify the dispatch routing (recoverable=True →
+submit+poll path; recoverable=False → sync /run path). The connection-
+drop recovery shape is exercised by the integration test (T5.24).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_run_recoverable_false_uses_sync_endpoint(httpx_mock: Any) -> None:
+    """Default ``recoverable=False`` hits POST /api/cluster/jobs/run."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/run",
+        status_code=200,
+        json={
+            "job_id": "job-123",
+            "status": "SUCCEEDED",
+            "result": {"answer": 42},
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.jobs.run(entrypoint="python query.py")
+
+    assert result.status == "SUCCEEDED"
+    assert result.job_id == "job-123"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_run_recoverable_true_uses_submit_then_poll(httpx_mock: Any) -> None:
+    """``recoverable=True`` hits submit then polls status + result.
+
+    Critical property: the job_id is available in the SDK after the
+    submit call (i.e., before the long poll loop completes). This is the
+    load-bearing reason for the recoverable path — a connection drop
+    mid-poll is recoverable from a saved job_id.
+    """
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/submit",
+        status_code=200,
+        json={"job_id": "job-recoverable-xyz"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/jobs/job-recoverable-xyz/status",
+        status_code=200,
+        json={"status": "SUCCEEDED"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/jobs/job-recoverable-xyz/result",
+        status_code=200,
+        json={
+            "job_id": "job-recoverable-xyz",
+            "status": "SUCCEEDED",
+            "result": {"answer": 42},
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.jobs.run(
+        entrypoint="python query.py",
+        recoverable=True,
+        timeout_seconds=300,
+    )
+
+    assert result.job_id == "job-recoverable-xyz"
+    assert result.status == "SUCCEEDED"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_run_recoverable_true_forwards_runtime_env_to_submit(
+    httpx_mock: Any,
+) -> None:
+    """runtime_env, target_cluster, timeout_seconds must reach the submit
+    body — they're how the server provisions the long-running job."""
+    from kamiwaza.client import Kamiwaza
+
+    captured_request = httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/submit",
+        status_code=200,
+        json={"job_id": "job-fwd-test"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/jobs/job-fwd-test/status",
+        status_code=200,
+        json={"status": "SUCCEEDED"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/jobs/job-fwd-test/result",
+        status_code=200,
+        json={"job_id": "job-fwd-test", "status": "SUCCEEDED", "result": {}},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.jobs.run(
+        entrypoint="python long.py",
+        target_cluster="ORION",
+        runtime_env={"env_vars": {"X": "1"}},
+        timeout_seconds=300,
+        recoverable=True,
+    )
+
+    # First request is the submit; assert its body shape.
+    submit_req = httpx_mock.get_requests(method="POST")[0]
+    import json
+
+    body = json.loads(submit_req.content)
+    assert body["entrypoint"] == "python long.py"
+    assert body["target_cluster"] == "ORION"
+    assert body["runtime_env"] == {"env_vars": {"X": "1"}}
+    assert body["timeout_seconds"] == 300
+    # Suppress unused-variable diag — fixture-injection side-effect captured above.
+    _ = captured_request

--- a/tests/unit/test_kamiwaza_jobs_runtime_env_kwargs.py
+++ b/tests/unit/test_kamiwaza_jobs_runtime_env_kwargs.py
@@ -1,0 +1,162 @@
+"""T5.38 / ENG-4715 — JobsAPI.run runtime_env convenience kwargs.
+
+Per design §4.2.11 + FR-94: demo authors shouldn't have to construct
+the Ray runtime_env dict by hand for the common cases (pip deps, local
+py_modules, working_dir bundling). The SDK packs these into runtime_env
+on the wire.
+
+When both runtime_env and one of the convenience kwargs are passed, the
+convenience kwargs merge into runtime_env (caller-provided runtime_env
+takes precedence on key collision — caller is explicit about wire shape).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_run_packs_pip_kwarg_into_runtime_env(httpx_mock: Any) -> None:
+    """pip=["numpy"] becomes runtime_env={"pip": ["numpy"]}."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/run",
+        status_code=200,
+        json={"job_id": "j1", "status": "SUCCEEDED"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat")
+    client.jobs.run(entrypoint="python q.py", pip=["numpy", "scipy==1.10"])
+
+    request = httpx_mock.get_requests(method="POST")[0]
+    body = json.loads(request.content)
+    assert body["runtime_env"] == {"pip": ["numpy", "scipy==1.10"]}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_run_packs_py_modules_and_working_dir(httpx_mock: Any) -> None:
+    """py_modules + working_dir + pip combine into one runtime_env dict."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/run",
+        status_code=200,
+        json={"job_id": "j2", "status": "SUCCEEDED"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat")
+    client.jobs.run(
+        entrypoint="python q.py",
+        pip=["numpy"],
+        py_modules=["./my_module"],
+        working_dir="./project",
+    )
+
+    request = httpx_mock.get_requests(method="POST")[0]
+    body = json.loads(request.content)
+    assert body["runtime_env"] == {
+        "pip": ["numpy"],
+        "py_modules": ["./my_module"],
+        "working_dir": "./project",
+    }
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_run_explicit_runtime_env_takes_precedence_over_convenience_kwargs(
+    httpx_mock: Any,
+) -> None:
+    """Caller-provided runtime_env keys win on collision.
+
+    Convenience kwargs are sugar; if the caller passed an explicit
+    runtime_env, they're being deliberate about wire shape and we don't
+    silently overwrite their fields.
+    """
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/run",
+        status_code=200,
+        json={"job_id": "j3", "status": "SUCCEEDED"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat")
+    client.jobs.run(
+        entrypoint="python q.py",
+        pip=["numpy"],  # convenience
+        runtime_env={"pip": ["explicit-pin==1.0"], "env_vars": {"X": "1"}},
+    )
+
+    request = httpx_mock.get_requests(method="POST")[0]
+    body = json.loads(request.content)
+    # Caller's runtime_env.pip wins; env_vars carried through.
+    assert body["runtime_env"]["pip"] == ["explicit-pin==1.0"]
+    assert body["runtime_env"]["env_vars"] == {"X": "1"}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_run_omits_runtime_env_when_neither_form_provided(
+    httpx_mock: Any,
+) -> None:
+    """No runtime_env in body when caller provides neither — preserves
+    pre-T5.38 wire shape for default callers."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/run",
+        status_code=200,
+        json={"job_id": "j4", "status": "SUCCEEDED"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat")
+    client.jobs.run(entrypoint="python q.py")
+
+    request = httpx_mock.get_requests(method="POST")[0]
+    body = json.loads(request.content)
+    assert "runtime_env" not in body
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_convenience_kwargs_work_on_recoverable_path_too(
+    httpx_mock: Any,
+) -> None:
+    """recoverable=True route uses submit, but the wire body shape must
+    match — convenience kwargs pack the same way."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/cluster/jobs/submit",
+        status_code=200,
+        json={"job_id": "j5"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/jobs/j5/status",
+        status_code=200,
+        json={"status": "SUCCEEDED"},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/jobs/j5/result",
+        status_code=200,
+        json={"job_id": "j5", "status": "SUCCEEDED", "result": {}},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat")
+    client.jobs.run(
+        entrypoint="python q.py",
+        pip=["numpy"],
+        recoverable=True,
+    )
+
+    submit_req = httpx_mock.get_requests(method="POST")[0]
+    body = json.loads(submit_req.content)
+    assert body["runtime_env"] == {"pip": ["numpy"]}

--- a/tests/unit/test_kamiwaza_retrieval.py
+++ b/tests/unit/test_kamiwaza_retrieval.py
@@ -1,0 +1,125 @@
+"""T5.36 / ENG-4713 — kamiwaza.retrieval module tests.
+
+Customer-facing surface per design §4.2.11:
+
+    kz.retrieval.list(...)         -> list of retrieval job records
+    kz.retrieval.cancel(query_id)  -> updated job status
+
+Plus operations() now populates the retrievals slice from this module
+(previously empty until cycle 5 retrieval work landed).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def test_kamiwaza_exposes_retrieval_attribute() -> None:
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    assert client.retrieval is not None
+
+
+def test_retrieval_is_lazy_loaded() -> None:
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    a = client.retrieval
+    b = client.retrieval
+    assert a is b
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_retrieval_list_hits_get_endpoint(httpx_mock: Any) -> None:
+    """kz.retrieval.list() GETs /api/retrieval/jobs."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/retrieval/jobs?limit=100&offset=0",
+        status_code=200,
+        json=[
+            {
+                "job_id": "00000000-0000-0000-0000-000000000001",
+                "status": "RUNNING",
+                "transport": "sse",
+                "dataset": {
+                    "urn": "urn:li:dataset:test",
+                    "platform": "foo",
+                    "format": "csv",
+                    "estimated_bytes": 1024,
+                },
+            }
+        ],
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    items = client.retrieval.list()
+
+    assert len(items) == 1
+    assert items[0]["job_id"] == "00000000-0000-0000-0000-000000000001"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_retrieval_cancel_posts_to_cancel_endpoint(httpx_mock: Any) -> None:
+    """kz.retrieval.cancel(query_id) POSTs to .../jobs/{id}/cancel."""
+    from kamiwaza.client import Kamiwaza
+
+    job_id = "00000000-0000-0000-0000-000000000002"
+
+    httpx_mock.add_response(
+        method="POST",
+        url=f"https://kamiwaza.test/api/retrieval/jobs/{job_id}/cancel",
+        status_code=200,
+        json={
+            "job_id": job_id,
+            "status": "CANCELED",
+            "transport": "sse",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.retrieval.cancel(job_id)
+
+    assert result["status"] == "CANCELED"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_operations_populates_retrievals_slice(httpx_mock: Any) -> None:
+    """cluster.operations() now surfaces in-flight retrievals (T5.37 thickening)."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/jobs/",
+        status_code=200,
+        json=[],
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/retrieval/jobs",
+        status_code=200,
+        json=[
+            {
+                "job_id": "00000000-0000-0000-0000-000000000003",
+                "status": "RUNNING",
+                "transport": "sse",
+                "dataset": {
+                    "urn": "urn:li:dataset:test",
+                    "platform": "foo",
+                    "format": "csv",
+                    "estimated_bytes": 1024,
+                },
+            }
+        ],
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.operations()
+
+    assert result.jobs == []
+    assert len(result.retrievals) == 1
+    assert result.retrievals[0]["status"] == "RUNNING"


### PR DESCRIPTION
## Summary

SDK companion PR to kamiwaza-internal/kamiwaza#1735 — WS-M2 cycle 2-6 SDK additions. Customer-facing surface for all 8 WS-M2 demo bullets. 57 new SDK tests; full M1+M2 SDK regression sweep green.

**Linear project:** [Federation API and SDK updates](https://linear.app/kamiwaza/project/federation-api-and-sdk-updates-00f00bf54d3a)

## New SDK surface (typed, with `extra=\"allow\"` forward-compat)

### `kamiwaza.cluster`

- `kz.cluster.capabilities()` → `ClusterCapabilities` (T5.21 / ENG-4698)
  - Hits `GET /api/cluster/cluster_capabilities`; surfaces hardware + federation pre-flight fields (federation_count, active_deployments, ray_ready) added by the server PR.
- `kz.cluster.diagnose()` → `ClusterDiagnostics` (T5.7 / ENG-4692)
  - Hits `GET /api/cluster/diagnose`; structured per-issue records.
- `kz.cluster.fix()` → `FixResult` (T5.8 / ENG-4693)
  - Iterates diagnose issues, POSTs `fix_endpoint` for auto-fixable ones. Generic dispatch — works for any future probe that ships a fix endpoint.
- `kz.cluster.operations()` → `ClusterOperations{jobs, retrievals}` (T5.37 / ENG-4714)
  - Hits `GET /api/cluster/jobs/`; retrievals stays empty until T5.30/T5.36 land.

### `kamiwaza.federations`

- `kz.federations[\"ORION\"].probe()` → `ClusterCapabilities` (T5.21 / ENG-4698)
  - Routes via mesh proxy at `/api/mesh/ORION/api/cluster/cluster_capabilities`; selector is the cluster name itself, no federation-id resolution round-trip.

### `kamiwaza.jobs`

- `kz.jobs.run(..., recoverable=True)` (T5.22 / ENG-4699)
  - Async submit + poll under the covers; job_id in customer hands immediately so mid-call SDK process kills are recoverable.
- `kz.jobs.cancel(job_id)` → JobRecord dict (T5.35 / ENG-4712)
  - POSTs to `/api/cluster/jobs/{id}/cancel` (server endpoint pre-existed in M1).

### `kamiwaza.models` (new Pydantic models)

- `ClusterCapabilities`, `ClusterDiagnostics`, `ClusterOperations`
- `DiagnoseIssue`, `FixOutcome`, `FixResult`
- All `extra=\"allow\"` for forward-compat per `.ai/knowledge/failures/common-pitfalls.md`.

## Test plan

- [x] 57 new SDK tests across cycles 2-5 (unit + integration), all green
- [x] M1 SDK regression (27 tests in federations/jobs/client/skeleton) still green
- [x] Demo bullet (8): integration test for connection-drop recovery via fresh SDK instance + saved job_id
- [ ] (reviewer) Verify the recoverable=True README rationale matches the FastAPI buffering observation

## Commits (5)

- `96d2fe9` ENG-4698 SDK probe + cluster.capabilities()
- `bdb4fe6` ENG-4692 SDK cluster.diagnose()
- `a735bd4` ENG-4693 SDK cluster.fix() orchestration
- `228929d` ENG-4699-4702 Recoverable long-jobs
- `54ca9e9` ENG-4712 + ENG-4714 SDK cancel + operations

## Companion server PR

[kamiwaza-internal/kamiwaza#1735](https://github.com/kamiwaza-internal/kamiwaza/pull/1735) — land both together to keep server + SDK contracts in sync.