### PR TITLE
fix(extensions): kz-ext publish preserves compose env placeholders (ENG-4860)

### DIFF
--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -431,9 +431,6 @@ def run_dev_remote(
         revision_tag=rev_tag,
         registry=registry,
     )
-    # The dev path ships compose straight to the K8s API, which reads
-    # env values as literal strings. Collapse ``${VAR}`` placeholders
-    # so pods don't see the raw substitution syntax.
     transformed = transformer.resolve_env_placeholders(transformed)
 
     # 5b. Resolve SDK override for build

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -431,6 +431,10 @@ def run_dev_remote(
         revision_tag=rev_tag,
         registry=registry,
     )
+    # The dev path ships compose straight to the K8s API, which reads
+    # env values as literal strings. Collapse ``${VAR}`` placeholders
+    # so pods don't see the raw substitution syntax.
+    transformed = transformer.resolve_env_placeholders(transformed)
 
     # 5b. Resolve SDK override for build
     build_overrides = None

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -134,17 +134,39 @@ class ComposeTransformer:
         svc.pop("container_name", None)
         svc.pop("networks", None)
 
-        # 7. Resolve compose ``${VAR:-default}`` substitutions:
-        #    - Non-platform vars (e.g. ``BACKEND_URL``) → resolve to
-        #      ``default`` so the value reaches the pod.
-        #    - Platform vars (``KAMIWAZA_*``) → drop, let the operator's
-        #      ConfigMap envFrom injection win (an explicit ``env``
-        #      would shadow the cluster-internal value).
-        #    - Unresolvable ``${VAR}`` (no default) → drop, same as before.
-        if "environment" in svc:
-            svc["environment"] = _resolve_shell_refs(svc["environment"])
-
         return svc
+
+    def resolve_env_placeholders(
+        self,
+        compose_data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Collapse compose ``${VAR}`` env-value placeholders in place.
+
+        Apply when the consumer of the transformed compose will NOT
+        perform its own variable substitution — e.g. shipping the
+        compose straight to a Kubernetes API. K8s reads env values as
+        literal strings, so an unresolved ``${VAR:-default}`` reaches
+        the pod verbatim.
+
+        Rules (per env var):
+        - ``${VAR:-default}`` / ``${VAR-default}`` for non-platform
+          keys → collapsed to the literal ``default``.
+        - ``${KAMIWAZA_*:-default}`` → dropped. The kamiwaza-extension
+          operator injects these via ConfigMap envFrom; an explicit
+          env entry would shadow the cluster-internal value.
+        - ``${VAR}`` (no default) and ``${VAR:?error}`` (required) →
+          dropped. No safe value to ship.
+        - Plain values pass through unchanged.
+
+        Skip this step when the destination DOES perform install-time
+        substitution (e.g. a catalog template consumed by the platform
+        installer that holds user-supplied ``required_env_vars``).
+        """
+        out = copy.deepcopy(compose_data)
+        for svc in (out.get("services") or {}).values():
+            if "environment" in svc:
+                svc["environment"] = _resolve_shell_refs(svc["environment"])
+        return out
 
 
 # ------------------------------------------------------------------

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -69,6 +69,11 @@ class ComposeTransformer:
         4. Add / update ``image`` fields with *registry*/*revision_tag*
         5. Add resource limits if missing
         6. Remove ``extra_hosts``, ``container_name``, ``networks`` keys
+
+        Env-value ``${VAR}`` placeholders pass through unchanged. Callers
+        shipping the result to a destination that does NOT perform its
+        own variable substitution (e.g. a Kubernetes API) must additionally
+        call :meth:`resolve_env_placeholders`.
         """
         out = copy.deepcopy(compose_data)
 
@@ -140,7 +145,8 @@ class ComposeTransformer:
         self,
         compose_data: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Collapse compose ``${VAR}`` env-value placeholders in place.
+        """Return a copy of *compose_data* with ``${VAR}`` env-value
+        placeholders collapsed.
 
         Apply when the consumer of the transformed compose will NOT
         perform its own variable substitution — e.g. shipping the

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -279,23 +279,22 @@ class TestFullTransform:
         assert "build" in compose["services"]["api"]
 
 
-class TestResolveShellRefs:
-    """The compose ``${VAR:-default}`` syntax must round-trip its
-    default value to the K8s pod env (was being dropped wholesale,
-    breaking cross-service URLs like ``BACKEND_URL``)."""
+class TestResolveEnvPlaceholders:
+    """``resolve_env_placeholders`` collapses ``${VAR:-default}`` env
+    placeholders to their default, drops unresolvable forms, and drops
+    ``KAMIWAZA_*`` keys (so the operator's ConfigMap envFrom wins)."""
 
     def test_resolves_default_substitution_dict_form(self, transformer):
         compose = {
             "services": {
                 "frontend": {
-                    "build": ".",
                     "environment": {
                         "BACKEND_URL": "${BACKEND_URL:-http://backend:8000}",
                     },
                 },
             },
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.resolve_env_placeholders(compose)
         assert result["services"]["frontend"]["environment"] == {
             "BACKEND_URL": "http://backend:8000",
         }
@@ -304,7 +303,6 @@ class TestResolveShellRefs:
         compose = {
             "services": {
                 "frontend": {
-                    "build": ".",
                     "environment": [
                         "BACKEND_URL=${BACKEND_URL:-http://backend:8000}",
                         "PLAIN_VAR=plain-value",
@@ -312,7 +310,7 @@ class TestResolveShellRefs:
                 },
             },
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.resolve_env_placeholders(compose)
         assert result["services"]["frontend"]["environment"] == [
             "BACKEND_URL=http://backend:8000",
             "PLAIN_VAR=plain-value",
@@ -325,7 +323,6 @@ class TestResolveShellRefs:
         compose = {
             "services": {
                 "backend": {
-                    "build": ".",
                     "environment": {
                         "KAMIWAZA_API_URL": "${KAMIWAZA_API_URL:-http://host.docker.internal:7777/api}",
                         "BACKEND_URL": "${BACKEND_URL:-http://backend:8000}",
@@ -333,7 +330,7 @@ class TestResolveShellRefs:
                 },
             },
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.resolve_env_placeholders(compose)
         # KAMIWAZA_* dropped; BACKEND_URL resolved to default.
         assert result["services"]["backend"]["environment"] == {
             "BACKEND_URL": "http://backend:8000",
@@ -345,7 +342,6 @@ class TestResolveShellRefs:
         compose = {
             "services": {
                 "backend": {
-                    "build": ".",
                     "environment": {
                         "OPENAI_API_KEY": "${OPENAI_API_KEY}",
                         "REQUIRED_VAR": "${REQUIRED_VAR:?missing}",
@@ -354,7 +350,7 @@ class TestResolveShellRefs:
                 },
             },
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.resolve_env_placeholders(compose)
         assert result["services"]["backend"]["environment"] == {"PLAIN": "kept"}
 
     def test_alternate_default_form_dash_only(self, transformer):
@@ -363,28 +359,133 @@ class TestResolveShellRefs:
         compose = {
             "services": {
                 "backend": {
-                    "build": ".",
                     "environment": {"X": "${UNSET-fallback}"},
                 },
             },
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.resolve_env_placeholders(compose)
         assert result["services"]["backend"]["environment"] == {"X": "fallback"}
 
     def test_plain_values_pass_through(self, transformer):
         compose = {
             "services": {
                 "backend": {
-                    "build": ".",
                     "environment": {"FOO": "bar", "PORT": "8000"},
+                },
+            },
+        }
+        result = transformer.resolve_env_placeholders(compose)
+        assert result["services"]["backend"]["environment"] == {
+            "FOO": "bar",
+            "PORT": "8000",
+        }
+
+    def test_does_not_mutate_input(self, transformer):
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": {
+                        "BACKEND_URL": "${BACKEND_URL:-http://backend:8000}",
+                        "REQUIRED_VAR": "${REQUIRED_VAR:?missing}",
+                    },
+                },
+            },
+        }
+        original = {
+            "BACKEND_URL": "${BACKEND_URL:-http://backend:8000}",
+            "REQUIRED_VAR": "${REQUIRED_VAR:?missing}",
+        }
+        transformer.resolve_env_placeholders(compose)
+        assert compose["services"]["backend"]["environment"] == original
+
+
+class TestTransformPreservesEnvPlaceholders:
+    """``transform()`` leaves env-value ``${...}`` placeholders verbatim
+    so callers whose destination performs its own substitution (e.g. the
+    platform installer reading a catalog template) receive an
+    unresolved compose."""
+
+    def test_required_placeholder_preserved(self, transformer):
+        """``${VAR:?error}`` survives verbatim so a downstream consumer
+        sees the required-var marker."""
+        compose = {
+            "services": {
+                "neo4j": {
+                    "image": "neo4j:5",
+                    "environment": {
+                        "NEO4J_AUTH": "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}",
+                        "KZ_NEO4J_PASSWORD": "${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}",
+                    },
+                },
+            },
+        }
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["neo4j"]["environment"] == {
+            "NEO4J_AUTH": "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}",
+            "KZ_NEO4J_PASSWORD": "${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}",
+        }
+
+    def test_default_placeholder_preserved(self, transformer):
+        """``${VAR:-default}`` survives verbatim so a downstream consumer
+        decides whether to substitute or fall through to the default."""
+        compose = {
+            "services": {
+                "graphiti": {
+                    "image": "graphiti:0.28",
+                    "environment": {
+                        "KAMIWAZA_ENDPOINT": "${KAMIWAZA_ENDPOINT:-http://host.docker.internal:8080}",
+                        "OPENAI_API_KEY": "${OPENAI_API_KEY:-not-needed-kamiwaza}",
+                        "NEO4J_HOST": "${NEO4J_HOST:-neo4j}",
+                    },
+                },
+            },
+        }
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["graphiti"]["environment"] == {
+            "KAMIWAZA_ENDPOINT": "${KAMIWAZA_ENDPOINT:-http://host.docker.internal:8080}",
+            "OPENAI_API_KEY": "${OPENAI_API_KEY:-not-needed-kamiwaza}",
+            "NEO4J_HOST": "${NEO4J_HOST:-neo4j}",
+        }
+
+    def test_bare_placeholder_preserved(self, transformer):
+        """``${VAR}`` with no default survives verbatim — extensions use
+        this when the caller must supply a value with no fallback."""
+        compose = {
+            "services": {
+                "backend": {
+                    "image": "backend:1",
+                    "environment": {"OPENAI_BASE_URL": "${OPENAI_BASE_URL}"},
                 },
             },
         }
         result = transformer.transform(compose, "test", "v1", "reg")
         assert result["services"]["backend"]["environment"] == {
-            "FOO": "bar",
-            "PORT": "8000",
+            "OPENAI_BASE_URL": "${OPENAI_BASE_URL}",
         }
+
+    def test_list_form_placeholders_preserved(self, transformer):
+        """Compose env can be ``KEY=value`` list form too. Placeholders
+        in list-form entries must also survive verbatim."""
+        compose = {
+            "services": {
+                "backend": {
+                    "image": "backend:1",
+                    "environment": [
+                        "NEO4J_PASSWORD=${NEO4J_PASSWORD:?required}",
+                        "BACKEND_URL=${BACKEND_URL:-http://backend:8000}",
+                        "OPENAI_API_KEY=${OPENAI_API_KEY}",
+                        "PLAIN=kept",
+                    ],
+                },
+            },
+        }
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["backend"]["environment"] == [
+            "NEO4J_PASSWORD=${NEO4J_PASSWORD:?required}",
+            "BACKEND_URL=${BACKEND_URL:-http://backend:8000}",
+            "OPENAI_API_KEY=${OPENAI_API_KEY}",
+            "PLAIN=kept",
+        ]
 
 
 class TestDetectServiceUrlRewrites:


### PR DESCRIPTION
## Why

`kz-ext publish` was running compose env values through the same `${VAR}`-resolution pass as `kz-ext dev` — which collapses `${VAR:-default}` to the laptop default and drops `${VAR:?required}`. That's correct for the dev path (K8s reads env values as literal strings) but wrong for catalog publish: placeholders are supposed to survive to R2 so the platform can substitute user-supplied `required_env_vars` at install time.

Live impact: graphiti's neo4j `NEO4J_AUTH` and `KZ_NEO4J_PASSWORD` were dropped from the published compose; resulting CRs had empty env entries, neo4j booted with no admin password set, startup probes failed, pods stuck.

## Contract

`ComposeTransformer.transform()` no longer touches env values — `${VAR}` placeholders pass through verbatim. A new `ComposeTransformer.resolve_env_placeholders()` method performs the existing resolve-and-drop pass; `kz-ext dev` calls it after `transform()`, `kz-ext publish` doesn't. The dev path behavior is unchanged.

## Verification

- `tests/unit/extensions/test_compose_transformer.py`: 41 pass. Existing 6 placeholder-resolution tests rewired against the new method; 5 new tests pin the contract (`test_does_not_mutate_input` for the new method; 4 in `TestTransformPreservesEnvPlaceholders` covering required, default, bare, and list-form survival through `transform()`).
- Full extension unit suite: 1105 pass.

## Notes

ENG-4856 (digest-aware app_templates sync) should land after this. Once 4856 ships, every cluster's stored `compose_yml` gets overwritten from R2 on the next refresh — that's only safe when R2 holds preserved placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)