### PR TITLE
fix(extensions): kz-ext publish reads docker-compose.appgarden.yml when present (ENG-4907)

### DIFF
--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -2,16 +2,98 @@
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import typer
+import yaml
 from rich.console import Console
 
 from kamiwaza_extensions.catalog_publisher import DEFAULT_CATALOG_SCHEMA
 from kamiwaza_extensions.extension_detector import infer_extension_type
 
 console = Console(stderr=True)
+
+
+APPGARDEN_COMPOSE_FILENAME = "docker-compose.appgarden.yml"
+
+
+def _load_appgarden_compose(
+    ext_dir: Path,
+) -> Optional[Tuple[Path, Dict[str, Any]]]:
+    """Return ``(path, data)`` for the extension's authored appgarden compose, or None.
+
+    ``docker-compose.appgarden.yml`` is the deployment-ready compose
+    produced by an extension's ``sync-compose.py`` (or equivalent). When
+    present it is the source of truth for catalog publishing — it
+    carries extension-specific transformations (env-shape tweaks,
+    hostname rewrites, etc.) that kz-ext's generic ``ComposeTransformer``
+    doesn't replicate.
+
+    Falls back to None (caller continues with the generic transform
+    against ``docker-compose.yml``) when the file is missing, unparseable,
+    or doesn't decode to a mapping.
+    """
+    candidate = ext_dir / APPGARDEN_COMPOSE_FILENAME
+    if not candidate.exists():
+        return None
+    try:
+        data = yaml.safe_load(candidate.read_text())
+    except yaml.YAMLError as exc:
+        console.print(
+            f"[yellow]Warning:[/yellow] failed to parse "
+            f"{APPGARDEN_COMPOSE_FILENAME}: {exc} — falling back to "
+            "docker-compose.yml + generic transform"
+        )
+        return None
+    if not isinstance(data, dict):
+        console.print(
+            f"[yellow]Warning:[/yellow] {APPGARDEN_COMPOSE_FILENAME} did not "
+            "decode to a mapping — falling back to docker-compose.yml"
+        )
+        return None
+    return candidate, data
+
+
+def _retag_appgarden_compose(
+    appgarden_data: Dict[str, Any],
+    source_compose_data: Optional[Dict[str, Any]],
+    *,
+    extension_name: str,
+    image_tag: str,
+    registry: str,
+) -> Dict[str, Any]:
+    """Rewrite image tags on services that this publish actually owns.
+
+    A service is "owned" by this publish if it has a ``build:`` block in
+    the source ``docker-compose.yml`` (i.e. ``ImageBuilder`` will build
+    and push an image for it). For those services we set
+    ``image: {registry}/{ext}-{svc}:{image_tag}`` so the catalog points
+    at the image we just built with the resolved ``--stage`` / ``--revision``
+    tag. External refs (``ghcr.io/.../neo4j``) and any service the
+    extension's ``sync-compose.py`` invented are passed through verbatim.
+
+    The appgarden file is otherwise considered deployment-ready by the
+    extension's authoring intent; no other transformations are applied.
+    """
+    out = copy.deepcopy(appgarden_data)
+    source_services = (
+        source_compose_data.get("services") or {}
+        if isinstance(source_compose_data, dict)
+        else {}
+    )
+    build_services = {
+        name
+        for name, svc in source_services.items()
+        if isinstance(svc, dict) and "build" in svc
+    }
+    for svc_name, svc in (out.get("services") or {}).items():
+        if not isinstance(svc, dict):
+            continue
+        if svc_name in build_services:
+            svc["image"] = f"{registry}/{extension_name}-{svc_name}:{image_tag}"
+    return out
 
 
 def _infer_extension_type(metadata: Dict[str, Any]) -> str:
@@ -198,6 +280,19 @@ def run_publish(
         console.print("[red]Error:[/red] No docker-compose.yml found.")
         raise typer.Exit(code=1)
 
+    # Prefer the extension's authored appgarden compose when present. It
+    # is the deployment-ready output of the extension's `sync-compose.py`
+    # and carries extension-specific transformations kz-ext's generic
+    # ComposeTransformer doesn't replicate (ENG-4907). Source compose
+    # is still used below for ImageBuilder and the buildable-services
+    # derivation — those care about `build:` contexts and host shape.
+    appgarden_pair = _load_appgarden_compose(info.path)
+    if appgarden_pair is not None:
+        publish_compose_path, appgarden_data = appgarden_pair
+    else:
+        publish_compose_path = info.compose_path
+        appgarden_data = None
+
     # Buildable services that will actually be published. Mirrors
     # ComposeTransformer's `profiles:` filter — services with a profiles
     # key are local-only and stripped before catalog construction, so
@@ -259,7 +354,7 @@ def run_publish(
     meta_result = meta_validator.validate(info.path / "kamiwaza.json")
 
     compose_validator = ComposeValidator()
-    compose_result = compose_validator.validate(info.compose_path, info.path)
+    compose_result = compose_validator.validate(publish_compose_path, info.path)
 
     all_errors = meta_result.errors[:]
     all_warnings = meta_result.warnings[:]
@@ -314,14 +409,27 @@ def run_publish(
     else:
         image_tag = f"{version}-{stage}"
 
-    # 4. Transform compose (uses the stage-aware image tag)
-    transformer = ComposeTransformer()
-    transformed = transformer.transform(
-        info.compose_data,
-        extension_name=info.name,
-        revision_tag=image_tag,
-        registry=registry,
-    )
+    # 4. Build the catalog-ready compose (uses the stage-aware image tag).
+    # When the extension supplied an authored appgarden compose, that file
+    # is the source of truth — we only retag the services we actually
+    # built. Otherwise run the generic ComposeTransformer against the
+    # source docker-compose.yml.
+    if appgarden_data is not None:
+        transformed = _retag_appgarden_compose(
+            appgarden_data,
+            info.compose_data,
+            extension_name=info.name,
+            image_tag=image_tag,
+            registry=registry,
+        )
+    else:
+        transformer = ComposeTransformer()
+        transformed = transformer.transform(
+            info.compose_data,
+            extension_name=info.name,
+            revision_tag=image_tag,
+            registry=registry,
+        )
 
     # -- Dry-run path (still runs merge check to detect conflicts) --
     if dry_run:

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -67,15 +67,24 @@ def _retag_appgarden_compose(
     """Rewrite image tags on services that this publish actually owns.
 
     A service is "owned" by this publish if it has a ``build:`` block in
-    the source ``docker-compose.yml`` (i.e. ``ImageBuilder`` will build
-    and push an image for it). For those services we set
+    the source ``docker-compose.yml`` and is *not* gated by ``profiles:``
+    (i.e. ``ImageBuilder`` will build and push an image for it; this
+    mirrors the ``buildable_services`` filter ``run_publish`` uses to
+    derive ``published_refs``/``digest_map``). For those services we set
     ``image: {registry}/{ext}-{svc}:{image_tag}`` so the catalog points
     at the image we just built with the resolved ``--stage`` / ``--revision``
     tag. External refs (``ghcr.io/.../neo4j``) and any service the
     extension's ``sync-compose.py`` invented are passed through verbatim.
 
     The appgarden file is otherwise considered deployment-ready by the
-    extension's authoring intent; no other transformations are applied.
+    extension's authoring intent and passed through unchanged: host port
+    bindings, bind mounts, ``extra_hosts``, ``container_name``,
+    top-level ``networks``, env-value placeholders, and the
+    ``_ensure_resource_limits`` defaults that ``ComposeTransformer``
+    used to backfill are NOT applied here. ``sync-compose.py`` owns that
+    shape; if a service is missing ``deploy.resources.limits``,
+    ``ComposeValidator`` will surface the warning and the catalog ships
+    without the auto-fill.
     """
     out = copy.deepcopy(appgarden_data)
     source_services = (
@@ -83,10 +92,15 @@ def _retag_appgarden_compose(
         if isinstance(source_compose_data, dict)
         else {}
     )
+    # Mirror `buildable_services` (publish.py): exclude `profiles:`-gated
+    # services. Without this filter, a `build: + profiles:` service that
+    # leaks into the authored appgarden file would be retagged into the
+    # catalog while being absent from `published_refs`/`digest_map` — a
+    # local-only ref shipping with no corresponding push.
     build_services = {
         name
         for name, svc in source_services.items()
-        if isinstance(svc, dict) and "build" in svc
+        if isinstance(svc, dict) and "build" in svc and not svc.get("profiles")
     }
     for svc_name, svc in (out.get("services") or {}).items():
         if not isinstance(svc, dict):

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -2008,6 +2008,47 @@ class TestRetagAppgardenCompose:
             "ghcr.io/my-org/my-app-backend:2.0.0-abc123"
         )
 
+    def test_profiled_build_service_not_retagged(self):
+        """Service with `build:` + `profiles:` in source must not be retagged.
+
+        Mirrors `buildable_services` filter in `run_publish`: profiled
+        services are local-only and excluded from `published_refs`/digest
+        pinning. Retagging them anyway would ship a catalog ref pointing
+        at an image that was never built/pushed.
+        """
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        appgarden = {
+            "services": {
+                "backend": {"image": "ghcr.io/my-org/my-app-backend:2.0.0"},
+                "dev-helper": {
+                    "image": "ghcr.io/my-org/my-app-dev-helper:local-only"
+                },
+            },
+        }
+        source = {
+            "services": {
+                "backend": {"build": {"context": "."}},
+                "dev-helper": {
+                    "build": {"context": "."},
+                    "profiles": ["dev-only"],
+                },
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="2.0.0-dev",
+            registry="ghcr.io/my-org",
+        )
+        # Non-profiled build service: retagged.
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:2.0.0-dev"
+        )
+        # Profiled build service: pass through, NOT retagged.
+        assert out["services"]["dev-helper"]["image"] == (
+            "ghcr.io/my-org/my-app-dev-helper:local-only"
+        )
+
 
 class TestPublishWithAppgarden:
     """End-to-end: appgarden.yml on disk skips ComposeTransformer.transform."""

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -1833,3 +1833,311 @@ class TestPublishDigest:
                 "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
             }
             assert "dev-helper" not in str(kwargs["digest_map"])
+
+
+# ------------------------------------------------------------------
+# Appgarden compose preference (ENG-4907)
+# ------------------------------------------------------------------
+
+
+class TestLoadAppgardenCompose:
+    """`_load_appgarden_compose` reads `docker-compose.appgarden.yml`."""
+
+    def test_returns_none_when_file_missing(self, tmp_path):
+        from kamiwaza_extensions.commands.publish import _load_appgarden_compose
+
+        assert _load_appgarden_compose(tmp_path) is None
+
+    def test_returns_path_and_data_when_present(self, tmp_path):
+        from kamiwaza_extensions.commands.publish import _load_appgarden_compose
+
+        appgarden = tmp_path / "docker-compose.appgarden.yml"
+        appgarden.write_text(
+            "services:\n"
+            "  backend:\n"
+            "    image: ghcr.io/my-org/my-app-backend:1.0.0\n"
+        )
+        result = _load_appgarden_compose(tmp_path)
+        assert result is not None
+        path, data = result
+        assert path == appgarden
+        assert data["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:1.0.0"
+        )
+
+    def test_returns_none_on_malformed_yaml(self, tmp_path):
+        from kamiwaza_extensions.commands.publish import _load_appgarden_compose
+
+        (tmp_path / "docker-compose.appgarden.yml").write_text(
+            "services:\n  backend: {unclosed\n"
+        )
+        assert _load_appgarden_compose(tmp_path) is None
+
+    def test_returns_none_when_top_level_not_mapping(self, tmp_path):
+        from kamiwaza_extensions.commands.publish import _load_appgarden_compose
+
+        (tmp_path / "docker-compose.appgarden.yml").write_text("- not\n- a mapping\n")
+        assert _load_appgarden_compose(tmp_path) is None
+
+
+class TestRetagAppgardenCompose:
+    """`_retag_appgarden_compose` retags only build-context services."""
+
+    def test_retags_build_context_service(self):
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        appgarden = {
+            "services": {
+                "backend": {"image": "ghcr.io/my-org/my-app-backend:2.0.0"},
+            },
+        }
+        source = {
+            "services": {
+                "backend": {"build": {"context": "."}},
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="2.0.0-dev",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:2.0.0-dev"
+        )
+
+    def test_passes_external_image_through_unchanged(self):
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        appgarden = {
+            "services": {
+                "neo4j": {"image": "ghcr.io/upstream/neo4j:v5.26.21"},
+            },
+        }
+        source = {
+            "services": {
+                "neo4j": {"image": "ghcr.io/upstream/neo4j:v5.26.21"},
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="2.0.0-dev",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["neo4j"]["image"] == (
+            "ghcr.io/upstream/neo4j:v5.26.21"
+        )
+
+    def test_mixed_services_only_build_owned_retagged(self):
+        """Graphiti-shaped: external neo4j + built graphiti."""
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        appgarden = {
+            "services": {
+                "neo4j": {
+                    "image": "ghcr.io/upstream/neo4j:v5.26.21",
+                    "environment": ["NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:?must be set}"],
+                },
+                "graphiti": {
+                    "image": (
+                        "ghcr.io/my-org/service-graphiti-graphiti:2.3.1"
+                    ),
+                    "environment": ["NEO4J_HOST=${NEO4J_HOST:-neo4j}"],
+                },
+            },
+        }
+        source = {
+            "services": {
+                "neo4j": {"image": "ghcr.io/upstream/neo4j:v5.26.21"},
+                "graphiti": {
+                    "build": {"context": "."},
+                    "image": "ghcr.io/my-org/service-graphiti-graphiti:2.3.1",
+                },
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="service-graphiti", image_tag="2.3.1-dev",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["neo4j"]["image"] == (
+            "ghcr.io/upstream/neo4j:v5.26.21"
+        )
+        assert out["services"]["graphiti"]["image"] == (
+            "ghcr.io/my-org/service-graphiti-graphiti:2.3.1-dev"
+        )
+        # Env placeholders preserved verbatim (ENG-4860 acceptance).
+        assert out["services"]["graphiti"]["environment"] == [
+            "NEO4J_HOST=${NEO4J_HOST:-neo4j}"
+        ]
+        # Original appgarden dict is not mutated (deep copy).
+        assert appgarden["services"]["graphiti"]["image"] == (
+            "ghcr.io/my-org/service-graphiti-graphiti:2.3.1"
+        )
+
+    def test_service_only_in_appgarden_passes_through(self):
+        """Service the extension's sync-compose invented (not in source) → external."""
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        appgarden = {
+            "services": {
+                "sidecar": {"image": "ghcr.io/third-party/sidecar:1.0"},
+            },
+        }
+        source = {"services": {}}
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="2.0.0-dev",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["sidecar"]["image"] == (
+            "ghcr.io/third-party/sidecar:1.0"
+        )
+
+    def test_revision_tag_overrides_stage_tag(self):
+        """`--revision` passes through `image_tag` verbatim (CI SHA-pinning)."""
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        appgarden = {"services": {"backend": {"image": "ghcr.io/my-org/my-app-backend:2.0.0"}}}
+        source = {"services": {"backend": {"build": {"context": "."}}}}
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="2.0.0-abc123",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:2.0.0-abc123"
+        )
+
+
+class TestPublishWithAppgarden:
+    """End-to-end: appgarden.yml on disk skips ComposeTransformer.transform."""
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_appgarden_file_bypasses_generic_transform(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # Authored appgarden compose carries the extension's intended shape.
+        (tmp_path / "docker-compose.appgarden.yml").write_text(
+            "services:\n"
+            "  neo4j:\n"
+            "    image: ghcr.io/upstream/neo4j:v5.26.21\n"
+            "  backend:\n"
+            "    image: ghcr.io/my-org/my-app-backend:1.0.0\n"
+            "    environment:\n"
+            "      - HOSTNAME_FROM_APPGARDEN=set-by-sync-compose\n"
+        )
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data={
+                "services": {
+                    "neo4j": {"image": "ghcr.io/upstream/neo4j:v5.26.21"},
+                    "backend": {
+                        "build": {"context": "."},
+                        "image": "ghcr.io/my-org/my-app-backend:1.0.0",
+                    },
+                },
+            },
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # ComposeTransformer.transform must NOT be invoked when appgarden present.
+        mock_transformer_cls.return_value.transform.assert_not_called()
+
+        # The compose validator was called against the appgarden file path.
+        validator_args, _ = (
+            mock_compose_validator_cls.return_value.validate.call_args
+        )
+        assert validator_args[0].name == "docker-compose.appgarden.yml"
+
+        # Catalog entry's `transformed_compose` is the retagged appgarden:
+        # - backend (had build:) → retagged with stage suffix
+        # - neo4j (external) → unchanged
+        # - environment values preserved verbatim from appgarden.yml
+        entry_kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        transformed = entry_kwargs["transformed_compose"]
+        assert transformed["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev"
+        )
+        assert transformed["services"]["neo4j"]["image"] == (
+            "ghcr.io/upstream/neo4j:v5.26.21"
+        )
+        assert transformed["services"]["backend"]["environment"] == [
+            "HOSTNAME_FROM_APPGARDEN=set-by-sync-compose"
+        ]
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_no_appgarden_falls_back_to_generic_transform(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # No docker-compose.appgarden.yml on disk → legacy behavior.
+        _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        mock_transformer_cls.return_value.transform.assert_called_once()
+        # Validator called against the source docker-compose.yml path.
+        validator_args, _ = (
+            mock_compose_validator_cls.return_value.validate.call_args
+        )
+        assert validator_args[0].name == "docker-compose.yml"


### PR DESCRIPTION
## Summary

- `kz-ext publish` now treats `docker-compose.appgarden.yml` as the source of truth for catalog publishing when present, replacing today's behavior of reading `docker-compose.yml` and applying its own `ComposeTransformer` (which bypasses each extension's `sync-compose.py` transformations).
- Only image tags for services with a `build:` block in source `docker-compose.yml` are rewritten, so `--stage`/`--revision` still pin the CI-built image. External refs (e.g. `ghcr.io/.../neo4j`) and any service the extension's `sync-compose.py` invented pass through verbatim.
- Falls back to today's `ComposeTransformer` behavior against `docker-compose.yml` when no appgarden file is present (or when it's malformed); a warning is surfaced in the malformed case.

## Why

Per [ENG-4907](https://linear.app/kamiwaza/issue/ENG-4907): each extension's `sync-compose.py` carries extension-specific transformations (env-shape tweaks, hostname rewrites, network policy hints, etc.) that kz-ext doesn't and can't replicate. For graphiti, three transformations were silently being dropped by kz-ext's generic transform; defensive shims in graphiti's runtime saved it, but other extensions in the auto-publish rollout queue (ENG-4612/4613/4615/4616/4638) wouldn't be so lucky. This unblocks fleet adoption of `extension-build.yml@main`.

## Design choice

`kz-ext publish` is a thin layer over the extension's authored deployment compose; the `build:`-context lookup against source compose is the line between "extension's domain (any shape in appgarden.yml)" and "publish's domain (tag for what we just built)." Sibling commands (`kz-ext dev`, `validate`, `dev_local`, `port_forward`, `shell`, `logs`, `bump`, `status`, `config`) keep reading `docker-compose.yml` — they need build contexts and host port mappings that only live there.

## Test plan

- [x] `tests/unit/extensions/test_publish_cmd.py` — 11 new tests across 3 classes:
  - `TestLoadAppgardenCompose`: file present / missing / malformed YAML / non-mapping top-level
  - `TestRetagAppgardenCompose`: retag build-context service / passthrough external image / graphiti-shaped mixed services with env-placeholder preservation / sync-compose-only services / `--revision`-shaped tag / no source mutation
  - `TestPublishWithAppgarden`: end-to-end — appgarden bypasses `ComposeTransformer`, validator called against appgarden path; fallback path unchanged when no appgarden file
- [x] All 1116 existing extension tests still pass (`uv run pytest tests/unit/extensions/`)
- [x] ruff clean on changed files

## Out of scope (per ticket)

- Compose-overlay model (`docker compose -f base -f overlay config`)
- `sync-compose.py` retirement across extension repos
- `ComposeTransformer` retirement inside kz-ext
- `x-kamiwaza:` extension annotations as a single-file alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)