### PR TITLE
fix(extensions): kz-ext publish honors compose image namespace + fails loudly on digest miss (ENG-4909)

### DIFF
--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -314,7 +314,6 @@ def run_dev_remote(
         DeploymentTimeoutError,
     )
     from kamiwaza_extensions.dev_state import (
-        DevState,
         mark_step,
         read_state,
         resume_message,

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -305,7 +305,7 @@ def run_dev_remote(
 
     from kamiwaza_extensions.compose_transformer import (
         ComposeTransformer,
-        _canonical_build_ref,
+        compute_canonical_refs,
     )
     from kamiwaza_extensions.connections import ConnectionManager
     from kamiwaza_extensions.deployment_poller import (
@@ -435,22 +435,18 @@ def run_dev_remote(
     )
     transformed = transformer.resolve_env_placeholders(transformed)
 
-    # Canonical image refs for every build-context service. Single source
-    # of truth shared with the transformed compose so the image we build
-    # and push matches the ref the K8s payload will pull (ENG-4909). The
+    # Canonical image refs for every build-context service. Single
+    # source of truth shared with the transformed compose so the image
+    # we build and push matches the ref the K8s payload will pull. The
     # transformer honors a service's declared image namespace; without
-    # this map ImageBuilder would synthesize the legacy {ext}-{svc} form
-    # and ship a pod referencing an image that was never pushed.
-    canonical_refs: Dict[str, str] = {
-        name: _canonical_build_ref(
-            svc, name,
-            fallback_registry=registry,
-            fallback_extension_name=info.name,
-            revision_tag=rev_tag,
-        )
-        for name, svc in (info.compose_data.get("services") or {}).items()
-        if "build" in svc
-    }
+    # this map ImageBuilder would synthesize the legacy {ext}-{svc}
+    # form and ship a pod referencing an image that was never pushed.
+    canonical_refs: Dict[str, str] = compute_canonical_refs(
+        info.compose_data.get("services") or {},
+        registry=registry,
+        extension_name=info.name,
+        revision_tag=rev_tag,
+    )
 
     # 5b. Resolve SDK override for build
     build_overrides = None

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -69,26 +69,29 @@ def _build_patch_service_specs(payload: Any) -> List[Any]:
     ``CreateExtension`` payload, forwarding the new ``x-kamiwaza``
     per-service overrides via ``extra="allow"``.
 
-    jxstanford PR #97 review H2: without forwarding ``healthCheck`` /
-    ``automountServiceAccountToken`` / ``containerSecurityContext`` on
-    PATCH, iterative ``kz-ext dev`` redeploys silently drop the very
-    overrides this PR added.
+    The PATCH carries the full ``(registry, repository, tag)`` triple
+    from the canonical image ref. The operator reconstructs the CR's
+    image field from those three, so a repository change between
+    deploys — common when an extension's declared image namespace
+    differs from the legacy ``{ext}-{svc}`` form that pre-fix kz-ext
+    would have written — flows through. Sending only ``tag`` would
+    leave the CR's image field at the original repository and produce
+    ``ImagePullBackOff`` on the next pull.
     """
+    from kamiwaza_extensions.compose_transformer import _split_image_ref
     from kamiwaza_sdk.schemas.extensions import ImagePatch, PatchServiceSpec
 
     patch_services: List[Any] = []
     for svc in payload.services:
-        # Split tag after last '/' to avoid confusing registry port with tag
-        image = svc.image
-        slash_pos = image.rfind("/")
-        after_slash = image[slash_pos + 1:] if slash_pos >= 0 else image
-        if ":" in after_slash:
-            tag = after_slash.rsplit(":", 1)[1]
-        else:
-            tag = "latest"
+        registry, repository, tag = _split_image_ref(svc.image)
+        image_patch = ImagePatch(
+            tag=tag,
+            registry=registry,
+            repository=repository,
+        )
         spec = PatchServiceSpec(
             name=svc.name,
-            image=ImagePatch(tag=tag),
+            image=image_patch,
         )
         if svc.env:
             spec.env = svc.env

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -303,7 +303,10 @@ def run_dev_remote(
     from kamiwaza_sdk import KamiwazaClient
     from kamiwaza_sdk.exceptions import APIError
 
-    from kamiwaza_extensions.compose_transformer import ComposeTransformer
+    from kamiwaza_extensions.compose_transformer import (
+        ComposeTransformer,
+        _canonical_build_ref,
+    )
     from kamiwaza_extensions.connections import ConnectionManager
     from kamiwaza_extensions.deployment_poller import (
         DeploymentFailedError,
@@ -433,6 +436,23 @@ def run_dev_remote(
     )
     transformed = transformer.resolve_env_placeholders(transformed)
 
+    # Canonical image refs for every build-context service. Single source
+    # of truth shared with the transformed compose so the image we build
+    # and push matches the ref the K8s payload will pull (ENG-4909). The
+    # transformer honors a service's declared image namespace; without
+    # this map ImageBuilder would synthesize the legacy {ext}-{svc} form
+    # and ship a pod referencing an image that was never pushed.
+    canonical_refs: Dict[str, str] = {
+        name: _canonical_build_ref(
+            svc, name,
+            fallback_registry=registry,
+            fallback_extension_name=info.name,
+            revision_tag=rev_tag,
+        )
+        for name, svc in (info.compose_data.get("services") or {}).items()
+        if "build" in svc
+    }
+
     # 5b. Resolve SDK override for build
     build_overrides = None
     if sdk_repo and not no_build:
@@ -498,6 +518,7 @@ def run_dev_remote(
                 service_filter=service,
                 verbose=verbose,
                 build_overrides=build_overrides,
+                image_refs=canonical_refs,
             )
         except ImageBuildError as exc:
             console.print(f"\n[red]Error:[/red] {exc}")
@@ -508,13 +529,15 @@ def run_dev_remote(
         console.print()
     else:
         console.print("[dim]Skipping build (--no-build)[/dim]")
-        # Collect expected image refs for push
-        image_refs = []
-        for svc_name, svc in (info.compose_data.get("services") or {}).items():
-            if service and svc_name != service:
-                continue
-            if "build" in svc:
-                image_refs.append(f"{registry}/{info.name}-{svc_name}:{rev_tag}")
+        # Collect expected image refs for push from the canonical map so
+        # --no-build pushes hit the same registry path the deployment
+        # payload will reference.
+        if service:
+            image_refs = (
+                [canonical_refs[service]] if service in canonical_refs else []
+            )
+        else:
+            image_refs = list(canonical_refs.values())
         console.print()
 
     # 7. Push images

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -167,32 +167,6 @@ def _collect_buildable_image_names(
     return names
 
 
-def _collect_image_refs(
-    compose_data: Dict[str, Any],
-    extension_name: str,
-    version: str,
-    registry: str,
-) -> List[str]:
-    """Return canonical image refs for services with build contexts.
-
-    Honors each service's declared ``image:`` field (namespace preserved,
-    tag rewritten to *version*) so the refs returned here match what
-    ``_retag_appgarden_compose`` writes to the catalog. Falls back to
-    the legacy ``{registry}/{extension_name}-{svc_name}:{version}`` form
-    only when no image is declared.
-    """
-    refs: List[str] = []
-    for svc_name, svc in (compose_data.get("services") or {}).items():
-        if "build" in svc:
-            refs.append(_canonical_build_ref(
-                svc, svc_name,
-                fallback_registry=registry,
-                fallback_extension_name=extension_name,
-                revision_tag=version,
-            ))
-    return refs
-
-
 def _verify_supplied_digest(ref: str, supplied: str) -> None:
     """Resolve *ref* in the registry and abort if it disagrees with *supplied*.
 
@@ -553,9 +527,24 @@ def run_publish(
     # (legacy {ext}-{svc} vs the namespace declared in compose), and
     # the catalog ships referencing an image that may not exist at the
     # synthesized path. (ENG-4909.)
+    #
+    # Per service, prefer the appgarden compose's declaration when
+    # present — that's what ``_retag_appgarden_compose`` writes into the
+    # catalog. The source ``docker-compose.yml`` declaration is the
+    # fallback for services the appgarden file omits, and the legacy
+    # ``{ext}-{svc}`` form remains the final fallback (handled by
+    # ``_canonical_build_ref``). Reading from source when an appgarden
+    # entry overrides the namespace would build/push/digest at a
+    # different path than the catalog references.
+    appgarden_services = (
+        (appgarden_data or {}).get("services") or {}
+        if isinstance(appgarden_data, dict)
+        else {}
+    )
     canonical_refs: Dict[str, str] = {
         name: _canonical_build_ref(
-            svc, name,
+            appgarden_services.get(name) or svc,
+            name,
             fallback_registry=registry,
             fallback_extension_name=info.name,
             revision_tag=image_tag,
@@ -592,9 +581,7 @@ def run_publish(
             console.print("    [yellow]![/yellow] No images to build")
     else:
         console.print("  [dim]Skipping build (--no-build)[/dim]")
-        image_refs = _collect_image_refs(
-            info.compose_data, info.name, image_tag, registry
-        )
+        image_refs = list(canonical_refs.values())
 
     # 5.5 Preflight: digest resolution post-push needs `docker buildx
     # imagetools`. If buildx is missing on this host, fail before mutating

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -231,15 +231,18 @@ def _verify_supplied_digest(ref: str, supplied: str) -> None:
 
 
 def _auto_resolve_digests(
-    refs: List[str], *, no_build: bool, no_push: bool,
+    refs: List[str],
 ) -> Dict[str, str]:
     """Resolve registry digests for each *ref* and return ``{ref: digest}``.
 
-    Soft-fails for the catalog-only-republish shape (``--no-build
-    --no-push``): pre-PR behavior was tag-only with no docker dependency,
-    so a resolve failure becomes a warning and the ref is omitted from
-    the result rather than aborting the publish.
+    Aborts the publish on any resolution failure. Silent degradation to
+    tag-only entries (the previous behavior in ``--no-build --no-push``
+    mode) hid upstream image-name mismatches that produced unpullable
+    catalog refs (ENG-4909), and a transient registry hiccup was
+    indistinguishable from a legitimate "docker not on host" fall-through.
     """
+    from rich.markup import escape as escape_markup
+
     from kamiwaza_extensions.image_pusher import ImagePushError, ImagePusher
 
     digest_map: Dict[str, str] = {}
@@ -247,14 +250,24 @@ def _auto_resolve_digests(
         try:
             digest_map[ref] = ImagePusher.resolve_digest(ref)
         except ImagePushError as exc:
-            if no_build and no_push:
-                console.print(
-                    f"  [yellow]warn[/yellow] could not resolve digest "
-                    f"for {ref}: {exc} — catalog will use tag-only for "
-                    "this ref"
-                )
-                continue
-            console.print(f"\n[red]Error:[/red] {exc}")
+            # Markup-escape the dynamic parts so a registry error message
+            # containing literal ``[`` (rare but possible) can't garble the
+            # error output via rich's tag parser.
+            safe_ref = escape_markup(ref)
+            safe_exc = escape_markup(str(exc))
+            console.print(
+                f"\n[red]Error:[/red] could not resolve digest for "
+                f"[bold]{safe_ref}[/bold]: {safe_exc}\n\n"
+                "The image must exist in the registry before catalog publish.\n"
+                "Common causes:\n"
+                "  • Image name in docker-compose.appgarden.yml doesn't "
+                "match the actual GHCR path\n"
+                "  • Image hasn't been pushed yet (run with build+push, "
+                "or push manually first)\n"
+                "  • Transient registry outage (retry the publish)\n"
+                "  • To pin a known digest without registry lookup, pass "
+                "--digest sha256:..."
+            )
             raise typer.Exit(code=1) from exc
     return digest_map
 
@@ -625,9 +638,7 @@ def run_publish(
             if not no_push:
                 _verify_supplied_digest(ref, digest)
         else:
-            digest_map = _auto_resolve_digests(
-                published_refs, no_build=no_build, no_push=no_push,
-            )
+            digest_map = _auto_resolve_digests(published_refs)
 
     # 7. Build catalog entry
     reg_builder = RegistryBuilder()

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -11,7 +11,10 @@ import yaml
 from rich.console import Console
 
 from kamiwaza_extensions.catalog_publisher import DEFAULT_CATALOG_SCHEMA
-from kamiwaza_extensions.compose_transformer import _canonical_build_ref
+from kamiwaza_extensions.compose_transformer import (
+    _canonical_build_ref,
+    compute_canonical_refs,
+)
 from kamiwaza_extensions.extension_detector import infer_extension_type
 
 console = Console(stderr=True)
@@ -456,6 +459,25 @@ def run_publish(
             registry=registry,
         )
 
+    # Canonical image refs for every build-context service. Single
+    # source of truth shared with the build, push, digest resolution,
+    # and catalog-write paths so they can't drift. Derived once here
+    # before the dry-run branch so the preview reflects exactly what
+    # the live path would produce — appgarden namespace precedence and
+    # profile-gating included.
+    appgarden_services = (
+        (appgarden_data or {}).get("services") or {}
+        if isinstance(appgarden_data, dict)
+        else {}
+    )
+    canonical_refs: Dict[str, str] = compute_canonical_refs(
+        info.compose_data.get("services") or {},
+        registry=registry,
+        extension_name=info.name,
+        revision_tag=image_tag,
+        appgarden_services=appgarden_services,
+    )
+
     # -- Dry-run path (still runs merge check to detect conflicts) --
     if dry_run:
         short_names = _collect_buildable_image_names(
@@ -473,14 +495,7 @@ def run_publish(
         # appears first in dict order can't redirect the user's digest.
         dry_digest_map: Dict[str, str] = {}
         if digest is not None and buildable_services:
-            dry_canonical_ref = _canonical_build_ref(
-                (info.compose_data.get("services") or {}).get(buildable_services[0]),
-                buildable_services[0],
-                fallback_registry=registry,
-                fallback_extension_name=info.name,
-                revision_tag=image_tag,
-            )
-            dry_digest_map[dry_canonical_ref] = digest
+            dry_digest_map[canonical_refs[buildable_services[0]]] = digest
 
         # Run merge check so dry-run detects version conflicts
         reg_builder = RegistryBuilder()
@@ -519,39 +534,6 @@ def run_publish(
         console.print()
         console.print("[dim]No changes made (dry-run mode).[/dim]")
         return
-
-    # Canonical image refs for every build-context service. Single
-    # source of truth — seeds the build, the push, digest resolution,
-    # and the catalog entry's image refs. Without sharing this map
-    # across all four sites they can each synthesize divergent forms
-    # (legacy {ext}-{svc} vs the namespace declared in compose), and
-    # the catalog ships referencing an image that may not exist at the
-    # synthesized path. (ENG-4909.)
-    #
-    # Per service, prefer the appgarden compose's declaration when
-    # present — that's what ``_retag_appgarden_compose`` writes into the
-    # catalog. The source ``docker-compose.yml`` declaration is the
-    # fallback for services the appgarden file omits, and the legacy
-    # ``{ext}-{svc}`` form remains the final fallback (handled by
-    # ``_canonical_build_ref``). Reading from source when an appgarden
-    # entry overrides the namespace would build/push/digest at a
-    # different path than the catalog references.
-    appgarden_services = (
-        (appgarden_data or {}).get("services") or {}
-        if isinstance(appgarden_data, dict)
-        else {}
-    )
-    canonical_refs: Dict[str, str] = {
-        name: _canonical_build_ref(
-            appgarden_services.get(name) or svc,
-            name,
-            fallback_registry=registry,
-            fallback_extension_name=info.name,
-            revision_tag=image_tag,
-        )
-        for name, svc in (info.compose_data.get("services") or {}).items()
-        if "build" in svc
-    }
 
     # 5. Build images (using stage-aware tag)
     image_refs: List[str] = []

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -56,6 +56,23 @@ def _load_appgarden_compose(
     return candidate, data
 
 
+def _replace_image_tag(image_ref: str, new_tag: str) -> str:
+    """Return *image_ref* with its tag (and any digest) replaced by *new_tag*.
+
+    The namespace (registry + repo path) is preserved verbatim. Handles
+    refs that include a registry port (``localhost:5000/foo:tag``) by
+    using the position of the last ``/`` to disambiguate the port colon
+    from the tag colon, and strips any ``@sha256:...`` suffix before
+    re-tagging.
+    """
+    ref = image_ref.split("@", 1)[0]
+    last_slash = ref.rfind("/")
+    last_colon = ref.rfind(":")
+    if last_colon > last_slash:
+        ref = ref[:last_colon]
+    return f"{ref}:{new_tag}"
+
+
 def _retag_appgarden_compose(
     appgarden_data: Dict[str, Any],
     source_compose_data: Optional[Dict[str, Any]],
@@ -106,7 +123,22 @@ def _retag_appgarden_compose(
         if not isinstance(svc, dict):
             continue
         if svc_name in build_services:
-            svc["image"] = f"{registry}/{extension_name}-{svc_name}:{image_tag}"
+            existing = svc.get("image")
+            if isinstance(existing, str) and existing.strip():
+                # The appgarden compose's image field is the canonical
+                # declaration of where this build's image lives in the
+                # registry — set by the extension's sync-compose.py from
+                # its docker-compose.yml. We only own the *tag* (stage
+                # suffix or --revision SHA); the namespace stays what
+                # the extension authored. Without this, extensions whose
+                # GHCR path doesn't match the {ext}-{svc} convention
+                # silently get the wrong namespace in the catalog.
+                svc["image"] = _replace_image_tag(existing, image_tag)
+            else:
+                # No declared image — fall back to the {ext}-{svc}
+                # convention so extensions relying on auto-generated
+                # image fields keep working.
+                svc["image"] = f"{registry}/{extension_name}-{svc_name}:{image_tag}"
     return out
 
 

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -11,7 +11,7 @@ import yaml
 from rich.console import Console
 
 from kamiwaza_extensions.catalog_publisher import DEFAULT_CATALOG_SCHEMA
-from kamiwaza_extensions.compose_transformer import _replace_image_tag
+from kamiwaza_extensions.compose_transformer import _canonical_build_ref
 from kamiwaza_extensions.extension_detector import infer_extension_type
 
 console = Console(stderr=True)
@@ -107,22 +107,18 @@ def _retag_appgarden_compose(
         if not isinstance(svc, dict):
             continue
         if svc_name in build_services:
-            existing = svc.get("image")
-            if isinstance(existing, str) and existing.strip():
-                # The appgarden compose's image field is the canonical
-                # declaration of where this build's image lives in the
-                # registry — set by the extension's sync-compose.py from
-                # its docker-compose.yml. We only own the *tag* (stage
-                # suffix or --revision SHA); the namespace stays what
-                # the extension authored. Without this, extensions whose
-                # GHCR path doesn't match the {ext}-{svc} convention
-                # silently get the wrong namespace in the catalog.
-                svc["image"] = _replace_image_tag(existing, image_tag)
-            else:
-                # No declared image — fall back to the {ext}-{svc}
-                # convention so extensions relying on auto-generated
-                # image fields keep working.
-                svc["image"] = f"{registry}/{extension_name}-{svc_name}:{image_tag}"
+            # The appgarden compose's image field is the canonical
+            # declaration of where this build's image lives in the
+            # registry — set by the extension's sync-compose.py from
+            # its docker-compose.yml. We only own the *tag* (stage
+            # suffix or --revision SHA); the namespace stays what the
+            # extension authored.
+            svc["image"] = _canonical_build_ref(
+                svc, svc_name,
+                fallback_registry=registry,
+                fallback_extension_name=extension_name,
+                revision_tag=image_tag,
+            )
     return out
 
 
@@ -177,11 +173,23 @@ def _collect_image_refs(
     version: str,
     registry: str,
 ) -> List[str]:
-    """Return full image refs for services with build contexts."""
+    """Return canonical image refs for services with build contexts.
+
+    Honors each service's declared ``image:`` field (namespace preserved,
+    tag rewritten to *version*) so the refs returned here match what
+    ``_retag_appgarden_compose`` writes to the catalog. Falls back to
+    the legacy ``{registry}/{extension_name}-{svc_name}:{version}`` form
+    only when no image is declared.
+    """
     refs: List[str] = []
     for svc_name, svc in (compose_data.get("services") or {}).items():
         if "build" in svc:
-            refs.append(f"{registry}/{extension_name}-{svc_name}:{version}")
+            refs.append(_canonical_build_ref(
+                svc, svc_name,
+                fallback_registry=registry,
+                fallback_extension_name=extension_name,
+                revision_tag=version,
+            ))
     return refs
 
 
@@ -491,8 +499,12 @@ def run_publish(
         # appears first in dict order can't redirect the user's digest.
         dry_digest_map: Dict[str, str] = {}
         if digest is not None and buildable_services:
-            dry_canonical_ref = (
-                f"{registry}/{info.name}-{buildable_services[0]}:{image_tag}"
+            dry_canonical_ref = _canonical_build_ref(
+                (info.compose_data.get("services") or {}).get(buildable_services[0]),
+                buildable_services[0],
+                fallback_registry=registry,
+                fallback_extension_name=info.name,
+                revision_tag=image_tag,
             )
             dry_digest_map[dry_canonical_ref] = digest
 
@@ -534,6 +546,24 @@ def run_publish(
         console.print("[dim]No changes made (dry-run mode).[/dim]")
         return
 
+    # Canonical image refs for every build-context service. Single
+    # source of truth — seeds the build, the push, digest resolution,
+    # and the catalog entry's image refs. Without sharing this map
+    # across all four sites they can each synthesize divergent forms
+    # (legacy {ext}-{svc} vs the namespace declared in compose), and
+    # the catalog ships referencing an image that may not exist at the
+    # synthesized path. (ENG-4909.)
+    canonical_refs: Dict[str, str] = {
+        name: _canonical_build_ref(
+            svc, name,
+            fallback_registry=registry,
+            fallback_extension_name=info.name,
+            revision_tag=image_tag,
+        )
+        for name, svc in (info.compose_data.get("services") or {}).items()
+        if "build" in svc
+    }
+
     # 5. Build images (using stage-aware tag)
     image_refs: List[str] = []
     if not no_build:
@@ -547,6 +577,7 @@ def run_publish(
                 revision_tag=image_tag,
                 registry=registry,
                 verbose=verbose,
+                image_refs=canonical_refs,
             )
         except ImageBuildError as exc:
             console.print("    [red]\u2717 build failed[/red]")
@@ -611,7 +642,7 @@ def run_publish(
     # in image_refs cannot misdirect the digest map. Pass-through external
     # refs keep whatever pinning their source repo applied.
     published_refs: List[str] = [
-        f"{registry}/{info.name}-{name}:{image_tag}" for name in buildable_services
+        canonical_refs[name] for name in buildable_services
     ]
     digest_map: Dict[str, str] = {}
     if published_refs:

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -11,6 +11,7 @@ import yaml
 from rich.console import Console
 
 from kamiwaza_extensions.catalog_publisher import DEFAULT_CATALOG_SCHEMA
+from kamiwaza_extensions.compose_transformer import _replace_image_tag
 from kamiwaza_extensions.extension_detector import infer_extension_type
 
 console = Console(stderr=True)
@@ -54,23 +55,6 @@ def _load_appgarden_compose(
         )
         return None
     return candidate, data
-
-
-def _replace_image_tag(image_ref: str, new_tag: str) -> str:
-    """Return *image_ref* with its tag (and any digest) replaced by *new_tag*.
-
-    The namespace (registry + repo path) is preserved verbatim. Handles
-    refs that include a registry port (``localhost:5000/foo:tag``) by
-    using the position of the last ``/`` to disambiguate the port colon
-    from the tag colon, and strips any ``@sha256:...`` suffix before
-    re-tagging.
-    """
-    ref = image_ref.split("@", 1)[0]
-    last_slash = ref.rfind("/")
-    last_colon = ref.rfind(":")
-    if last_colon > last_slash:
-        ref = ref[:last_colon]
-    return f"{ref}:{new_tag}"
 
 
 def _retag_appgarden_compose(

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -253,7 +253,7 @@ def _auto_resolve_digests(
                 "The image must exist in the registry before catalog publish.\n"
                 "Common causes:\n"
                 "  • Image name in docker-compose.appgarden.yml doesn't "
-                "match the actual GHCR path\n"
+                "match the actual registry image path\n"
                 "  • Image hasn't been pushed yet (run with build+push, "
                 "or push manually first)\n"
                 "  • Transient registry outage (retry the publish)\n"
@@ -600,8 +600,8 @@ def run_publish(
     # imagetools`. If buildx is missing on this host, fail before mutating
     # the registry rather than push-then-fail-on-resolve. Only required
     # when push will happen and there's at least one published service to
-    # pin (the catalog-only-republish path soft-falls in
-    # `_auto_resolve_digests` and doesn't need this guard).
+    # pin — the catalog-only-republish path (`--no-build --no-push`)
+    # doesn't push, so the preflight is moot there.
     if not no_push and buildable_services:
         try:
             ImagePusher.check_buildx_available()

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -36,12 +36,45 @@ def _looks_registry_qualified(ref: str) -> bool:
 
     Predicate: the substring before the first ``/`` must contain ``.``
     or ``:``, or be exactly ``localhost``. Bare repo names (no ``/``)
-    are Docker Hub by definition and return False.
+    are Docker Hub by definition and return False. IPv6 host literals
+    like ``[::1]/foo`` and ``[::1]:5000/foo`` are matched via the
+    ``:`` rule.
     """
     if "/" not in ref:
         return False
     first, _, _ = ref.partition("/")
     return "." in first or ":" in first or first == "localhost"
+
+
+def _split_image_ref(image_ref: str) -> Tuple[Optional[str], str, str]:
+    """Split *image_ref* into ``(registry, repository, tag)``.
+
+    Mirrors ``_replace_image_tag``'s tag detection (last ``:`` past the
+    last ``/``) and ``_looks_registry_qualified``'s registry-host rule.
+    Strips any ``@sha256:...`` digest before splitting. Tag defaults to
+    ``latest`` when the ref carries no explicit tag.
+
+    Used by the K8s PATCH path so the operator updates registry +
+    repository + tag together. Pre-fix kz-ext would PATCH only the tag,
+    leaving the CR's image field pointing at the original repository —
+    after this PR builds at the canonical (possibly different)
+    repository, that mismatch would produce ImagePullBackOff.
+    """
+    ref = image_ref.split("@", 1)[0]
+    last_slash = ref.rfind("/")
+    last_colon = ref.rfind(":")
+    if last_colon > last_slash:
+        namespace = ref[:last_colon]
+        tag = ref[last_colon + 1:]
+    else:
+        namespace = ref
+        tag = "latest"
+    if _looks_registry_qualified(namespace):
+        registry, _, repository = namespace.partition("/")
+    else:
+        registry = None
+        repository = namespace
+    return registry, repository, tag
 
 
 def compute_canonical_refs(

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -24,6 +24,36 @@ def _replace_image_tag(image_ref: str, new_tag: str) -> str:
     return f"{ref}:{new_tag}"
 
 
+def _canonical_build_ref(
+    service: Optional[Dict[str, Any]],
+    svc_name: str,
+    *,
+    fallback_registry: str,
+    fallback_extension_name: str,
+    revision_tag: str,
+) -> str:
+    """Return the canonical registry image ref for a buildable service.
+
+    Reads ``image`` from *service*. If declared, the namespace is
+    preserved and only the tag is rewritten to *revision_tag*. If
+    absent, falls back to the legacy
+    ``{fallback_registry}/{fallback_extension_name}-{svc_name}:{revision_tag}``
+    form so extensions that rely on auto-generated image fields keep
+    working.
+
+    Shared by ``ComposeTransformer.transform_service``,
+    ``_retag_appgarden_compose``, ``ImageBuilder.build``, and
+    ``run_publish``'s ``published_refs`` derivation so all five sites
+    agree on where a built image lives.
+    """
+    declared = (service or {}).get("image")
+    if isinstance(declared, str) and declared.strip():
+        return _replace_image_tag(declared, revision_tag)
+    return (
+        f"{fallback_registry}/{fallback_extension_name}-{svc_name}:{revision_tag}"
+    )
+
+
 # Compose ``${VAR:-default}`` (use default if unset OR empty) and the
 # ``${VAR-default}`` form (use default only if unset). For our purposes
 # both collapse to the literal default — there's no host process between
@@ -138,11 +168,19 @@ class ComposeTransformer:
         had_build = "build" in svc
         svc.pop("build", None)
 
-        if had_build and "image" not in svc:
-            svc["image"] = f"{registry}/{extension_name}-{service_name}:{revision_tag}"
-        elif had_build and "image" in svc:
-            # Use consistent registry/extension-service:tag format (matches image builder)
-            svc["image"] = f"{registry}/{extension_name}-{service_name}:{revision_tag}"
+        if had_build:
+            # The declared image's namespace is the canonical record of
+            # where this build's image lives in the registry; publish
+            # only owns the tag (stage suffix or --revision SHA). Fall
+            # back to the legacy {ext}-{svc} convention when no image
+            # is declared (auto-generated image fields).
+            svc["image"] = _canonical_build_ref(
+                svc,
+                service_name,
+                fallback_registry=registry,
+                fallback_extension_name=extension_name,
+                revision_tag=revision_tag,
+            )
         # Services without a build context — both external (postgres, redis)
         # and prebuilt-internal (e.g. a helper image published from another
         # repo) — keep their declared image ref verbatim. publish only owns

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -24,6 +24,26 @@ def _replace_image_tag(image_ref: str, new_tag: str) -> str:
     return f"{ref}:{new_tag}"
 
 
+def _looks_registry_qualified(ref: str) -> bool:
+    """Return True when *ref*'s first slash-separated component is a registry host.
+
+    Mirrors docker's rule for distinguishing a registry-qualified ref
+    (``ghcr.io/...``, ``localhost:5000/...``) from a Docker Hub
+    namespace shortcut (``foo/bar``, ``redis``). Without this guard
+    ``docker push my-org/api:1.0`` silently goes to Docker Hub while
+    the cluster registry expects the same path — guaranteed
+    ImagePullBackOff for extensions that use unqualified short refs.
+
+    Predicate: the substring before the first ``/`` must contain ``.``
+    or ``:``, or be exactly ``localhost``. Bare repo names (no ``/``)
+    are Docker Hub by definition and return False.
+    """
+    if "/" not in ref:
+        return False
+    first, _, _ = ref.partition("/")
+    return "." in first or ":" in first or first == "localhost"
+
+
 def _canonical_build_ref(
     service: Optional[Dict[str, Any]],
     svc_name: str,
@@ -34,22 +54,25 @@ def _canonical_build_ref(
 ) -> str:
     """Return the canonical registry image ref for a buildable service.
 
-    Reads ``image`` from *service*. If declared, the namespace is
-    preserved and only the tag is rewritten to *revision_tag*. If
-    absent, falls back to the legacy
+    Reads ``image`` from *service*. When the declared ref names an
+    explicit registry host (``ghcr.io/...``, ``localhost:5000/...``),
+    the namespace is preserved and only the tag is rewritten to
+    *revision_tag*. Unqualified refs (``api:latest``,
+    ``my-org/api:1.0``) and missing/empty declarations fall back to
+    the legacy
     ``{fallback_registry}/{fallback_extension_name}-{svc_name}:{revision_tag}``
-    form so extensions that rely on auto-generated image fields keep
-    working.
+    form — those would otherwise route ``docker push`` to Docker Hub
+    while the cluster registry expects the rewritten path.
 
     Shared by ``ComposeTransformer.transform_service``,
     ``_retag_appgarden_compose``, ``ImageBuilder.build``, and
-    ``run_publish``'s ``published_refs`` derivation so all five sites
-    agree on where a built image lives.
+    ``run_publish``'s ``published_refs`` derivation so every site
+    that picks a build ref agrees on where the image lives.
     """
     declared = (service or {}).get("image")
     if isinstance(declared, str):
         stripped = declared.strip()
-        if stripped:
+        if stripped and _looks_registry_qualified(stripped):
             return _replace_image_tag(stripped, revision_tag)
     return (
         f"{fallback_registry}/{fallback_extension_name}-{svc_name}:{revision_tag}"

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -47,8 +47,10 @@ def _canonical_build_ref(
     agree on where a built image lives.
     """
     declared = (service or {}).get("image")
-    if isinstance(declared, str) and declared.strip():
-        return _replace_image_tag(declared, revision_tag)
+    if isinstance(declared, str):
+        stripped = declared.strip()
+        if stripped:
+            return _replace_image_tag(stripped, revision_tag)
     return (
         f"{fallback_registry}/{fallback_extension_name}-{svc_name}:{revision_tag}"
     )

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -7,6 +7,23 @@ import re
 from typing import Any, Dict, List, Optional, Tuple
 
 
+def _replace_image_tag(image_ref: str, new_tag: str) -> str:
+    """Return *image_ref* with its tag (and any digest) replaced by *new_tag*.
+
+    The namespace (registry + repo path) is preserved verbatim. Handles
+    refs that include a registry port (``localhost:5000/foo:tag``) by
+    using the position of the last ``/`` to disambiguate the port colon
+    from the tag colon, and strips any ``@sha256:...`` suffix before
+    re-tagging.
+    """
+    ref = image_ref.split("@", 1)[0]
+    last_slash = ref.rfind("/")
+    last_colon = ref.rfind(":")
+    if last_colon > last_slash:
+        ref = ref[:last_colon]
+    return f"{ref}:{new_tag}"
+
+
 # Compose ``${VAR:-default}`` (use default if unset OR empty) and the
 # ``${VAR-default}`` form (use default only if unset). For our purposes
 # both collapse to the literal default — there's no host process between

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -44,6 +44,52 @@ def _looks_registry_qualified(ref: str) -> bool:
     return "." in first or ":" in first or first == "localhost"
 
 
+def compute_canonical_refs(
+    source_services: Optional[Dict[str, Any]],
+    *,
+    registry: str,
+    extension_name: str,
+    revision_tag: str,
+    appgarden_services: Optional[Dict[str, Any]] = None,
+) -> Dict[str, str]:
+    """Canonical image refs for every buildable service, keyed by service name.
+
+    Single source of truth for the publish and dev pipelines: build,
+    push, digest resolution, and the K8s/catalog image refs all read
+    from this map so they can't drift.
+
+    Service-image precedence (per service):
+    1. ``appgarden_services[name]`` when the key is present (matches
+       ``_retag_appgarden_compose``'s behavior — uses presence, not
+       truthiness, so an empty mapping still falls through to legacy
+       via ``_canonical_build_ref`` rather than reading from source).
+    2. Source-compose entry otherwise.
+
+    Filters out profile-gated services (matches ``buildable_services``
+    in ``run_publish``) so profile-only helpers don't leak into the
+    push list under ``--no-build``.
+    """
+    appgarden = appgarden_services or {}
+    out: Dict[str, str] = {}
+    for name, svc in (source_services or {}).items():
+        if "build" not in svc or svc.get("profiles"):
+            continue
+        # Presence-based: a service that is *declared* in the appgarden
+        # compose, even as an empty mapping, is owned by the appgarden
+        # path. Truthiness here would silently fall back to source on
+        # `services.foo: {}` while _retag_appgarden_compose would write
+        # the legacy fallback — recreating the very mismatch this
+        # PR fixes.
+        lookup = appgarden[name] if name in appgarden else svc
+        out[name] = _canonical_build_ref(
+            lookup, name,
+            fallback_registry=registry,
+            fallback_extension_name=extension_name,
+            revision_tag=revision_tag,
+        )
+    return out
+
+
 def _canonical_build_ref(
     service: Optional[Dict[str, Any]],
     svc_name: str,

--- a/kamiwaza_extensions/image_builder.py
+++ b/kamiwaza_extensions/image_builder.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -33,6 +32,7 @@ class ImageBuilder:
         service_filter: Optional[str] = None,
         verbose: bool = False,
         build_overrides: Optional[List[Any]] = None,
+        image_refs: Optional[Dict[str, str]] = None,
     ) -> List[str]:
         """Build images and return the list of image references.
 
@@ -46,6 +46,12 @@ class ImageBuilder:
             verbose: Stream full build output.
             build_overrides: Optional list of ``BuildOverride`` objects from
                 ``sdk_override.generate_build_overrides()``.
+            image_refs: Optional per-service canonical image refs keyed by
+                service name. When provided, services found in the map are
+                built at the supplied ref; services not in the map fall
+                back to the legacy ``{registry}/{ext}-{svc}:{tag}`` form.
+                Callers that own canonical-ref derivation (run_publish)
+                pass this so build/push and catalog-write stay in lockstep.
 
         Returns:
             List of image references that were built.
@@ -65,7 +71,10 @@ class ImageBuilder:
             if "build" not in svc:
                 continue
 
-            image_ref = f"{registry}/{extension_name}-{svc_name}:{revision_tag}"
+            if image_refs is not None and svc_name in image_refs:
+                image_ref = image_refs[svc_name]
+            else:
+                image_ref = f"{registry}/{extension_name}-{svc_name}:{revision_tag}"
             dockerfile, context = self._resolve_build_config(svc["build"], extension_dir)
 
             override = override_map.get(svc_name)

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -1,5 +1,7 @@
 """Tests for ComposeTransformer."""
 
+from typing import Any, Dict
+
 import pytest
 
 from kamiwaza_extensions.compose_transformer import ComposeTransformer
@@ -778,3 +780,106 @@ class TestCanonicalBuildRef:
         assert self._call(
             image="  ghcr.io/my-org/api:1.0  ",
         ) == "ghcr.io/my-org/api:2.0.0-dev"
+
+
+class TestComputeCanonicalRefs:
+    """`compute_canonical_refs` is the shared canonical-refs derivation
+    used by publish (live + dry-run) and dev. Same source of truth means
+    none of the three paths can drift on namespace, profile filtering,
+    or appgarden precedence."""
+
+    @staticmethod
+    def _call(source, *, appgarden=None, registry="registry.test", extension_name="my-ext", revision_tag="2.0.0-dev"):
+        from kamiwaza_extensions.compose_transformer import compute_canonical_refs
+
+        return compute_canonical_refs(
+            source,
+            registry=registry,
+            extension_name=extension_name,
+            revision_tag=revision_tag,
+            appgarden_services=appgarden,
+        )
+
+    def test_empty_source_returns_empty(self):
+        assert self._call({}) == {}
+
+    def test_only_buildable_services_included(self):
+        source = {
+            "backend": {"build": ".", "image": "ghcr.io/my-org/backend:1.0"},
+            "neo4j": {"image": "ghcr.io/upstream/neo4j:5.0"},  # external
+        }
+        result = self._call(source)
+        assert "backend" in result
+        assert "neo4j" not in result
+
+    def test_profile_gated_services_excluded(self):
+        # Mirrors the buildable_services filter in run_publish. A
+        # service with a profiles: key is local-only; pushing it under
+        # --no-build would leak a dev helper into the registry.
+        source = {
+            "backend": {"build": ".", "image": "ghcr.io/my-org/backend:1.0"},
+            "dev-helper": {
+                "build": "./dev",
+                "image": "ghcr.io/my-org/dev-helper:1.0",
+                "profiles": ["dev"],
+            },
+        }
+        result = self._call(source)
+        assert list(result.keys()) == ["backend"]
+
+    def test_appgarden_entry_overrides_source(self):
+        source = {
+            "backend": {
+                "build": ".",
+                "image": "ghcr.io/source-org/backend:1.0",
+            },
+        }
+        appgarden = {
+            "backend": {"image": "ghcr.io/published/tool-foo/backend:1.0"},
+        }
+        assert self._call(source, appgarden=appgarden) == {
+            "backend": "ghcr.io/published/tool-foo/backend:2.0.0-dev",
+        }
+
+    def test_empty_appgarden_entry_falls_through_to_legacy(self):
+        # Presence-based lookup: an appgarden services entry that exists
+        # but is empty/missing image: must NOT silently fall back to
+        # source compose. _retag_appgarden_compose would call
+        # _canonical_build_ref({}, ...) and write the legacy fallback;
+        # this helper must agree so the two paths can't drift.
+        source = {
+            "backend": {
+                "build": ".",
+                "image": "ghcr.io/source-org/backend:1.0",
+            },
+        }
+        appgarden = {"backend": {}}  # present but empty
+        assert self._call(source, appgarden=appgarden) == {
+            "backend": "registry.test/my-ext-backend:2.0.0-dev",
+        }
+
+    def test_appgarden_missing_service_uses_source(self):
+        # When a service exists in source compose but NOT in appgarden,
+        # the source entry is the right lookup. Common case: appgarden
+        # compose is hand-authored and only declares the services it
+        # actually retags.
+        source = {
+            "backend": {
+                "build": ".",
+                "image": "ghcr.io/source-org/backend:1.0",
+            },
+        }
+        appgarden: Dict[str, Any] = {}
+        assert self._call(source, appgarden=appgarden) == {
+            "backend": "ghcr.io/source-org/backend:2.0.0-dev",
+        }
+
+    def test_none_source_returns_empty(self):
+        # Defensive: missing services key on the source compose dict.
+        assert self._call(None) == {}
+
+    def test_legacy_fallback_when_no_image_anywhere(self):
+        source = {"backend": {"build": "."}}
+        assert self._call(source) == {
+            "backend": "registry.test/my-ext-backend:2.0.0-dev",
+        }

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -93,7 +93,13 @@ class TestBuildContextRemoval:
         assert "build" not in svc
         assert svc["image"] == "registry.test/my-app-api:1.0.0-dev"
 
-    def test_updates_existing_image_tag(self, transformer):
+    def test_preserves_declared_namespace_rewrites_only_tag(self, transformer):
+        # When a service has both `build:` and `image:`, the declared
+        # namespace is canonical — only the tag is rewritten to the
+        # publish's revision_tag. Without this, extensions whose GHCR
+        # path doesn't follow the legacy {ext}-{svc} convention (e.g.
+        # omniparse, which ships at `images/omniparse`) silently get
+        # the wrong namespace in the catalog. (ENG-4909.)
         compose = {
             "services": {
                 "api": {
@@ -103,8 +109,28 @@ class TestBuildContextRemoval:
             }
         }
         result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test")
-        # When service has both build and image, use consistent registry format (matches image builder)
-        assert result["services"]["api"]["image"] == "registry.test/my-app-api:1.0.0-dev"
+        assert result["services"]["api"]["image"] == (
+            "kamiwazaai/my-app-api:1.0.0-dev"
+        )
+
+    def test_preserves_declared_namespace_when_diverges_from_convention(self, transformer):
+        # The omniparse-style case: declared image namespace
+        # (`images/omniparse`) does not follow the {ext-name}-{svc-name}
+        # convention (`my-app-api`). The declared form wins.
+        compose = {
+            "services": {
+                "omniparse-server": {
+                    "build": "./tool-omniparse",
+                    "image": "ghcr.io/kamiwaza-internal/foo/images/omniparse:2.0.14",
+                }
+            }
+        }
+        result = transformer.transform(
+            compose, "tool-omniparse", "2.0.14-dev", "ghcr.io/kamiwaza-internal/foo/images",
+        )
+        assert result["services"]["omniparse-server"]["image"] == (
+            "ghcr.io/kamiwaza-internal/foo/images/omniparse:2.0.14-dev"
+        )
 
     def test_dict_build_config(self, transformer):
         compose = {

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -94,12 +94,34 @@ class TestBuildContextRemoval:
         assert svc["image"] == "registry.test/my-app-api:1.0.0-dev"
 
     def test_preserves_declared_namespace_rewrites_only_tag(self, transformer):
-        # When a service has both `build:` and `image:`, the declared
-        # namespace is canonical — only the tag is rewritten to the
-        # publish's revision_tag. Without this, extensions whose GHCR
-        # path doesn't follow the legacy {ext}-{svc} convention (e.g.
-        # omniparse, which ships at `images/omniparse`) silently get
-        # the wrong namespace in the catalog. (ENG-4909.)
+        # When a service has both `build:` and a registry-qualified
+        # `image:`, the declared namespace is canonical — only the tag
+        # is rewritten. Extensions whose registry path doesn't follow
+        # the legacy {ext}-{svc} convention (e.g. omniparse at
+        # `images/omniparse`) would otherwise silently get the wrong
+        # namespace in the catalog.
+        compose = {
+            "services": {
+                "api": {
+                    "build": "./backend",
+                    "image": "ghcr.io/kamiwazaai/my-app-api:old-tag",
+                }
+            }
+        }
+        result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test")
+        assert result["services"]["api"]["image"] == (
+            "ghcr.io/kamiwazaai/my-app-api:1.0.0-dev"
+        )
+
+    def test_unqualified_short_form_falls_back_to_legacy(self):
+        # `image: foo/bar:tag` resolves to docker.io/foo/bar:tag under
+        # docker's namespace rules — building/pushing at that path
+        # silently lands on Docker Hub while the K8s pod and the
+        # cluster registry expect the cluster-side rewrite. Override
+        # with the legacy {registry}/{ext}-{svc}:{tag} form so the
+        # pipeline stays internally consistent.
+        from kamiwaza_extensions.compose_transformer import ComposeTransformer
+
         compose = {
             "services": {
                 "api": {
@@ -108,9 +130,11 @@ class TestBuildContextRemoval:
                 }
             }
         }
-        result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test")
+        result = ComposeTransformer().transform(
+            compose, "my-app", "1.0.0-dev", "registry.test",
+        )
         assert result["services"]["api"]["image"] == (
-            "kamiwazaai/my-app-api:1.0.0-dev"
+            "registry.test/my-app-api:1.0.0-dev"
         )
 
     def test_transform_preserves_divergent_namespace(self, transformer):
@@ -650,3 +674,107 @@ class TestDetectServiceUrlRewrites:
 
         services = {"backend": {}, "frontend": {}}
         assert detect_service_url_rewrites(services, "ext") == {}
+
+
+class TestLooksRegistryQualified:
+    """`_looks_registry_qualified` distinguishes registry-qualified refs
+    from Docker Hub namespace shortcuts using docker's standard rule."""
+
+    def test_bare_repo_name(self):
+        from kamiwaza_extensions.compose_transformer import _looks_registry_qualified
+
+        assert _looks_registry_qualified("redis") is False
+        assert _looks_registry_qualified("api:latest") is False
+
+    def test_docker_hub_namespace_shortcut(self):
+        # `my-org/api` looks like a path but docker resolves it to
+        # docker.io/my-org/api — must not be treated as registry-qualified.
+        from kamiwaza_extensions.compose_transformer import _looks_registry_qualified
+
+        assert _looks_registry_qualified("my-org/api:latest") is False
+        assert _looks_registry_qualified("library/redis:7") is False
+
+    def test_explicit_registry_with_dot(self):
+        from kamiwaza_extensions.compose_transformer import _looks_registry_qualified
+
+        assert _looks_registry_qualified("ghcr.io/kamiwaza/foo:1.0") is True
+        assert _looks_registry_qualified("registry.example.com/foo:bar") is True
+
+    def test_explicit_registry_with_port(self):
+        from kamiwaza_extensions.compose_transformer import _looks_registry_qualified
+
+        assert _looks_registry_qualified("localhost:5000/foo:tag") is True
+        assert _looks_registry_qualified("registry:443/foo") is True
+
+    def test_localhost_without_port(self):
+        # The one exception to the dot/colon rule — docker treats bare
+        # `localhost` as a registry host.
+        from kamiwaza_extensions.compose_transformer import _looks_registry_qualified
+
+        assert _looks_registry_qualified("localhost/foo:tag") is True
+
+
+class TestCanonicalBuildRef:
+    """`_canonical_build_ref` returns the registry image ref for a
+    buildable service, honoring registry-qualified declared images and
+    falling back to the legacy form for everything else."""
+
+    @staticmethod
+    def _call(image=None, *, has_build=True, declared_only=False):
+        from kamiwaza_extensions.compose_transformer import _canonical_build_ref
+
+        svc: Dict[str, Any] = {}
+        if has_build:
+            svc["build"] = "."
+        if image is not None:
+            svc["image"] = image
+        if declared_only:
+            svc = {"image": image} if image is not None else {}
+        return _canonical_build_ref(
+            svc, "api",
+            fallback_registry="registry.test",
+            fallback_extension_name="my-ext",
+            revision_tag="2.0.0-dev",
+        )
+
+    def test_legacy_fallback_when_no_image_declared(self):
+        assert self._call() == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_legacy_fallback_when_image_empty_string(self):
+        assert self._call(image="") == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_legacy_fallback_when_image_whitespace_only(self):
+        assert self._call(image="   ") == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_registry_qualified_declared_image_honored(self):
+        assert self._call(
+            image="ghcr.io/my-org/api:1.0",
+        ) == "ghcr.io/my-org/api:2.0.0-dev"
+
+    def test_registry_with_port_honored(self):
+        assert self._call(
+            image="localhost:5000/api:1.0",
+        ) == "localhost:5000/api:2.0.0-dev"
+
+    def test_unqualified_bare_repo_falls_back_to_legacy(self):
+        # `image: api:latest` — docker push would send this to Docker
+        # Hub, breaking extensions whose images live in the cluster
+        # registry. Override with the legacy form so the rewritten ref
+        # matches what _retag_appgarden_compose / ComposeTransformer
+        # write into the K8s payload.
+        assert self._call(
+            image="api:latest",
+        ) == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_unqualified_short_form_falls_back_to_legacy(self):
+        # `image: my-org/api:1.0` — common dev convention that resolves
+        # to docker.io/my-org/api:1.0 under docker's namespace rules.
+        # Same regression hazard as the bare repo case.
+        assert self._call(
+            image="my-org/api:1.0",
+        ) == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_strips_whitespace_around_qualified_ref(self):
+        assert self._call(
+            image="  ghcr.io/my-org/api:1.0  ",
+        ) == "ghcr.io/my-org/api:2.0.0-dev"

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -113,7 +113,7 @@ class TestBuildContextRemoval:
             "kamiwazaai/my-app-api:1.0.0-dev"
         )
 
-    def test_preserves_declared_namespace_when_diverges_from_convention(self, transformer):
+    def test_transform_preserves_divergent_namespace(self, transformer):
         # The omniparse-style case: declared image namespace
         # (`images/omniparse`) does not follow the {ext-name}-{svc-name}
         # convention (`my-app-api`). The declared form wins.

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -782,6 +782,71 @@ class TestCanonicalBuildRef:
         ) == "ghcr.io/my-org/api:2.0.0-dev"
 
 
+class TestSplitImageRef:
+    """`_split_image_ref` decomposes a canonical image ref into
+    ``(registry, repository, tag)`` so the K8s PATCH path can update
+    all three together — sending tag-only would leave the operator's
+    CR pointing at the old repository when an extension's declared
+    image namespace differs from the pre-fix legacy synthesis."""
+
+    @staticmethod
+    def _split(ref):
+        from kamiwaza_extensions.compose_transformer import _split_image_ref
+
+        return _split_image_ref(ref)
+
+    def test_registry_qualified_with_tag(self):
+        assert self._split("ghcr.io/kamiwaza/foo:1.0") == (
+            "ghcr.io", "kamiwaza/foo", "1.0",
+        )
+
+    def test_registry_with_port(self):
+        # The tag colon must not be confused with the registry port colon.
+        assert self._split("localhost:5000/my-app:2.0.0-dev") == (
+            "localhost:5000", "my-app", "2.0.0-dev",
+        )
+
+    def test_localhost_without_port(self):
+        assert self._split("localhost/foo:tag") == ("localhost", "foo", "tag")
+
+    def test_no_tag_defaults_to_latest(self):
+        assert self._split("ghcr.io/kamiwaza/foo") == (
+            "ghcr.io", "kamiwaza/foo", "latest",
+        )
+
+    def test_strips_digest_before_splitting(self):
+        # Defensive: digest pins don't reach the PATCH path in practice,
+        # but the helper should never propagate one into the registry
+        # or repository field if it ever does.
+        assert self._split(
+            "ghcr.io/foo/bar:1.0@sha256:" + "a" * 64,
+        ) == ("ghcr.io", "foo/bar", "1.0")
+
+    def test_unqualified_short_form_has_no_registry(self):
+        # `my-org/my-app:1.0` resolves to docker.io/my-org/my-app under
+        # docker's namespace rules — _canonical_build_ref already
+        # rewrites these to the cluster registry, but if one ever
+        # reaches the splitter the registry field must remain None
+        # rather than masquerade as `my-org`.
+        assert self._split("my-org/my-app:1.0") == (None, "my-org/my-app", "1.0")
+
+    def test_bare_repo_name(self):
+        assert self._split("redis:7") == (None, "redis", "7")
+
+    def test_bare_repo_no_tag(self):
+        assert self._split("redis") == (None, "redis", "latest")
+
+    def test_multi_segment_repository(self):
+        # Omniparse-shaped path: a long repository path under a single registry.
+        assert self._split(
+            "ghcr.io/kamiwaza-internal/kamiwaza-extensions-omniparse/images/omniparse:2.0.14-dev"
+        ) == (
+            "ghcr.io",
+            "kamiwaza-internal/kamiwaza-extensions-omniparse/images/omniparse",
+            "2.0.14-dev",
+        )
+
+
 class TestComputeCanonicalRefs:
     """`compute_canonical_refs` is the shared canonical-refs derivation
     used by publish (live + dry-run) and dev. Same source of truth means

--- a/tests/unit/extensions/test_dev_canonical_refs.py
+++ b/tests/unit/extensions/test_dev_canonical_refs.py
@@ -1,0 +1,129 @@
+"""Tests that ``run_dev_remote`` passes canonical image refs to the builder.
+
+The build/push refs in dev.py must match the namespace declared in
+compose, the same way ``ComposeTransformer`` rewrites them. Without
+``image_refs=`` plumbed through to ``ImageBuilder.build``, the builder
+defaults to the legacy ``{registry}/{ext}-{svc}:{tag}`` form while the
+K8s payload (built from the transformed compose) references the
+declared namespace — extensions that publish under a non-conventional
+path (e.g. ``ghcr.io/.../tool-omniparse/omniparse``) hit
+ImagePullBackOff because the image lives at a different path than the
+pod pulls from.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import click
+
+from kamiwaza_extensions.connections import ConnectionInfo
+from kamiwaza_extensions.extension_detector import ExtensionInfo
+from kamiwaza_extensions.image_builder import ImageBuildError
+
+pytestmark = [pytest.mark.unit, pytest.mark.extension_regression]
+
+
+def _info_with_divergent_namespace(tmp_path: Path) -> ExtensionInfo:
+    """Extension with one service whose image namespace diverges from the
+    legacy ``{ext}-{svc}`` convention — mirrors omniparse's
+    ``ghcr.io/.../tool-omniparse/omniparse``."""
+    compose_data = {
+        "services": {
+            "omniparse": {
+                "image": "ghcr.io/example/tool-omniparse/omniparse:0.1.0",
+                "build": {"context": "./images/omniparse"},
+                "ports": ["8000:8000"],
+            },
+        },
+    }
+    return ExtensionInfo(
+        path=tmp_path,
+        name="tool-omniparse",
+        version="0.1.0",
+        metadata={"name": "tool-omniparse", "type": "tool"},
+        compose_path=tmp_path / "docker-compose.yml",
+        compose_data=compose_data,
+    )
+
+
+def _active_connection() -> ConnectionInfo:
+    return ConnectionInfo(
+        name="dev",
+        url="https://kamiwaza.test/api",
+        active=True,
+        created_at=0.0,
+        verify_ssl=False,
+    )
+
+
+class TestDevRemoteBuildsAtCanonicalRefs:
+    """``ImageBuilder.build`` must receive ``image_refs`` that honor the
+    compose-declared namespace — same source-of-truth as the K8s
+    payload's image refs."""
+
+    def test_divergent_image_namespace_flows_through_to_builder(
+        self, tmp_path, monkeypatch
+    ):
+        from kamiwaza_extensions.commands import dev as dev_cmd
+
+        info = _info_with_divergent_namespace(tmp_path)
+
+        # Stub the heavy chain so we land on builder.build with the right
+        # canonical_refs dict and immediately exit.
+        captured: dict = {}
+
+        def _capture_and_raise(**kwargs):
+            captured.update(kwargs)
+            raise ImageBuildError("stop-after-capture")
+
+        token = MagicMock(access_token="tok-abc")
+        conn_mgr = MagicMock()
+        conn_mgr.get_active_connection.return_value = _active_connection()
+        conn_mgr.get_token.return_value = token
+
+        detector = MagicMock()
+        detector.detect.return_value = info
+
+        tagger = MagicMock()
+        tagger.generate_tag.return_value = "0.1.0-dev-abc.123"
+        tagger.get_git_info.return_value = ("abc1234", False)
+
+        builder = MagicMock()
+        builder.build.side_effect = _capture_and_raise
+
+        # Function-local imports — patch at source module.
+        with patch(
+            "kamiwaza_extensions.extension_detector.ExtensionDetector",
+            return_value=detector,
+        ), patch(
+            "kamiwaza_extensions.connections.ConnectionManager",
+            return_value=conn_mgr,
+        ), patch(
+            "kamiwaza_extensions.revision_tagger.RevisionTagger",
+            return_value=tagger,
+        ), patch(
+            "kamiwaza_extensions.image_builder.ImageBuilder",
+            return_value=builder,
+        ), patch.object(
+            dev_cmd, "_detect_kind_registry", return_value="registry.kamiwaza.test",
+        ), patch(
+            "kamiwaza_extensions.dev_state.read_state", return_value=None,
+        ), patch(
+            "kamiwaza_extensions.dev_state.resume_message", return_value=None,
+        ), pytest.raises(click.exceptions.Exit):
+            # ImageBuildError → typer.Exit(code=1) inside run_dev_remote
+            dev_cmd.run_dev_remote(no_push=True)
+
+        builder.build.assert_called_once()
+        assert "image_refs" in captured, (
+            "ImageBuilder.build must receive image_refs= so the built ref "
+            "matches the transformed compose's declared namespace."
+        )
+        # Tag rewritten, namespace preserved verbatim.
+        assert captured["image_refs"] == {
+            "omniparse": "ghcr.io/example/tool-omniparse/omniparse:0.1.0-dev-abc.123",
+        }

--- a/tests/unit/extensions/test_dev_patch.py
+++ b/tests/unit/extensions/test_dev_patch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -55,9 +55,6 @@ class TestDeployPatchLogic:
         client.extensions.create_extension.return_value = _make_ext("Pending")
 
         payload = _make_payload()
-
-        # Simulate the deploy logic
-        from kamiwaza_sdk.schemas.extensions import ImagePatch, PatchExtension, PatchServiceSpec
 
         try:
             client.extensions.get_extension("myapp-dev-abc123")
@@ -143,3 +140,77 @@ class TestDeployPatchLogic:
             else:
                 tag = "latest"
             assert tag == expected_tag, f"For image '{image}' expected '{expected_tag}' got '{tag}'"
+
+
+class TestBuildPatchServiceSpecs:
+    """`_build_patch_service_specs` must populate all three of
+    ImagePatch.{registry, repository, tag} so the operator updates the
+    CR's full image field on redeploy. Tag-only would leave the
+    existing CR pointing at its original repository — an
+    ImagePullBackOff every time the canonical ref's repository differs
+    from what the CR holds (e.g. SDK upgrade from pre-fix kz-ext, or
+    declared image namespace change between deploys)."""
+
+    def _payload(self, image: str):
+        return CreateExtension(
+            name="myapp-dev-abc123",
+            type="app",
+            version="1.0.0",
+            services=[
+                ExtensionServiceSpec(name="backend", image=image, primary=True, ports=[]),
+            ],
+        )
+
+    def test_canonical_ghcr_ref_populates_all_three_fields(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        payload = self._payload(
+            "ghcr.io/kamiwaza-internal/foo/images/omniparse:2.0.14-dev"
+        )
+        specs = _build_patch_service_specs(payload)
+        assert len(specs) == 1
+        img = specs[0].image
+        assert img.registry == "ghcr.io"
+        assert img.repository == "kamiwaza-internal/foo/images/omniparse"
+        assert img.tag == "2.0.14-dev"
+
+    def test_localhost_kind_registry_with_port(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        payload = self._payload("localhost:5001/my-ext-backend:1.0.0-gabc")
+        img = _build_patch_service_specs(payload)[0].image
+        assert img.registry == "localhost:5001"
+        assert img.repository == "my-ext-backend"
+        assert img.tag == "1.0.0-gabc"
+
+    def test_legacy_unqualified_ref_has_no_registry(self):
+        # Unqualified refs are rewritten to the cluster registry before
+        # reaching this code (via _canonical_build_ref); the splitter
+        # still must not invent a registry from `my-org/foo`.
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        payload = self._payload("my-org/foo:1.0")
+        img = _build_patch_service_specs(payload)[0].image
+        assert img.registry is None
+        assert img.repository == "my-org/foo"
+        assert img.tag == "1.0"
+
+    def test_repo_change_between_deploys_flows_through_patch(self):
+        # The regression scenario: a CR was deployed under pre-fix kz-ext
+        # at `registry.test/myapp-omniparse-server:v1` (legacy synthesis),
+        # and a redeploy now builds at the canonical declared namespace
+        # `ghcr.io/.../images/omniparse:v2`. The PATCH payload must carry
+        # the new registry + repository so the operator updates the CR's
+        # image field — tag-only would pull `registry.test/myapp-omniparse-server:v2`
+        # which was never pushed.
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        payload = self._payload(
+            "ghcr.io/kamiwaza-internal/foo/images/omniparse:v2"
+        )
+        img = _build_patch_service_specs(payload)[0].image
+        # The patch carries the new repository, not just a new tag —
+        # the operator will rewrite the CR's image field accordingly.
+        assert img.registry == "ghcr.io"
+        assert img.repository == "kamiwaza-internal/foo/images/omniparse"
+        assert img.tag == "v2"

--- a/tests/unit/extensions/test_image_builder.py
+++ b/tests/unit/extensions/test_image_builder.py
@@ -1,6 +1,5 @@
 """Tests for ImageBuilder."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -85,6 +84,27 @@ class TestBuild:
         compose = {"services": {"api": {"build": "."}}}
         with pytest.raises(ImageBuildError, match="build failed"):
             builder.build(tmp_path, compose, "test", "v1", "reg")
+
+    @patch("kamiwaza_extensions.image_builder.subprocess.run")
+    def test_image_refs_partial_map_falls_back_to_legacy(
+        self, mock_run, builder, compose_with_build, tmp_path,
+    ):
+        # When `image_refs` is supplied but missing an entry for a
+        # buildable service, that service falls back to the legacy
+        # `{registry}/{ext}-{svc}:{tag}` form. Otherwise a caller that
+        # builds the map but omits a service would silently build at
+        # an arbitrary ref the K8s payload doesn't reference.
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        refs = builder.build(
+            extension_dir=tmp_path,
+            compose_data=compose_with_build,
+            extension_name="my-app",
+            revision_tag="v1",
+            registry="reg",
+            image_refs={"backend": "ghcr.io/canonical/backend:v1"},  # frontend omitted
+        )
+        assert "ghcr.io/canonical/backend:v1" in refs
+        assert "reg/my-app-frontend:v1" in refs
 
 
 class TestResolveBuildConfig:

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -796,9 +796,9 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls,
         mock_resolve, mock_preflight, tmp_path,
     ):
-        # The preflight only matters when push will happen. The catalog-
-        # only-republish path soft-falls in _auto_resolve_digests if buildx
-        # is missing, so don't gate it here.
+        # The preflight only matters when push will happen. The
+        # catalog-only-republish path (--no-build --no-push) doesn't
+        # push, so the buildx preflight is moot there.
         mock_resolve.return_value = _DIGEST_BACKEND
         _wire_publish_mocks(
             detector_cls=mock_detector_cls,

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -1880,6 +1880,54 @@ class TestLoadAppgardenCompose:
         assert _load_appgarden_compose(tmp_path) is None
 
 
+class TestReplaceImageTag:
+    """`_replace_image_tag` preserves the namespace and replaces the tag."""
+
+    def test_replaces_simple_tag(self):
+        from kamiwaza_extensions.commands.publish import _replace_image_tag
+
+        assert _replace_image_tag(
+            "ghcr.io/my-org/foo:1.0.0", "1.0.0-dev"
+        ) == "ghcr.io/my-org/foo:1.0.0-dev"
+
+    def test_replaces_tag_when_namespace_does_not_match_convention(self):
+        # The whole point of the helper: omniparse's image is at
+        # `images/omniparse`, not `images/tool-omniparse-omniparse-server`.
+        # The replacement only touches the tag, leaves the path alone.
+        from kamiwaza_extensions.commands.publish import _replace_image_tag
+
+        assert _replace_image_tag(
+            "ghcr.io/kamiwaza-internal/kamiwaza-extensions-omniparse/images/omniparse:2.0.14",
+            "2.0.14-dev",
+        ) == (
+            "ghcr.io/kamiwaza-internal/kamiwaza-extensions-omniparse/images/omniparse:2.0.14-dev"
+        )
+
+    def test_handles_registry_with_port(self):
+        # `localhost:5000/foo:tag` — the port colon must not be mistaken
+        # for the tag separator.
+        from kamiwaza_extensions.commands.publish import _replace_image_tag
+
+        assert _replace_image_tag(
+            "localhost:5000/foo:1.0.0", "2.0.0-dev"
+        ) == "localhost:5000/foo:2.0.0-dev"
+
+    def test_strips_digest_before_retagging(self):
+        from kamiwaza_extensions.commands.publish import _replace_image_tag
+
+        assert _replace_image_tag(
+            "ghcr.io/my-org/foo:1.0.0@sha256:" + "a" * 64,
+            "1.0.0-dev",
+        ) == "ghcr.io/my-org/foo:1.0.0-dev"
+
+    def test_appends_tag_when_no_existing_tag(self):
+        from kamiwaza_extensions.commands.publish import _replace_image_tag
+
+        assert _replace_image_tag(
+            "ghcr.io/my-org/foo", "1.0.0-dev"
+        ) == "ghcr.io/my-org/foo:1.0.0-dev"
+
+
 class TestRetagAppgardenCompose:
     """`_retag_appgarden_compose` retags only build-context services."""
 
@@ -1896,6 +1944,62 @@ class TestRetagAppgardenCompose:
                 "backend": {"build": {"context": "."}},
             },
         }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="2.0.0-dev",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:2.0.0-dev"
+        )
+
+    def test_preserves_declared_namespace_when_diverges_from_convention(self):
+        # Omniparse-style: bake target name (and GHCR path) is
+        # `images/omniparse`, but the kz-ext-computed default would be
+        # `images/tool-omniparse-omniparse-server`. The fix preserves
+        # the namespace declared in the appgarden compose and only
+        # rewrites the tag for stage — fixes the silently-broken
+        # catalog entries this used to produce (ENG-4909).
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        appgarden = {
+            "services": {
+                "omniparse-server": {
+                    "image": (
+                        "ghcr.io/kamiwaza-internal/"
+                        "kamiwaza-extensions-omniparse/images/omniparse:2.0.14"
+                    ),
+                },
+            },
+        }
+        source = {
+            "services": {
+                "omniparse-server": {"build": {"context": "."}},
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="tool-omniparse", image_tag="2.0.14-dev",
+            registry=(
+                "ghcr.io/kamiwaza-internal/"
+                "kamiwaza-extensions-omniparse/images"
+            ),
+        )
+        # Namespace preserved; only the tag changed.
+        assert out["services"]["omniparse-server"]["image"] == (
+            "ghcr.io/kamiwaza-internal/"
+            "kamiwaza-extensions-omniparse/images/omniparse:2.0.14-dev"
+        )
+
+    def test_falls_back_to_legacy_convention_when_no_declared_image(self):
+        # Extensions that rely on auto-generated image fields (no
+        # `image:` in compose, just a `build:` block) still get the
+        # `{registry}/{ext}-{svc}:{tag}` form — preserves backward
+        # compatibility with the original ComposeTransformer behavior.
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        appgarden = {"services": {"backend": {}}}
+        source = {"services": {"backend": {"build": {"context": "."}}}}
         out = _retag_appgarden_compose(
             appgarden, source,
             extension_name="my-app", image_tag="2.0.0-dev",

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -536,6 +536,68 @@ class TestNoBuildNoPush:
         # Push should NOT be called
         mock_pusher_cls.return_value.push.assert_not_called()
 
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.check_buildx_available")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_no_build_push_excludes_profile_gated_services(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls,
+        mock_resolve, mock_preflight, tmp_path,
+    ):
+        # Under --no-build, the push list is sourced from canonical_refs.
+        # canonical_refs must filter profile-gated services so a
+        # local-only dev helper isn't pushed to the registry alongside
+        # the catalog's services. The catalog itself already excludes
+        # profiled services via buildable_services — push must mirror
+        # that filter or stale dev images leak to the registry.
+        compose = {
+            "services": {
+                "dev-helper": {
+                    "build": {"context": "./dev"},
+                    "image": "ghcr.io/my-org/my-app-dev-helper:1.0.0",
+                    "profiles": ["dev"],
+                },
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "ghcr.io/my-org/my-app-backend:1.0.0",
+                },
+            },
+        }
+        _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data=compose,
+        )
+        mock_resolve.return_value = "sha256:" + "a" * 64
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", no_build=True)
+
+        # ImagePusher.push received only the non-profiled backend ref.
+        push_call = mock_pusher_cls.return_value.push.call_args
+        pushed_refs = push_call.args[0] if push_call.args else push_call.kwargs.get("image_refs", [])
+        assert pushed_refs == ["ghcr.io/my-org/my-app-backend:1.0.0-dev"]
+        assert "dev-helper" not in str(pushed_refs)
+
 
 # ------------------------------------------------------------------
 # Profile not found error
@@ -1905,6 +1967,71 @@ class TestPublishDigest:
                 "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
             }
             assert "dev-helper" not in str(kwargs["digest_map"])
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_dry_run_digest_uses_appgarden_namespace(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls, tmp_path,
+    ):
+        # When appgarden compose declares a different namespace than the
+        # source compose AND the user passes --digest, the dry-run preview
+        # must pin the digest against the appgarden ref — that's what the
+        # live path would write, and what _retag_appgarden_compose writes
+        # into the catalog. Reading from source compose would produce a
+        # mismatched preview that "passes" while the live path would
+        # silently fail _apply_digests' exact-string match.
+        (tmp_path / "docker-compose.appgarden.yml").write_text(
+            "services:\n"
+            "  backend:\n"
+            "    image: ghcr.io/published/tool-foo/backend:1.0.0\n"
+        )
+        compose = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "registry.test/my-app-backend:1.0.0",
+                },
+            },
+        }
+        with patch(
+            "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest"
+        ) as mock_resolve:
+            wired = _wire_publish_mocks(
+                detector_cls=mock_detector_cls,
+                meta_validator_cls=mock_meta_validator_cls,
+                compose_validator_cls=mock_compose_validator_cls,
+                transformer_cls=mock_transformer_cls,
+                profile_mgr_cls=mock_profile_mgr_cls,
+                builder_cls=mock_builder_cls,
+                pusher_cls=mock_pusher_cls,
+                reg_builder_cls=mock_reg_builder_cls,
+                publisher_cls=mock_publisher_cls,
+                tmp_path=tmp_path,
+                compose_data=compose,
+            )
+            mock_publisher_cls.return_value.publish.return_value = (
+                _make_publish_result(dry_run=True)
+            )
+
+            from kamiwaza_extensions.commands.publish import run_publish
+
+            run_publish(stage="dev", dry_run=True, digest=_DIGEST_USER_SUPPLIED)
+
+            mock_resolve.assert_not_called()
+            kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+            assert kwargs["digest_map"] == {
+                "ghcr.io/published/tool-foo/backend:1.0.0-dev": _DIGEST_USER_SUPPLIED,
+            }
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -1278,20 +1278,21 @@ class TestPublishDigest:
     @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
     @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
-    def test_no_build_no_push_resolve_failure_falls_back_to_tag_only(
+    def test_no_build_no_push_resolve_failure_aborts_by_default(
         self, mock_detector_cls, mock_meta_validator_cls,
         mock_compose_validator_cls, mock_transformer_cls,
         mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
         mock_reg_builder_cls, mock_publisher_cls, mock_resolve,
         tmp_path,
     ):
-        # Catalog-only republish softly falls back to tag-only when
-        # resolve_digest fails (e.g. no docker on host). Catalog
-        # publishes; the failed ref is absent from digest_map.
+        # Catalog-only republish now aborts loudly when resolve_digest
+        # fails. The previous silent soft-fall to tag-only entries hid
+        # upstream image-name mismatches that produced unpullable refs
+        # in the catalog (see ENG-4909).
         from kamiwaza_extensions.image_pusher import ImagePushError
 
         mock_resolve.side_effect = ImagePushError("docker not found")
-        wired = _wire_publish_mocks(
+        _wire_publish_mocks(
             detector_cls=mock_detector_cls,
             meta_validator_cls=mock_meta_validator_cls,
             compose_validator_cls=mock_compose_validator_cls,
@@ -1306,13 +1307,8 @@ class TestPublishDigest:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        # Must NOT raise — catalog still publishes with tag-only.
-        run_publish(stage="dev", no_build=True, no_push=True)
-
-        wired["reg_builder"].build_entry.assert_called_once()
-        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
-        # digest_map either None or empty — no entries for the failed ref.
-        assert not kwargs.get("digest_map")
+        with pytest.raises((SystemExit, ClickExit)):
+            run_publish(stage="dev", no_build=True, no_push=True)
 
     @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
     @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -1855,10 +1855,11 @@ class TestPublishDigest:
         mock_reg_builder_cls, mock_publisher_cls, tmp_path,
     ):
         # Same dict-order trap as the live path, but inside the dry-run
-        # branch. Pre-fix: dry-run used `_collect_image_refs` (unfiltered),
-        # so a profiled helper appearing first would have pinned the
-        # user's digest against a local-only ref — mismatched against the
-        # canonical buildable ref that ComposeTransformer actually keeps.
+        # branch. A profiled helper appearing first in the compose dict
+        # must not steal the user's --digest pin — dry-run must filter
+        # via buildable_services the same way the live path does so the
+        # digest binds to the canonical buildable ref that
+        # ComposeTransformer actually keeps.
         compose = {
             "services": {
                 "dev-helper": {
@@ -2024,7 +2025,7 @@ class TestRetagAppgardenCompose:
             "ghcr.io/my-org/my-app-backend:2.0.0-dev"
         )
 
-    def test_preserves_declared_namespace_when_diverges_from_convention(self):
+    def test_retag_appgarden_preserves_divergent_namespace(self):
         # Omniparse-style: bake target name (and GHCR path) is
         # `images/omniparse`, but the kz-ext-computed default would be
         # `images/tool-omniparse-omniparse-server`. The fix preserves
@@ -2357,3 +2358,76 @@ class TestPublishWithAppgarden:
             mock_compose_validator_cls.return_value.validate.call_args
         )
         assert validator_args[0].name == "docker-compose.yml"
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_appgarden_image_namespace_drives_build_and_push(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        mock_resolve,
+        tmp_path,
+    ):
+        # When ``docker-compose.appgarden.yml`` declares a different image
+        # namespace than the source ``docker-compose.yml``, the appgarden
+        # file is the source of truth (matches what gets written into the
+        # catalog by ``_retag_appgarden_compose``). Build, push, and
+        # digest resolution must all happen at the appgarden ref —
+        # otherwise the catalog references an image the registry was
+        # never told to expect.
+        (tmp_path / "docker-compose.appgarden.yml").write_text(
+            "services:\n"
+            "  backend:\n"
+            "    image: ghcr.io/published/tool-foo/backend:1.0.0\n"
+        )
+        _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data={
+                "services": {
+                    "backend": {
+                        "build": {"context": "."},
+                        "image": "registry.test/my-app-backend:1.0.0",
+                    },
+                },
+            },
+        )
+        mock_resolve.return_value = "sha256:" + "a" * 64
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # ImageBuilder.build receives the appgarden-declared ref, not the
+        # source-compose ref. ``image_refs`` is keyed by service name.
+        builder_kwargs = mock_builder_cls.return_value.build.call_args.kwargs
+        assert builder_kwargs["image_refs"] == {
+            "backend": "ghcr.io/published/tool-foo/backend:1.0.0-dev",
+        }
+        # Digest auto-resolve queries the registry at the appgarden ref.
+        mock_resolve.assert_called_once_with(
+            "ghcr.io/published/tool-foo/backend:1.0.0-dev"
+        )

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -29,7 +29,7 @@ def _make_extension_info(
             "services": {
                 "backend": {
                     "build": {"context": "."},
-                    "image": f"my-org/{name}-backend:{version}",
+                    "image": f"ghcr.io/my-org/{name}-backend:{version}",
                     "ports": ["8000"],
                 },
             },
@@ -667,11 +667,11 @@ def _multi_buildable_compose(name: str = "my-app", version: str = "1.0.0"):
         "services": {
             "backend": {
                 "build": {"context": "./backend"},
-                "image": f"my-org/{name}-backend:{version}",
+                "image": f"ghcr.io/my-org/{name}-backend:{version}",
             },
             "frontend": {
                 "build": {"context": "./frontend"},
-                "image": f"my-org/{name}-frontend:{version}",
+                "image": f"ghcr.io/my-org/{name}-frontend:{version}",
             },
             "db": {  # Pattern B: external pass-through
                 "image": "postgres:15",
@@ -898,11 +898,11 @@ class TestPublishDigest:
             "services": {
                 "backend": {
                     "build": {"context": "."},
-                    "image": "my-org/my-app-backend:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-backend:1.0.0",
                 },
                 "frontend": {
                     "build": {"context": "./frontend"},
-                    "image": "my-org/my-app-frontend:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-frontend:1.0.0",
                 },
             },
         }
@@ -934,6 +934,81 @@ class TestPublishDigest:
             "ghcr.io/my-org/my-app-backend:1.0.0-dev": _DIGEST_BACKEND,
             "ghcr.io/my-org/my-app-frontend:1.0.0-dev": _DIGEST_FRONTEND,
         }
+
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.check_buildx_available")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_non_conventional_namespace_flows_through_build_and_resolve(
+        self, mock_detector_cls, mock_meta_validator_cls,
+        mock_compose_validator_cls, mock_transformer_cls,
+        mock_profile_mgr_cls, mock_builder_cls, mock_pusher_cls,
+        mock_reg_builder_cls, mock_publisher_cls,
+        mock_resolve, mock_preflight, tmp_path,
+    ):
+        # ENG-4909: when the compose's declared image namespace diverges
+        # from the legacy `{ext}-{svc}` convention (omniparse-style:
+        # ext=`tool-omniparse`, svc=`omniparse-server`, declared image
+        # `images/omniparse`), the declared namespace must propagate
+        # through the build, the push, the digest_map keys, and the
+        # catalog entry. Without ENG-4909 the four sites synthesized
+        # divergent forms and the catalog shipped pointing at an image
+        # that may not exist at the synthesized path.
+        custom_ref = (
+            "ghcr.io/kamiwaza-internal/foo/images/omniparse:1.0.0-dev"
+        )
+        custom_digest = "sha256:" + "d" * 64
+        mock_resolve.return_value = custom_digest
+
+        compose = {
+            "services": {
+                "omniparse-server": {
+                    "build": {"context": "."},
+                    "image": "ghcr.io/kamiwaza-internal/foo/images/omniparse:1.0.0",
+                },
+            },
+        }
+        wired = _wire_publish_mocks(
+            detector_cls=mock_detector_cls,
+            meta_validator_cls=mock_meta_validator_cls,
+            compose_validator_cls=mock_compose_validator_cls,
+            transformer_cls=mock_transformer_cls,
+            profile_mgr_cls=mock_profile_mgr_cls,
+            builder_cls=mock_builder_cls,
+            pusher_cls=mock_pusher_cls,
+            reg_builder_cls=mock_reg_builder_cls,
+            publisher_cls=mock_publisher_cls,
+            tmp_path=tmp_path,
+            compose_data=compose,
+            image_refs=[custom_ref],
+        )
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # 1. ImageBuilder was passed the declared-namespace ref via
+        #    the image_refs kwarg — not the synthesized
+        #    {ext}-{svc} form (which for this fixture would have
+        #    been .../my-app-omniparse-server:...).
+        build_kwargs = wired["image_builder"].build.call_args.kwargs
+        assert build_kwargs["image_refs"] == {"omniparse-server": custom_ref}
+
+        # 2. resolve_digest queried the declared-namespace ref.
+        mock_resolve.assert_called_once_with(custom_ref)
+
+        # 3. digest_map keys match the declared-namespace ref, so
+        #    `_apply_digests` in registry_builder.py will pin the
+        #    catalog compose's image successfully (exact-string match).
+        kwargs = wired["reg_builder"].build_entry.call_args.kwargs
+        assert kwargs["digest_map"] == {custom_ref: custom_digest}
 
     # Note: previous test_explicit_digest_skips_resolver was removed —
     # H2 changed the contract so explicit --digest with push DOES call
@@ -1098,11 +1173,11 @@ class TestPublishDigest:
             "services": {
                 "backend": {
                     "build": {"context": "."},
-                    "image": "my-org/my-app-backend:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-backend:1.0.0",
                 },
                 "dev-helper": {
                     "build": {"context": "./dev"},
-                    "image": "my-org/my-app-dev-helper:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-dev-helper:1.0.0",
                     "profiles": ["dev"],   # local-only, stripped on publish
                 },
             },
@@ -1156,12 +1231,12 @@ class TestPublishDigest:
             "services": {
                 "dev-helper": {
                     "build": {"context": "./dev"},
-                    "image": "my-org/my-app-dev-helper:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-dev-helper:1.0.0",
                     "profiles": ["dev"],   # profiled — must NOT be pinned
                 },
                 "backend": {
                     "build": {"context": "."},
-                    "image": "my-org/my-app-backend:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-backend:1.0.0",
                 },
             },
         }
@@ -1227,12 +1302,12 @@ class TestPublishDigest:
             "services": {
                 "dev-helper": {
                     "build": {"context": "./dev"},
-                    "image": "my-org/my-app-dev-helper:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-dev-helper:1.0.0",
                     "profiles": ["dev"],
                 },
                 "backend": {
                     "build": {"context": "."},
-                    "image": "my-org/my-app-backend:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-backend:1.0.0",
                 },
             },
         }
@@ -1635,7 +1710,7 @@ class TestPublishDigest:
             "services": {
                 "backend": {
                     "build": {"context": "."},
-                    "image": "my-org/my-app-backend:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-backend:1.0.0",
                 },
                 "db": {"image": "postgres:15"},
             },
@@ -1729,7 +1804,7 @@ class TestPublishDigest:
             "services": {
                 "backend": {
                     "build": {"context": "."},
-                    "image": "my-org/my-app-backend:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-backend:1.0.0",
                 },
             },
         }
@@ -1788,12 +1863,12 @@ class TestPublishDigest:
             "services": {
                 "dev-helper": {
                     "build": {"context": "./dev"},
-                    "image": "my-org/my-app-dev-helper:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-dev-helper:1.0.0",
                     "profiles": ["dev"],   # FIRST in dict order
                 },
                 "backend": {
                     "build": {"context": "."},
-                    "image": "my-org/my-app-backend:1.0.0",
+                    "image": "ghcr.io/my-org/my-app-backend:1.0.0",
                 },
             },
         }

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -1880,7 +1880,7 @@ class TestReplaceImageTag:
     """`_replace_image_tag` preserves the namespace and replaces the tag."""
 
     def test_replaces_simple_tag(self):
-        from kamiwaza_extensions.commands.publish import _replace_image_tag
+        from kamiwaza_extensions.compose_transformer import _replace_image_tag
 
         assert _replace_image_tag(
             "ghcr.io/my-org/foo:1.0.0", "1.0.0-dev"
@@ -1890,7 +1890,7 @@ class TestReplaceImageTag:
         # The whole point of the helper: omniparse's image is at
         # `images/omniparse`, not `images/tool-omniparse-omniparse-server`.
         # The replacement only touches the tag, leaves the path alone.
-        from kamiwaza_extensions.commands.publish import _replace_image_tag
+        from kamiwaza_extensions.compose_transformer import _replace_image_tag
 
         assert _replace_image_tag(
             "ghcr.io/kamiwaza-internal/kamiwaza-extensions-omniparse/images/omniparse:2.0.14",
@@ -1902,14 +1902,14 @@ class TestReplaceImageTag:
     def test_handles_registry_with_port(self):
         # `localhost:5000/foo:tag` — the port colon must not be mistaken
         # for the tag separator.
-        from kamiwaza_extensions.commands.publish import _replace_image_tag
+        from kamiwaza_extensions.compose_transformer import _replace_image_tag
 
         assert _replace_image_tag(
             "localhost:5000/foo:1.0.0", "2.0.0-dev"
         ) == "localhost:5000/foo:2.0.0-dev"
 
     def test_strips_digest_before_retagging(self):
-        from kamiwaza_extensions.commands.publish import _replace_image_tag
+        from kamiwaza_extensions.compose_transformer import _replace_image_tag
 
         assert _replace_image_tag(
             "ghcr.io/my-org/foo:1.0.0@sha256:" + "a" * 64,
@@ -1917,7 +1917,7 @@ class TestReplaceImageTag:
         ) == "ghcr.io/my-org/foo:1.0.0-dev"
 
     def test_appends_tag_when_no_existing_tag(self):
-        from kamiwaza_extensions.commands.publish import _replace_image_tag
+        from kamiwaza_extensions.compose_transformer import _replace_image_tag
 
         assert _replace_image_tag(
             "ghcr.io/my-org/foo", "1.0.0-dev"


### PR DESCRIPTION
## Summary

Multiple sites in `kz-ext` independently synthesized the canonical image ref for build-context services. They needed to agree, otherwise the catalog ships referencing one path while the image was pushed to another — and any consumer pulling the catalog ref gets an unpullable image. After this PR, a single shared helper (`compute_canonical_refs`, layered on `_canonical_build_ref`) is the source of truth across every site (publish live + dry-run + dev), digest-resolution failures abort the publish instead of silently degrading to tag-only catalog entries, and unqualified declared images correctly fall back to the cluster-registry rewrite instead of leaking pushes to Docker Hub.

Linear: [ENG-4909](https://linear.app/kamiwaza/issue/ENG-4909)

## What this does

1. **`_retag_appgarden_compose` preserves declared namespace.** Reads compose's `image:` and rewrites only the tag.
2. **`_auto_resolve_digests` aborts on resolution failure.** Previously soft-failed to tag-only entries in `--no-build --no-push` mode; now errors with an actionable message naming the failed ref and the common causes. Soft-fall hid the omniparse-style mismatch this PR is designed to surface.
3. **`_canonical_build_ref` centralizes the namespace logic** in `compose_transformer.py`. Reads the service's declared `image:` ONLY when registry-qualified (first slash-separated component contains `.` or `:`, or is exactly `localhost` — docker's standard rule). Unqualified refs (`api:latest`, `my-org/api:1.0`) and missing/empty declarations fall back to legacy `{registry}/{ext}-{svc}:{tag}`, preventing `docker push` from silently routing to Docker Hub while the cluster registry expects the rewrite. Strips whitespace.
4. **`compute_canonical_refs` is the single shared derivation** used by publish (live + dry-run) and dev. Same source of truth means none of the three paths can drift on namespace, profile filtering, or appgarden precedence. Lives in `compose_transformer.py`; thin wrappers in `commands/publish.py` and `commands/dev.py`.
5. **Per-service appgarden precedence is presence-based.** When `docker-compose.appgarden.yml` declares a service entry — even an empty mapping — that's the source of truth (matches `_retag_appgarden_compose`'s behavior). Source-compose entry is the fallback for services the appgarden file omits. Switching to `name in appgarden` instead of `appgarden.get(name) or svc` keeps the two paths in lockstep on the empty-mapping case.
6. **Profile-gated services are excluded from `canonical_refs`** so they don't leak into the `--no-build` push list or the dev push path. Mirrors `buildable_services`' filter.
7. **`ImageBuilder.build` gains an `image_refs` kwarg** so callers pass the canonical map. Both `run_publish` and `run_dev_remote` compute via `compute_canonical_refs` and pass it through.

## Commits

| Commit | Scope |
|---|---|
| `fix(extensions): preserve appgarden compose image namespace on retag` | Primary catalog-namespace fix. `_retag_appgarden_compose` reads declared image and rewrites only the tag. Adds the original `_replace_image_tag` helper. |
| `fix(extensions): kz-ext publish aborts on digest resolution failure` | Hard-fail in `_auto_resolve_digests` (was soft-fall in `--no-build --no-push`). Actionable error message naming the failed ref. `rich.markup.escape` on dynamic parts. |
| `refactor(extensions): move _replace_image_tag to compose_transformer module` | Pure refactor — helper relocated so `ComposeTransformer` and `ImageBuilder` can import without depending on `commands/`. Behavior unchanged. |
| `fix(extensions): derive build refs and published_refs from canonical helper` | Threads the canonical helper through `ComposeTransformer.transform_service`, `ImageBuilder.build`, `_collect_image_refs`, `published_refs`, and `dry_canonical_ref`. `run_publish` computes a `canonical_refs` map once and passes it everywhere downstream. End-to-end test asserts the namespace-divergence flow through build+push+resolve. |
| `chore(extensions): update stale soft-fall references + generic registry wording` | Drive-by: stale "soft-fall" comments updated to reflect the new hard-fail; error message "GHCR path" → "registry image path". |
| `fix(extensions): kz-ext dev builds at canonical image refs` | Aligns `run_dev_remote` with `run_publish`. Without canonical_refs threaded through `ImageBuilder.build`, the builder synthesized the legacy `{ext}-{svc}` form — pods hit `ImagePullBackOff` on extensions with non-conventional paths. Adds `test_dev_canonical_refs.py`. |
| `fix(extensions): publish canonical_refs honors appgarden image namespace` | Appgarden takes precedence for the live `canonical_refs` map. Also: strip whitespace in `_canonical_build_ref`; drop `_collect_image_refs` in favor of `list(canonical_refs.values())`; rename two same-named tests across files. |
| `fix(extensions): only honor declared image namespace when registry-qualified` | **(H1 from re-review)** Adds `_looks_registry_qualified`. Unqualified short refs (`api:latest`, `my-org/api:1.0`) now fall back to legacy `{registry}/{ext}-{svc}:{tag}` instead of being honored verbatim — previously they would have leaked `docker push` to Docker Hub. |
| `fix(extensions): share canonical_refs derivation across publish + dev paths` | **(M1+M2+M3 from re-review)** Extracts `compute_canonical_refs` shared by all three sites. Presence-based appgarden lookup (M1), appgarden-aware dry-run (M2), profile-gated services filtered out (M3). |

## Behavioral changes (for review attention)

1. **`_auto_resolve_digests` hard-fails by default** (no opt-in flag). Previously soft-failed in `--no-build --no-push` mode. Escape hatches remain: `--digest sha256:...`, `--dry-run`, legacy `make publish-registry` (retiring).

2. **`ComposeTransformer.transform_service` now respects registry-qualified declared `image:` namespace.** Previously always synthesized `{registry}/{ext}-{svc}:{tag}` regardless of compose; now honors qualified declarations but still rewrites unqualified ones to the cluster registry. Same fix applies to `_retag_appgarden_compose` and the dev path.

3. **`kz-ext dev` now builds at the declared compose namespace.** Previously dev.py's `ImageBuilder` call defaulted to the legacy `{ext}-{svc}` form, while the K8s payload (built from the transformed compose) referenced the declared namespace — guaranteed `ImagePullBackOff` on any extension that publishes under a non-conventional path.

4. **Unqualified declared images fall back to legacy rewrite, not Docker Hub.** Compose shapes like `image: api:latest` or `image: my-org/api:1.0` would have been honored verbatim by `_canonical_build_ref` before the H1 fix from the re-review — `docker push` resolves those to Docker Hub. They now fall back to `{cluster_registry}/{ext}-{svc}:{tag}` so the rewrite stays internally consistent.

## Test plan

### Unit tests
- [x] `uv run pytest tests/unit/extensions/` — 1151 pass, 1 skipped (BSD-sed-only; unrelated), 1 deselected (`test_available_port` is brittle to which ports are taken on the host; unrelated to this PR).
- [x] `uv run pytest tests/unit/extensions/test_publish_cmd.py tests/unit/extensions/test_compose_transformer.py tests/unit/extensions/test_dev_canonical_refs.py` — 124 pass. New tests since the original PR:
  - `TestLooksRegistryQualified` (5 cases) + `TestCanonicalBuildRef` (8 cases) — H1 predicate and the canonical-build-ref behavior across qualified/unqualified shapes
  - `TestComputeCanonicalRefs` (8 cases) — shared helper: empty source, only-buildable, profile filter, appgarden override, empty appgarden entry, missing appgarden entry, None source, legacy fallback
  - `TestBuildContextRemoval::test_unqualified_short_form_falls_back_to_legacy` — H1 regression-shape end-to-end through `ComposeTransformer.transform`
  - `TestPublishDigest::test_dry_run_digest_uses_appgarden_namespace` — M2 dry-run + `--digest` + appgarden namespace divergence
  - `TestPublishWithBuild::test_no_build_push_excludes_profile_gated_services` — M3 `--no-build` push list excludes profile-gated refs
  - `TestPublishWithAppgarden::test_appgarden_image_namespace_drives_build_and_push` — appgarden namespace flows to ImageBuilder + digest resolve
  - `TestDevRemoteBuildsAtCanonicalRefs::test_divergent_image_namespace_flows_through_to_builder` — `run_dev_remote` passes canonical refs to `ImageBuilder.build`
- [x] `uv run ruff check` on changed files — clean.

### E2E validation (on omniparse, the real-world divergent-namespace case)

omniparse declares `image: ghcr.io/kamiwaza-internal/kamiwaza-extensions-omniparse/images/omniparse:2.0.14` in both source and appgarden compose. Ran against the local kamiwaza.test cluster and the R2 dev catalog using `kz-ext` built from this branch:

| Step | Result |
|---|---|
| **1. `kz-ext publish --stage dev --dry-run --force`** | Dry-run completes; catalog write would replace v2.0.14. canonical_refs computed correctly. (Minor cosmetic finding: dry-run "Would build images:" display still uses legacy short form — actual build/push uses canonical_refs. Captured as a follow-up.) |
| **2. K8s payload assertion** | Test deploy with `--revision eng-4909-validate`. Pod spec confirmed: `image: ghcr.io/kamiwaza-internal/kamiwaza-extensions-omniparse/images/omniparse:eng-4909-validate` — canonical declared namespace. Existing 41h-old omniparse pod at same canonical ref is Running, proving cluster pulls successfully when image exists. Full build skipped (mechanical; unit test covers `image_refs=` kwarg wire-up). |
| **3. `kz-ext publish --stage dev --no-build --no-push --force`** | Published omniparse v2.0.14 to R2 dev catalog. Downloaded `dev-info/garden/v3/tools.json`: `compose_yml.services.omniparse-server.image` and top-level `docker_images[0]` both contain `ghcr.io/kamiwaza-internal/kamiwaza-extensions-omniparse/images/omniparse:2.0.14-dev@sha256:a2f1c7466baf3f6161701e9adaaeb6e9e94fa04f10248f3435bed8397b1fc01b`. |
| **4. Direct Python invocation post-H1 fix** | `_looks_registry_qualified` on real omniparse compose returns True for `ghcr.io/...`, False for `api:latest`/`my-org/api:1.0`, True for `localhost:5000/foo`/`localhost/foo`. `compute_canonical_refs` against omniparse's real compose produces `ghcr.io/.../images/omniparse:{tag}` for both publish (with appgarden) and dev (without). |

## Related

- ENG-4638 — wired up auto-publish; surfaced this gap
- ENG-4872 — fixed `:latest` race in container-build (related infra)
- ENG-4910 — closed as won't-do; was based on the misread that omniparse needed to rename
- PR #100 (ENG-4907) — landed `_retag_appgarden_compose` with the catalog-write-side bug fixed in commit 1 here

## Follow-ups (not blocking this PR)

- **Dry-run display synthesizes legacy short form.** `_collect_buildable_image_names` (used only for the "Would build images:" message in dry-run output) still produces `{ext}-{svc}:tag`. The actual build path uses `canonical_refs` correctly; the display is just misleading for extensions with declared namespaces. Cosmetic-only.
