### PR TITLE
fix(extensions): kz-ext publish preserves kamiwaza.json fields (ENG-4919)

### DIFF
--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -118,36 +118,28 @@ class RegistryBuilder:
                 ]
             docker_images = list(dict.fromkeys(docker_images + extra_images))
 
-        entry: Dict[str, Any] = {
-            "name": metadata.get("name", ""),
-            "version": version,
-            "description": metadata.get("description", ""),
-            "source_type": metadata.get("source_type", "kamiwaza"),
-            "visibility": metadata.get("visibility", "public"),
-            "compose_yml": compose_yml,
-            "docker_images": docker_images,
-        }
+        # Pass-through: start from kamiwaza.json so every top-level field
+        # the developer authored reaches the catalog. The legacy
+        # `make publish-registry` path treats source kamiwaza.json as the
+        # contract — env_defaults, required_env_vars, template_type,
+        # display_name, strip_path_prefix, capabilities, and friends all
+        # flow through. The platform sync code (templates.py) reads many
+        # of these via `.get(field, default)` and silently degrades when
+        # they're missing (ENG-4919).
+        entry: Dict[str, Any] = copy.deepcopy(metadata)
+        entry["name"] = metadata.get("name", "")
+        entry["version"] = version
+        entry.setdefault("description", "")
+        entry.setdefault("source_type", "kamiwaza")
+        entry.setdefault("visibility", "public")
+        entry["compose_yml"] = compose_yml
+        entry["docker_images"] = docker_images
 
         if revision is not None:
             entry["revision"] = revision
 
-        # Optional fields -- only include when present in metadata.
-        kamiwaza_version = metadata.get("kamiwaza_version")
-        if kamiwaza_version:
-            entry["kamiwaza_version"] = kamiwaza_version
-
-        preview_image = metadata.get("preview_image")
-        if preview_image:
-            entry["preview_image"] = _normalize_preview_image(preview_image)
-
-        risk_tier = metadata.get("risk_tier")
-        if risk_tier is not None:
-            entry["risk_tier"] = risk_tier
-
-        for optional_key in ("tags", "category", "verified"):
-            val = metadata.get(optional_key)
-            if val is not None:
-                entry[optional_key] = val
+        if entry.get("preview_image"):
+            entry["preview_image"] = _normalize_preview_image(entry["preview_image"])
 
         return entry
 

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -135,6 +135,12 @@ class RegistryBuilder:
         entry["compose_yml"] = compose_yml
         entry["docker_images"] = docker_images
 
+        # `revision` is owned exclusively by the publish-time parameter,
+        # never by source kamiwaza.json. Pop first so a stale value in
+        # metadata (or a catalog entry re-fed as metadata) can't leak
+        # through and trip CatalogDedupGuard with a revision that was
+        # never used to tag the images.
+        entry.pop("revision", None)
         if revision is not None:
             entry["revision"] = revision
 

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -118,14 +118,16 @@ class RegistryBuilder:
                 ]
             docker_images = list(dict.fromkeys(docker_images + extra_images))
 
-        # Pass-through: start from kamiwaza.json so every top-level field
-        # the developer authored reaches the catalog. The legacy
-        # `make publish-registry` path treats source kamiwaza.json as the
-        # contract — env_defaults, required_env_vars, template_type,
-        # display_name, strip_path_prefix, capabilities, and friends all
-        # flow through. The platform sync code (templates.py) reads many
-        # of these via `.get(field, default)` and silently degrades when
-        # they're missing (ENG-4919).
+        # Source kamiwaza.json is the catalog contract: every top-level
+        # field the developer authored reaches the catalog entry. The
+        # platform's _update_template_from_remote
+        # (kamiwaza/serving/garden/apps/templates.py) reads
+        # env_defaults, required_env_vars, capabilities, display_name,
+        # strip_path_prefix, and friends via `.get(field, default)` —
+        # any field a slim entry omits silently degrades to {} / [] /
+        # None on the platform side, breaking required-env validation,
+        # env-default injection, and UI metadata. Curating the entry
+        # down to a known-fields subset has bitten us before; don't.
         entry: Dict[str, Any] = copy.deepcopy(metadata)
         entry["name"] = metadata.get("name", "")
         entry["version"] = version

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -279,7 +279,8 @@ class TestBuildEntryPassthrough:
     def test_metadata_not_mutated(self, builder, transformed_compose):
         # build_entry must not mutate the caller's metadata dict — it's
         # often the parsed kamiwaza.json shared with other code paths
-        # (validators, dedup guard, etc.).
+        # (validators, dedup guard, etc.). deepcopy must protect nested
+        # structures, not just top-level keys.
         meta = {
             "name": "my-app",
             "version": "1.0.0",
@@ -289,9 +290,47 @@ class TestBuildEntryPassthrough:
             "env_defaults": {"FOO": "bar"},
             "preview_image": "./logo.png",
         }
-        builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
+        entry = builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
         assert meta["preview_image"] == "./logo.png"  # not normalized
-        assert meta["env_defaults"] == {"FOO": "bar"}
+        # Mutating the entry's nested dict must not bleed into source.
+        entry["env_defaults"]["FOO"] = "mutated"
+        assert meta["env_defaults"]["FOO"] == "bar"
+
+    def test_revision_not_inherited_from_metadata(
+        self, builder, transformed_compose,
+    ):
+        # `revision` is publish-time only — owned by the --revision CLI
+        # arg, never by source kamiwaza.json. Without explicit pop, a
+        # stale revision in metadata (or a catalog entry round-tripped
+        # through metadata) would survive deepcopy and trip
+        # CatalogDedupGuard with a revision that wasn't used to tag the
+        # images.
+        meta = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "revision": "stale-from-prior-publish",
+        }
+        entry = builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
+        assert "revision" not in entry
+
+    def test_revision_param_overrides_metadata(
+        self, builder, transformed_compose,
+    ):
+        meta = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "revision": "stale",
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "reg", "1.0.0", revision="fresh",
+        )
+        assert entry["revision"] == "fresh"
 
     def test_defaults_applied_for_missing_required_fields(
         self, builder, transformed_compose,

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -173,11 +173,13 @@ class TestBuildEntry:
 
 # ------------------------------------------------------------------
 # build_entry passes every top-level kamiwaza.json field through to
-# the catalog entry (ENG-4919). The platform's catalog→DB sync code
+# the catalog entry. The platform's catalog→DB sync
 # (kamiwaza/serving/garden/apps/templates.py::_update_template_from_remote)
-# reads many of these via `.get(field, default)` and silently degrades
-# to empty/None when slim entries omit them — no required_env_vars
-# validation, no env_defaults injection, missing UI metadata.
+# reads many fields via `.get(field, default)` and silently degrades
+# to empty/None when entries omit them — no required_env_vars
+# validation, no env_defaults injection, missing UI metadata. The
+# regression these tests pin: don't curate the entry down to a
+# known-fields subset.
 # ------------------------------------------------------------------
 
 

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -172,6 +172,141 @@ class TestBuildEntry:
 
 
 # ------------------------------------------------------------------
+# build_entry passes every top-level kamiwaza.json field through to
+# the catalog entry (ENG-4919). The platform's catalog→DB sync code
+# (kamiwaza/serving/garden/apps/templates.py::_update_template_from_remote)
+# reads many of these via `.get(field, default)` and silently degrades
+# to empty/None when slim entries omit them — no required_env_vars
+# validation, no env_defaults injection, missing UI metadata.
+# ------------------------------------------------------------------
+
+
+class TestBuildEntryPassthrough:
+    """Every top-level field in kamiwaza.json survives to the catalog entry."""
+
+    def test_platform_consumed_fields_pass_through(
+        self, builder, transformed_compose,
+    ):
+        # The fields the platform's _update_template_from_remote reads.
+        meta = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "An app",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "display_name": "My App",
+            "env_defaults": {"FOO": "bar", "PORT": "8000"},
+            "env_metadata": {"FOO": {"description": "foo var"}},
+            "required_env_vars": ["API_KEY"],
+            "capabilities": ["chat", "completion"],
+            "category": "chatbot",
+            "tags": ["ai"],
+            "author": "Kamiwaza",
+            "license": "Apache-2.0",
+            "homepage": "https://example.com",
+            "image": "kamiwazaai/my-app:1.0.0",
+            "strip_path_prefix": True,
+            "preferred_model_type": "reasoning",
+            "preferred_model_name": "gpt-4",
+            "fail_if_model_type_unavailable": False,
+            "fail_if_model_name_unavailable": False,
+        }
+        entry = builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
+        for key, value in meta.items():
+            assert entry[key] == value, f"{key} did not pass through"
+
+    def test_unknown_fields_pass_through(self, builder, transformed_compose):
+        # omniparse-style: `validation` block (e.g. allowed_images) and
+        # `template_type` are not enumerated anywhere in build_entry but
+        # the platform and the legacy publish path treat kamiwaza.json
+        # as the contract. New fields must not require a kz-ext change.
+        meta = {
+            "name": "tool-omniparse",
+            "version": "2.0.14",
+            "description": "OmniParse",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "template_type": "tool",
+            "validation": {"allowed_images": ["ghcr.io/foo/*"]},
+            "x_custom_extension": {"any": "shape"},
+        }
+        entry = builder.build_entry(meta, transformed_compose, "reg", "2.0.14")
+        assert entry["template_type"] == "tool"
+        assert entry["validation"] == {"allowed_images": ["ghcr.io/foo/*"]}
+        assert entry["x_custom_extension"] == {"any": "shape"}
+
+    def test_entry_keys_are_superset_of_source(
+        self, builder, transformed_compose,
+    ):
+        # Stricter check: legacy `make publish-registry` AC #1 says the
+        # entry's top-level keys are a superset of source kamiwaza.json
+        # plus the generated `compose_yml` / `docker_images`.
+        meta = {
+            "name": "svc",
+            "version": "1.0.0",
+            "description": "svc",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "template_type": "service",
+            "env_defaults": {"X": "1"},
+            "required_env_vars": ["Y"],
+            "strip_path_prefix": False,
+        }
+        entry = builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
+        for key in meta:
+            assert key in entry, f"source field {key} dropped from entry"
+
+    def test_publish_generated_fields_win_over_metadata(
+        self, builder, transformed_compose,
+    ):
+        # If the source kamiwaza.json carries a stale `compose_yml` or
+        # `docker_images` from a hand-edit, the publish-time values
+        # (from ComposeTransformer + extract_docker_images) must win.
+        meta = {
+            "name": "my-app",
+            "version": "0.9.0-stale",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "compose_yml": "stale: data",
+            "docker_images": ["stale:image"],
+        }
+        entry = builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
+        assert entry["version"] == "1.0.0"
+        assert entry["compose_yml"] != "stale: data"
+        assert "stale:image" not in entry["docker_images"]
+
+    def test_metadata_not_mutated(self, builder, transformed_compose):
+        # build_entry must not mutate the caller's metadata dict — it's
+        # often the parsed kamiwaza.json shared with other code paths
+        # (validators, dedup guard, etc.).
+        meta = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "env_defaults": {"FOO": "bar"},
+            "preview_image": "./logo.png",
+        }
+        builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
+        assert meta["preview_image"] == "./logo.png"  # not normalized
+        assert meta["env_defaults"] == {"FOO": "bar"}
+
+    def test_defaults_applied_for_missing_required_fields(
+        self, builder, transformed_compose,
+    ):
+        # Belt-and-suspenders: the upstream MetadataValidator should
+        # catch these, but build_entry still papers over with the same
+        # defaults the prior enumerated implementation used.
+        meta = {"name": "my-app", "version": "1.0.0"}
+        entry = builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
+        assert entry["description"] == ""
+        assert entry["source_type"] == "kamiwaza"
+        assert entry["visibility"] == "public"
+
+
+# ------------------------------------------------------------------
 # build_entry treats ComposeTransformer as canonical (ENG-3591)
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`kz-ext publish`'s `RegistryBuilder.build_entry` enumerated ~10 catalog fields and silently dropped everything else from `kamiwaza.json`. The platform's `_update_template_from_remote` (in `kamiwaza/serving/garden/apps/templates.py`) reads many of those dropped fields via `.get(field, default)` and degrades to `{}` / `[]` / `None` — no `required_env_vars` validation at deploy time, no `env_defaults` injection, missing UI metadata, broken `strip_path_prefix`, lost `validation` blocks. Discovered while migrating DDE (ENG-4613).

Linear: [ENG-4919](https://linear.app/kamiwaza/issue/ENG-4919)

## Contract

`build_entry` now treats source `kamiwaza.json` as the contract — same shape the legacy `make publish-registry` path has always shipped:

```python
entry = copy.deepcopy(metadata)
entry["name"] = metadata.get("name", "")
entry["version"] = version
entry.setdefault("description", "")
entry.setdefault("source_type", "kamiwaza")
entry.setdefault("visibility", "public")
entry["compose_yml"] = compose_yml
entry["docker_images"] = docker_images
if revision is not None: entry["revision"] = revision
if entry.get("preview_image"): entry["preview_image"] = _normalize_preview_image(...)
```

Publish-generated fields (`compose_yml`, `docker_images`, `revision`, normalized `preview_image`, `version`) win over whatever the source carries. The deepcopy guarantees the caller's `kamiwaza.json` dict isn't mutated.

## Verification

- `tests/unit/extensions/test_registry_builder.py` — 76/76 pass; 6 new `TestBuildEntryPassthrough` tests cover the platform-consumed fields, unknown-field pass-through (omniparse-style `validation` block, arbitrary `x_*` keys), key-set superset, generated-fields-win-over-source, no-mutation, and validator-fallback defaults.
- Full `tests/unit/extensions/` suite: 1122 pass, 1 skip (BSD sed). Unrelated pre-existing `test_dev_local::test_available_port` failure on this host (port already in use by gvproxy); not exercised by this change.

E2E against `dev-info.kamiwaza.ai` deferred to a separate live republish run for skills-library + diff vs. current catalog state (ENG-4919's snapshot script).

## Noteworthy

- **`revision` field is still emitted.** Legacy `make publish-registry` doesn't write `revision`; kz-ext does (read by `CatalogDedupGuard` for CI idempotency). Interpreting AC #2 as legacy keys ⊆ kz-ext keys rather than strict equality — `revision` is the one allowed extra key.
- **Per-stage tag rewrites on `extra_docker_images` and top-level `image` are NOT ported.** Legacy `scripts/build-registry.py` rewrites `1.0.0` → `1.0.0-dev` on these fields for dev stage. With pass-through, whatever the developer wrote in `kamiwaza.json` flows through verbatim — the published image tags already carry the correct stage suffix from the build/push pipeline, so this metadata is what the developer intended, not what the publisher should be auto-rewriting.

## Related

- [ENG-4909](https://linear.app/kamiwaza/issue/ENG-4909) / PR #101 — orthogonal compose-image-namespace fix. Zero file overlap; either can land first.
- [ENG-4613](https://linear.app/kamiwaza/issue/ENG-4613) — DDE migration where this surfaced.