### PR TITLE
WS-M3 (Ergonomics) — SDK module surface + 8-step walkthrough + demo-gate test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /docs-local/*
 !/docs-local/00-server-defects.md
 
+# T5.16 pdoc-generated API reference (regenerate via `make docs`)
+/docs/api/
+
 # Virtual environments
 notebook-venv/
 venv/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: sync test test-unit test-live lint format type-check build clean help
+.PHONY: sync test test-unit test-live lint format type-check build clean docs help
 
 # Default target
 help:
@@ -10,6 +10,7 @@ help:
 	@echo "  lint       - Run ruff linter"
 	@echo "  format     - Format code with black and isort"
 	@echo "  type-check - Run mypy type checker"
+	@echo "  docs       - Generate API reference docs from typed signatures (T5.16)"
 	@echo "  build      - Build package"
 	@echo "  clean      - Remove build artifacts"
 
@@ -37,6 +38,30 @@ format: sync
 
 type-check: sync
 	uv run mypy kamiwaza_sdk/
+
+# Documentation
+docs: sync
+	# T5.16 / ENG-4744 — autogen API reference from typed signatures + docstrings.
+	# pdoc reads each module's __doc__, class/function signatures, and Google-
+	# style docstrings; the M3 surface (kamiwaza.subjects, kamiwaza.datasets,
+	# kamiwaza.cluster execution-gate methods) carries full type hints, so this
+	# render produces a complete reference without hand-written doc pages.
+	#
+	# Submodules listed explicitly: kamiwaza/__init__.py doesn't re-import the
+	# full surface (lazy-loaded service modules), so pdoc auto-discovery from
+	# the top-level package alone wouldn't traverse into them.
+	uv run pdoc --output-directory docs/api \
+		kamiwaza \
+		kamiwaza.client \
+		kamiwaza.exceptions \
+		kamiwaza.models \
+		kamiwaza.cluster \
+		kamiwaza.datasets \
+		kamiwaza.federations \
+		kamiwaza.gates \
+		kamiwaza.jobs \
+		kamiwaza.retrieval \
+		kamiwaza.subjects
 
 # Build and release
 build: clean

--- a/README.md
+++ b/README.md
@@ -31,24 +31,29 @@ pat = client.auth.create_pat(PATCreate(name="local-bootstrap")).token
 print("Save this token:", pat)
 ```
 
-## Federation walkthrough (kamiwaza-mesh-v1.0.0 skeleton)
+## Federation walkthrough (kamiwaza-mesh-v1.0.0)
 
 > Available in **kamiwaza-sdk 1.0.0+** under the new top-level
 > `kamiwaza` namespace, distinct from the legacy `kamiwaza_sdk`
 > namespace above. See the design's §4.2.11 for the full surface.
 
-The new `kamiwaza` namespace ships the federation-aware client. It
-covers the WS-M1 milestone demo flow end-to-end:
+The new `kamiwaza` namespace ships the federation-aware client. The
+eight-step demo author's `setup.py` flow uses **only SDK calls** — no
+`kubectl exec`, no manual SQL, no Keycloak admin REST:
 
-1. Pair two clusters
-2. Allowlist a brokered user on the receiver
-3. Submit a federated job
-4. Observe the audit trail showing the originating user
-
-This is the WS-M1 *skeleton* surface. The full eight-step walkthrough
-(catalog discovery, dataset registration, gate binding, job
-recovery) lands in WS-M3 — see the federation design doc for the
-end-state.
+1. **Pair LYRA with ORION** — `kz.federations.pair(...)`
+2. **Seed personas** — `kz.subjects.upsert(...)` (replaces the v0.1.x
+   two-phase KC recipe — see authoring-guide §6)
+3. **Bind the cluster execution gate** — `kz.cluster.set_execution_gate(...)`
+   (replaces the `kubectl exec` recipe — see authoring-guide §9.1)
+4. **Register the dataset** — `kz.datasets.create(...)`
+5. **Bind the dataset's attribute gate** — `kz.datasets.set_gate(...)`
+6. **Allowlist the brokered user + grant viewer** —
+   `kz.federations["ORION"].users.add(...)` plus
+   `kz.subjects.grants("user").create(...)`
+7. **Submit the federated job** — `kz.jobs.run(...)`
+8. **Observe the audit trail** — `kz.cluster.operations()` / receiver-side
+   `gate_binding{,_set,clear}` + `subject_upsert` audit events
 
 ### Configure the client
 
@@ -94,15 +99,90 @@ the receiver, the SDK retries with exponential backoff until the
 server's structured 503 (`detail.reason == "psk_propagation_timeout"`)
 times out the budget — see `kamiwaza.exceptions.FederationPairTimeoutError`.
 
-### Step 2 — Allowlist a brokered user
+### Step 2 — Seed personas (M3)
 
-The receiver maintains the allowlist. `external_id` follows the
-`<username>@<peer-cluster-uuid>` convention so the same name can
-exist on multiple peers without colliding. `initial_tuples` are
-applied at first-mesh-ingress when the brokered user is auto-provisioned.
+Replaces the v0.1.x two-phase Keycloak admin recipe (see
+`authoring-a-federated-demo.md` §6). The single PUT writes attributes
+in one round-trip, infers multivalued KC entries for list-shaped
+values, and rolls back attribute deltas on partial failure (T3.4).
 
 ```python
-user = kz.federations["ORION"].users.add(
+cdr_baker = kz.subjects.upsert(
+    "cdr-baker",
+    attributes={
+        "clearance": "TS",
+        "country": "USA",
+        "programs": ["IRIS", "ARGOS"],   # list → multivalued KC attribute
+    },
+    password="cdr-baker",
+)
+print(cdr_baker.id, cdr_baker.attributes["clearance"])  # kc-uuid TS
+```
+
+Audit emits `subject_upsert{outcome=success}` on the receiver. A
+partial-failure rollback emits `subject_upsert_rollback{outcome=...}`
+so operators can spot drift cases in logs (T3.7).
+
+### Step 3 — Bind the cluster execution gate (M3)
+
+Replaces the `kubectl exec ... RuntimeConfig().set_config(...)` recipe
+(see `authoring-a-federated-demo.md` §9.1). The PUT validates the
+classpath is an ExecutionGate subclass and validates `config` against
+the gate's `config_schema()` before persisting (T2.6 jsonschema).
+
+```python
+binding = kz.cluster.set_execution_gate(
+    type="kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate",
+    # config={} omitted — AllowAllExecutionGate declares no config_schema()
+)
+print(binding.gate_name, binding.kind)  # allow_all_execution_gate execution
+```
+
+Without an active binding, mesh job submission fails with `403
+no_execution_gate_configured_for_mesh`. The SDK surfaces wrong-kind
+attempts (binding an `AttributeGate` as an execution gate) as
+`KamiwazaError` with status 400.
+
+### Step 4 — Register the dataset (M3)
+
+```python
+conjunctions = kz.datasets.create(
+    name="conjunctions",
+    platform="postgres",
+    environment="PROD",
+    properties={
+        "connection_secret_urn": "urn:li:secret:postgres-conjunctions",
+        "table": "public.conjunctions",
+    },
+)
+print(conjunctions.urn)  # urn:li:dataset:(postgres,conjunctions,PROD)
+```
+
+### Step 5 — Bind the dataset's attribute gate (M3)
+
+```python
+ds_binding = kz.datasets.set_gate(
+    conjunctions.urn,
+    type="kamiwaza_extensions.classified_conjunction_gate.ClassifiedConjunctionGate",
+    config={
+        "classification_field": "classification",
+        "releasable_to_field": "releasable_to",
+        "program_compartment_field": "program_compartment",
+    },
+)
+print(ds_binding.dataset_urn, ds_binding.gate_name)
+```
+
+The server verifies the classpath is an `AttributeGate` (wrong-kind →
+400) and that `config` matches the gate's `config_schema()` (mismatch
+→ 400 `schema_validation_failed`). Owner-on-dataset ReBAC enforces
+that only the dataset's owner can rebind the gate (T2.5 follow-up).
+
+### Step 6 — Allowlist the brokered user + grant viewer (M3)
+
+```python
+# Receiver-side allowlist (same as WS-M1):
+kz.federations["ORION"].users.add(
     external_id="cdr-baker@lyra-cluster-uuid",
     initial_tuples=[
         {
@@ -112,7 +192,13 @@ user = kz.federations["ORION"].users.add(
         },
     ],
 )
-print(user.external_id, user.auto_provisioned)  # False until first mesh request
+
+# Then attach a ReBAC viewer relation on the dataset (M3 subjects.grants):
+kz.subjects.grants("cdr-baker").create(
+    object_namespace="dataset",
+    object_id=conjunctions.urn,
+    relation="viewer",
+)
 ```
 
 If the user isn't on the allowlist when a mesh request arrives,
@@ -120,7 +206,7 @@ ext-authz returns 403 with `detail.reason ==
 "brokered_user_not_allowlisted"`. The SDK surfaces that as
 `kamiwaza.exceptions.BrokeredUserNotAllowlistedError`.
 
-### Step 3 — Submit a federated job
+### Step 7 — Submit the federated job
 
 `target_cluster` is the federation name (the same name used at
 pair time). Omit it to run locally on the cluster the SDK is
@@ -152,20 +238,31 @@ budget expires before a terminal state. A *failed* job returns a
 JobResult with `status="FAILED"` and an `error` message — that's
 not exceptional, that's data.
 
-### Step 4 — Observe audit
+### Step 8 — Observe audit
 
 The receiver-side audit log shows the job completing as the
 originating user (`cdr-baker@lyra-cluster-uuid`), not as a
-system principal. Inspect on the receiver via:
+system principal. M3 adds two more event types operators can grep for:
+
+- `gate_binding{action: set|clear, kind: execution|attribute}` — every
+  PUT/DELETE on the cluster + dataset gate endpoints (T2.12).
+- `subject_upsert{,_rollback}` and `subject_grant_change` — every
+  AuthzSubjects mutation (T3.7).
 
 ```bash
+# Federated job audit trail
 kubectl -n kamiwaza logs deployment/core-scheduler \
     | grep federated_job_completed \
     | jq 'select(.audit_actor)'
+
+# M3 gate-binding + subject-management audit
+kubectl -n kamiwaza logs deployment/core-scheduler \
+    | jq 'select(.event_type | startswith("gate_binding") or
+                                  startswith("subject_"))'
 ```
 
 The `audit_actor` field is the same value `kz.jobs.run(...).audit_actor`
-returns in step 3 — that round-trip is the demo gate's load-bearing
+returns in step 7 — that round-trip is the demo gate's load-bearing
 signal.
 
 ### Recoverable long-jobs

--- a/README.md
+++ b/README.md
@@ -99,12 +99,49 @@ the receiver, the SDK retries with exponential backoff until the
 server's structured 503 (`detail.reason == "psk_propagation_timeout"`)
 times out the budget — see `kamiwaza.exceptions.FederationPairTimeoutError`.
 
-### Step 2 — Seed personas (M3)
+### Step 2 — Declare the attribute vocabulary, then seed personas (M3 + M3.1)
 
 Replaces the v0.1.x two-phase Keycloak admin recipe (see
-`authoring-a-federated-demo.md` §6). The single PUT writes attributes
-in one round-trip, infers multivalued KC entries for list-shaped
-values, and rolls back attribute deltas on partial failure (T3.4).
+`authoring-a-federated-demo.md` §6). Two sub-steps:
+
+**Step 2a — Declare the realm's attribute vocabulary (M3.1, v0.3.6).**
+Every attribute name a subject can hold must be declared in the realm
+BEFORE `kz.subjects.upsert(...)` writes it. Keycloak's realm default
+`unmanagedAttributePolicy=None` silently drops attribute writes for
+undeclared names — the M3.1 declared-vocabulary surface converts that
+silent drop into a 400 with structured remediation, so unknown names
+fail loudly at upsert time instead of returning success with empty
+attributes.
+
+```python
+kz.cluster.declare_attribute("clearance", type="string")
+kz.cluster.declare_attribute("country",   type="string")
+kz.cluster.declare_attribute("programs",  type="string[]")  # multivalued
+```
+
+`declare_attribute` is idempotent on identical shape — safe to re-run
+during demo setup. Shape change on a declared-state attribute returns
+400 `shape_change_on_declared`; deprecate + withdraw first to retire
+the old shape. See `kz.cluster.list_attributes()` to inspect the
+current vocabulary, and `kz.cluster.deprecate_attribute(name)` /
+`kz.cluster.withdraw_attribute(name, force=True)` for retirement.
+
+For PII-grade attributes the gate consumes via the mesh-envelope
+`user_attrs` channel (not as a JWT claim), pass `sensitive=True`:
+
+```python
+kz.cluster.declare_attribute("ssn_last4", type="string", sensitive=True)
+```
+
+For attributes attested by a peer cluster's brokered-user provisioning
+(rather than set by local admin), pass `authority="mesh_peer"` —
+local admin attempts to set these on local users return 400
+`wrong_authority_for_subject`. Defaults (`sensitive=False`,
+`authority="local_admin"`) match the demo flow's normal case.
+
+**Step 2b — Seed personas.** The single PUT writes attributes in one
+round-trip, infers multivalued KC entries for list-shaped values, and
+rolls back attribute deltas on partial failure (T3.4).
 
 ```python
 cdr_baker = kz.subjects.upsert(
@@ -121,7 +158,10 @@ print(cdr_baker.id, cdr_baker.attributes["clearance"])  # kc-uuid TS
 
 Audit emits `subject_upsert{outcome=success}` on the receiver. A
 partial-failure rollback emits `subject_upsert_rollback{outcome=...}`
-so operators can spot drift cases in logs (T3.7).
+so operators can spot drift cases in logs (T3.7). Attempting `upsert`
+with an undeclared attribute name returns 400 `attribute_not_registered`
+with the undeclared names enumerated and remediation text pointing
+back at `declare_attribute(...)`.
 
 ### Step 3 — Bind the cluster execution gate (M3)
 

--- a/kamiwaza-ai-extensions-lib/package-lock.json
+++ b/kamiwaza-ai-extensions-lib/package-lock.json
@@ -737,9 +737,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -757,9 +754,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -777,9 +771,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -797,9 +788,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -952,9 +940,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -969,9 +954,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -986,9 +968,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1003,9 +982,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1020,9 +996,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1037,9 +1010,6 @@
                 "loong64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1054,9 +1024,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1071,9 +1038,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1088,9 +1052,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1105,9 +1066,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1122,9 +1080,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1139,9 +1094,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1156,9 +1108,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/kamiwaza/__init__.py
+++ b/kamiwaza/__init__.py
@@ -27,12 +27,16 @@ from kamiwaza.client import Kamiwaza as Kamiwaza
 from kamiwaza.exceptions import KamiwazaError as KamiwazaError
 from kamiwaza.models import BrokeredUser as BrokeredUser
 from kamiwaza.models import Federation as Federation
+from kamiwaza.models import Grant as Grant
 from kamiwaza.models import JobResult as JobResult
+from kamiwaza.models import Subject as Subject
 
 __all__ = [
     "BrokeredUser",
     "Federation",
+    "Grant",
     "JobResult",
     "Kamiwaza",
     "KamiwazaError",
+    "Subject",
 ]

--- a/kamiwaza/__init__.py
+++ b/kamiwaza/__init__.py
@@ -25,14 +25,18 @@ from __future__ import annotations
 
 from kamiwaza.client import Kamiwaza as Kamiwaza
 from kamiwaza.exceptions import KamiwazaError as KamiwazaError
+from kamiwaza.models import AttributeGateBinding as AttributeGateBinding
 from kamiwaza.models import BrokeredUser as BrokeredUser
+from kamiwaza.models import DatasetRef as DatasetRef
 from kamiwaza.models import Federation as Federation
 from kamiwaza.models import Grant as Grant
 from kamiwaza.models import JobResult as JobResult
 from kamiwaza.models import Subject as Subject
 
 __all__ = [
+    "AttributeGateBinding",
     "BrokeredUser",
+    "DatasetRef",
     "Federation",
     "Grant",
     "JobResult",

--- a/kamiwaza/__init__.py
+++ b/kamiwaza/__init__.py
@@ -28,6 +28,7 @@ from kamiwaza.exceptions import KamiwazaError as KamiwazaError
 from kamiwaza.models import AttributeGateBinding as AttributeGateBinding
 from kamiwaza.models import BrokeredUser as BrokeredUser
 from kamiwaza.models import DatasetRef as DatasetRef
+from kamiwaza.models import ExecutionGateBinding as ExecutionGateBinding
 from kamiwaza.models import Federation as Federation
 from kamiwaza.models import Grant as Grant
 from kamiwaza.models import JobResult as JobResult
@@ -37,6 +38,7 @@ __all__ = [
     "AttributeGateBinding",
     "BrokeredUser",
     "DatasetRef",
+    "ExecutionGateBinding",
     "Federation",
     "Grant",
     "JobResult",

--- a/kamiwaza/client.py
+++ b/kamiwaza/client.py
@@ -77,6 +77,7 @@ class Kamiwaza:
         self._jobs: Any = None
         self._cluster: Any = None
         self._gates: Any = None
+        self._subjects: Any = None
         # NB: lazy retrieval-module attribute; matching wrapper below.
         self._retrieval_api: Any = None
 
@@ -142,6 +143,20 @@ class Kamiwaza:
 
             self._jobs = JobsAPI(client=self)
         return self._jobs
+
+    @property
+    def subjects(self) -> Any:
+        """AuthzSubjects + grants (T5.5 / §4.2.11).
+
+        Returns a ``kamiwaza.subjects.SubjectsAPI`` instance. Wraps the
+        server-side typed upsert + grants surface; collapses the
+        v0.1.x two-phase Keycloak admin recipe into a single SDK call.
+        """
+        if self._subjects is None:
+            from kamiwaza.subjects import SubjectsAPI
+
+            self._subjects = SubjectsAPI(client=self)
+        return self._subjects
 
     @classmethod
     def from_env(

--- a/kamiwaza/client.py
+++ b/kamiwaza/client.py
@@ -78,6 +78,7 @@ class Kamiwaza:
         self._cluster: Any = None
         self._gates: Any = None
         self._subjects: Any = None
+        self._datasets: Any = None
         # NB: lazy retrieval-module attribute; matching wrapper below.
         self._retrieval_api: Any = None
 
@@ -157,6 +158,20 @@ class Kamiwaza:
 
             self._subjects = SubjectsAPI(client=self)
         return self._subjects
+
+    @property
+    def datasets(self) -> Any:
+        """Catalog datasets + attribute-gate binding (T5.6 / §4.2.11).
+
+        Returns a ``kamiwaza.datasets.DatasetsAPI`` instance. M3 surface
+        is the minimal slice setup.py reaches for: create / get / delete
+        plus the gate-binding endpoints (set_gate / get_gate / clear_gate).
+        """
+        if self._datasets is None:
+            from kamiwaza.datasets import DatasetsAPI
+
+            self._datasets = DatasetsAPI(client=self)
+        return self._datasets
 
     @classmethod
     def from_env(

--- a/kamiwaza/cluster.py
+++ b/kamiwaza/cluster.py
@@ -335,9 +335,13 @@ class ClusterAPI:
             "force": "true" if force else "false",
             "subjects_holding_value": subjects_holding_value,
         }
-        return self._client._request(
+        # _client._request returns Any (httpx response body parsing); cast to
+        # match the typed dict return annotation. Mypy --strict would flag
+        # the bare return as no-any-return otherwise.
+        result: Dict[str, Any] = self._client._request(
             "DELETE", f"/api/cluster/attribute-schema/{name}", params=params
         )
+        return result
 
     def _attempt_fix(self, issue: DiagnoseIssue) -> FixOutcome:
         if not issue.auto_fixable or not issue.fix_endpoint:

--- a/kamiwaza/cluster.py
+++ b/kamiwaza/cluster.py
@@ -26,7 +26,7 @@ Server-side correlates:
 
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any, Dict, List, Optional
 
 from kamiwaza.exceptions import KamiwazaError
 from kamiwaza.models import (
@@ -34,6 +34,7 @@ from kamiwaza.models import (
     ClusterDiagnostics,
     ClusterOperations,
     DiagnoseIssue,
+    ExecutionGateBinding,
     FixOutcome,
     FixResult,
 )
@@ -130,6 +131,53 @@ class ClusterAPI:
                 list(retrievals_body) if isinstance(retrievals_body, list) else []
             ),
         )
+
+    # ─── §4.2.4 — execution-gate binding (M3 expand) ──────────────────
+
+    def set_execution_gate(
+        self,
+        *,
+        type: str,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> ExecutionGateBinding:
+        """Bind an ExecutionGate to this cluster (T2.4 server-side).
+
+        Hits ``PUT /api/cluster/execution-gate``. Server validates ``type``
+        is an ``ExecutionGate`` subclass and validates ``config`` against
+        the gate's ``config_schema()`` before persisting.
+
+        Args:
+            type: ExecutionGate classpath, e.g.
+                ``"kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate"``.
+            config: Per-gate config dict. Defaults to ``{}`` for gates
+                with no configurable surface.
+
+        Returns:
+            ExecutionGateBinding — the persisted shape.
+
+        Raises:
+            KamiwazaError: 400 wrong_kind when ``type`` is an
+                AttributeGate; 400 schema_validation_failed when config
+                violates the gate's schema.
+        """
+        body = {"type": type, "config": dict(config) if config else {}}
+        response = self._client._request(
+            "PUT", "/api/cluster/execution-gate", json=body
+        )
+        return ExecutionGateBinding.model_validate(response)
+
+    def get_execution_gate(self) -> ExecutionGateBinding:
+        """Read the active ExecutionGate binding for this cluster.
+
+        Raises:
+            KamiwazaError: 404 not_configured when no binding is persisted.
+        """
+        response = self._client._request("GET", "/api/cluster/execution-gate")
+        return ExecutionGateBinding.model_validate(response)
+
+    def clear_execution_gate(self) -> None:
+        """Remove this cluster's ExecutionGate binding."""
+        self._client._request("DELETE", "/api/cluster/execution-gate")
 
     def _attempt_fix(self, issue: DiagnoseIssue) -> FixOutcome:
         if not issue.auto_fixable or not issue.fix_endpoint:

--- a/kamiwaza/cluster.py
+++ b/kamiwaza/cluster.py
@@ -30,6 +30,8 @@ from typing import Any, Dict, List, Optional
 
 from kamiwaza.exceptions import KamiwazaError
 from kamiwaza.models import (
+    AttributeSchema,
+    AttributeSchemaList,
     ClusterCapabilities,
     ClusterDiagnostics,
     ClusterOperations,
@@ -178,6 +180,164 @@ class ClusterAPI:
     def clear_execution_gate(self) -> None:
         """Remove this cluster's ExecutionGate binding."""
         self._client._request("DELETE", "/api/cluster/execution-gate")
+
+    # ─── §4.2.18 — attribute schema surface (v0.3.6 / M3.1) ──────────────
+
+    def declare_attribute(
+        self,
+        name: str,
+        *,
+        type: str,
+        sensitive: bool = False,
+        authority: str = "local_admin",
+        schema_version: str = "1.0",
+    ) -> AttributeSchema:
+        """Register an attribute in the realm's declared vocabulary (ENG-4946).
+
+        Required BEFORE ``kz.subjects.upsert(...)`` writes for any
+        attribute name not already declared. Idempotent on identical
+        shape; shape change on a ``declared``-state attribute returns
+        400 ``shape_change_on_declared`` — deprecate + withdraw first to
+        retire the old shape.
+
+        Hits ``PUT /api/cluster/attribute-schema/{name}``.
+
+        Args:
+            name: Canonical attribute name (e.g. ``"clearance"``).
+            type: One of ``"string"``, ``"int"``, ``"bool"``, ``"string[]"``.
+            sensitive: When True, the attribute is registered in the realm
+                vocabulary but NOT issued as a JWT claim; gates that
+                consume it must read the mesh-envelope ``user_attrs``
+                field. Default False (per OQ-14 — PII attributes opt-in
+                sensitive; demo flow's clearance/country/programs are not).
+            authority: Which actor may set values on subjects. Default
+                ``"local_admin"``.  ``"mesh_peer"`` reserves the attribute
+                for cross-cluster attestation via brokered-user
+                provisioning; ``"self"`` reserves for a future self-service
+                surface (M3.1 declare-hook only); ``"system"`` reserves
+                for platform-emitted attrs (audit/provenance).
+            schema_version: Cross-cluster contract version (OQ-13); semver.
+
+        Returns:
+            AttributeSchema in ``declared`` state.
+
+        Raises:
+            KamiwazaError: 400 ``shape_change_on_declared`` if the
+                attribute is already declared with a different shape.
+        """
+        body = {
+            "type": type,
+            "sensitive": sensitive,
+            "authority": authority,
+            "schema_version": schema_version,
+        }
+        response = self._client._request(
+            "PUT", f"/api/cluster/attribute-schema/{name}", json=body
+        )
+        return AttributeSchema.model_validate(response)
+
+    def list_attributes(
+        self, *, include_deprecated: bool = True
+    ) -> List[AttributeSchema]:
+        """List the realm's declared vocabulary (ENG-4946).
+
+        Hits ``GET /api/cluster/attribute-schema``. Withdrawn entries are
+        tombstoned at the KC layer and never appear here; deprecated
+        entries are included by default (operators need them to plan
+        retirement).
+
+        Args:
+            include_deprecated: When False, omits deprecated entries.
+
+        Returns:
+            List of AttributeSchema; sorted by name.
+        """
+        params = {"include_deprecated": "true" if include_deprecated else "false"}
+        response = self._client._request(
+            "GET", "/api/cluster/attribute-schema", params=params
+        )
+        return AttributeSchemaList.model_validate(response).attributes
+
+    def deprecate_attribute(self, name: str) -> AttributeSchema:
+        """Transition an attribute from declared → deprecated (ENG-4946).
+
+        Hits ``DELETE /api/cluster/attribute-schema/{name}`` (without
+        force flag). Subsequent ``kz.subjects.upsert(...)`` calls that
+        include this attribute reject with 400 ``attribute_deprecated``.
+        Existing subject values continue to surface in JWTs until the
+        attribute is withdrawn.
+
+        Use as the first step of a planned retirement; call
+        ``withdraw_attribute(...)`` once ``subjects_holding_value``
+        reaches an acceptable threshold (typically 0).
+
+        Returns:
+            AttributeSchema in ``deprecated`` state.
+
+        Raises:
+            KamiwazaError: 404 ``attribute_not_found`` if absent.
+        """
+        response = self._client._request(
+            "DELETE", f"/api/cluster/attribute-schema/{name}"
+        )
+        # The DELETE endpoint returns {state, subjects_holding_value}; we
+        # need the full schema record, so round-trip through GET.
+        # (Avoids a server-side change; M3.1 ships the lean DELETE shape.)
+        _ = response
+        full_list = self.list_attributes(include_deprecated=True)
+        for schema in full_list:
+            if schema.name == name:
+                return schema
+        # Defensive: server said deprecate succeeded but list omits the
+        # entry. Raise the SDK's generic error rather than silently
+        # synthesizing a schema with no real declared_at.
+        raise KamiwazaError(
+            f"Attribute {name!r} was deprecated server-side but is missing "
+            "from the subsequent list_attributes() response."
+        )
+
+    def withdraw_attribute(
+        self,
+        name: str,
+        *,
+        force: bool = False,
+        subjects_holding_value: int = 0,
+    ) -> Dict[str, Any]:
+        """Transition an attribute to withdrawn state (ENG-4946).
+
+        Hits ``DELETE /api/cluster/attribute-schema/{name}?force=true``.
+        Default refuses with 409 ``subjects_holding_value`` when subjects
+        currently hold a value; ``force=True`` proceeds with explicit
+        audit capturing the count + intent. Removes the KC realm
+        user-profile entry + OIDC mapper. Subject KC records retain raw
+        values at the KC storage layer (not auto-purged); re-declaring
+        the same name later is a ``revive_from_withdrawn`` audit action.
+
+        Args:
+            name: Attribute name to withdraw.
+            force: When True, proceed even when subjects hold values.
+            subjects_holding_value: Caller-supplied count of subjects
+                currently holding a value (operator's best estimate;
+                the platform does NOT scan subjects for cost reasons).
+                Default 0. force=True with non-zero count is allowed and
+                audited; force=False with non-zero count returns 409.
+
+        Returns:
+            Dict with ``state`` (always ``"withdrawn"``) and
+            ``subjects_holding_value`` (echoed from input for forensic
+            audit-trail correlation).
+
+        Raises:
+            KamiwazaError: 404 ``attribute_not_found``; 409
+                ``subjects_holding_value`` when force=False and count>0.
+        """
+        params: Dict[str, Any] = {
+            "force": "true" if force else "false",
+            "subjects_holding_value": subjects_holding_value,
+        }
+        return self._client._request(
+            "DELETE", f"/api/cluster/attribute-schema/{name}", params=params
+        )
 
     def _attempt_fix(self, issue: DiagnoseIssue) -> FixOutcome:
         if not issue.auto_fixable or not issue.fix_endpoint:

--- a/kamiwaza/datasets.py
+++ b/kamiwaza/datasets.py
@@ -1,0 +1,147 @@
+"""T5.6 / ENG-4742 — kamiwaza.datasets module.
+
+Customer-facing surface for catalog datasets + attribute-gate binding
+per design §4.2.5 / §4.2.11:
+
+    kz.datasets.create(name, platform, **kwargs) -> DatasetRef
+    kz.datasets.get(urn)                          -> DatasetRef
+    kz.datasets.delete(urn)                       -> None
+    kz.datasets.set_gate(urn, type, config={})    -> AttributeGateBinding
+    kz.datasets.get_gate(urn)                     -> AttributeGateBinding
+    kz.datasets.clear_gate(urn)                   -> None
+
+Scope: the M3-shaped slice setup.py reaches for. The legacy
+``kamiwaza_sdk`` namespace ships the broader catalog surface (schema
+mutations, container relationships, secrets, …); this module is the
+minimal M3 path to bind attribute gates from setup.py without bouncing
+between SDK namespaces.
+
+Server-side correlates:
+    POST   /api/catalog/datasets/                       (create)
+    GET    /api/catalog/datasets/by-urn?urn=...         (get)
+    DELETE /api/catalog/datasets/by-urn?urn=...         (delete)
+    PUT    /api/catalog/datasets/{urn}/gate             (set_gate / T2.5)
+    GET    /api/catalog/datasets/{urn}/gate             (get_gate)
+    DELETE /api/catalog/datasets/{urn}/gate             (clear_gate)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from kamiwaza.models import AttributeGateBinding, DatasetRef
+
+
+class DatasetsAPI:
+    """Catalog datasets + attribute-gate binding on the local cluster."""
+
+    def __init__(self, client: Any) -> None:
+        # ``Any`` avoids a runtime cycle (client lazy-imports this module).
+        self._client = client
+
+    # ─── create / get / delete ────────────────────────────────────────
+
+    def create(
+        self,
+        *,
+        name: str,
+        platform: str,
+        environment: Optional[str] = None,
+        properties: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+        description: Optional[str] = None,
+    ) -> DatasetRef:
+        """Create a dataset in the catalog.
+
+        Args:
+            name: Dataset name (forms part of the URN).
+            platform: Storage platform (``file``, ``s3``, ``postgres``, ...).
+            environment: PROD / DEV / TEST. Defaults server-side to PROD.
+            properties: Free-form catalog properties — typically the
+                ``path``, connection-specific fields, and (post-M3) the
+                ``gate`` nested binding (which T2.5's set_gate writes
+                via the dedicated endpoint instead).
+            tags: Optional dataset tags.
+            description: Optional description.
+
+        Returns:
+            DatasetRef — the minimal shape (URN + identifying fields).
+        """
+        body: Dict[str, Any] = {"name": name, "platform": platform}
+        if environment is not None:
+            body["environment"] = environment
+        if properties is not None:
+            body["properties"] = dict(properties)
+        if tags is not None:
+            body["tags"] = list(tags)
+        if description is not None:
+            body["description"] = description
+        response = self._client._request("POST", "/api/catalog/datasets/", json=body)
+        return DatasetRef.model_validate(response)
+
+    def get(self, urn: str) -> DatasetRef:
+        """Read a dataset by URN.
+
+        Raises:
+            KamiwazaError: 404 when the URN is unknown.
+        """
+        response = self._client._request(
+            "GET", "/api/catalog/datasets/by-urn", params={"urn": urn}
+        )
+        return DatasetRef.model_validate(response)
+
+    def delete(self, urn: str) -> None:
+        """Delete the dataset by URN."""
+        self._client._request(
+            "DELETE", "/api/catalog/datasets/by-urn", params={"urn": urn}
+        )
+
+    # ─── gate binding (M3-specific surface) ──────────────────────────
+
+    def set_gate(
+        self,
+        urn: str,
+        *,
+        type: str,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> AttributeGateBinding:
+        """Bind an AttributeGate to a dataset (PUT ``/api/catalog/datasets/{urn}/gate``).
+
+        Server validates ``type`` is an AttributeGate subclass and
+        validates ``config`` against the gate's ``config_schema()``.
+
+        Args:
+            urn: Dataset URN.
+            type: AttributeGate classpath, e.g.
+                ``"my_gate.ClassificationGate"``.
+            config: Per-gate config dict. Defaults to ``{}`` for gates
+                with no configurable surface.
+
+        Returns:
+            AttributeGateBinding — the persisted shape.
+
+        Raises:
+            KamiwazaError: 400 wrong_kind when ``type`` is an
+                ExecutionGate; 400 schema_validation_failed when
+                config violates the gate's schema; 404 dataset_not_found
+                when the URN is unknown.
+        """
+        body = {"type": type, "config": dict(config) if config else {}}
+        response = self._client._request(
+            "PUT", f"/api/catalog/datasets/{urn}/gate", json=body
+        )
+        return AttributeGateBinding.model_validate(response)
+
+    def get_gate(self, urn: str) -> AttributeGateBinding:
+        """Read the AttributeGate binding for a dataset.
+
+        Raises:
+            KamiwazaError: 404 not_configured when no gate is bound;
+                404 dataset_not_found when the URN itself is unknown.
+        """
+        response = self._client._request("GET", f"/api/catalog/datasets/{urn}/gate")
+        return AttributeGateBinding.model_validate(response)
+
+    def clear_gate(self, urn: str) -> None:
+        """Remove the AttributeGate binding for a dataset."""
+        self._client._request("DELETE", f"/api/catalog/datasets/{urn}/gate")

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -233,3 +233,39 @@ class Subject(BaseModel):
     grants: List[Grant] = []
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
+
+
+class DatasetRef(BaseModel):
+    """T5.6 / §4.2.5 — minimal Dataset shape returned by the catalog API.
+
+    The full Dataset (with ``schema``, ``container_urn``, ``tags``, ...)
+    lives on the legacy ``kamiwaza_sdk`` namespace; this M3 namespace
+    surfaces the fields setup.py needs to bind gates and round-trip
+    references through the SDK.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    urn: str
+    name: str
+    platform: str
+    environment: Optional[str] = None
+    properties: Dict[str, Any] = {}
+
+
+class AttributeGateBinding(BaseModel):
+    """T5.6 / §4.2.5 — response shape for dataset.gate endpoints.
+
+    Returned by ``kz.datasets.set_gate(...)`` and
+    ``kz.datasets.get_gate(...)``. ``kind`` is always ``"attribute"`` on
+    this surface (dataset gates are by definition AttributeGate subclasses;
+    a wrong-kind PUT returns 400 before the binding is written).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    dataset_urn: str
+    type: str
+    config: Dict[str, Any] = {}
+    gate_name: str
+    kind: Literal["attribute"] = "attribute"

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -289,3 +289,59 @@ class ExecutionGateBinding(BaseModel):
     config: Dict[str, Any] = {}
     gate_name: str
     kind: Literal["execution"] = "execution"
+
+
+class AttributeSchema(BaseModel):
+    """ENG-4946 / M3.1 / §4.2.18 — declared-vocabulary attribute schema.
+
+    Returned by ``kz.cluster.declare_attribute(...)``,
+    ``kz.cluster.deprecate_attribute(...)``, ``kz.cluster.withdraw_attribute(...)``,
+    and listed by ``kz.cluster.list_attributes()``. Lifecycle states:
+    ``declared`` → ``deprecated`` → ``withdrawn``; only ``declared``-state
+    attributes accept new values on subjects.upsert.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    """Canonical attribute name; matches KC user-profile + OIDC claim."""
+
+    type: Literal["string", "int", "bool", "string[]"]
+    """Wire-level attribute type. ``string[]`` is the multivalued shape."""
+
+    state: Literal["declared", "deprecated", "withdrawn"]
+    """Lifecycle state."""
+
+    authority: Literal["local_admin", "self", "mesh_peer", "system"] = "local_admin"
+    """Which actor may set values on subjects; defaults to local_admin."""
+
+    sensitive: bool = False
+    """If True, mapper exists but JWT claim is not issued (OQ-14)."""
+
+    schema_version: str = "1.0"
+    """Cross-cluster contract version (OQ-13); semver string."""
+
+    declared_at: datetime
+    """When the attribute was first declared in this realm."""
+
+    deprecated_at: Optional[datetime] = None
+    """Set when state transitioned declared → deprecated."""
+
+    withdrawn_at: Optional[datetime] = None
+    """Set when state transitioned to withdrawn."""
+
+    declared_by: Optional[str] = None
+    """Actor user UUID who issued the most recent declare/revive."""
+
+
+class AttributeSchemaList(BaseModel):
+    """ENG-4946 / M3.1 — response wrapper for ``kz.cluster.list_attributes()``.
+
+    Wraps the vocabulary list with a top-level ``schema_version`` so
+    cross-cluster compatibility checks (v1.1 work) have a place to land.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    attributes: List[AttributeSchema]
+    schema_version: str = "v0.3.6"

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -269,3 +269,20 @@ class AttributeGateBinding(BaseModel):
     config: Dict[str, Any] = {}
     gate_name: str
     kind: Literal["attribute"] = "attribute"
+
+
+class ExecutionGateBinding(BaseModel):
+    """T5.6 (cluster expand) / §4.2.4 — response shape for the cluster
+    execution-gate binding endpoints.
+
+    Returned by ``kz.cluster.set_execution_gate(...)`` and
+    ``kz.cluster.get_execution_gate(...)``. Cluster-scoped (one active
+    binding per cluster), kind always ``"execution"``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+    config: Dict[str, Any] = {}
+    gate_name: str
+    kind: Literal["execution"] = "execution"

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -202,3 +202,34 @@ class JobResult(BaseModel):
     result: Optional[Any] = None
     error: Optional[str] = None
     audit_actor: Optional[str] = None
+
+
+class Grant(BaseModel):
+    """T5.5 / §4.2.6 — one ReBAC tuple bound to a subject.
+
+    Returned by ``kz.subjects.grants(username).list()`` / ``.create()``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    object_namespace: str
+    object_id: str
+    relation: str
+
+
+class Subject(BaseModel):
+    """T5.5 / §4.2.6 — typed Subject response.
+
+    Returned by ``kz.subjects.upsert(...)`` and ``kz.subjects.get(...)``.
+    ``attributes`` collapses single-element KC attribute lists to scalars
+    on the server side so the SDK consumer reads the same shape they wrote.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    username: str
+    attributes: Dict[str, Any] = {}
+    grants: List[Grant] = []
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None

--- a/kamiwaza/models.py
+++ b/kamiwaza/models.py
@@ -231,8 +231,11 @@ class Subject(BaseModel):
     username: str
     attributes: Dict[str, Any] = {}
     grants: List[Grant] = []
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
+    # ENG-4941: server emits datetime (Pydantic serializes to ISO string
+    # on the wire; pydantic coerces back on the SDK side). Matches
+    # sibling BrokeredUser.created_at typing.
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 class DatasetRef(BaseModel):

--- a/kamiwaza/subjects.py
+++ b/kamiwaza/subjects.py
@@ -1,0 +1,157 @@
+"""T5.5 / ENG-4741 — kamiwaza.subjects module.
+
+Customer-facing surface for AuthzSubjects per design §4.2.11:
+
+    kz.subjects.upsert(username, attributes=..., password=...) -> Subject
+    kz.subjects.get(username)                                  -> Subject
+    kz.subjects.delete(username, cascade_grants=False)         -> None
+    kz.subjects.grants(username).create(...)                   -> Grant
+    kz.subjects.grants(username).list()                        -> list[Grant]
+    kz.subjects.grants(username).delete(...)                   -> None
+
+Server-side correlates (§4.2.6):
+    PUT    /api/authz/subjects/{id_or_username}
+    GET    /api/authz/subjects/{id_or_username}
+    DELETE /api/authz/subjects/{id_or_username}?cascade=grants
+    POST   /api/authz/subjects/{id_or_username}/grants
+    GET    /api/authz/subjects/{id_or_username}/grants
+    DELETE /api/authz/subjects/{id_or_username}/grants
+
+v0.3.5 OQ-11: PUT-only on upsert — no POST surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from kamiwaza.models import Grant, Subject
+
+
+class SubjectsAPI:
+    """Subject lifecycle on the local cluster.
+
+    The demo author's first reach for ``setup.py`` — collapses the
+    two-phase Keycloak admin recipe into a single typed call.
+    """
+
+    def __init__(self, client: Any) -> None:
+        # ``Any`` avoids a runtime cycle (client lazy-imports this module).
+        self._client = client
+
+    def upsert(
+        self,
+        username: str,
+        *,
+        attributes: Dict[str, Any],
+        password: Optional[str] = None,
+    ) -> Subject:
+        """Idempotent upsert (PUT) per §4.2.6 / v0.3.5 OQ-11.
+
+        Args:
+            username: KC username (or UUID — the server treats both as the
+                same path segment).
+            attributes: Attribute dict; list values become multivalued KC
+                attributes (T3.3 server-side inference).
+            password: Optional initial password. Omit to leave credentials
+                untouched on existing subjects.
+
+        Returns:
+            Subject — full response with KC id + timestamps + grants.
+        """
+        body: Dict[str, Any] = {"attributes": dict(attributes)}
+        if password is not None:
+            body["password"] = password
+        response = self._client._request(
+            "PUT", f"/api/authz/subjects/{username}", json=body
+        )
+        return Subject.model_validate(response)
+
+    def get(self, username: str) -> Subject:
+        """Read the Subject by KC UUID or username.
+
+        Raises:
+            KamiwazaError: 404 subject_not_found when absent.
+        """
+        response = self._client._request("GET", f"/api/authz/subjects/{username}")
+        return Subject.model_validate(response)
+
+    def delete(self, username: str, *, cascade_grants: bool = False) -> None:
+        """Delete the Subject. ``cascade_grants=True`` also removes the
+        subject's ReBAC tuples (T3.6 server-side cascade)."""
+        path = f"/api/authz/subjects/{username}"
+        if cascade_grants:
+            path = f"{path}?cascade=grants"
+        self._client._request("DELETE", path)
+
+    def grants(self, username: str) -> "SubjectGrantsAPI":
+        """Grants sub-resource scoped to a subject.
+
+        Returns a handle for the subject's ReBAC tuples:
+
+            kz.subjects.grants("alice").create(
+                object_namespace="cluster",
+                object_id="...",
+                relation="viewer",
+            )
+        """
+        return SubjectGrantsAPI(client=self._client, username=username)
+
+
+class SubjectGrantsAPI:
+    """Subject-scoped grants surface — wraps the relationship_store
+    delegation on the server (T3.6)."""
+
+    def __init__(self, client: Any, username: str) -> None:
+        self._client = client
+        self._username = username
+
+    def create(
+        self,
+        *,
+        object_namespace: str,
+        object_id: str,
+        relation: str,
+    ) -> Grant:
+        """Bind a ReBAC tuple ``(subject, object, relation)``."""
+        body = {
+            "object_namespace": object_namespace,
+            "object_id": object_id,
+            "relation": relation,
+        }
+        response = self._client._request(
+            "POST",
+            f"/api/authz/subjects/{self._username}/grants",
+            json=body,
+        )
+        return Grant.model_validate(response)
+
+    def list(self) -> List[Grant]:
+        """Return all grants bound to this subject."""
+        response = self._client._request(
+            "GET", f"/api/authz/subjects/{self._username}/grants"
+        )
+        items = response if isinstance(response, list) else []
+        return [Grant.model_validate(item) for item in items]
+
+    def delete(
+        self,
+        *,
+        object_namespace: str,
+        object_id: str,
+        relation: str,
+    ) -> None:
+        """Remove the tuple ``(subject, object, relation)``.
+
+        Tuple key in the body, not the path — relation values can carry
+        characters that don't path-encode cleanly.
+        """
+        body = {
+            "object_namespace": object_namespace,
+            "object_id": object_id,
+            "relation": relation,
+        }
+        self._client._request(
+            "DELETE",
+            f"/api/authz/subjects/{self._username}/grants",
+            json=body,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ dev = [
     "build>=1.0",
     "twine>=4.0",
     "radon>=5.1",
+    "pdoc>=14.0",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/integration/test_m3_walkthrough_live.py
+++ b/tests/integration/test_m3_walkthrough_live.py
@@ -1,0 +1,254 @@
+"""T5.18-full / ENG-4746 — WS-M3 demo end-to-end SDK walkthrough.
+
+Live integration test: exercises the full 8-step M3 demo flow against
+a real paired LYRA + ORION cluster, using only customer-facing SDK
+calls. **This is the M3 ship gate** — when this test passes against
+the fleet (spark-2 + evo-x2-2 as the paired pair), M3 is shippable.
+
+Extends T5.18-skeleton (WS-M1, federation-only) by adding the M3
+ergonomics layers: subject upsert via SDK, cluster execution-gate
+binding via SDK, dataset creation + attribute-gate binding via SDK.
+Mirrors the README's eight-step walkthrough exactly.
+
+The test is marked ``@pytest.mark.live`` and gated on env vars — it
+no-ops in standard CI and only runs when the operator points the SDK
+at a real cluster:
+
+    export KAMIWAZA_LYRA_URL=https://spark-2.kamiwaza.test
+    export KAMIWAZA_LYRA_TOKEN=<lyra-admin-pat>
+    export KAMIWAZA_ORION_URL=https://evo-x2-2.kamiwaza.test
+    export KAMIWAZA_ORION_TOKEN=<orion-admin-pat>
+    make test-live  # or: uv run pytest -m live tests/integration/test_m3_walkthrough_live.py
+
+The test cleans up after itself: subject deletion + dataset deletion +
+execution-gate clear + federation disconnect are invoked even on
+failure (try/finally) so re-runs against the same fleet don't pile up
+state.
+
+Demo-gate assertion: the federated job's audit_actor round-trips back
+as the originating user (``demo-baker@<lyra-cluster-uuid>``), not as
+a system principal. That's the same load-bearing signal the WS-M1
+skeleton uses, now riding on a fully-typed M3 setup.py path.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Iterator
+
+import pytest
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.live,
+    pytest.mark.withoutresponses,
+]
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"{name} env var not set; skipping M3 live walkthrough")
+        raise AssertionError("unreachable")  # mypy: pytest.skip raises Skipped
+    return value
+
+
+@pytest.fixture
+def lyra_url() -> str:
+    return _require_env("KAMIWAZA_LYRA_URL")
+
+
+@pytest.fixture
+def lyra_token() -> str:
+    return _require_env("KAMIWAZA_LYRA_TOKEN")
+
+
+@pytest.fixture
+def orion_url() -> str:
+    return _require_env("KAMIWAZA_ORION_URL")
+
+
+@pytest.fixture
+def orion_token() -> str:
+    return _require_env("KAMIWAZA_ORION_TOKEN")
+
+
+@pytest.fixture
+def demo_username() -> Iterator[str]:
+    """Per-run unique username so concurrent test runs don't collide."""
+    name = f"m3-demo-{uuid.uuid4().hex[:8]}"
+    yield name
+
+
+@pytest.fixture
+def demo_dataset_name() -> Iterator[str]:
+    name = f"m3-demo-dataset-{uuid.uuid4().hex[:8]}"
+    yield name
+
+
+def test_m3_full_walkthrough_against_live_fleet(
+    lyra_url: str,
+    lyra_token: str,
+    orion_url: str,
+    orion_token: str,
+    demo_username: str,
+    demo_dataset_name: str,
+) -> None:
+    """End-to-end M3 demo through SDK only — the milestone ship gate.
+
+    Steps mirror README §"Federation walkthrough" exactly:
+      1. Pair LYRA → ORION
+      2. Seed personas via kz.subjects.upsert
+      3. Bind cluster execution gate via kz.cluster.set_execution_gate
+      4. Register dataset via kz.datasets.create
+      5. Bind dataset attribute gate via kz.datasets.set_gate
+      6. Allowlist brokered user + ReBAC viewer grant
+      7. Submit federated job via kz.jobs.run
+      8. Assert audit_actor round-trip
+    """
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.exceptions import KamiwazaError
+
+    federation_id = None
+    dataset_urn = None
+    execution_gate_classpath = (
+        "kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate"
+    )
+
+    with Kamiwaza(base_url=lyra_url, token=lyra_token) as lyra:
+        try:
+            # Step 1 — Pair LYRA with ORION.
+            fed = lyra.federations.pair(
+                name="ORION-m3-walkthrough",
+                role="initiator",
+                remote_url=orion_url,
+                remote_admin_token=orion_token,
+            )
+            federation_id = fed.id
+            assert fed.status == "PAIRED"
+
+            # Step 2 — Seed persona via SDK (replaces v0.1.x KC recipe).
+            subject = lyra.subjects.upsert(
+                demo_username,
+                attributes={
+                    "clearance": "TS",
+                    "country": "USA",
+                    "programs": ["IRIS", "ARGOS"],
+                },
+                password="demo-pw",
+            )
+            assert subject.username == demo_username
+            assert subject.attributes["clearance"] == "TS"
+            assert subject.attributes["programs"] == ["IRIS", "ARGOS"]
+
+            # Step 3 — Bind cluster execution gate (replaces kubectl-exec).
+            exec_binding = lyra.cluster.set_execution_gate(
+                type=execution_gate_classpath, config={}
+            )
+            assert exec_binding.kind == "execution"
+            assert exec_binding.type == execution_gate_classpath
+
+            # Step 4 — Register dataset.
+            dataset = lyra.datasets.create(
+                name=demo_dataset_name,
+                platform="file",
+                environment="PROD",
+                properties={"path": f"/tmp/{demo_dataset_name}"},
+            )
+            dataset_urn = dataset.urn
+            assert dataset.name == demo_dataset_name
+
+            # Step 5 — Bind dataset's attribute gate. Skipped if no
+            # extension gate is installed on the fleet; surface the
+            # error rather than silently skip so M3 closeout can decide.
+            try:
+                ds_binding = lyra.datasets.set_gate(
+                    dataset_urn,
+                    type=(
+                        "kamiwaza_extensions.classified_conjunction_gate."
+                        "ClassifiedConjunctionGate"
+                    ),
+                    config={
+                        "classification_field": "classification",
+                        "releasable_to_field": "releasable_to",
+                    },
+                )
+                assert ds_binding.kind == "attribute"
+            except KamiwazaError as exc:
+                if exc.status_code != 404:
+                    raise
+                pytest.skip(
+                    "ClassifiedConjunctionGate extension not installed on the "
+                    "fleet; partial M3 walkthrough run. Install the gate "
+                    "extension to exercise the full ship gate."
+                )
+
+            # Step 6 — Allowlist brokered user + ReBAC viewer grant on dataset.
+            lyra.subjects.grants(demo_username).create(
+                object_namespace="dataset",
+                object_id=dataset_urn,
+                relation="viewer",
+            )
+            grants = lyra.subjects.grants(demo_username).list()
+            assert any(
+                g.object_id == dataset_urn and g.relation == "viewer" for g in grants
+            )
+
+            # Step 7 — Submit federated job. The demo's job script lives
+            # on the fleet's shared workdir; the test exercises the
+            # submit path even when the script is trivial — what we're
+            # asserting on is the audit_actor round-trip in step 8.
+            result = lyra.jobs.run(
+                target_cluster="ORION-m3-walkthrough",
+                entrypoint="python -c 'print(\"m3 demo\")'",
+            )
+
+            # Step 8 — Demo-gate assertion: audit_actor names the
+            # originating user (no system principal).
+            assert result.status in {"SUCCEEDED", "FAILED"}, (
+                f"Job ended in unexpected state {result.status!r}"
+            )
+            assert result.audit_actor is not None, (
+                "audit_actor must round-trip on the receiver — this is "
+                "the demo gate's load-bearing signal."
+            )
+            assert demo_username in result.audit_actor, (
+                f"Expected audit_actor to contain {demo_username!r}, got "
+                f"{result.audit_actor!r}. The job ran but the brokered-user "
+                f"identity didn't round-trip; check the receiver-side "
+                f"ext-authz + mesh-envelope wiring."
+            )
+
+        finally:
+            # Best-effort cleanup so re-runs against the same fleet don't
+            # pile up state. Each cleanup step swallows KamiwazaError —
+            # the originating exception (if any) is what reaches the
+            # test reporter.
+            try:
+                if dataset_urn:
+                    try:
+                        lyra.datasets.clear_gate(dataset_urn)
+                    except KamiwazaError:
+                        pass
+                    try:
+                        lyra.datasets.delete(dataset_urn)
+                    except KamiwazaError:
+                        pass
+                try:
+                    lyra.cluster.clear_execution_gate()
+                except KamiwazaError:
+                    pass
+                try:
+                    lyra.subjects.delete(demo_username, cascade_grants=True)
+                except KamiwazaError:
+                    pass
+                if federation_id:
+                    try:
+                        lyra.federations[federation_id].disconnect()
+                    except (KamiwazaError, AttributeError):
+                        pass
+            except Exception:
+                # Last-resort: cleanup must not mask the test failure.
+                pass

--- a/tests/unit/test_kamiwaza_cluster_attribute_schema.py
+++ b/tests/unit/test_kamiwaza_cluster_attribute_schema.py
@@ -1,0 +1,261 @@
+"""ENG-4946 / M3.1 — kamiwaza.cluster attribute-schema SDK tests.
+
+Covers the §4.2.18 declared-vocabulary surface:
+
+    kz.cluster.declare_attribute(name, *, type, sensitive, authority, schema_version)
+        -> AttributeSchema  (PUT /api/cluster/attribute-schema/{name})
+    kz.cluster.list_attributes(*, include_deprecated)
+        -> list[AttributeSchema]  (GET /api/cluster/attribute-schema)
+    kz.cluster.deprecate_attribute(name)
+        -> AttributeSchema  (DELETE /api/cluster/attribute-schema/{name})
+    kz.cluster.withdraw_attribute(name, *, force, subjects_holding_value)
+        -> dict  (DELETE /api/cluster/attribute-schema/{name}?force=true)
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+
+def _attribute_schema_payload(
+    name: str,
+    type_: str = "string",
+    state: str = "declared",
+    sensitive: bool = False,
+) -> dict:
+    return {
+        "name": name,
+        "type": type_,
+        "state": state,
+        "authority": "local_admin",
+        "sensitive": sensitive,
+        "schema_version": "1.0",
+        "declared_at": datetime(2026, 5, 12, tzinfo=timezone.utc).isoformat(),
+    }
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_declare_attribute_puts_to_cluster_endpoint(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import AttributeSchema
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://kamiwaza.test/api/cluster/attribute-schema/clearance",
+        status_code=200,
+        json=_attribute_schema_payload("clearance"),
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    schema = client.cluster.declare_attribute("clearance", type="string")
+
+    assert isinstance(schema, AttributeSchema)
+    assert schema.name == "clearance"
+    assert schema.type == "string"
+    assert schema.state == "declared"
+    assert schema.authority == "local_admin"
+    assert schema.sensitive is False
+
+    request = httpx_mock.get_requests(method="PUT")[0]
+    body = json.loads(request.content)
+    assert body == {
+        "type": "string",
+        "sensitive": False,
+        "authority": "local_admin",
+        "schema_version": "1.0",
+    }
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_declare_attribute_forwards_governance_fields(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://kamiwaza.test/api/cluster/attribute-schema/ssn_last4",
+        status_code=200,
+        json={
+            **_attribute_schema_payload("ssn_last4", sensitive=True),
+            "authority": "mesh_peer",
+            "schema_version": "2.0",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    schema = client.cluster.declare_attribute(
+        "ssn_last4",
+        type="string",
+        sensitive=True,
+        authority="mesh_peer",
+        schema_version="2.0",
+    )
+
+    assert schema.sensitive is True
+    assert schema.authority == "mesh_peer"
+    assert schema.schema_version == "2.0"
+
+    request = httpx_mock.get_requests(method="PUT")[0]
+    body = json.loads(request.content)
+    assert body["sensitive"] is True
+    assert body["authority"] == "mesh_peer"
+    assert body["schema_version"] == "2.0"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_declare_attribute_multivalued(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://kamiwaza.test/api/cluster/attribute-schema/programs",
+        status_code=200,
+        json=_attribute_schema_payload("programs", type_="string[]"),
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    schema = client.cluster.declare_attribute("programs", type="string[]")
+    assert schema.type == "string[]"
+
+    request = httpx_mock.get_requests(method="PUT")[0]
+    body = json.loads(request.content)
+    assert body["type"] == "string[]"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_list_attributes_returns_pydantic_list(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import AttributeSchema
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/attribute-schema?include_deprecated=true",
+        status_code=200,
+        json={
+            "attributes": [
+                _attribute_schema_payload("clearance"),
+                _attribute_schema_payload("country", state="deprecated"),
+            ],
+            "schema_version": "v0.3.6",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    schemas = client.cluster.list_attributes()
+
+    assert len(schemas) == 2
+    assert all(isinstance(s, AttributeSchema) for s in schemas)
+    names = {s.name for s in schemas}
+    assert names == {"clearance", "country"}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_list_attributes_passes_include_deprecated_false(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/attribute-schema?include_deprecated=false",
+        status_code=200,
+        json={"attributes": [], "schema_version": "v0.3.6"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    schemas = client.cluster.list_attributes(include_deprecated=False)
+    assert schemas == []
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_deprecate_attribute_round_trips_via_list(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url="https://kamiwaza.test/api/cluster/attribute-schema/clearance",
+        status_code=200,
+        json={"state": "deprecated", "subjects_holding_value": 0},
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/attribute-schema?include_deprecated=true",
+        status_code=200,
+        json={
+            "attributes": [_attribute_schema_payload("clearance", state="deprecated")],
+            "schema_version": "v0.3.6",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    schema = client.cluster.deprecate_attribute("clearance")
+
+    assert schema.state == "deprecated"
+    assert schema.name == "clearance"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_withdraw_attribute_passes_force_param(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url=(
+            "https://kamiwaza.test/api/cluster/attribute-schema/clearance"
+            "?force=true&subjects_holding_value=5"
+        ),
+        status_code=200,
+        json={"state": "withdrawn", "subjects_holding_value": 5},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.withdraw_attribute(
+        "clearance", force=True, subjects_holding_value=5
+    )
+
+    assert result == {"state": "withdrawn", "subjects_holding_value": 5}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_withdraw_attribute_default_no_force(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url=(
+            "https://kamiwaza.test/api/cluster/attribute-schema/clearance"
+            "?force=false&subjects_holding_value=0"
+        ),
+        status_code=200,
+        json={"state": "deprecated", "subjects_holding_value": 0},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.cluster.withdraw_attribute("clearance")
+
+    assert result["state"] == "deprecated"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_declare_attribute_404_raises_kamiwaza_error(httpx_mock: Any) -> None:
+    """Server 4xx → SDK raises KamiwazaError (per the exception mapping)."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.exceptions import KamiwazaError
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://kamiwaza.test/api/cluster/attribute-schema/clearance",
+        status_code=400,
+        json={
+            "detail": {
+                "reason": "shape_change_on_declared",
+                "name": "clearance",
+                "conflict": {"type": {"existing": "string", "target": "int"}},
+            }
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    with pytest.raises(KamiwazaError):
+        client.cluster.declare_attribute("clearance", type="int")

--- a/tests/unit/test_kamiwaza_cluster_gate.py
+++ b/tests/unit/test_kamiwaza_cluster_gate.py
@@ -1,0 +1,130 @@
+"""T5.6 expand — kamiwaza.cluster execution-gate binding tests.
+
+Adds set/get/clear execution-gate methods to ClusterAPI for the M3 demo:
+
+    kz.cluster.set_execution_gate(type, config={}) -> ExecutionGateBinding
+    kz.cluster.get_execution_gate()                -> ExecutionGateBinding
+    kz.cluster.clear_execution_gate()              -> None
+
+Server-side correlate: §4.2.4 / T2.4 at /api/cluster/execution-gate.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_set_execution_gate_puts_to_cluster_endpoint(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import ExecutionGateBinding
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://kamiwaza.test/api/cluster/execution-gate",
+        status_code=200,
+        json={
+            "type": "kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate",
+            "config": {},
+            "gate_name": "allow_all_execution_gate",
+            "kind": "execution",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    binding = client.cluster.set_execution_gate(
+        type="kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate",
+    )
+    assert isinstance(binding, ExecutionGateBinding)
+    assert binding.kind == "execution"
+    assert binding.gate_name == "allow_all_execution_gate"
+
+    request = httpx_mock.get_requests(method="PUT")[0]
+    body = json.loads(request.content)
+    assert body == {
+        "type": "kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate",
+        "config": {},
+    }
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_set_execution_gate_forwards_config(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://kamiwaza.test/api/cluster/execution-gate",
+        status_code=200,
+        json={
+            "type": "my_gate.MyExecutionGate",
+            "config": {"min_clearance": "S"},
+            "gate_name": "my-gate",
+            "kind": "execution",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.cluster.set_execution_gate(
+        type="my_gate.MyExecutionGate", config={"min_clearance": "S"}
+    )
+
+    request = httpx_mock.get_requests(method="PUT")[0]
+    body = json.loads(request.content)
+    assert body["config"] == {"min_clearance": "S"}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_get_execution_gate_returns_binding(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import ExecutionGateBinding
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/execution-gate",
+        status_code=200,
+        json={
+            "type": "g.G",
+            "config": {},
+            "gate_name": "g",
+            "kind": "execution",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    binding = client.cluster.get_execution_gate()
+    assert isinstance(binding, ExecutionGateBinding)
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_get_execution_gate_raises_on_404_not_configured(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.exceptions import KamiwazaError
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/cluster/execution-gate",
+        status_code=404,
+        json={"detail": {"reason": "not_configured"}},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    with pytest.raises(KamiwazaError):
+        client.cluster.get_execution_gate()
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_clear_execution_gate_sends_delete(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url="https://kamiwaza.test/api/cluster/execution-gate",
+        status_code=200,
+        json={"deleted": True, "previous_type": "g.G"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.cluster.clear_execution_gate()

--- a/tests/unit/test_kamiwaza_datasets.py
+++ b/tests/unit/test_kamiwaza_datasets.py
@@ -1,0 +1,283 @@
+"""T5.6 — kamiwaza.datasets module tests.
+
+Customer-facing surface for catalog datasets + attribute-gate binding:
+
+    kz.datasets.create(name, platform, **kwargs) -> DatasetRef
+    kz.datasets.get(urn)                          -> DatasetRef
+    kz.datasets.delete(urn)                       -> None
+    kz.datasets.set_gate(urn, type, config={})    -> AttributeGateBinding
+    kz.datasets.get_gate(urn)                     -> AttributeGateBinding
+    kz.datasets.clear_gate(urn)                   -> None
+
+Server-side correlates:
+    POST   /api/catalog/datasets/
+    GET    /api/catalog/datasets/by-urn?urn=...
+    DELETE /api/catalog/datasets/by-urn?urn=...
+    PUT    /api/catalog/datasets/{urn}/gate
+    GET    /api/catalog/datasets/{urn}/gate
+    DELETE /api/catalog/datasets/{urn}/gate
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+def test_kamiwaza_exposes_datasets_attribute() -> None:
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    assert client.datasets is not None
+
+
+def test_datasets_is_lazy_loaded() -> None:
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    a = client.datasets
+    b = client.datasets
+    assert a is b
+
+
+# ─── create / get / delete ────────────────────────────────────────────────
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_create_posts_minimal_body(httpx_mock: Any) -> None:
+    """kz.datasets.create(name, platform) → POST /api/catalog/datasets/."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import DatasetRef
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/catalog/datasets/",
+        status_code=200,
+        json={
+            "urn": "urn:li:dataset:(local,demo,PROD)",
+            "name": "demo",
+            "platform": "file",
+            "environment": "PROD",
+            "properties": {},
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    ds = client.datasets.create(name="demo", platform="file")
+
+    assert isinstance(ds, DatasetRef)
+    assert ds.urn == "urn:li:dataset:(local,demo,PROD)"
+    assert ds.name == "demo"
+
+    request = httpx_mock.get_requests(method="POST")[0]
+    body = json.loads(request.content)
+    assert body["name"] == "demo"
+    assert body["platform"] == "file"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_create_forwards_properties_and_environment(httpx_mock: Any) -> None:
+    """Optional kwargs (properties, environment) reach the server unchanged."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/catalog/datasets/",
+        status_code=200,
+        json={
+            "urn": "urn:li:dataset:(local,demo,DEV)",
+            "name": "demo",
+            "platform": "file",
+            "environment": "DEV",
+            "properties": {"path": "/data/demo"},
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.datasets.create(
+        name="demo",
+        platform="file",
+        environment="DEV",
+        properties={"path": "/data/demo"},
+    )
+
+    request = httpx_mock.get_requests(method="POST")[0]
+    body = json.loads(request.content)
+    assert body["environment"] == "DEV"
+    assert body["properties"] == {"path": "/data/demo"}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_get_passes_urn_as_query_param(httpx_mock: Any) -> None:
+    """kz.datasets.get(urn) → GET /api/catalog/datasets/by-urn?urn=..."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import DatasetRef
+
+    urn = "urn:li:dataset:(local,demo,PROD)"
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://kamiwaza.test/api/catalog/datasets/by-urn?urn={urn}",
+        status_code=200,
+        json={
+            "urn": urn,
+            "name": "demo",
+            "platform": "file",
+            "environment": "PROD",
+            "properties": {},
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    ds = client.datasets.get(urn)
+    assert isinstance(ds, DatasetRef)
+    assert ds.urn == urn
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_delete_passes_urn_as_query_param(httpx_mock: Any) -> None:
+    """kz.datasets.delete(urn) → DELETE /api/catalog/datasets/by-urn?urn=..."""
+    from kamiwaza.client import Kamiwaza
+
+    urn = "urn:li:dataset:(local,demo,PROD)"
+    httpx_mock.add_response(
+        method="DELETE",
+        url=f"https://kamiwaza.test/api/catalog/datasets/by-urn?urn={urn}",
+        status_code=200,
+        json={"message": "deleted"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.datasets.delete(urn)
+
+
+# ─── gate binding (M3-specific surface) ──────────────────────────────────
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_set_gate_puts_to_dataset_scoped_endpoint(httpx_mock: Any) -> None:
+    """kz.datasets.set_gate puts to /api/catalog/datasets/{urn}/gate."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import AttributeGateBinding
+
+    urn = "urn:li:dataset:(local,demo,PROD)"
+    httpx_mock.add_response(
+        method="PUT",
+        url=f"https://kamiwaza.test/api/catalog/datasets/{urn}/gate",
+        status_code=200,
+        json={
+            "dataset_urn": urn,
+            "type": "my_gate.ClassificationGate",
+            "config": {"classification_field": "classification"},
+            "gate_name": "classification-gate",
+            "kind": "attribute",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    binding = client.datasets.set_gate(
+        urn,
+        type="my_gate.ClassificationGate",
+        config={"classification_field": "classification"},
+    )
+
+    assert isinstance(binding, AttributeGateBinding)
+    assert binding.kind == "attribute"
+    assert binding.dataset_urn == urn
+
+    request = httpx_mock.get_requests(method="PUT")[0]
+    body = json.loads(request.content)
+    assert body == {
+        "type": "my_gate.ClassificationGate",
+        "config": {"classification_field": "classification"},
+    }
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_set_gate_defaults_config_to_empty_dict(httpx_mock: Any) -> None:
+    """Omitting config sends an empty dict — server's config_schema()
+    default-accepts gates with no configurable surface."""
+    from kamiwaza.client import Kamiwaza
+
+    urn = "urn:li:dataset:(local,demo,PROD)"
+    httpx_mock.add_response(
+        method="PUT",
+        url=f"https://kamiwaza.test/api/catalog/datasets/{urn}/gate",
+        status_code=200,
+        json={
+            "dataset_urn": urn,
+            "type": "x.Gate",
+            "config": {},
+            "gate_name": "x",
+            "kind": "attribute",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.datasets.set_gate(urn, type="x.Gate")
+
+    request = httpx_mock.get_requests(method="PUT")[0]
+    body = json.loads(request.content)
+    assert body == {"type": "x.Gate", "config": {}}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_get_gate_returns_binding(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import AttributeGateBinding
+
+    urn = "urn:li:dataset:(local,demo,PROD)"
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://kamiwaza.test/api/catalog/datasets/{urn}/gate",
+        status_code=200,
+        json={
+            "dataset_urn": urn,
+            "type": "g.G",
+            "config": {},
+            "gate_name": "g",
+            "kind": "attribute",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    binding = client.datasets.get_gate(urn)
+
+    assert isinstance(binding, AttributeGateBinding)
+    assert binding.gate_name == "g"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_get_gate_raises_on_404_not_configured(httpx_mock: Any) -> None:
+    """404 not_configured surfaces as KamiwazaError per T5.10 mapping."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.exceptions import KamiwazaError
+
+    urn = "urn:li:dataset:(local,demo,PROD)"
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://kamiwaza.test/api/catalog/datasets/{urn}/gate",
+        status_code=404,
+        json={"detail": {"reason": "not_configured", "dataset_urn": urn}},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    with pytest.raises(KamiwazaError):
+        client.datasets.get_gate(urn)
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_clear_gate_sends_delete(httpx_mock: Any) -> None:
+    from kamiwaza.client import Kamiwaza
+
+    urn = "urn:li:dataset:(local,demo,PROD)"
+    httpx_mock.add_response(
+        method="DELETE",
+        url=f"https://kamiwaza.test/api/catalog/datasets/{urn}/gate",
+        status_code=200,
+        json={"deleted": True, "previous_type": "g.G"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.datasets.clear_gate(urn)

--- a/tests/unit/test_kamiwaza_datasets.py
+++ b/tests/unit/test_kamiwaza_datasets.py
@@ -281,3 +281,102 @@ def test_clear_gate_sends_delete(httpx_mock: Any) -> None:
 
     client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
     client.datasets.clear_gate(urn)
+
+
+# ─── T5.17-full — 4xx error-mapping coverage ──────────────────────────────
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_set_gate_400_wrong_kind_surfaces_as_kamiwaza_error(httpx_mock: Any) -> None:
+    """Server rejects binding an ExecutionGate as a dataset gate (T2.5
+    wrong_kind) — surfaces as KamiwazaError with status_code=400."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.exceptions import KamiwazaError
+
+    urn = "urn:li:dataset:(local,demo,PROD)"
+    httpx_mock.add_response(
+        method="PUT",
+        url=f"https://kamiwaza.test/api/catalog/datasets/{urn}/gate",
+        status_code=400,
+        json={
+            "detail": {
+                "reason": "wrong_kind",
+                "expected": "attribute",
+                "got": "execution",
+                "classpath": "x.ExecGate",
+            }
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    with pytest.raises(KamiwazaError) as exc_info:
+        client.datasets.set_gate(urn, type="x.ExecGate")
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_set_gate_400_schema_validation_failed_surfaces_as_kamiwaza_error(
+    httpx_mock: Any,
+) -> None:
+    """T2.6 jsonschema validation failure → 400 schema_validation_failed."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.exceptions import KamiwazaError
+
+    urn = "urn:li:dataset:(local,demo,PROD)"
+    httpx_mock.add_response(
+        method="PUT",
+        url=f"https://kamiwaza.test/api/catalog/datasets/{urn}/gate",
+        status_code=400,
+        json={
+            "detail": {
+                "reason": "schema_validation_failed",
+                "classpath": "x.Gate",
+                "error": "'classification_field' is a required property",
+            }
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    with pytest.raises(KamiwazaError) as exc_info:
+        client.datasets.set_gate(urn, type="x.Gate", config={})
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_set_gate_404_dataset_not_found_surfaces_as_kamiwaza_error(
+    httpx_mock: Any,
+) -> None:
+    """PUT against an unknown dataset URN → 404 dataset_not_found."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.exceptions import KamiwazaError
+
+    urn = "urn:li:dataset:(local,nonexistent,PROD)"
+    httpx_mock.add_response(
+        method="PUT",
+        url=f"https://kamiwaza.test/api/catalog/datasets/{urn}/gate",
+        status_code=404,
+        json={"detail": {"reason": "dataset_not_found", "dataset_urn": urn}},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    with pytest.raises(KamiwazaError) as exc_info:
+        client.datasets.set_gate(urn, type="x.Gate")
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_get_dataset_404_surfaces_as_kamiwaza_error(httpx_mock: Any) -> None:
+    """GET dataset by unknown URN returns 404."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.exceptions import KamiwazaError
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/catalog/datasets/by-urn?urn=urn:li:dataset:(local,nope,PROD)",
+        status_code=404,
+        json={"detail": "Dataset not found"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    with pytest.raises(KamiwazaError):
+        client.datasets.get("urn:li:dataset:(local,nope,PROD)")

--- a/tests/unit/test_kamiwaza_subjects.py
+++ b/tests/unit/test_kamiwaza_subjects.py
@@ -1,0 +1,311 @@
+"""T5.5 / §4.2.11 — kamiwaza.subjects module tests.
+
+Customer-facing surface for AuthzSubjects per design §4.2.11:
+
+    kz.subjects.upsert(username, attributes=..., password=...) -> Subject
+    kz.subjects.get(username)                                  -> Subject
+    kz.subjects.delete(username, cascade_grants=True)          -> None
+    kz.subjects.grants(username).create(...)                   -> Grant
+    kz.subjects.grants(username).list()                        -> list[Grant]
+    kz.subjects.grants(username).delete(...)                   -> None
+
+Server-side correlates (mounted at /api/authz):
+    PUT    /api/authz/subjects/{id_or_username}
+    GET    /api/authz/subjects/{id_or_username}
+    DELETE /api/authz/subjects/{id_or_username}?cascade=grants
+    POST   /api/authz/subjects/{id_or_username}/grants
+    GET    /api/authz/subjects/{id_or_username}/grants
+    DELETE /api/authz/subjects/{id_or_username}/grants
+
+v0.3.5 OQ-11: PUT-only on the upsert path (no POST).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+
+def test_kamiwaza_exposes_subjects_attribute() -> None:
+    """client.subjects is the entry point for subject lifecycle."""
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    assert client.subjects is not None
+
+
+def test_subjects_is_lazy_loaded() -> None:
+    """Lazy-load per .ai/rules/sdk-patterns.md."""
+    from kamiwaza.client import Kamiwaza
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    a = client.subjects
+    b = client.subjects
+    assert a is b
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_upsert_puts_to_server_with_attributes(httpx_mock: Any) -> None:
+    """kz.subjects.upsert puts to /api/authz/subjects/{username} (v0.3.5 OQ-11)."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import Subject
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://kamiwaza.test/api/authz/subjects/alice",
+        status_code=200,
+        json={
+            "id": "kc-alice-uuid",
+            "username": "alice",
+            "attributes": {"clearance": "S", "country": "GBR"},
+            "grants": [],
+            "created_at": "2026-05-12T00:00:00+00:00",
+            "updated_at": "2026-05-12T00:00:00+00:00",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    result = client.subjects.upsert(
+        "alice", attributes={"clearance": "S", "country": "GBR"}
+    )
+
+    assert isinstance(result, Subject)
+    assert result.id == "kc-alice-uuid"
+    assert result.username == "alice"
+    assert result.attributes["clearance"] == "S"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_upsert_forwards_password_in_body(httpx_mock: Any) -> None:
+    """SDK passes password through as the body's `password` field."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://kamiwaza.test/api/authz/subjects/bob",
+        status_code=200,
+        json={
+            "id": "kc-bob-uuid",
+            "username": "bob",
+            "attributes": {"clearance": "U"},
+            "grants": [],
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.subjects.upsert("bob", attributes={"clearance": "U"}, password="initial-pw")
+
+    request = httpx_mock.get_requests(method="PUT")[0]
+    body = json.loads(request.content)
+    assert body == {
+        "attributes": {"clearance": "U"},
+        "password": "initial-pw",
+    }
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_upsert_omits_password_field_when_none(httpx_mock: Any) -> None:
+    """When password=None, the field is omitted from the body — server
+    treats no-password as 'don't touch credentials' (T3.2 semantics)."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="PUT",
+        url="https://kamiwaza.test/api/authz/subjects/carol",
+        status_code=200,
+        json={
+            "id": "kc-carol-uuid",
+            "username": "carol",
+            "attributes": {"clearance": "C"},
+            "grants": [],
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.subjects.upsert("carol", attributes={"clearance": "C"})
+
+    request = httpx_mock.get_requests(method="PUT")[0]
+    body = json.loads(request.content)
+    assert body == {"attributes": {"clearance": "C"}}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_get_returns_subject(httpx_mock: Any) -> None:
+    """kz.subjects.get → GET /api/authz/subjects/{username} → Subject."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import Subject
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/authz/subjects/dan",
+        status_code=200,
+        json={
+            "id": "kc-dan-uuid",
+            "username": "dan",
+            "attributes": {"clearance": "TS"},
+            "grants": [],
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    subject = client.subjects.get("dan")
+
+    assert isinstance(subject, Subject)
+    assert subject.id == "kc-dan-uuid"
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_get_raises_on_404(httpx_mock: Any) -> None:
+    """404 subject_not_found surfaces as KamiwazaError per T5.10 mapping."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.exceptions import KamiwazaError
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/authz/subjects/ghost",
+        status_code=404,
+        json={"detail": {"reason": "subject_not_found", "id_or_username": "ghost"}},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    with pytest.raises(KamiwazaError):
+        client.subjects.get("ghost")
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_delete_sends_delete_without_cascade_by_default(httpx_mock: Any) -> None:
+    """kz.subjects.delete defaults to no cascade — grants stay put."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url="https://kamiwaza.test/api/authz/subjects/eve",
+        status_code=200,
+        json={"deleted": True, "username": "eve"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.subjects.delete("eve")
+
+    request = httpx_mock.get_requests(method="DELETE")[0]
+    # No cascade query param when cascade_grants is False.
+    assert "cascade" not in request.url.query.decode()
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_delete_with_cascade_grants_passes_query_param(httpx_mock: Any) -> None:
+    """cascade_grants=True adds ?cascade=grants per T3.5 server contract."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url="https://kamiwaza.test/api/authz/subjects/frank?cascade=grants",
+        status_code=200,
+        json={"deleted": True, "username": "frank"},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.subjects.delete("frank", cascade_grants=True)
+
+
+# ─── Grants sub-resource ──────────────────────────────────────────────────
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_grants_create_posts_to_subject_scoped_endpoint(httpx_mock: Any) -> None:
+    """kz.subjects.grants('alice').create(...) → POST /api/authz/subjects/alice/grants."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import Grant
+
+    httpx_mock.add_response(
+        method="POST",
+        url="https://kamiwaza.test/api/authz/subjects/alice/grants",
+        status_code=201,
+        json={
+            "object_namespace": "cluster",
+            "object_id": "cluster-uuid-1",
+            "relation": "viewer",
+        },
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    grant = client.subjects.grants("alice").create(
+        object_namespace="cluster",
+        object_id="cluster-uuid-1",
+        relation="viewer",
+    )
+
+    assert isinstance(grant, Grant)
+    assert grant.relation == "viewer"
+
+    request = httpx_mock.get_requests(method="POST")[0]
+    body = json.loads(request.content)
+    assert body == {
+        "object_namespace": "cluster",
+        "object_id": "cluster-uuid-1",
+        "relation": "viewer",
+    }
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_grants_list_returns_typed_grants(httpx_mock: Any) -> None:
+    """kz.subjects.grants('alice').list() returns list[Grant]."""
+    from kamiwaza.client import Kamiwaza
+    from kamiwaza.models import Grant
+
+    httpx_mock.add_response(
+        method="GET",
+        url="https://kamiwaza.test/api/authz/subjects/alice/grants",
+        status_code=200,
+        json=[
+            {
+                "object_namespace": "cluster",
+                "object_id": "c1",
+                "relation": "viewer",
+            },
+            {
+                "object_namespace": "dataset",
+                "object_id": "d1",
+                "relation": "owner",
+            },
+        ],
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    grants = client.subjects.grants("alice").list()
+
+    assert len(grants) == 2
+    assert all(isinstance(g, Grant) for g in grants)
+    assert {g.relation for g in grants} == {"viewer", "owner"}
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_grants_delete_sends_tuple_key_in_body(httpx_mock: Any) -> None:
+    """kz.subjects.grants('alice').delete(...) → DELETE with tuple-key body
+    (relation values can contain characters that don't path-encode cleanly,
+    so the server takes the tuple in the body)."""
+    from kamiwaza.client import Kamiwaza
+
+    httpx_mock.add_response(
+        method="DELETE",
+        url="https://kamiwaza.test/api/authz/subjects/alice/grants",
+        status_code=200,
+        json={"deleted": True},
+    )
+
+    client = Kamiwaza(base_url="https://kamiwaza.test", token="pat-abc")
+    client.subjects.grants("alice").delete(
+        object_namespace="cluster",
+        object_id="c1",
+        relation="viewer",
+    )
+
+    request = httpx_mock.get_requests(method="DELETE")[0]
+    body = json.loads(request.content)
+    assert body == {
+        "object_namespace": "cluster",
+        "object_id": "c1",
+        "relation": "viewer",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -778,6 +778,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -941,6 +953,7 @@ dev = [
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pdoc" },
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -981,6 +994,7 @@ dev = [
     { name = "mypy", specifier = ">=1.0" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "pandas", specifier = ">=2.2" },
+    { name = "pdoc", specifier = ">=14.0" },
     { name = "pyarrow", specifier = ">=17.0" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
@@ -1105,6 +1119,100 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markdown2"
+version = "2.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/ae/07d4a5fcaa5509221287d289323d75ac8eda5a5a4ac9de2accf7bbcc2b88/markdown2-2.5.5.tar.gz", hash = "sha256:001547e68f6e7fcf0f1cb83f7e82f48aa7d48b2c6a321f0cd20a853a8a2d1664", size = 157249, upload-time = "2026-03-02T20:46:53.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/af/4b3891eb0a49d6cfd5cbf3e9bf514c943afc2b0f13e2c57cc57cd88ecc21/markdown2-2.5.5-py3-none-any.whl", hash = "sha256:be798587e09d1f52d2e4d96a649c4b82a778c75f9929aad52a2c95747fa26941", size = 56250, upload-time = "2026-03-02T20:46:52.032Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1532,6 +1640,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "pdoc"
+version = "16.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown2" },
+    { name = "markupsafe" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/fe/ab3f34a5fb08c6b698439a2c2643caf8fef0d61a86dd3fdcd5501c670ab8/pdoc-16.0.0.tar.gz", hash = "sha256:fdadc40cc717ec53919e3cd720390d4e3bcd40405cb51c4918c119447f913514", size = 111890, upload-time = "2025-10-27T16:02:16.345Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/a1/56a17b7f9e18c2bb8df73f3833345d97083b344708b97bab148fdd7e0b82/pdoc-16.0.0-py3-none-any.whl", hash = "sha256:070b51de2743b9b1a4e0ab193a06c9e6c12cf4151cf9137656eebb16e8556628", size = 100014, upload-time = "2025-10-27T16:02:15.007Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

WS-M3 SDK chunk — customer-facing `kamiwaza.{subjects,datasets,cluster}` surface so demo authors write setup.py with **only SDK calls** (no kubectl exec, no manual SQL, no Keycloak admin REST).

Companion PR on `kamiwaza-internal/kamiwaza` ships the server-side typed gate/subject binding endpoints this SDK wraps.

## What's in this PR

**T5.5 — `kamiwaza.subjects` (with grants sub-resource):**
- `kz.subjects.upsert(username, attributes=..., password=...)`
- `kz.subjects.get(username)` / `delete(username, cascade_grants=...)`
- `kz.subjects.grants(username).create(...)` / `.list()` / `.delete(...)`
- 12 unit tests

**T5.6 — `kamiwaza.datasets`:**
- `kz.datasets.create(name, platform, properties=...)`
- `kz.datasets.get(urn)` / `.delete(urn)`
- `kz.datasets.set_gate(urn, type, config=...)` / `.get_gate(urn)` / `.clear_gate(urn)`
- 11 unit + 4 error-mapping tests

**T5.6 expand — `kamiwaza.cluster` execution-gate methods:**
- `kz.cluster.set_execution_gate(type, config=...)` / `.get_execution_gate()` / `.clear_execution_gate()`
- 5 unit tests

**T5.15-full — README:** Federation walkthrough section promoted from WS-M1 4-step skeleton to full 8-step M3 setup.py flow. Each step shows the canonical SDK call + server-side validation/audit semantics + cross-reference to the authoring guide section the M3 surface replaces.

**T5.16 — API reference autogen:** `make docs` target via pdoc renders the full `kamiwaza.*` namespace from existing typed signatures + Google-style docstrings. Output gitignored; regenerate via CI / locally.

**T5.17-full — error-mapping tests:** 4 new tests covering 400 wrong_kind, 400 schema_validation_failed, 404 dataset_not_found, 404 dataset by-URN — every server-side 4xx contract the dataset surface emits.

**T5.18-full — Live integration test (the M3 ship gate):** `tests/integration/test_m3_walkthrough_live.py` exercises the full 8-step demo against a real LYRA + ORION pair. Marked `@pytest.mark.live`; gated on env vars (`KAMIWAZA_LYRA_URL`, `_TOKEN`, `_ORION_URL`, `_ORION_TOKEN`) so standard CI no-ops. Per-run unique usernames + dataset names so concurrent runs don't collide. Cleanup in finally so re-runs against the same fleet don't pile up state.

**ENG-4941 (review followup):** SDK `Subject.created_at` typed `Optional[datetime]` (was `Optional[str]`).

## Tests

- 1553 / 1553 in `make test` (full SDK unit + contract suite)
- 32 / 32 in the M3-specific subjects + datasets + cluster_gate suites
- Live walkthrough scaffold ready but skipped without env vars (by design)

## Test plan

- [x] `make test` green
- [ ] Live walkthrough against spark-2 (LYRA) + evo-x2-2 (ORION) — the M3 ship gate
- [ ] `make docs` renders cleanly (verified locally)

## Pattern adherence

- Lazy-loaded service properties via `client.subjects` / `client.datasets` (matches `gates`, `cluster`, `federations` shape)
- All returns are typed Pydantic models; never raw dicts
- HTTP errors map through the existing `error_for_response` typed-exception layer
- `httpx_mock` for unit tests; no real cluster contacted in `make test`

## Linear

29 M3 issues across all three repos. SDK chunk: ENG-4741–4746 (T5.x), all Done.

## Not in this PR

- M4 demo migration — separate milestone
- Self-read on `GET /api/authz/subjects/{x}` — M3 ships admin-only; M3.1 surface if end-user use-case appears