### PR TITLE
fix(extensions): preserve compose service order in kz-ext publish (ENG-4947)

### DIFF
--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -94,7 +94,13 @@ class RegistryBuilder:
         if digest_map:
             transformed_compose = _apply_digests(transformed_compose, digest_map)
 
-        compose_yml = yaml.dump(transformed_compose, default_flow_style=False)
+        # sort_keys=False preserves service key order from the source compose.
+        # Downstream consumers infer primary-service selection from the order
+        # services appear in compose, so alphabetizing here silently flips
+        # which service the platform routes to.
+        compose_yml = yaml.dump(
+            transformed_compose, default_flow_style=False, sort_keys=False
+        )
         docker_images = self.extract_docker_images(transformed_compose)
 
         extra_images = metadata.get("extra_docker_images") or []

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -67,6 +67,25 @@ class TestBuildEntry:
         parsed = yaml.safe_load(entry["compose_yml"])
         assert "services" in parsed
 
+    def test_compose_yml_preserves_service_order(self, builder, metadata):
+        # Platform infers primary-service selection from compose order
+        # when no service declares x-kamiwaza.primary. Alphabetizing keys on
+        # serialization silently changes which service becomes primary.
+        # Use a database-first ordering that would re-sort under sort_keys=True.
+        compose = {
+            "services": {
+                "neo4j": {"image": "neo4j:5", "ports": ["7687"]},
+                "graphiti": {
+                    "image": "kamiwazaai/service-graphiti-graphiti:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+
+        entry = builder.build_entry(metadata, compose, "kamiwazaai", "1.0.0")
+        parsed = yaml.safe_load(entry["compose_yml"])
+        assert list(parsed["services"].keys()) == ["neo4j", "graphiti"]
+
     def test_docker_images_extracted(self, builder, metadata, transformed_compose):
         entry = builder.build_entry(metadata, transformed_compose, "kamiwazaai", "1.0.0")
         assert "kamiwazaai/my-app-frontend:1.0.0" in entry["docker_images"]


### PR DESCRIPTION
## Summary

`kz-ext publish` was serializing `compose_yml` with default `yaml.dump()`, which alphabetizes service keys. Adding `sort_keys=False` preserves source order.

## Why this matters

The platform's K8s App Garden adapter falls back to compose service order to pick the primary service when no `x-kamiwaza.primary` marker is declared. Alphabetizing on publish silently flipped Graphiti's order, which broke the Context Service ontology endpoint binding — [ENG-4920](https://linear.app/kamiwaza/issue/ENG-4920).

kamiwaza-internal/kamiwaza#1739 shipped the platform-side durable fix (explicit primary marker + Graphiti override + repair script). This PR fixes the upstream regression in `kz-ext` so the fallback isn't tripped for the next extension that needs source-order preservation.

## Verification

Unit test added: `test_compose_yml_preserves_service_order`. Constructs a `[neo4j, graphiti]` compose (database-first ordering that would re-sort under `sort_keys=True`) and asserts `build_entry` round-trips in source order. Confirmed it fails against pre-fix code, passes after.

## Linear

[ENG-4947](https://linear.app/kamiwaza/issue/ENG-4947)