### PR TITLE
fix(extensions): kz-ext bump propagates version everywhere (ENG-4835)

### DIFF
--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -323,10 +323,11 @@ def port_forward(
 @run_with_error_handling
 def bump(
     level: str = typer.Option("patch", "--level", "-l", help="Bump level: major, minor, or patch"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview file changes without writing"),
 ) -> None:
-    """Bump extension version in kamiwaza.json."""
+    """Bump extension version across kamiwaza.json, compose, Dockerfile, pyproject, package.json."""
     from kamiwaza_extensions.commands.bump import run_bump
-    run_bump(level=level)
+    run_bump(level=level, dry_run=dry_run)
 
 
 @app.command()

--- a/kamiwaza_extensions/commands/bump.py
+++ b/kamiwaza_extensions/commands/bump.py
@@ -62,10 +62,16 @@ def run_bump(*, level: str = "patch", dry_run: bool = False) -> None:
         )
         raise typer.Exit(code=1)
 
+    # Scope compose/drift rewrites to the extension's own image repo so we
+    # don't accidentally retag a sidecar that happens to share `old`
+    # (e.g. `vendor/sidecar:2.0.14` while bumping our `app` to 2.1.0).
+    manifest = json.loads(kamiwaza_json_path.read_text(encoding="utf-8"))
+    ext_repo = extension_image_repo(manifest.get("image"))
+
     updates: List[FileUpdate] = []
     for update in (
         _update_kamiwaza_json(kamiwaza_json_path, old_version, new_version),
-        *_update_compose_files(ext_dir, old_version, new_version),
+        *_update_compose_files(ext_dir, old_version, new_version, ext_repo),
         _update_dockerfile(ext_dir / "Dockerfile", old_version, new_version),
         _update_pyproject(ext_dir / "pyproject.toml", old_version, new_version),
         *_update_package_json_files(ext_dir, old_version, new_version),
@@ -212,7 +218,22 @@ def _update_kamiwaza_json(path: Path, old: str, new: str) -> Optional[FileUpdate
     return FileUpdate(path=path, before=before, after=after, summary=summary)
 
 
-def _update_compose_files(ext_dir: Path, old: str, new: str) -> List[Optional[FileUpdate]]:
+def extension_image_repo(manifest_image: object) -> Optional[str]:
+    """Return the manifest image's repo (e.g. ``ghcr.io/x/y``) or ``None``.
+
+    Used to scope compose rewrites and drift warnings to images that belong
+    to the extension, so a sidecar with a coincidentally matching tag isn't
+    silently retagged.
+    """
+    if not isinstance(manifest_image, str):
+        return None
+    repo, _, _ = _split_image_ref(manifest_image)
+    return repo or None
+
+
+def _update_compose_files(
+    ext_dir: Path, old: str, new: str, ext_repo: Optional[str]
+) -> List[Optional[FileUpdate]]:
     from kamiwaza_extensions.constants import ALL_COMPOSE_FILENAMES
 
     seen: set = set()
@@ -222,7 +243,7 @@ def _update_compose_files(ext_dir: Path, old: str, new: str) -> List[Optional[Fi
         if not path.exists() or path in seen:
             continue
         seen.add(path)
-        results.append(_update_compose_file(path, old, new))
+        results.append(_update_compose_file(path, old, new, ext_repo))
     return results
 
 
@@ -237,7 +258,9 @@ _COMPOSE_IMAGE_RE = re.compile(
 )
 
 
-def _update_compose_file(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+def _update_compose_file(
+    path: Path, old: str, new: str, ext_repo: Optional[str]
+) -> Optional[FileUpdate]:
     before = path.read_text(encoding="utf-8")
 
     count = 0
@@ -247,6 +270,12 @@ def _update_compose_file(path: Path, old: str, new: str) -> Optional[FileUpdate]
         ref = match.group("ref")
         repo, tag, digest = _split_image_ref(ref)
         if tag != old:
+            return match.group(0)
+        # If the manifest declares an image repo, only retag images that
+        # belong to the extension. Without a manifest repo we fall back to
+        # tag-equality alone (the original behavior, exercised by tests
+        # for manifests that omit `image`).
+        if ext_repo is not None and repo != ext_repo:
             return match.group(0)
         count += 1
         new_ref = f"{repo}:{new}{digest or ''}"
@@ -370,12 +399,68 @@ def _update_package_json(path: Path, old: str, new: str) -> Optional[FileUpdate]
         return None
     if not isinstance(data, dict) or data.get("version") != old:
         return None
-    # Targeted line rewrite preserves the source file's indentation,
-    # key order, and trailing newline — re-serializing via json.dumps
-    # would normalize 4-space or tab indentation to 2 and create
-    # gratuitous diffs.
-    version_re = re.compile(r'("version"\s*:\s*")[^"]+(")')
-    after, count = version_re.subn(rf"\g<1>{new}\g<2>", before, count=1)
-    if count == 0 or after == before:
+    # Targeted rewrite of the **top-level** `"version"` key. A bare regex
+    # match-first would rewrite the first textual `"version"` — which could
+    # be a nested one like `engines.version` or `config.version` — and
+    # leave the real package version stale. Walk the source with brace
+    # depth + string awareness to locate the depth-1 value span and splice
+    # in the new version, preserving the file's indentation and key order.
+    span = _find_top_level_string_value_span(before, "version")
+    if span is None or before[span[0] : span[1]] != old:
+        return None
+    after = before[: span[0]] + new + before[span[1] :]
+    if after == before:
         return None
     return FileUpdate(path=path, before=before, after=after, summary='"version"')
+
+
+def _find_top_level_string_value_span(text: str, key: str) -> Optional[Tuple[int, int]]:
+    """Return ``(start, end)`` of the string value bound to top-level *key*.
+
+    Walks the JSON text tracking brace/bracket depth so nested objects
+    that happen to use the same key name (e.g. ``engines.version``) are
+    ignored. Returns ``None`` if the key isn't found at depth 1 with a
+    string value.
+    """
+    depth = 0
+    i = 0
+    n = len(text)
+    in_string = False
+    string_start = -1
+    pending_key: Optional[str] = None
+    awaiting_value = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == '"':
+                token = text[string_start + 1 : i]
+                in_string = False
+                if awaiting_value and depth == 1:
+                    if pending_key == key:
+                        return string_start + 1, i
+                    awaiting_value = False
+                    pending_key = None
+                else:
+                    pending_key = token
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            string_start = i
+        elif ch in "{[":
+            depth += 1
+        elif ch in "}]":
+            depth -= 1
+            awaiting_value = False
+            pending_key = None
+        elif ch == ":":
+            if depth == 1 and pending_key is not None:
+                awaiting_value = True
+        elif ch == ",":
+            awaiting_value = False
+            pending_key = None
+        i += 1
+    return None

--- a/kamiwaza_extensions/commands/bump.py
+++ b/kamiwaza_extensions/commands/bump.py
@@ -1,10 +1,18 @@
-"""Bump command — increment extension version in kamiwaza.json."""
+"""Bump command — propagate an extension's new version across well-known files.
+
+Updates ``kamiwaza.json`` plus image tags in compose files, ``ARG`` defaults
+in ``Dockerfile``, and the ``[project] version`` line in ``pyproject.toml`` /
+``package.json`` so the manifest doesn't drift from the rest of the tree.
+"""
 
 from __future__ import annotations
 
+import difflib
 import json
+import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import typer
 from rich.console import Console
@@ -12,8 +20,18 @@ from rich.console import Console
 console = Console(stderr=True)
 
 
-def run_bump(*, level: str = "patch") -> None:
-    """Bump the version in kamiwaza.json."""
+@dataclass
+class FileUpdate:
+    """A pending rewrite of a single file."""
+
+    path: Path
+    before: str
+    after: str
+    summary: str
+
+
+def run_bump(*, level: str = "patch", dry_run: bool = False) -> None:
+    """Bump the version in kamiwaza.json and propagate to sibling files."""
     from packaging.version import Version
 
     from kamiwaza_extensions.extension_detector import ExtensionDetector
@@ -21,12 +39,12 @@ def run_bump(*, level: str = "patch") -> None:
     detector = ExtensionDetector()
     info = detector.detect()
 
-    kamiwaza_json_path = info.path / "kamiwaza.json"
+    ext_dir = info.path
+    kamiwaza_json_path = ext_dir / "kamiwaza.json"
     if not kamiwaza_json_path.exists():
         console.print("[red]Error:[/red] kamiwaza.json not found.")
         raise typer.Exit(code=1)
 
-    # Parse current version
     try:
         current = Version(info.version)
     except Exception:
@@ -35,35 +53,220 @@ def run_bump(*, level: str = "patch") -> None:
         )
         raise typer.Exit(code=1)
 
-    # Compute new version
-    major, minor, patch = current.major, current.minor, current.micro
-    if level == "major":
-        new_version = f"{major + 1}.0.0"
-    elif level == "minor":
-        new_version = f"{major}.{minor + 1}.0"
-    elif level == "patch":
-        new_version = f"{major}.{minor}.{patch + 1}"
-    else:
+    old_version = info.version
+    new_version = _compute_new_version(current, level)
+    if new_version is None:
         console.print(
             f"[red]Error:[/red] Unknown level '{level}'. Use: major, minor, patch"
         )
         raise typer.Exit(code=1)
 
-    # Update kamiwaza.json
-    with kamiwaza_json_path.open("r", encoding="utf-8") as f:
-        data = json.load(f)
+    updates: List[FileUpdate] = []
+    for update in (
+        _update_kamiwaza_json(kamiwaza_json_path, old_version, new_version),
+        *_update_compose_files(ext_dir, old_version, new_version),
+        _update_dockerfile(ext_dir / "Dockerfile", old_version, new_version),
+        _update_pyproject(ext_dir / "pyproject.toml", old_version, new_version),
+        _update_package_json(ext_dir / "package.json", old_version, new_version),
+    ):
+        if update is not None:
+            updates.append(update)
 
-    old_version = data.get("version", info.version)
-    data["version"] = new_version
+    if dry_run:
+        for update in updates:
+            rel = _relative(update.path, ext_dir)
+            diff = difflib.unified_diff(
+                update.before.splitlines(keepends=True),
+                update.after.splitlines(keepends=True),
+                fromfile=f"a/{rel}",
+                tofile=f"b/{rel}",
+            )
+            console.print("".join(diff), end="", highlight=False)
+        console.print(
+            f"[yellow]Would bump:[/yellow] "
+            f"[bold]{old_version}[/bold] → [bold]{new_version}[/bold] "
+            f"({level}) — {len(updates)} file(s)"
+        )
+        return
 
-    # Atomic write via temp file + rename
-    tmp_path = kamiwaza_json_path.with_suffix(".tmp")
-    with tmp_path.open("w", encoding="utf-8") as f:
-        json.dump(data, f, indent=4)
-        f.write("\n")
-    tmp_path.replace(kamiwaza_json_path)
+    for update in updates:
+        _atomic_write(update.path, update.after)
 
+    extras = [u for u in updates if u.path != kamiwaza_json_path]
     console.print(
-        f"[green]\u2713[/green] Bumped version: "
+        f"[green]✓[/green] Bumped version: "
         f"[bold]{old_version}[/bold] → [bold]{new_version}[/bold] ({level})"
     )
+    for update in extras:
+        console.print(f"  [dim]→[/dim] {_relative(update.path, ext_dir)}: {update.summary}")
+
+
+def _compute_new_version(current, level: str) -> Optional[str]:
+    major, minor, patch = current.major, current.minor, current.micro
+    if level == "major":
+        return f"{major + 1}.0.0"
+    if level == "minor":
+        return f"{major}.{minor + 1}.0"
+    if level == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    return None
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        f.write(content)
+    tmp.replace(path)
+
+
+# ---------------------------------------------------------------------------
+# Per-file updaters
+# ---------------------------------------------------------------------------
+
+
+def _update_kamiwaza_json(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    before = path.read_text(encoding="utf-8")
+    data = json.loads(before)
+
+    data["version"] = new
+
+    # Rewrite top-level image tag if it matches the old version.
+    image = data.get("image")
+    image_changed = False
+    if isinstance(image, str) and ":" in image:
+        repo, _, tag = image.rpartition(":")
+        if tag == old:
+            data["image"] = f"{repo}:{new}"
+            image_changed = True
+
+    after = json.dumps(data, indent=4) + "\n"
+    if after == before:
+        return None
+
+    summary = "version" + (" + image tag" if image_changed else "")
+    return FileUpdate(path=path, before=before, after=after, summary=summary)
+
+
+def _update_compose_files(ext_dir: Path, old: str, new: str) -> List[Optional[FileUpdate]]:
+    from kamiwaza_extensions.constants import COMPOSE_FILENAMES
+
+    # Include appgarden overlay alongside the canonical compose names.
+    candidates = list(COMPOSE_FILENAMES) + [
+        "docker-compose.appgarden.yml",
+        "docker-compose.appgarden.yaml",
+    ]
+    seen: set = set()
+    results: List[Optional[FileUpdate]] = []
+    for name in candidates:
+        path = ext_dir / name
+        if not path.exists() or path in seen:
+            continue
+        seen.add(path)
+        results.append(_update_compose_file(path, old, new))
+    return results
+
+
+# Match `image: <repo>:<tag>` (optionally quoted). Anchored on `:` separator so
+# external images like `postgres:16` won't match unless they happen to share
+# the bumped version literally.
+_COMPOSE_IMAGE_RE = re.compile(
+    r"""(?P<prefix>^\s*image\s*:\s*['"]?)(?P<repo>[^\s'":]+):(?P<tag>[^\s'"]+)(?P<suffix>['"]?\s*(?:\#.*)?$)""",
+    re.MULTILINE,
+)
+
+
+def _update_compose_file(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    before = path.read_text(encoding="utf-8")
+
+    count = 0
+
+    def repl(match: re.Match) -> str:
+        nonlocal count
+        if match.group("tag") != old:
+            return match.group(0)
+        count += 1
+        return f"{match.group('prefix')}{match.group('repo')}:{new}{match.group('suffix')}"
+
+    after = _COMPOSE_IMAGE_RE.sub(repl, before)
+    if count == 0 or after == before:
+        return None
+    return FileUpdate(
+        path=path,
+        before=before,
+        after=after,
+        summary=f"{count} image tag(s)",
+    )
+
+
+def _update_dockerfile(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    if not path.exists():
+        return None
+    before = path.read_text(encoding="utf-8")
+
+    # ARG NAME=<old> or ARG NAME="<old>" — default value must exactly equal
+    # `old` for us to touch it (per ticket heuristic).
+    arg_re = re.compile(
+        rf"""(?m)^(?P<prefix>\s*ARG\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*)(?P<q>["']?){re.escape(old)}(?P=q)(?P<suffix>\s*)$"""
+    )
+
+    count = 0
+
+    def repl(match: re.Match) -> str:
+        nonlocal count
+        count += 1
+        q = match.group("q")
+        return f"{match.group('prefix')}{q}{new}{q}{match.group('suffix')}"
+
+    after = arg_re.sub(repl, before)
+    if count == 0 or after == before:
+        return None
+    return FileUpdate(
+        path=path,
+        before=before,
+        after=after,
+        summary=f"{count} ARG default(s)",
+    )
+
+
+# Anchored on the `[project]` table to avoid touching [tool.poetry] or
+# similar sections — those need their own rewriter if we ever support them.
+_PYPROJECT_VERSION_RE = re.compile(
+    r"""(?ms)^(?P<header>\[project\][^\[]*?\nversion\s*=\s*["'])(?P<value>[^"']+)(?P<tail>["'])"""
+)
+
+
+def _update_pyproject(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    if not path.exists():
+        return None
+    before = path.read_text(encoding="utf-8")
+    match = _PYPROJECT_VERSION_RE.search(before)
+    if not match or match.group("value") != old:
+        return None
+    after = (
+        before[: match.start("value")] + new + before[match.end("value") :]
+    )
+    return FileUpdate(path=path, before=before, after=after, summary="[project] version")
+
+
+def _update_package_json(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    if not path.exists():
+        return None
+    before = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(before)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or data.get("version") != old:
+        return None
+    data["version"] = new
+    after = json.dumps(data, indent=2) + "\n"
+    if after == before:
+        return None
+    return FileUpdate(path=path, before=before, after=after, summary='"version"')

--- a/kamiwaza_extensions/commands/bump.py
+++ b/kamiwaza_extensions/commands/bump.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import difflib
 import json
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import typer
 from rich.console import Console
@@ -67,7 +68,7 @@ def run_bump(*, level: str = "patch", dry_run: bool = False) -> None:
         *_update_compose_files(ext_dir, old_version, new_version),
         _update_dockerfile(ext_dir / "Dockerfile", old_version, new_version),
         _update_pyproject(ext_dir / "pyproject.toml", old_version, new_version),
-        _update_package_json(ext_dir / "package.json", old_version, new_version),
+        *_update_package_json_files(ext_dir, old_version, new_version),
     ):
         if update is not None:
             updates.append(update)
@@ -75,13 +76,19 @@ def run_bump(*, level: str = "patch", dry_run: bool = False) -> None:
     if dry_run:
         for update in updates:
             rel = _relative(update.path, ext_dir)
-            diff = difflib.unified_diff(
-                update.before.splitlines(keepends=True),
-                update.after.splitlines(keepends=True),
-                fromfile=f"a/{rel}",
-                tofile=f"b/{rel}",
+            diff = "".join(
+                difflib.unified_diff(
+                    update.before.splitlines(keepends=True),
+                    update.after.splitlines(keepends=True),
+                    fromfile=f"a/{rel}",
+                    tofile=f"b/{rel}",
+                )
             )
-            console.print("".join(diff), end="", highlight=False)
+            # Diff body goes to stdout (so `kz-ext bump --dry-run > patch.diff`
+            # captures it) and bypasses Rich markup so TOML/Dockerfile syntax
+            # like `[project]` isn't parsed as a style tag.
+            sys.stdout.write(diff)
+        sys.stdout.flush()
         console.print(
             f"[yellow]Would bump:[/yellow] "
             f"[bold]{old_version}[/bold] → [bold]{new_version}[/bold] "
@@ -89,8 +96,7 @@ def run_bump(*, level: str = "patch", dry_run: bool = False) -> None:
         )
         return
 
-    for update in updates:
-        _atomic_write(update.path, update.after)
+    _commit_updates(updates)
 
     extras = [u for u in updates if u.path != kamiwaza_json_path]
     console.print(
@@ -119,11 +125,64 @@ def _relative(path: Path, root: Path) -> str:
         return str(path)
 
 
-def _atomic_write(path: Path, content: str) -> None:
-    tmp = path.with_suffix(path.suffix + ".tmp")
-    with tmp.open("w", encoding="utf-8") as f:
-        f.write(content)
-    tmp.replace(path)
+def _commit_updates(updates: List[FileUpdate]) -> None:
+    """Two-phase write: stage every tmp file first, then rename all.
+
+    Single-file atomicity is preserved by ``Path.replace``; the two-phase
+    ordering reduces the window in which a half-bumped tree is observable.
+    If any tmp write fails, no rename has happened yet, so the tree is
+    unchanged and the caller sees the original exception.
+    """
+    staged: List[Tuple[Path, Path]] = []
+    try:
+        for update in updates:
+            tmp = update.path.with_suffix(update.path.suffix + ".tmp")
+            with tmp.open("w", encoding="utf-8") as f:
+                f.write(update.after)
+            staged.append((tmp, update.path))
+    except Exception:
+        # Best-effort cleanup of already-staged tmp files.
+        for tmp, _ in staged:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise
+
+    for tmp, dest in staged:
+        tmp.replace(dest)
+
+
+# ---------------------------------------------------------------------------
+# Image-ref parsing
+# ---------------------------------------------------------------------------
+
+
+def _split_image_ref(ref: str) -> Tuple[str, Optional[str], Optional[str]]:
+    """Split a Docker image reference into ``(repo, tag, digest)``.
+
+    Handles registry ports (``localhost:5000/app``) by splitting tag from
+    repo on the **last** ``:`` that isn't inside the digest suffix, and
+    preserves any trailing ``@sha256:...`` digest so callers can re-attach
+    it after rewriting the tag.
+    """
+    digest: Optional[str] = None
+    if "@" in ref:
+        ref, _, digest = ref.partition("@")
+        digest = "@" + digest
+
+    # If there's a `/`, tag (if any) lives after the last `/`'s segment.
+    if "/" in ref:
+        head, _, last = ref.rpartition("/")
+        if ":" in last:
+            name, _, tag = last.rpartition(":")
+            return f"{head}/{name}", tag, digest
+        return ref, None, digest
+    # No `/` — single-segment image like `app:2.0.14` or `postgres:16`.
+    if ":" in ref:
+        repo, _, tag = ref.rpartition(":")
+        return repo, tag, digest
+    return ref, None, digest
 
 
 # ---------------------------------------------------------------------------
@@ -137,13 +196,12 @@ def _update_kamiwaza_json(path: Path, old: str, new: str) -> Optional[FileUpdate
 
     data["version"] = new
 
-    # Rewrite top-level image tag if it matches the old version.
     image = data.get("image")
     image_changed = False
-    if isinstance(image, str) and ":" in image:
-        repo, _, tag = image.rpartition(":")
+    if isinstance(image, str):
+        repo, tag, digest = _split_image_ref(image)
         if tag == old:
-            data["image"] = f"{repo}:{new}"
+            data["image"] = f"{repo}:{new}{digest or ''}"
             image_changed = True
 
     after = json.dumps(data, indent=4) + "\n"
@@ -155,16 +213,11 @@ def _update_kamiwaza_json(path: Path, old: str, new: str) -> Optional[FileUpdate
 
 
 def _update_compose_files(ext_dir: Path, old: str, new: str) -> List[Optional[FileUpdate]]:
-    from kamiwaza_extensions.constants import COMPOSE_FILENAMES
+    from kamiwaza_extensions.constants import ALL_COMPOSE_FILENAMES
 
-    # Include appgarden overlay alongside the canonical compose names.
-    candidates = list(COMPOSE_FILENAMES) + [
-        "docker-compose.appgarden.yml",
-        "docker-compose.appgarden.yaml",
-    ]
     seen: set = set()
     results: List[Optional[FileUpdate]] = []
-    for name in candidates:
+    for name in ALL_COMPOSE_FILENAMES:
         path = ext_dir / name
         if not path.exists() or path in seen:
             continue
@@ -173,11 +226,13 @@ def _update_compose_files(ext_dir: Path, old: str, new: str) -> List[Optional[Fi
     return results
 
 
-# Match `image: <repo>:<tag>` (optionally quoted). Anchored on `:` separator so
-# external images like `postgres:16` won't match unless they happen to share
-# the bumped version literally.
+# Capture the full image reference token (everything between optional quotes
+# and any trailing whitespace/comment) so a ref like
+# `localhost:5000/app:2.0.14@sha256:...` is handed off to `_split_image_ref`
+# intact rather than mangled by a regex that doesn't understand digests or
+# registry ports.
 _COMPOSE_IMAGE_RE = re.compile(
-    r"""(?P<prefix>^\s*image\s*:\s*['"]?)(?P<repo>[^\s'":]+):(?P<tag>[^\s'"]+)(?P<suffix>['"]?\s*(?:\#.*)?$)""",
+    r"""(?P<prefix>^\s*image\s*:\s*)(?P<quote>['"]?)(?P<ref>\S+?)(?P=quote)(?P<suffix>\s*(?:\#.*)?)$""",
     re.MULTILINE,
 )
 
@@ -189,10 +244,16 @@ def _update_compose_file(path: Path, old: str, new: str) -> Optional[FileUpdate]
 
     def repl(match: re.Match) -> str:
         nonlocal count
-        if match.group("tag") != old:
+        ref = match.group("ref")
+        repo, tag, digest = _split_image_ref(ref)
+        if tag != old:
             return match.group(0)
         count += 1
-        return f"{match.group('prefix')}{match.group('repo')}:{new}{match.group('suffix')}"
+        new_ref = f"{repo}:{new}{digest or ''}"
+        return (
+            f"{match.group('prefix')}{match.group('quote')}"
+            f"{new_ref}{match.group('quote')}{match.group('suffix')}"
+        )
 
     after = _COMPOSE_IMAGE_RE.sub(repl, before)
     if count == 0 or after == before:
@@ -211,9 +272,10 @@ def _update_dockerfile(path: Path, old: str, new: str) -> Optional[FileUpdate]:
     before = path.read_text(encoding="utf-8")
 
     # ARG NAME=<old> or ARG NAME="<old>" — default value must exactly equal
-    # `old` for us to touch it (per ticket heuristic).
+    # `old`. Allows trailing whitespace and `# comment` so Dockerfiles using
+    # the common `ARG FOO=1.0.0  # bumped` style aren't silently skipped.
     arg_re = re.compile(
-        rf"""(?m)^(?P<prefix>\s*ARG\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*)(?P<q>["']?){re.escape(old)}(?P=q)(?P<suffix>\s*)$"""
+        rf"""(?m)^(?P<prefix>\s*ARG\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*)(?P<q>["']?){re.escape(old)}(?P=q)(?P<suffix>\s*(?:\#.*)?)$"""
     )
 
     count = 0
@@ -235,29 +297,72 @@ def _update_dockerfile(path: Path, old: str, new: str) -> Optional[FileUpdate]:
     )
 
 
-# Anchored on the `[project]` table to avoid touching [tool.poetry] or
-# similar sections — those need their own rewriter if we ever support them.
-_PYPROJECT_VERSION_RE = re.compile(
-    r"""(?ms)^(?P<header>\[project\][^\[]*?\nversion\s*=\s*["'])(?P<value>[^"']+)(?P<tail>["'])"""
-)
-
-
 def _update_pyproject(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    """Rewrite ``[project] version`` while preserving comments and formatting.
+
+    Locates the ``[project]`` table by header line, then scans only that
+    table's body for the ``version`` key — sidesteps the lazy-regex trap
+    where a TOML array like ``classifiers = [...]`` before the version
+    line defeats a single anchored pattern.
+    """
     if not path.exists():
         return None
     before = path.read_text(encoding="utf-8")
-    match = _PYPROJECT_VERSION_RE.search(before)
+    span = _find_project_table_span(before)
+    if span is None:
+        return None
+    start, end = span
+    version_re = re.compile(
+        r"""(?m)^(?P<prefix>version\s*=\s*["'])(?P<value>[^"']+)(?P<tail>["'])"""
+    )
+    body = before[start:end]
+    match = version_re.search(body)
     if not match or match.group("value") != old:
         return None
-    after = (
-        before[: match.start("value")] + new + before[match.end("value") :]
-    )
+    new_body = body[: match.start("value")] + new + body[match.end("value") :]
+    after = before[:start] + new_body + before[end:]
     return FileUpdate(path=path, before=before, after=after, summary="[project] version")
 
 
+_TOML_SECTION_RE = re.compile(r"(?m)^\[([^\]\n]+)\]\s*$")
+
+
+def _find_project_table_span(text: str) -> Optional[Tuple[int, int]]:
+    """Return ``(start, end)`` indices of the ``[project]`` table body."""
+    for header in _TOML_SECTION_RE.finditer(text):
+        if header.group(1).strip() != "project":
+            continue
+        body_start = header.end()
+        next_header = _TOML_SECTION_RE.search(text, body_start)
+        body_end = next_header.start() if next_header else len(text)
+        return body_start, body_end
+    return None
+
+
+def _update_package_json_files(
+    ext_dir: Path, old: str, new: str
+) -> List[Optional[FileUpdate]]:
+    """Update root and any first-level ``package.json`` (e.g. ``frontend/``).
+
+    Scaffolded app extensions keep their JS package file under
+    ``frontend/package.json``; a root-only check would silently leave it
+    stale. Restricting to depth 1 keeps the scan bounded and avoids
+    crawling ``node_modules``.
+    """
+    candidates: List[Path] = []
+    root = ext_dir / "package.json"
+    if root.exists():
+        candidates.append(root)
+    for child in sorted(ext_dir.iterdir() if ext_dir.exists() else []):
+        if not child.is_dir() or child.name in {"node_modules", ".git"} or child.name.startswith("."):
+            continue
+        nested = child / "package.json"
+        if nested.exists():
+            candidates.append(nested)
+    return [_update_package_json(p, old, new) for p in candidates]
+
+
 def _update_package_json(path: Path, old: str, new: str) -> Optional[FileUpdate]:
-    if not path.exists():
-        return None
     before = path.read_text(encoding="utf-8")
     try:
         data = json.loads(before)
@@ -265,8 +370,12 @@ def _update_package_json(path: Path, old: str, new: str) -> Optional[FileUpdate]
         return None
     if not isinstance(data, dict) or data.get("version") != old:
         return None
-    data["version"] = new
-    after = json.dumps(data, indent=2) + "\n"
-    if after == before:
+    # Targeted line rewrite preserves the source file's indentation,
+    # key order, and trailing newline — re-serializing via json.dumps
+    # would normalize 4-space or tab indentation to 2 and create
+    # gratuitous diffs.
+    version_re = re.compile(r'("version"\s*:\s*")[^"]+(")')
+    after, count = version_re.subn(rf"\g<1>{new}\g<2>", before, count=1)
+    if count == 0 or after == before:
         return None
     return FileUpdate(path=path, before=before, after=after, summary='"version"')

--- a/kamiwaza_extensions/commands/bump.py
+++ b/kamiwaza_extensions/commands/bump.py
@@ -205,21 +205,48 @@ def _split_image_ref(ref: str) -> Tuple[str, Optional[str], Optional[str]]:
 def _update_kamiwaza_json(path: Path, old: str, new: str) -> Optional[FileUpdate]:
     before = path.read_text(encoding="utf-8")
     data = json.loads(before)
+    if data.get("version") != old:
+        # Manifest already drifted (or its detector value was different);
+        # fall back to writing through json.dumps so the file is at least
+        # internally consistent post-bump.
+        data["version"] = new
+        return FileUpdate(
+            path=path,
+            before=before,
+            after=json.dumps(data, indent=4) + "\n",
+            summary="version",
+        )
 
-    data["version"] = new
+    # Targeted rewrite of the top-level ``"version"`` string. Mirrors the
+    # package.json approach so a manifest with non-default indentation,
+    # key order, or non-ASCII content doesn't get a full-file reformat
+    # diff on bump.
+    span = _find_top_level_string_value_span(before, "version")
+    if span is None or before[span[0] : span[1]] != old:
+        # Pathological: top-level version isn't a string. Re-serialize.
+        data["version"] = new
+        return FileUpdate(
+            path=path,
+            before=before,
+            after=json.dumps(data, indent=4) + "\n",
+            summary="version",
+        )
+    after = before[: span[0]] + new + before[span[1] :]
 
+    # Conditional image-tag rewrite.
     image = data.get("image")
     image_changed = False
     if isinstance(image, str):
         repo, tag, digest = _split_image_ref(image)
         if tag == old:
-            data["image"] = f"{repo}:{new}{digest or ''}"
-            image_changed = True
+            new_image = f"{repo}:{new}{digest or ''}"
+            image_span = _find_top_level_string_value_span(after, "image")
+            if image_span is not None and after[image_span[0] : image_span[1]] == image:
+                after = after[: image_span[0]] + new_image + after[image_span[1] :]
+                image_changed = True
 
-    after = json.dumps(data, indent=4) + "\n"
     if after == before:
         return None
-
     summary = "version" + (" + image tag" if image_changed else "")
     return FileUpdate(path=path, before=before, after=after, summary=summary)
 
@@ -361,7 +388,9 @@ def _update_pyproject(path: Path, old: str, new: str) -> Optional[FileUpdate]:
     return FileUpdate(path=path, before=before, after=after, summary="[project] version")
 
 
-_TOML_SECTION_RE = re.compile(r"(?m)^\[([^\]\n]+)\]\s*$")
+# TOML allows a comment after a table header (`[project]  # main metadata`),
+# so match `]` followed by optional whitespace and an optional `# comment`.
+_TOML_SECTION_RE = re.compile(r"(?m)^\[([^\]\n]+)\]\s*(?:#.*)?$")
 
 
 def _find_project_table_span(text: str) -> Optional[Tuple[int, int]]:

--- a/kamiwaza_extensions/commands/bump.py
+++ b/kamiwaza_extensions/commands/bump.py
@@ -13,10 +13,13 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import typer
 from rich.console import Console
+
+if TYPE_CHECKING:
+    from packaging.version import Version
 
 console = Console(stderr=True)
 
@@ -113,7 +116,7 @@ def run_bump(*, level: str = "patch", dry_run: bool = False) -> None:
         console.print(f"  [dim]→[/dim] {_relative(update.path, ext_dir)}: {update.summary}")
 
 
-def _compute_new_version(current, level: str) -> Optional[str]:
+def _compute_new_version(current: "Version", level: str) -> Optional[str]:
     major, minor, patch = current.major, current.minor, current.micro
     if level == "major":
         return f"{major + 1}.0.0"
@@ -142,7 +145,10 @@ def _commit_updates(updates: List[FileUpdate]) -> None:
     staged: List[Tuple[Path, Path]] = []
     try:
         for update in updates:
-            tmp = update.path.with_suffix(update.path.suffix + ".tmp")
+            # Use ``with_name`` instead of ``with_suffix(suffix + ".tmp")``
+            # — Python 3.13 tightened ``with_suffix`` to reject suffixes
+            # that contain internal dots (e.g. ``.json.tmp``).
+            tmp = update.path.with_name(update.path.name + ".tmp")
             with tmp.open("w", encoding="utf-8") as f:
                 f.write(update.after)
             staged.append((tmp, update.path))
@@ -300,11 +306,13 @@ def _update_dockerfile(path: Path, old: str, new: str) -> Optional[FileUpdate]:
         return None
     before = path.read_text(encoding="utf-8")
 
-    # ARG NAME=<old> or ARG NAME="<old>" — default value must exactly equal
-    # `old`. Allows trailing whitespace and `# comment` so Dockerfiles using
-    # the common `ARG FOO=1.0.0  # bumped` style aren't silently skipped.
+    # ARG <NAME>_VERSION=<old> — only retag ARGs whose name ends in
+    # ``_VERSION`` so we don't silently rewrite an unrelated pin like
+    # ``ARG PYTHON_VERSION=3.11.9`` when the extension itself is at
+    # ``3.11.9``. Matches the drift detector's heuristic and keeps the
+    # blast radius narrow.
     arg_re = re.compile(
-        rf"""(?m)^(?P<prefix>\s*ARG\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*)(?P<q>["']?){re.escape(old)}(?P=q)(?P<suffix>\s*(?:\#.*)?)$"""
+        rf"""(?m)^(?P<prefix>\s*ARG\s+[A-Za-z_][A-Za-z0-9_]*_VERSION\s*=\s*)(?P<q>["']?){re.escape(old)}(?P=q)(?P<suffix>\s*(?:\#.*)?)$"""
     )
 
     count = 0

--- a/kamiwaza_extensions/constants.py
+++ b/kamiwaza_extensions/constants.py
@@ -16,6 +16,13 @@ COMPOSE_FILENAMES = (
     "compose.yaml",
 )
 
+# All compose-file names a version bump / drift check should inspect. Includes
+# the appgarden deployment overlay alongside the canonical compose names.
+ALL_COMPOSE_FILENAMES = COMPOSE_FILENAMES + (
+    "docker-compose.appgarden.yml",
+    "docker-compose.appgarden.yaml",
+)
+
 EXTENSIONS_NAMESPACE = "kamiwaza-extensions"
 
 

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from kamiwaza_extensions import __version__
 from kamiwaza_extensions.validators.result import ValidationResult
@@ -222,7 +222,50 @@ def _check_version_drift(
                 f"but kamiwaza.json version='{version}'"
             )
 
+    # package.json — root and any first-level subdir (e.g. frontend/),
+    # mirroring what `kz-ext bump` propagates so the validator can spot
+    # the same drift the bumper handles.
+    for pkg in _candidate_package_jsons(ext_dir):
+        try:
+            data = json.loads(pkg.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        pkg_version = data.get("version")
+        if isinstance(pkg_version, str) and pkg_version != version:
+            try:
+                rel = pkg.relative_to(ext_dir)
+            except ValueError:
+                rel = pkg
+            warnings.append(
+                f"Version drift: {rel} version='{pkg_version}' "
+                f"but kamiwaza.json version='{version}'"
+            )
+
     return warnings
+
+
+def _candidate_package_jsons(ext_dir: Path) -> List[Path]:
+    candidates: List[Path] = []
+    root = ext_dir / "package.json"
+    if root.exists():
+        candidates.append(root)
+    try:
+        children = sorted(ext_dir.iterdir())
+    except OSError:
+        return candidates
+    for child in children:
+        if (
+            not child.is_dir()
+            or child.name in {"node_modules", ".git"}
+            or child.name.startswith(".")
+        ):
+            continue
+        nested = child / "package.json"
+        if nested.exists():
+            candidates.append(nested)
+    return candidates
 
 
 def _find_pyproject_version(text: str) -> Optional[str]:

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -138,27 +138,27 @@ class MetadataValidator:
 def _check_version_drift(
     ext_dir: Path, version: str, manifest_image: Optional[Any]
 ) -> List[str]:
+    # Import locally to share the canonical image-ref parser with the bump
+    # command — keeps the updater and the drift detector from diverging on
+    # what counts as a "tag" (registry ports, digest suffixes, etc.).
+    from kamiwaza_extensions.commands.bump import _split_image_ref
+    from kamiwaza_extensions.constants import ALL_COMPOSE_FILENAMES
+
     warnings: List[str] = []
 
     # kamiwaza.json image tag
-    if isinstance(manifest_image, str) and ":" in manifest_image:
-        tag = manifest_image.rpartition(":")[2]
-        if tag != version and _looks_like_semver(tag):
+    if isinstance(manifest_image, str):
+        _, tag, _ = _split_image_ref(manifest_image)
+        if tag is not None and tag != version and _looks_like_semver(tag):
             warnings.append(
                 f"Version drift: kamiwaza.json version='{version}' but image tag='{tag}'"
             )
 
-    from kamiwaza_extensions.constants import COMPOSE_FILENAMES
-
-    compose_candidates = list(COMPOSE_FILENAMES) + [
-        "docker-compose.appgarden.yml",
-        "docker-compose.appgarden.yaml",
-    ]
     image_re = re.compile(
-        r"""^\s*image\s*:\s*['"]?(?P<repo>[^\s'":]+):(?P<tag>[^\s'"]+)['"]?""",
+        r"""^\s*image\s*:\s*['"]?(?P<ref>\S+?)['"]?\s*(?:\#.*)?$""",
         re.MULTILINE,
     )
-    for name in compose_candidates:
+    for name in ALL_COMPOSE_FILENAMES:
         compose = ext_dir / name
         if not compose.exists():
             continue
@@ -167,10 +167,10 @@ def _check_version_drift(
         except OSError:
             continue
         for match in image_re.finditer(content):
-            tag = match.group("tag")
+            _, tag, _ = _split_image_ref(match.group("ref"))
             # Only flag images that look like extension-owned versions:
             # tag is semver-shaped *and* differs from manifest version.
-            if tag != version and _looks_like_semver(tag):
+            if tag is not None and tag != version and _looks_like_semver(tag):
                 warnings.append(
                     f"Version drift: {name} has image tag='{tag}' but kamiwaza.json version='{version}'"
                 )
@@ -195,24 +195,37 @@ def _check_version_drift(
                     f"but kamiwaza.json version='{version}'"
                 )
 
-    # pyproject.toml [project] version
+    # pyproject.toml [project] version — scan only inside the [project]
+    # table to survive arrays (e.g. `classifiers = [...]`) before the
+    # version line.
     pyproject = ext_dir / "pyproject.toml"
     if pyproject.exists():
         try:
             content = pyproject.read_text(encoding="utf-8")
         except OSError:
             content = ""
-        match = re.search(
-            r"""(?ms)^\[project\][^\[]*?\nversion\s*=\s*["'](?P<value>[^"']+)["']""",
-            content,
-        )
-        if match and match.group("value") != version:
+        pyproject_version = _find_pyproject_version(content)
+        if pyproject_version is not None and pyproject_version != version:
             warnings.append(
-                f"Version drift: pyproject.toml version='{match.group('value')}' "
+                f"Version drift: pyproject.toml version='{pyproject_version}' "
                 f"but kamiwaza.json version='{version}'"
             )
 
     return warnings
+
+
+def _find_pyproject_version(text: str) -> Optional[str]:
+    from kamiwaza_extensions.commands.bump import _find_project_table_span
+
+    span = _find_project_table_span(text)
+    if span is None:
+        return None
+    start, end = span
+    match = re.search(
+        r"""(?m)^version\s*=\s*["'](?P<value>[^"']+)["']""",
+        text[start:end],
+    )
+    return match.group("value") if match else None
 
 
 def _looks_like_semver(value: str) -> bool:

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -26,6 +26,23 @@ _SEMVER_RE = re.compile(
 # Valid image extensions for preview_image
 _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
 
+# Dockerfile ARGs that pin third-party runtime / base-image versions and
+# intentionally don't track the extension's own semver. Excluded from drift
+# checks so a clean Dockerfile doesn't emit noisy warnings.
+_RUNTIME_VERSION_ARGS = frozenset({
+    "NODE_VERSION",
+    "PYTHON_VERSION",
+    "ALPINE_VERSION",
+    "DEBIAN_VERSION",
+    "UBUNTU_VERSION",
+    "GO_VERSION",
+    "BUN_VERSION",
+    "RUBY_VERSION",
+    "RUST_VERSION",
+    "JAVA_VERSION",
+    "BASE_IMAGE_VERSION",
+})
+
 
 class KamiwazaMetadata(BaseModel):
     """Pydantic model for kamiwaza.json schema validation."""
@@ -199,10 +216,17 @@ def _check_version_drift(
             re.MULTILINE,
         )
         for match in arg_re.finditer(content):
+            name = match.group("name")
             value = match.group("value")
+            # Skip well-known third-party runtime ARGs — they pin
+            # interpreter/base-image versions that intentionally don't
+            # track the extension's own semver, so any "drift" against
+            # the manifest is noise.
+            if name in _RUNTIME_VERSION_ARGS:
+                continue
             if value != version and _looks_like_semver(value):
                 warnings.append(
-                    f"Version drift: Dockerfile ARG {match.group('name')}='{value}' "
+                    f"Version drift: Dockerfile ARG {name}='{value}' "
                     f"but kamiwaza.json version='{version}'"
                 )
 

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -126,7 +126,97 @@ class MetadataValidator:
             if not image_path.exists():
                 warnings.append(f"preview_image file not found: {metadata.preview_image}")
 
+        # Version-drift checks: surface mismatches between kamiwaza.json
+        # version and the same version recorded in sibling files. Drift
+        # silently breaks publishes (manifest claims 2.1.0, image tag still
+        # points at 2.0.14) — warn here so it's visible before deploy.
+        warnings.extend(_check_version_drift(path.parent, metadata.version, data.get("image")))
+
         return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings)
+
+
+def _check_version_drift(
+    ext_dir: Path, version: str, manifest_image: Optional[Any]
+) -> List[str]:
+    warnings: List[str] = []
+
+    # kamiwaza.json image tag
+    if isinstance(manifest_image, str) and ":" in manifest_image:
+        tag = manifest_image.rpartition(":")[2]
+        if tag != version and _looks_like_semver(tag):
+            warnings.append(
+                f"Version drift: kamiwaza.json version='{version}' but image tag='{tag}'"
+            )
+
+    from kamiwaza_extensions.constants import COMPOSE_FILENAMES
+
+    compose_candidates = list(COMPOSE_FILENAMES) + [
+        "docker-compose.appgarden.yml",
+        "docker-compose.appgarden.yaml",
+    ]
+    image_re = re.compile(
+        r"""^\s*image\s*:\s*['"]?(?P<repo>[^\s'":]+):(?P<tag>[^\s'"]+)['"]?""",
+        re.MULTILINE,
+    )
+    for name in compose_candidates:
+        compose = ext_dir / name
+        if not compose.exists():
+            continue
+        try:
+            content = compose.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for match in image_re.finditer(content):
+            tag = match.group("tag")
+            # Only flag images that look like extension-owned versions:
+            # tag is semver-shaped *and* differs from manifest version.
+            if tag != version and _looks_like_semver(tag):
+                warnings.append(
+                    f"Version drift: {name} has image tag='{tag}' but kamiwaza.json version='{version}'"
+                )
+                break  # one warning per compose file is enough signal
+
+    # Dockerfile *_VERSION ARG defaults
+    dockerfile = ext_dir / "Dockerfile"
+    if dockerfile.exists():
+        try:
+            content = dockerfile.read_text(encoding="utf-8")
+        except OSError:
+            content = ""
+        arg_re = re.compile(
+            r"""^\s*ARG\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*_VERSION)\s*=\s*["']?(?P<value>[^\s"']+)["']?""",
+            re.MULTILINE,
+        )
+        for match in arg_re.finditer(content):
+            value = match.group("value")
+            if value != version and _looks_like_semver(value):
+                warnings.append(
+                    f"Version drift: Dockerfile ARG {match.group('name')}='{value}' "
+                    f"but kamiwaza.json version='{version}'"
+                )
+
+    # pyproject.toml [project] version
+    pyproject = ext_dir / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            content = pyproject.read_text(encoding="utf-8")
+        except OSError:
+            content = ""
+        match = re.search(
+            r"""(?ms)^\[project\][^\[]*?\nversion\s*=\s*["'](?P<value>[^"']+)["']""",
+            content,
+        )
+        if match and match.group("value") != version:
+            warnings.append(
+                f"Version drift: pyproject.toml version='{match.group('value')}' "
+                f"but kamiwaza.json version='{version}'"
+            )
+
+    return warnings
+
+
+def _looks_like_semver(value: str) -> bool:
+    return bool(_SEMVER_RE.match(value))
 
 
 def _is_valid_specifier_set(value: str) -> bool:

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -141,10 +141,14 @@ def _check_version_drift(
     # Import locally to share the canonical image-ref parser with the bump
     # command — keeps the updater and the drift detector from diverging on
     # what counts as a "tag" (registry ports, digest suffixes, etc.).
-    from kamiwaza_extensions.commands.bump import _split_image_ref
+    from kamiwaza_extensions.commands.bump import (
+        _split_image_ref,
+        extension_image_repo,
+    )
     from kamiwaza_extensions.constants import ALL_COMPOSE_FILENAMES
 
     warnings: List[str] = []
+    ext_repo = extension_image_repo(manifest_image)
 
     # kamiwaza.json image tag
     if isinstance(manifest_image, str):
@@ -167,14 +171,21 @@ def _check_version_drift(
         except OSError:
             continue
         for match in image_re.finditer(content):
-            _, tag, _ = _split_image_ref(match.group("ref"))
-            # Only flag images that look like extension-owned versions:
-            # tag is semver-shaped *and* differs from manifest version.
-            if tag is not None and tag != version and _looks_like_semver(tag):
-                warnings.append(
-                    f"Version drift: {name} has image tag='{tag}' but kamiwaza.json version='{version}'"
-                )
-                break  # one warning per compose file is enough signal
+            repo, tag, _ = _split_image_ref(match.group("ref"))
+            # Only flag images that belong to the extension. Without a
+            # manifest image repo we fall back to "semver tag != manifest
+            # version" alone, which keeps drift detection useful for
+            # manifests that omit `image` but risks noise for unrelated
+            # third-party services (e.g. redis:7.2.4); scoping eliminates
+            # that noise when the manifest declares its repo.
+            if tag is None or tag == version or not _looks_like_semver(tag):
+                continue
+            if ext_repo is not None and repo != ext_repo:
+                continue
+            warnings.append(
+                f"Version drift: {name} has image tag='{tag}' but kamiwaza.json version='{version}'"
+            )
+            break  # one warning per compose file is enough signal
 
     # Dockerfile *_VERSION ARG defaults
     dockerfile = ext_dir / "Dockerfile"

--- a/tests/unit/extensions/test_bump_cmd.py
+++ b/tests/unit/extensions/test_bump_cmd.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -208,11 +208,14 @@ class TestBump:
 
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
     def test_only_kamiwaza_json_present(self, mock_detector_cls, tmp_path):
-        _write_kamiwaza_json(tmp_path, "1.0.0")
+        kj = _write_kamiwaza_json(tmp_path, "1.0.0")
         mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "1.0.0")
 
         from kamiwaza_extensions.commands.bump import run_bump
-        run_bump(level="patch")  # should not raise
+        run_bump(level="patch")
+
+        # No sibling files means only kamiwaza.json should change.
+        assert json.loads(kj.read_text())["version"] == "1.0.1"
 
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
     def test_dry_run_does_not_write(self, mock_detector_cls, tmp_path):

--- a/tests/unit/extensions/test_bump_cmd.py
+++ b/tests/unit/extensions/test_bump_cmd.py
@@ -235,6 +235,150 @@ class TestBump:
         assert compose.read_text() == before_compose
 
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_compose_handles_registry_port(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: localhost:5000/omniparse:2.0.14\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        assert "localhost:5000/omniparse:2.1.0" in compose.read_text()
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_compose_preserves_digest_suffix(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        compose = tmp_path / "docker-compose.yml"
+        digest = "sha256:" + "a" * 64
+        compose.write_text(
+            f"services:\n  app:\n    image: ghcr.io/x/y:2.0.14@{digest}\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")
+
+        content = compose.read_text()
+        assert f"ghcr.io/x/y:2.0.15@{digest}" in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_compose_handles_quoted_image(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text(
+            'services:\n  app:\n    image: "ghcr.io/x/y:2.0.14"\n'
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        assert '"ghcr.io/x/y:2.1.0"' in compose.read_text()
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_pyproject_with_arrays_before_version(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[project]\n"
+            'name = "omniparse"\n'
+            'classifiers = [\n'
+            '    "Topic :: Software Development",\n'
+            '    "License :: OSI Approved",\n'
+            ']\n'
+            'dependencies = ["requests", "typer"]\n'
+            'version = "2.0.14"\n'
+            "\n"
+            "[tool.ruff]\n"
+            "line-length = 88\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        assert 'version = "2.1.0"' in pyproject.read_text()
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_nested_package_json(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        frontend = tmp_path / "frontend"
+        frontend.mkdir()
+        pkg = frontend / "package.json"
+        pkg.write_text(json.dumps({"name": "x", "version": "2.0.14"}, indent=2) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        data = json.loads(pkg.read_text())
+        assert data["version"] == "2.1.0"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_package_json_preserves_indent(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pkg = tmp_path / "package.json"
+        # Use 4-space indent; expect it to survive.
+        original = (
+            '{\n'
+            '    "name": "x",\n'
+            '    "version": "2.0.14",\n'
+            '    "scripts": {\n'
+            '        "build": "next build"\n'
+            '    }\n'
+            '}\n'
+        )
+        pkg.write_text(original)
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")
+
+        content = pkg.read_text()
+        assert '"version": "2.0.15"' in content
+        assert '    "name": "x"' in content  # 4-space indent preserved
+        assert '"scripts"' in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_dockerfile_arg_with_trailing_comment(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text(
+            "FROM python:3.11\n"
+            "ARG OMNIPARSE_VERSION=2.0.14  # injected at build\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = dockerfile.read_text()
+        assert "ARG OMNIPARSE_VERSION=2.1.0" in content
+        assert "# injected at build" in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_image_with_digest_in_kamiwaza_json(self, mock_detector_cls, tmp_path):
+        kj = tmp_path / "kamiwaza.json"
+        digest = "sha256:" + "b" * 64
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": f"ghcr.io/x/y:2.0.14@{digest}",
+        }, indent=4) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        data = json.loads(kj.read_text())
+        assert data["image"] == f"ghcr.io/x/y:2.1.0@{digest}"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
     def test_invalid_level_exits(self, mock_detector_cls, tmp_path):
         _write_kamiwaza_json(tmp_path)
         mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path)

--- a/tests/unit/extensions/test_bump_cmd.py
+++ b/tests/unit/extensions/test_bump_cmd.py
@@ -437,6 +437,54 @@ class TestBump:
         assert data["engines"]["version"] == "2.0.14"  # untouched
 
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_kamiwaza_json_preserves_indent_and_unicode(
+        self, mock_detector_cls, tmp_path
+    ):
+        """A hand-authored manifest with 2-space indent and Unicode
+        description should not be reformatted by bump."""
+        kj = tmp_path / "kamiwaza.json"
+        original = (
+            '{\n'
+            '  "name": "test-app",\n'
+            '  "version": "2.0.14",\n'
+            '  "description": "Café ☕ tooling",\n'
+            '  "image": "ghcr.io/x/y:2.0.14"\n'
+            '}\n'
+        )
+        kj.write_text(original)
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = kj.read_text()
+        # Targeted rewrite — 2-space indent and the Unicode char survive.
+        assert '  "name": "test-app"' in content
+        assert "Café ☕ tooling" in content
+        assert '"version": "2.1.0"' in content
+        assert '"image": "ghcr.io/x/y:2.1.0"' in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_pyproject_header_with_comment(self, mock_detector_cls, tmp_path):
+        """A `[project]` header followed by a TOML comment should still
+        be located by the table-span scanner."""
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]  # main metadata\n'
+            'name = "x"\n'
+            'version = "2.0.14"\n'
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = pyproject.read_text()
+        assert 'version = "2.1.0"' in content
+        assert "[project]  # main metadata" in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
     def test_invalid_level_exits(self, mock_detector_cls, tmp_path):
         _write_kamiwaza_json(tmp_path)
         mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path)

--- a/tests/unit/extensions/test_bump_cmd.py
+++ b/tests/unit/extensions/test_bump_cmd.py
@@ -94,6 +94,147 @@ class TestBump:
         assert data["tags"] == ["ai"]
 
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_image_tag(self, mock_detector_cls, tmp_path):
+        kj = tmp_path / "kamiwaza.json"
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": "ghcr.io/kamiwaza/omniparse:2.0.14",
+        }, indent=4) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        data = json.loads(kj.read_text())
+        assert data["version"] == "2.1.0"
+        assert data["image"] == "ghcr.io/kamiwaza/omniparse:2.1.0"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_leaves_latest_tag_alone(self, mock_detector_cls, tmp_path):
+        kj = tmp_path / "kamiwaza.json"
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": "ghcr.io/kamiwaza/omniparse:latest",
+        }, indent=4) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")
+
+        data = json.loads(kj.read_text())
+        assert data["image"] == "ghcr.io/kamiwaza/omniparse:latest"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_compose_files(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: ghcr.io/kamiwaza/omniparse:2.0.14\n"
+            "  db:\n"
+            "    image: postgres:16\n"
+        )
+        appgarden = tmp_path / "docker-compose.appgarden.yml"
+        appgarden.write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: ghcr.io/kamiwaza/omniparse:2.0.14\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        assert "ghcr.io/kamiwaza/omniparse:2.1.0" in compose.read_text()
+        assert "postgres:16" in compose.read_text()
+        assert "ghcr.io/kamiwaza/omniparse:2.1.0" in appgarden.read_text()
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_dockerfile_arg(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text(
+            "FROM python:3.11\n"
+            "ARG OMNIPARSE_VERSION=2.0.14\n"
+            "ARG UNRELATED=something-else\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = dockerfile.read_text()
+        assert "ARG OMNIPARSE_VERSION=2.1.0" in content
+        assert "ARG UNRELATED=something-else" in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_pyproject(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "# top comment\n"
+            "[project]\n"
+            'name = "omniparse"\n'
+            'version = "2.0.14"  # bumped by kz-ext\n'
+            "\n"
+            "[tool.ruff]\n"
+            "line-length = 88\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")
+
+        content = pyproject.read_text()
+        assert 'version = "2.0.15"' in content
+        assert "# bumped by kz-ext" in content  # comment preserved
+        assert "# top comment" in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_package_json(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pkg = tmp_path / "package.json"
+        pkg.write_text(json.dumps({"name": "x", "version": "2.0.14"}, indent=2) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="major")
+
+        data = json.loads(pkg.read_text())
+        assert data["version"] == "3.0.0"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_only_kamiwaza_json_present(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "1.0.0")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "1.0.0")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")  # should not raise
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_dry_run_does_not_write(self, mock_detector_cls, tmp_path):
+        kj = tmp_path / "kamiwaza.json"
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": "ghcr.io/x/y:2.0.14",
+        }, indent=4) + "\n")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text("services:\n  app:\n    image: ghcr.io/x/y:2.0.14\n")
+        before_kj = kj.read_text()
+        before_compose = compose.read_text()
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor", dry_run=True)
+
+        assert kj.read_text() == before_kj
+        assert compose.read_text() == before_compose
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
     def test_invalid_level_exits(self, mock_detector_cls, tmp_path):
         _write_kamiwaza_json(tmp_path)
         mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path)

--- a/tests/unit/extensions/test_bump_cmd.py
+++ b/tests/unit/extensions/test_bump_cmd.py
@@ -379,6 +379,61 @@ class TestBump:
         assert data["image"] == f"ghcr.io/x/y:2.1.0@{digest}"
 
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_compose_scopes_to_extension_repo(self, mock_detector_cls, tmp_path):
+        """A sidecar whose tag happens to equal `old` must not be retagged
+        when the manifest declares its own image repo."""
+        kj = tmp_path / "kamiwaza.json"
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": "ghcr.io/kamiwaza/app:2.0.14",
+        }, indent=4) + "\n")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: ghcr.io/kamiwaza/app:2.0.14\n"
+            "  sidecar:\n"
+            "    image: vendor/sidecar:2.0.14\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = compose.read_text()
+        assert "ghcr.io/kamiwaza/app:2.1.0" in content
+        assert "vendor/sidecar:2.0.14" in content  # untouched
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_package_json_targets_top_level_version(self, mock_detector_cls, tmp_path):
+        """Nested `"version"` keys (engines, config, …) must not be
+        rewritten when the top-level version is the bump target."""
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pkg = tmp_path / "package.json"
+        # `engines.version` appears textually before top-level `version`
+        # and shares the same string value — a naive first-match regex
+        # would rewrite the wrong one.
+        original = (
+            '{\n'
+            '  "name": "x",\n'
+            '  "engines": {\n'
+            '    "version": "2.0.14"\n'
+            '  },\n'
+            '  "version": "2.0.14"\n'
+            '}\n'
+        )
+        pkg.write_text(original)
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        data = json.loads(pkg.read_text())
+        assert data["version"] == "2.1.0"
+        assert data["engines"]["version"] == "2.0.14"  # untouched
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
     def test_invalid_level_exits(self, mock_detector_cls, tmp_path):
         _write_kamiwaza_json(tmp_path)
         mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path)

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -298,6 +298,29 @@ class TestVersionDrift:
         drift = [w for w in result.warnings if "drift" in w.lower()]
         assert drift == []
 
+    def test_package_json_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "package.json").write_text(
+            json.dumps({"name": "x", "version": "2.0.14"}, indent=2)
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("package.json" in w and "2.0.14" in w for w in result.warnings)
+
+    def test_nested_package_json_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "frontend").mkdir()
+        (tmp_path / "frontend" / "package.json").write_text(
+            json.dumps({"name": "x", "version": "2.0.14"}, indent=2)
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("frontend/package.json" in w and "2.0.14" in w for w in result.warnings)
+
     def test_unrelated_thirdparty_image_no_drift_warning(self, tmp_path):
         """A redis/postgres sidecar's semver tag must not trigger a drift
         warning when the extension declares its own image repo."""

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -222,3 +222,78 @@ class TestRunValidateMonorepo:
         assert output["passed"] is False
         joined = " ".join(output["errors"])
         assert "Multiple kamiwaza.json found" in joined
+
+
+class TestVersionDrift:
+    """ENG-4835: surface drift between kamiwaza.json version and sibling files."""
+
+    def _meta(self, version: str, image: str | None = None) -> dict:
+        m = _valid_metadata()
+        m["version"] = version
+        if image is not None:
+            m["image"] = image
+        return m
+
+    def test_image_tag_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(
+            json.dumps(self._meta("2.1.0", "ghcr.io/x/y:2.0.14"))
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert result.passed
+        assert any("image tag" in w and "2.0.14" in w for w in result.warnings)
+
+    def test_compose_image_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n  app:\n    image: ghcr.io/x/y:2.0.14\n"
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("docker-compose.yml" in w and "2.0.14" in w for w in result.warnings)
+
+    def test_dockerfile_arg_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "Dockerfile").write_text(
+            "FROM python:3.11\nARG OMNIPARSE_VERSION=2.0.14\n"
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("OMNIPARSE_VERSION" in w for w in result.warnings)
+
+    def test_pyproject_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "2.0.14"\n'
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("pyproject.toml" in w and "2.0.14" in w for w in result.warnings)
+
+    def test_aligned_versions_no_drift_warnings(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(
+            json.dumps(self._meta("2.1.0", "ghcr.io/x/y:2.1.0"))
+        )
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n  app:\n    image: ghcr.io/x/y:2.1.0\n"
+        )
+        (tmp_path / "Dockerfile").write_text(
+            "FROM python:3.11\nARG OMNIPARSE_VERSION=2.1.0\n"
+        )
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "2.1.0"\n'
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        drift = [w for w in result.warnings if "drift" in w.lower()]
+        assert drift == []

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -267,6 +267,23 @@ class TestVersionDrift:
         result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
         assert any("OMNIPARSE_VERSION" in w for w in result.warnings)
 
+    def test_runtime_arg_drift_not_warned(self, tmp_path):
+        """Common third-party runtime ARGs (NODE_VERSION, ALPINE_VERSION,
+        …) intentionally don't track the extension's semver, so they
+        must not trigger drift warnings."""
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "Dockerfile").write_text(
+            "FROM node:20-alpine\n"
+            "ARG NODE_VERSION=20.11.1\n"
+            "ARG ALPINE_VERSION=3.19.1\n"
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        drift = [w for w in result.warnings if "drift" in w.lower()]
+        assert drift == []
+
     def test_pyproject_drift_warns(self, tmp_path):
         from pathlib import Path
         from kamiwaza_extensions.validators.metadata import MetadataValidator

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -297,3 +297,23 @@ class TestVersionDrift:
         result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
         drift = [w for w in result.warnings if "drift" in w.lower()]
         assert drift == []
+
+    def test_unrelated_thirdparty_image_no_drift_warning(self, tmp_path):
+        """A redis/postgres sidecar's semver tag must not trigger a drift
+        warning when the extension declares its own image repo."""
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(
+            json.dumps(self._meta("2.1.0", "ghcr.io/kamiwaza/app:2.1.0"))
+        )
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: ghcr.io/kamiwaza/app:2.1.0\n"
+            "  redis:\n"
+            "    image: redis:7.2.4\n"
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        drift = [w for w in result.warnings if "drift" in w.lower()]
+        assert drift == []


### PR DESCRIPTION
## Summary
- `kz-ext bump` now propagates the new version beyond `kamiwaza.json` to: the manifest's `image` tag, compose files (incl. `docker-compose.appgarden.yml`), `Dockerfile` `ARG <NAME>=<old>` defaults, `pyproject.toml` `[project] version`, and `package.json` `"version"` — only rewriting tags/values that match the old version, so external images like `postgres:16` are untouched.
- New `kz-ext bump --dry-run` prints per-file unified diffs and writes nothing.
- `kz-ext validate` now warns on version drift between `kamiwaza.json` and image tags, compose files, Dockerfile `*_VERSION` ARGs, or `pyproject.toml`.

Fixes [ENG-4835](https://linear.app/kamiwaza/issue/ENG-4835/kz-ext-bump-only-updates-kamiwazajson-version-leaves-image-tags).

## Test plan
- [x] `uv run pytest tests/unit/extensions/` — 1113 passed
- [x] New unit tests cover: image tag rewrite, `:latest` skipped, compose rewrite (postgres untouched), Dockerfile ARG, pyproject (comments preserved), package.json, only-manifest-present case, `--dry-run`, and 5 drift-detection cases in validate
- [ ] Manual: against `kamiwaza-extensions-omniparse` post-flatten branch, `kz-ext bump --level minor --dry-run` shows diffs for all five files; running without `--dry-run` updates all five
- [ ] Manual: hand-edit `kamiwaza.json` `version` to disagree with `image:` tag; `kz-ext validate` warns naming both

🤖 Generated with [Claude Code](https://claude.com/claude-code)