### PR TITLE
fix(extensions): resolve extra_docker_images tag + digest; stop merging into docker_images (ENG-5181)

### DIFF
--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -270,7 +270,10 @@ def run_publish(
         validate_digest,
     )
     from kamiwaza_extensions.profile_manager import ProfileManager
-    from kamiwaza_extensions.registry_builder import RegistryBuilder
+    from kamiwaza_extensions.registry_builder import (
+        RegistryBuilder,
+        resolve_extra_image,
+    )
     from kamiwaza_extensions.validators.compose import ComposeValidator
     from kamiwaza_extensions.validators.metadata import MetadataValidator
 
@@ -623,6 +626,25 @@ def run_publish(
                 _verify_supplied_digest(ref, digest)
         else:
             digest_map = _auto_resolve_digests(published_refs)
+
+    # Extras under our registry get the same tag-and-digest pinning as
+    # compose buildable services. External refs and author-pinned
+    # `@sha256:...` refs pass through untouched. Refs already in
+    # digest_map (e.g. the buildable service redundantly listed in extras
+    # when the user supplied `--digest`) are left alone — re-resolving
+    # would hit the registry and could overwrite an explicit user pin.
+    resolved_extras = [
+        resolve_extra_image(img, registry, version, stage)
+        for img in (info.metadata.get("extra_docker_images") or [])
+    ]
+    extras_to_resolve = [
+        r for r in resolved_extras
+        if r.startswith(f"{registry}/")
+        and "@" not in r
+        and r not in digest_map
+    ]
+    if extras_to_resolve:
+        digest_map.update(_auto_resolve_digests(extras_to_resolve))
 
     # 7. Build catalog entry
     reg_builder = RegistryBuilder()

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -70,12 +70,14 @@ class RegistryBuilder:
                 are tagged with publish's revision; services without one
                 keep their declared image ref verbatim).
             registry: Docker registry prefix (e.g. ``"kamiwazaai"``).
-            version: Semver version string for this release.
+            version: Semver version string for this release. Substituted
+                into ``{version}`` placeholders in ``extra_docker_images``
+                entries.
             stage: One of ``"prod"``, ``"stage"``, ``"dev"``, or any custom name.
-                Currently unused in the body — ``ComposeTransformer`` already
-                applied the stage-derived tag to buildable services. Kept on
-                the signature for call-site compatibility with prior callers
-                of ``RegistryBuilder``.
+                Applied as a tag suffix to ``extra_docker_images`` entries
+                under *registry* (``<registry>/agent:{version}`` →
+                ``<registry>/agent:<version>-<stage>``), mirroring the
+                rewrite ``ComposeTransformer`` applies to compose services.
             revision: Optional revision identifier. When provided, included
                 as a top-level ``revision`` field on the entry; consumed by
                 ``CatalogDedupGuard`` to make CI re-publishes idempotent.
@@ -103,26 +105,20 @@ class RegistryBuilder:
         )
         docker_images = self.extract_docker_images(transformed_compose)
 
-        extra_images = metadata.get("extra_docker_images") or []
-        if extra_images:
-            # Apply the same digest-pinning rule to extras so a service
-            # ref that's redundantly listed in `extra_docker_images`
-            # collapses against its already-pinned compose copy during
-            # dedup, instead of leaking an unpinned duplicate.
-            #
-            # Match is exact-string against the post-stage-suffix ref
-            # (e.g. `<reg>/<ext>-<svc>:<version>-dev`); a pre-suffix
-            # entry like `<reg>/<ext>-<svc>:<version>` won't collapse.
-            # Author the entry to match what compose carries after
-            # transform.
-            if digest_map:
-                extra_images = [
-                    f"{img}@{digest_map[img]}"
-                    if img in digest_map and "@" not in img
-                    else img
-                    for img in extra_images
-                ]
-            docker_images = list(dict.fromkeys(docker_images + extra_images))
+        # `docker_images` and `extra_docker_images` are disjoint catalog
+        # fields: compose-derived vs. author-declared. Downstream consumers
+        # iterate each list separately; do not merge.
+        extra_images = [
+            resolve_extra_image(img, registry, version, stage)
+            for img in (metadata.get("extra_docker_images") or [])
+        ]
+        if extra_images and digest_map:
+            extra_images = [
+                f"{img}@{digest_map[img]}"
+                if img in digest_map and "@" not in img
+                else img
+                for img in extra_images
+            ]
 
         # Source kamiwaza.json is the catalog contract: every top-level
         # field the developer authored reaches the catalog entry. The
@@ -142,6 +138,12 @@ class RegistryBuilder:
         entry.setdefault("visibility", "public")
         entry["compose_yml"] = compose_yml
         entry["docker_images"] = docker_images
+        # Overwrite the deepcopy carryover; source metadata's
+        # `extra_docker_images` carries unresolved `{version}` placeholders.
+        if extra_images:
+            entry["extra_docker_images"] = extra_images
+        else:
+            entry.pop("extra_docker_images", None)
 
         # `revision` is owned exclusively by the publish-time parameter,
         # never by source kamiwaza.json. Pop first so a stale value in
@@ -427,6 +429,48 @@ def _apply_digests(
         if img and "@" not in img and img in digest_map:
             svc["image"] = f"{img}@{digest_map[img]}"
     return result
+
+
+def resolve_extra_image(
+    image: str, registry: str, version: str, stage: str,
+) -> str:
+    """Resolve ``{version}`` + stage suffix in an ``extra_docker_images`` ref.
+
+    Substitutes ``{version}`` literally, then applies the stage-derived
+    suffix to substituted refs under *registry*. Refs without a
+    ``{version}`` placeholder are left verbatim: a literal tag like
+    ``kamiwazaai/shared-helper:0.5.0`` signals an independent release
+    cadence and re-suffixing it would point at a tag this publish never
+    built. External images and already-digest-pinned refs also pass
+    through.
+    """
+    substituted = image.replace("{version}", version)
+
+    if (
+        substituted == image
+        or "@" in substituted
+        or not substituted.startswith(f"{registry}/")
+    ):
+        return substituted
+
+    # OCI refs allow `:` in the host segment (registry port) and again
+    # before the tag, so split on the last `:` that appears AFTER the
+    # final `/` — anything earlier is part of the repository path.
+    suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
+    slash = substituted.rfind("/")
+    last_segment = substituted[slash + 1:]
+    if ":" in last_segment:
+        colon = last_segment.index(":")
+        name = substituted[: slash + 1 + colon]
+        tag = last_segment[colon + 1:]
+        # Strip an existing stage suffix so `agent:{version}-dev` published
+        # against a prod stage emits the unsuffixed tag rather than
+        # `agent:1.8.13-dev` reapplied.
+        clean_tag = re.sub(r"-(dev|stage)$", "", tag)
+    else:
+        name, clean_tag = substituted, "latest"
+
+    return f"{name}:{clean_tag}{suffix}"
 
 
 def _normalize_preview_image(path: str) -> str:

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -75,9 +75,8 @@ class RegistryBuilder:
                 entries.
             stage: One of ``"prod"``, ``"stage"``, ``"dev"``, or any custom name.
                 Applied as a tag suffix to ``extra_docker_images`` entries
-                under *registry* (``<registry>/agent:{version}`` →
-                ``<registry>/agent:<version>-<stage>``), mirroring the
-                rewrite ``ComposeTransformer`` applies to compose services.
+                under *registry* that carried a ``{version}`` placeholder.
+                Author-pinned literal tags pass through untouched.
             revision: Optional revision identifier. When provided, included
                 as a top-level ``revision`` field on the entry; consumed by
                 ``CatalogDedupGuard`` to make CI re-publishes idempotent.
@@ -138,8 +137,10 @@ class RegistryBuilder:
         entry.setdefault("visibility", "public")
         entry["compose_yml"] = compose_yml
         entry["docker_images"] = docker_images
-        # Overwrite the deepcopy carryover; source metadata's
-        # `extra_docker_images` carries unresolved `{version}` placeholders.
+        # Overwrite the deepcopy carryover with the resolved list (source
+        # entries are in author format; the catalog needs post-substitution
+        # refs). Drop the field entirely when metadata declared no extras
+        # so the catalog field is absent rather than an empty array.
         if extra_images:
             entry["extra_docker_images"] = extra_images
         else:
@@ -434,15 +435,15 @@ def _apply_digests(
 def resolve_extra_image(
     image: str, registry: str, version: str, stage: str,
 ) -> str:
-    """Resolve ``{version}`` + stage suffix in an ``extra_docker_images`` ref.
+    """Apply ``{version}`` substitution and stage suffix to one ref.
 
     Substitutes ``{version}`` literally, then applies the stage-derived
-    suffix to substituted refs under *registry*. Refs without a
-    ``{version}`` placeholder are left verbatim: a literal tag like
-    ``kamiwazaai/shared-helper:0.5.0`` signals an independent release
-    cadence and re-suffixing it would point at a tag this publish never
-    built. External images and already-digest-pinned refs also pass
-    through.
+    suffix only to substituted refs under *registry*. Returns *image*
+    unchanged when:
+
+    - The ref carried no ``{version}`` placeholder (author-pinned tag).
+    - The ref is already digest-pinned (``@sha256:...``).
+    - The ref is outside *registry* (external pass-through).
     """
     substituted = image.replace("{version}", version)
 
@@ -453,9 +454,8 @@ def resolve_extra_image(
     ):
         return substituted
 
-    # OCI refs allow `:` in the host segment (registry port) and again
-    # before the tag, so split on the last `:` that appears AFTER the
-    # final `/` — anything earlier is part of the repository path.
+    # The tag, if any, lives after the last `/`. Splitting on the leftmost
+    # `:` would catch a registry port (e.g. `localhost:5000/...`) instead.
     suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
     slash = substituted.rfind("/")
     last_segment = substituted[slash + 1:]

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -184,6 +184,300 @@ class TestPublishHappyPath:
 
 
 # ------------------------------------------------------------------
+# extra_docker_images: digest resolution
+# ------------------------------------------------------------------
+
+
+class TestPublishExtrasDigestResolution:
+    """`kz-ext publish` resolves digests for extra_docker_images."""
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_extras_under_registry_get_digest_resolved_and_passed_to_build_entry(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # An extra_docker_images entry with `{version}` under the
+        # configured registry must be substituted, stage-suffixed, and
+        # digest-pinned via the same registry-resolution path compose
+        # buildable services use.
+        metadata = {
+            "name": "kaizenv3",
+            "version": "1.8.13",
+            "description": "Kaizen v3",
+            "extra_docker_images": [
+                "ghcr.io/my-org/images/agent:{version}",
+            ],
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path, name="kaizenv3", version="1.8.13", metadata=metadata,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer = MagicMock()
+        mock_transformer.transform.return_value = {
+            "services": {
+                "backend": {"image": "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev"},
+            },
+        }
+        mock_transformer_cls.return_value = mock_transformer
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        # Distinct digests per ref so the assertion can pin which ref
+        # got which digest.
+        digest_by_ref = {
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev": "sha256:" + "a" * 64,
+            "ghcr.io/my-org/images/agent:1.8.13-dev": "sha256:" + "b" * 64,
+        }
+        mock_pusher_cls.resolve_digest.side_effect = lambda ref: digest_by_ref[ref]
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {
+            "name": "kaizenv3",
+            "version": "1.8.13",
+        }
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result(
+            extension_name="kaizenv3", version="1.8.13",
+        )
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        resolved_refs = [
+            call.args[0] for call in mock_pusher_cls.resolve_digest.call_args_list
+        ]
+        assert "ghcr.io/my-org/images/agent:1.8.13-dev" in resolved_refs
+        assert "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev" in resolved_refs
+
+        # Both digests reach digest_map.
+        build_entry_kwargs = mock_reg_builder.build_entry.call_args.kwargs
+        digest_map = build_entry_kwargs["digest_map"]
+        assert digest_map["ghcr.io/my-org/images/agent:1.8.13-dev"] == (
+            "sha256:" + "b" * 64
+        )
+        assert digest_map["ghcr.io/my-org/kaizenv3-backend:1.8.13-dev"] == (
+            "sha256:" + "a" * 64
+        )
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_extras_already_in_digest_map_skipped_from_auto_resolve(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # When `--digest` pins a buildable ref and that same ref is
+        # redundantly listed in extras, the explicit pin must survive:
+        # no registry lookup, no overwrite.
+        metadata = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "Test",
+            "extra_docker_images": ["ghcr.io/my-org/my-app-backend:{version}"],
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path, metadata=metadata,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer = MagicMock()
+        mock_transformer.transform.return_value = {
+            "services": {
+                "backend": {"image": "ghcr.io/my-org/my-app-backend:1.0.0-dev"},
+            },
+        }
+        mock_transformer_cls.return_value = mock_transformer
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        # If anything calls resolve_digest, fail the test loudly — the
+        # user-supplied digest must be the only source of truth here.
+        mock_pusher_cls.resolve_digest.side_effect = AssertionError(
+            "resolve_digest should not be called when --digest pins the ref"
+        )
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result()
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        supplied_digest = "sha256:" + "e" * 64
+        # --digest implies --no-push so the supplied digest is trusted
+        # without a post-push verification round-trip.
+        run_publish(stage="dev", digest=supplied_digest, no_push=True)
+
+        # The supplied digest survived end-to-end into build_entry's map.
+        build_entry_kwargs = mock_reg_builder.build_entry.call_args.kwargs
+        digest_map = build_entry_kwargs["digest_map"]
+        assert digest_map["ghcr.io/my-org/my-app-backend:1.0.0-dev"] == supplied_digest
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_external_extras_skipped_from_digest_resolution(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # External refs and already-pinned refs skip the digest lookup:
+        # external images aren't ours to pin, and re-tagging a pinned ref
+        # would break its immutable identity.
+        metadata = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "Test",
+            "extra_docker_images": [
+                "postgres:15",                              # external
+                "ghcr.io/external/sidecar:2.0",             # external
+                "ghcr.io/my-org/images/util@sha256:" + "c" * 64,  # already pinned
+            ],
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path, metadata=metadata,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer = MagicMock()
+        mock_transformer.transform.return_value = {
+            "services": {
+                "backend": {"image": "ghcr.io/my-org/my-app-backend:1.0.0-dev"},
+            },
+        }
+        mock_transformer_cls.return_value = mock_transformer
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        compose_digest = "sha256:" + "d" * 64
+        mock_pusher_cls.resolve_digest.return_value = compose_digest
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result()
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # Only the compose backend hits the registry; the three extras
+        # are filtered out before resolution.
+        resolved_refs = [
+            call.args[0] for call in mock_pusher_cls.resolve_digest.call_args_list
+        ]
+        assert resolved_refs == ["ghcr.io/my-org/my-app-backend:1.0.0-dev"]
+
+
+# ------------------------------------------------------------------
 # Dry-run mode
 # ------------------------------------------------------------------
 

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -167,7 +167,11 @@ class TestBuildEntry:
         assert entry["category"] == "chatbot"
         assert entry["verified"] is True
 
-    def test_extra_docker_images_appended(self, builder, transformed_compose):
+    def test_extra_docker_images_emitted_on_their_own_field(
+        self, builder, transformed_compose,
+    ):
+        # Extras live in their own catalog field; docker_images is
+        # compose-derived only. The two lists never merge.
         meta = {
             "name": "my-app",
             "description": "test",
@@ -176,9 +180,15 @@ class TestBuildEntry:
             "extra_docker_images": ["custom/sidecar:latest"],
         }
         entry = builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
-        assert "custom/sidecar:latest" in entry["docker_images"]
+        assert entry["extra_docker_images"] == ["custom/sidecar:latest"]
+        # docker_images stays compose-derived only.
+        assert "custom/sidecar:latest" not in entry["docker_images"]
 
-    def test_extra_docker_images_deduped(self, builder):
+    def test_extra_docker_images_disjoint_from_docker_images(self, builder):
+        # If the same ref appears in compose AND extras, each list retains
+        # its own copy — no dedup across the two fields. They represent
+        # different intents (runtime service vs. additional pull manifest)
+        # and downstream consumers iterate them separately.
         compose = {"services": {"web": {"image": "custom/sidecar:latest"}}}
         meta = {
             "name": "my-app",
@@ -188,7 +198,175 @@ class TestBuildEntry:
             "extra_docker_images": ["custom/sidecar:latest"],
         }
         entry = builder.build_entry(meta, compose, "reg", "1.0.0")
-        assert entry["docker_images"].count("custom/sidecar:latest") == 1
+        assert entry["docker_images"] == ["custom/sidecar:latest"]
+        assert entry["extra_docker_images"] == ["custom/sidecar:latest"]
+
+    def test_no_extra_docker_images_field_when_metadata_omits_it(
+        self, builder, metadata, transformed_compose,
+    ):
+        entry = builder.build_entry(metadata, transformed_compose, "reg", "1.0.0")
+        assert "extra_docker_images" not in entry
+
+    # `{version}` in extra_docker_images entries must be substituted
+    # before reaching the catalog — same rewrite ComposeTransformer
+    # applies to compose service images.
+    def test_extra_docker_images_version_placeholder_substituted(
+        self, builder, transformed_compose,
+    ):
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13", stage="prod",
+        )
+        # No raw `{version}` placeholder reaches the catalog.
+        assert "myreg/images/agent:{version}" not in entry["extra_docker_images"]
+        assert "myreg/images/agent:1.8.13" in entry["extra_docker_images"]
+        # Extras stay out of docker_images.
+        assert all(
+            "agent" not in ref for ref in entry["docker_images"]
+        ), entry["docker_images"]
+
+    def test_extra_docker_images_stage_suffix_applied(
+        self, builder, transformed_compose,
+    ):
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        for stage, expected_tag in [
+            ("prod", "1.8.13"),
+            ("dev", "1.8.13-dev"),
+            ("stage", "1.8.13-stage"),
+        ]:
+            entry = builder.build_entry(
+                meta, transformed_compose, "myreg/images", "1.8.13", stage=stage,
+            )
+            expected_ref = f"myreg/images/agent:{expected_tag}"
+            assert expected_ref in entry["extra_docker_images"], (
+                f"stage={stage}: expected {expected_ref} in extras, "
+                f"got {entry['extra_docker_images']}"
+            )
+            # Extras don't leak into docker_images regardless of stage.
+            assert expected_ref not in entry["docker_images"]
+
+    def test_extra_docker_images_external_ref_not_suffixed(
+        self, builder, transformed_compose,
+    ):
+        # Refs outside the configured registry namespace pass through
+        # untouched — postgres, redis, third-party sidecars, etc.
+        meta = {
+            "name": "my-app",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": [
+                "ghcr.io/external/sidecar:2.0",
+                "quay.io/org/util:{version}",
+            ],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        # External ref with no placeholder: untouched.
+        assert "ghcr.io/external/sidecar:2.0" in entry["extra_docker_images"]
+        # External ref with placeholder: substituted but NOT stage-suffixed.
+        # External tags aren't ours to rewrite.
+        assert "quay.io/org/util:1.8.13" in entry["extra_docker_images"]
+
+    def test_extra_docker_images_fixed_tag_under_registry_passthrough(
+        self, builder, transformed_compose,
+    ):
+        # A literal tag (no `{version}`) signals an independent release
+        # cadence — a vendored helper at its own version. Re-suffixing it
+        # would point at a tag this publish never built.
+        meta = {
+            "name": "my-app",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/shared-helper:0.5.0"],
+        }
+        for stage in ["dev", "stage", "prod"]:
+            entry = builder.build_entry(
+                meta, transformed_compose, "myreg/images", "1.8.13", stage=stage,
+            )
+            assert entry["extra_docker_images"] == [
+                "myreg/images/shared-helper:0.5.0"
+            ], f"stage={stage}: fixed tag should pass through verbatim"
+
+    def test_extra_docker_images_registry_with_port_untagged(
+        self, builder, transformed_compose,
+    ):
+        # OCI refs allow `:` in the host segment (registry port). For an
+        # untagged ref like `localhost:5000/org/agent`, the tag (if any)
+        # lives after the last `/`, not at the first `:`. Splitting on the
+        # leftmost colon would mangle the repository path.
+        meta = {
+            "name": "my-app",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["localhost:5000/org/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "localhost:5000/org", "1.8.13",
+            stage="dev",
+        )
+        assert entry["extra_docker_images"] == [
+            "localhost:5000/org/agent:1.8.13-dev"
+        ]
+
+    def test_extra_docker_images_digest_pinned_ref_passthrough(
+        self, builder, transformed_compose,
+    ):
+        # Already-digest-pinned refs are left exactly as-authored. Re-tagging
+        # would mismatch the digest and break the immutable-identity contract.
+        pinned = (
+            "myreg/images/agent:1.8.13-dev"
+            "@sha256:" + "a" * 64
+        )
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": [pinned],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13", stage="prod",
+        )
+        assert pinned in entry["extra_docker_images"]
+
+    def test_extra_docker_images_digest_pinned_when_in_digest_map(
+        self, builder, transformed_compose,
+    ):
+        # When the caller supplies a digest_map entry keyed by the
+        # post-substitution ref, build_entry pins the extra and emits it
+        # only via extra_docker_images.
+        digest = "sha256:" + "b" * 64
+        digest_map = {"myreg/images/agent:1.8.13-dev": digest}
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13", stage="dev",
+            digest_map=digest_map,
+        )
+        pinned_ref = f"myreg/images/agent:1.8.13-dev@{digest}"
+        assert entry["extra_docker_images"] == [pinned_ref]
+        assert pinned_ref not in entry["docker_images"]
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`extra_docker_images` now goes through the same substitution and digest-resolution path as compose buildable services. The two catalog fields stay disjoint — `docker_images` is compose-derived, `extra_docker_images` is author-declared — matching the legacy `make publish-registry` contract that downstream consumers (kind-load, marketplace tarball, export-images) already assume.

- `RegistryBuilder.build_entry()` resolves `{version}` and applies the stage-derived tag suffix to substituted refs under the configured registry. Literal tags (e.g. `helper:0.5.0`) and external refs pass through verbatim. Tag parsing splits after the last `/` so registry-with-port refs like `localhost:5000/org/agent` aren't misread.
- `kz-ext publish` feeds resolved extras through `_auto_resolve_digests`, skipping refs already pinned in `digest_map` so an explicit `--digest` user pin survives.
- Extras are no longer merged into `docker_images`.

Kaizen's per-conversation sandbox agent — a docker-bake target absent from compose — was the case where `agent:{version}` leaked unresolved into both lists. Live `apps.json` will need a republish after this lands to clear the existing `agent:{version}` literal.

Linear: [ENG-5181](https://linear.app/kamiwaza/issue/ENG-5181)

## Verification

- `uv run pytest tests/unit/extensions/` — 1188 passed, 1 skipped (pre-existing BSD `sed` skip), 0 regressions.
- New tests cover: placeholder substitution, stage suffix per stage, external-ref passthrough, already-pinned-ref passthrough, fixed-tag passthrough, registry-with-port parsing, digest pinning into `extra_docker_images`, list-disjointness, absent-field omission, `--digest` user pin survives when redundant in extras.
- Side-by-side against Kaizen's actual `kamiwaza.json` + compose: new entry has `docker_images` = 4 compose-derived refs (all digest-pinned) and `extra_docker_images` = `agent:1.8.13-dev@sha256:<digest>`, with agent removed from `docker_images`.
- Codex CLI review: 3 P2 findings, all addressed in this PR.

## Test plan

- [ ] Reviewer confirms the contract change (extras separate from `docker_images`) matches the downstream-consumer expectation in `kind-load-images.sh` and `export-images.py`.
- [ ] After merge: republish Kaizen's catalog so the live `apps.json` picks up the resolved + pinned agent ref.

## Follow-ups (separate tickets)

- Teach `kamiwaza-marketplace/.../downloads.py` + `tar_parser.py` to package `extra_docker_images` alongside `docker_images` in the marketplace tarball download path. Current state pre-dates this PR (the field has always existed); no regression here, just gap visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)