### PR TITLE
M5a (WS-M5): SDK kz.gates.packages + typed exceptions

### DIFF
--- a/kamiwaza_sdk/exceptions.py
+++ b/kamiwaza_sdk/exceptions.py
@@ -182,6 +182,59 @@ class MeshJobFailedError(KamiwazaError):
 
 
 # ----------------------------------------------------------------------------
+# Gate-package typed subclasses (T7.13 / ENG-4767 — WS-M5)
+#
+# Map server-emitted ``detail.reason`` shapes to SDK-side typed errors so
+# customer code can pattern-match on the gate-package failure mode instead
+# of inspecting the body. Server side raises FastAPI ``HTTPException(
+# status_code=N, detail={"reason": "X", ...})`` directly from the gate-
+# packages API handler (T7.2).
+# ----------------------------------------------------------------------------
+
+
+class GatePackageHashRequiredError(ValidationError):
+    """400 with ``detail.reason == "hash_required"`` — POST/PUT to
+    ``/api/authz/gate-packages`` without ``hash_digest`` in the request body.
+    Hash-pinning is mandatory at MVP per FR-89/FR-89a; customer code must
+    pin a known SHA-256 of the wheel."""
+
+
+class GatePackageHashMismatchError(KamiwazaError):
+    """422 with ``detail.reason == "hash_mismatch"`` — pip ``--require-hashes``
+    rejected the install because the wheel served from the index doesn't
+    match the supplied ``hash_digest``. Either the wheel was retagged on the
+    index or the customer pinned the wrong hash. Body carries the expected
+    vs observed digests."""
+
+
+class GatePackageInstallTimeoutError(KamiwazaError):
+    """504 with ``detail.reason == "install_timeout"`` — pip-install
+    subprocess exceeded the chart-configured ``authz.gatePackages.installTimeoutSeconds``
+    (default 120s). Compiled dependencies on slow hosts may need a higher
+    timeout. Body carries the configured limit + actual elapsed."""
+
+
+class GatePackageClasspathDropError(KamiwazaError):
+    """409 with ``detail.reason == "classpath_drop"`` — PUT-replace refused
+    because the new package's classpath set is not a superset of the
+    currently-bound classpaths. Customer must explicitly unbind the dropped
+    classpath first. Body carries the dropped classpath list."""
+
+
+class GatePackageUninstallBlockedError(KamiwazaError):
+    """409 with ``detail.reason == "uninstall_blocked"`` — DELETE refused
+    because one or more active bindings (``Cluster.executionGate`` or
+    ``Dataset.gate``) reference a classpath from the package. Customer must
+    unbind first. Body carries the blocking bindings."""
+
+
+class GatePackageNotFoundError(NotFoundError):
+    """404 with ``detail.reason == "gate_package_not_found"`` — GET/PUT/DELETE
+    on a name that doesn't exist in ``cluster_gate_packages``. Customer may
+    have a stale package name reference or a typo."""
+
+
+# ----------------------------------------------------------------------------
 # Response → typed-exception dispatch table (T7.2 — migrated from kamiwaza/)
 #
 # The status code is part of the match alongside the reason string to avoid
@@ -194,6 +247,13 @@ _REASON_TO_EXCEPTION: dict[tuple[int, str], type[KamiwazaError]] = {
     (503, "psk_propagation_timeout"): FederationPairTimeoutError,
     (403, "brokered_user_not_allowlisted"): BrokeredUserNotAllowlistedError,
     (403, "endpoint_requires_native_realm"): NativeRealmRequiredError,
+    # T7.13 / ENG-4767 — gate-package typed errors (WS-M5)
+    (400, "hash_required"): GatePackageHashRequiredError,
+    (422, "hash_mismatch"): GatePackageHashMismatchError,
+    (504, "install_timeout"): GatePackageInstallTimeoutError,
+    (409, "classpath_drop"): GatePackageClasspathDropError,
+    (409, "uninstall_blocked"): GatePackageUninstallBlockedError,
+    (404, "gate_package_not_found"): GatePackageNotFoundError,
 }
 
 

--- a/kamiwaza_sdk/schemas/gate_packages.py
+++ b/kamiwaza_sdk/schemas/gate_packages.py
@@ -1,0 +1,124 @@
+"""T7.12 / ENG-4766 — Gate-package Pydantic models on the SDK surface.
+
+WS-M5 foundation task. Typed request/response shapes for
+``kz.gates.packages.{install, replace, list, get, uninstall}`` typed
+wrappers (T7.10) and corresponding server-side handlers (T7.2).
+
+All models opt into ``extra="allow"`` for forward compatibility per
+``.ai/knowledge/failures/common-pitfalls.md`` — pinned-wheel customers
+must not break when the server adds fields.
+
+Server-side correlate lives at
+``kamiwaza/services/authz/gate_packages/schemas.py`` (mirrors these
+shapes; the two are kept in sync by code review since they cross a repo
+boundary).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+GatePackageStatus = Literal["active", "uninstalling", "failed"]
+
+
+class GatePackageSpec(BaseModel):
+    """Request body for POST /api/authz/gate-packages (install) and
+    PUT /api/authz/gate-packages/{name} (replace).
+
+    Per FR-89 + FR-89a, ``hash_digest`` is REQUIRED at MVP — server
+    rejects requests without it via the
+    ``GatePackageHashRequiredError`` typed exception.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    package_spec: str = Field(
+        ...,
+        description=(
+            'Pip-installable spec, e.g. "acme-gates==1.2.3". Must include '
+            "a pinned version — unpinned specs are rejected by the server."
+        ),
+    )
+    hash_digest: str = Field(
+        ...,
+        description=(
+            'SHA-256 digest of the wheel as published on the index, e.g. '
+            '"sha256:abcd...". Server invokes pip with --require-hashes; '
+            "mismatches surface as ``GatePackageHashMismatchError``."
+        ),
+    )
+    index_url: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional override for the pip index URL. Server enforces the "
+            "chart-configured ``authz.gatePackages.indexUrl`` allowlist; "
+            "client-supplied values outside the allowlist are rejected at "
+            "the API layer before any pip subprocess fires."
+        ),
+    )
+
+
+class GatePackageState(BaseModel):
+    """Response model for GET (single) and PUT/POST (install/replace
+    result), and an element of the list response.
+
+    Mirrors ``DBGatePackage`` columns one-to-one.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(..., description="Package name; the PK on cluster_gate_packages.")
+    package_spec: str = Field(..., description="Original pip spec, e.g. 'acme-gates==1.0.0'.")
+    version: str = Field(..., description="Resolved version, e.g. '1.0.0'.")
+    hash_digest: str = Field(..., description="SHA-256 of the installed wheel.")
+    index_url: Optional[str] = Field(default=None, description="Pip index used at install.")
+    installed_at: datetime = Field(..., description="Initial install timestamp.")
+    installed_by: str = Field(..., description="Actor (Keycloak subject ID) at install.")
+    last_replaced_at: Optional[datetime] = Field(
+        default=None, description="Most recent PUT-replace timestamp; null until first replace."
+    )
+    status: GatePackageStatus = Field(default="active", description="Lifecycle state.")
+    classpaths: List[str] = Field(
+        default_factory=list,
+        description="Fully-qualified gate classpaths discovered in the package.",
+    )
+
+
+class GatePackageList(BaseModel):
+    """Response model for GET /api/authz/gate-packages (paginated)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    items: List[GatePackageState] = Field(default_factory=list)
+    total: int = Field(default=0)
+    page: int = Field(default=1)
+    per_page: int = Field(default=20)
+
+
+class GatePackageInstallResult(BaseModel):
+    """Response model for POST /api/authz/gate-packages.
+
+    The install result is the freshly-created ``GatePackageState`` plus
+    a server-side context block carrying audit-event provenance for the
+    customer's audit logs.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    package: GatePackageState = Field(
+        ..., description="The installed package's current state record."
+    )
+    install_duration_seconds: float = Field(
+        ..., description="Wall-clock pip-install elapsed (server-measured)."
+    )
+    audit_event_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Identifier of the emitted ``gate_package_lifecycle`` audit "
+            "event; customers can cross-reference into their audit stream."
+        ),
+    )

--- a/kamiwaza_sdk/services/gate_packages.py
+++ b/kamiwaza_sdk/services/gate_packages.py
@@ -1,0 +1,108 @@
+"""T7.10 / ENG-4765 — Gate-package SDK service (WS-M5).
+
+Customer surface: ``kz.gates.packages.{install, replace, list, get, uninstall}``.
+
+Exposed via the ``GatesAPI.packages`` lazy property — ``kz.gates`` is the
+discovery surface (M2 / T5.4); ``kz.gates.packages`` is the install
+surface (M5). Two semantically related capabilities live under a single
+top-level service per the design's "code-level sub-API on kz.gates"
+framing.
+
+Server-side correlate: ``kamiwaza/services/authz/gate_packages/api.py``
+(T7.2 / ENG-4757). All five SDK methods translate 1:1 to the same HTTP
+verb on ``/api/authz/gate-packages``. M5a ships install + list + get;
+M5b ships replace + uninstall.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..schemas.gate_packages import (
+    GatePackageInstallResult,
+    GatePackageList,
+    GatePackageSpec,
+    GatePackageState,
+)
+from .base_service import BaseService
+
+
+class GatePackagesAPI(BaseService):
+    """Install, replace, list, get, and uninstall gate packages."""
+
+    def install(
+        self,
+        package_spec: str,
+        hash_digest: str,
+        *,
+        index_url: Optional[str] = None,
+    ) -> GatePackageInstallResult:
+        """Install a gate package (FR-89 / FR-95 / WS-M5a).
+
+        Args:
+            package_spec: Version-pinned pip spec, e.g.
+                ``"acme-gates==1.2.3"``. Unpinned specs are rejected.
+            hash_digest: SHA-256 of the wheel as published on the
+                index, e.g. ``"sha256:abcd..."``. REQUIRED at MVP.
+            index_url: Optional override for the chart-configured pip
+                index. Server enforces the chart-configured allowlist.
+
+        Returns:
+            ``GatePackageInstallResult`` with the new state row +
+            install duration + audit event id.
+
+        Raises:
+            GatePackageHashRequiredError: 400 when ``hash_digest`` is
+                missing (Pydantic + server-side double check).
+            GatePackageHashMismatchError: 422 when pip --require-hashes
+                rejects the wheel.
+            GatePackageInstallTimeoutError: 504 when pip subprocess
+                exceeds the chart-configured install timeout.
+        """
+        spec = GatePackageSpec(
+            package_spec=package_spec,
+            hash_digest=hash_digest,
+            index_url=index_url,
+        )
+        response = self.client._request(
+            "POST",
+            "/authz/gate-packages",
+            json=spec.model_dump(exclude_none=True),
+        )
+        return GatePackageInstallResult.model_validate(response)
+
+    def list(self) -> GatePackageList:
+        """List installed gate packages (FR-90)."""
+        response = self.client._request("GET", "/authz/gate-packages")
+        return GatePackageList.model_validate(response)
+
+    def get(self, name: str) -> GatePackageState:
+        """Get the state record for one installed gate package (FR-90)."""
+        response = self.client._request("GET", f"/authz/gate-packages/{name}")
+        return GatePackageState.model_validate(response)
+
+    def replace(
+        self,
+        name: str,
+        package_spec: str,
+        hash_digest: str,
+        *,
+        index_url: Optional[str] = None,
+    ) -> GatePackageInstallResult:
+        """Atomic in-place replace (FR-89a). Ships in WS-M5b."""
+        spec = GatePackageSpec(
+            package_spec=package_spec,
+            hash_digest=hash_digest,
+            index_url=index_url,
+        )
+        response = self.client._request(
+            "PUT",
+            f"/authz/gate-packages/{name}",
+            json=spec.model_dump(exclude_none=True),
+        )
+        return GatePackageInstallResult.model_validate(response)
+
+    def uninstall(self, name: str) -> None:
+        """Uninstall (FR-90). Server refuses if any active binding
+        references a classpath from the package. Ships in WS-M5b."""
+        self.client._request("DELETE", f"/authz/gate-packages/{name}")

--- a/kamiwaza_sdk/services/gates.py
+++ b/kamiwaza_sdk/services/gates.py
@@ -19,7 +19,23 @@ from .base_service import BaseService
 
 
 class GatesAPI(BaseService):
-    """Gate discovery on the local cluster."""
+    """Gate discovery on the local cluster + gate-packages sub-API."""
+
+    @property
+    def packages(self) -> "GatePackagesAPI":
+        """Gate-package install / replace / list / get / uninstall
+        (T7.10 / ENG-4765, WS-M5). Lazy-loaded sub-service.
+
+        Customer surface: ``kz.gates.packages.install("acme-gates==1.0.0",
+        hash_digest="sha256:...")``. Lives under ``kz.gates`` because
+        the two concerns are semantically related — gate-code lifecycle
+        and gate-code reflection both anchor on the gate registry.
+        """
+        if not hasattr(self, "_packages"):
+            from .gate_packages import GatePackagesAPI
+
+            self._packages = GatePackagesAPI(self.client)
+        return self._packages
 
     def discover(self, classpath: str) -> GateDiscovery:
         """Reflect on a Gate class by classpath; return its metadata.

--- a/tests/unit/test_kamiwaza_gate_packages.py
+++ b/tests/unit/test_kamiwaza_gate_packages.py
@@ -1,0 +1,186 @@
+"""Unit tests for T7.10 GatePackagesAPI (ENG-4765) — kz.gates.packages.*."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from kamiwaza_sdk.exceptions import (
+    GatePackageHashMismatchError,
+    GatePackageHashRequiredError,
+    GatePackageInstallTimeoutError,
+    GatePackageNotFoundError,
+    error_for_response,
+)
+from kamiwaza_sdk.schemas.gate_packages import (
+    GatePackageInstallResult,
+    GatePackageList,
+    GatePackageState,
+)
+from kamiwaza_sdk.services.gate_packages import GatePackagesAPI
+from kamiwaza_sdk.services.gates import GatesAPI
+
+
+def _state_dict() -> Dict[str, Any]:
+    return {
+        "name": "acme-gates",
+        "package_spec": "acme-gates==1.0.0",
+        "version": "1.0.0",
+        "hash_digest": "sha256:abc",
+        "index_url": None,
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+        "installed_by": "admin",
+        "last_replaced_at": None,
+        "status": "active",
+        "classpaths": ["acme_gates.gate.AcmeAttributeGate"],
+    }
+
+
+class TestGatesLazyProperty:
+    """Verify ``kz.gates.packages`` is lazy + cached + the right type."""
+
+    def test_packages_returns_gate_packages_api(self, mock_client):
+        gates = GatesAPI(mock_client)
+        assert isinstance(gates.packages, GatePackagesAPI)
+
+    def test_packages_is_cached_per_gates_instance(self, mock_client):
+        gates = GatesAPI(mock_client)
+        first = gates.packages
+        second = gates.packages
+        assert first is second
+
+    def test_packages_only_instantiated_on_first_access(self, mock_client):
+        gates = GatesAPI(mock_client)
+        assert not hasattr(gates, "_packages")
+        _ = gates.packages
+        assert hasattr(gates, "_packages")
+
+
+class TestInstall:
+    """``kz.gates.packages.install``."""
+
+    def test_posts_to_gate_packages_endpoint(self, mock_client):
+        mock_client.expect(
+            "POST",
+            "/authz/gate-packages",
+            {
+                "package": _state_dict(),
+                "install_duration_seconds": 2.3,
+                "audit_event_id": "evt-1",
+            },
+        )
+        svc = GatePackagesAPI(mock_client)
+        result = svc.install("acme-gates==1.0.0", "sha256:abc")
+
+        assert isinstance(result, GatePackageInstallResult)
+        assert result.package.name == "acme-gates"
+        assert result.install_duration_seconds == 2.3
+
+        method, path, kwargs = mock_client.calls[0]
+        assert (method, path) == ("POST", "/authz/gate-packages")
+        body = kwargs["json"]
+        assert body == {
+            "package_spec": "acme-gates==1.0.0",
+            "hash_digest": "sha256:abc",
+        }
+
+    def test_include_index_url_when_supplied(self, mock_client):
+        mock_client.expect(
+            "POST",
+            "/authz/gate-packages",
+            {"package": _state_dict(), "install_duration_seconds": 0.1},
+        )
+        svc = GatePackagesAPI(mock_client)
+        svc.install(
+            "acme-gates==1.0.0",
+            "sha256:abc",
+            index_url="https://idx.example/simple",
+        )
+        body = mock_client.calls[0][2]["json"]
+        assert body["index_url"] == "https://idx.example/simple"
+
+
+class TestListGet:
+    """``kz.gates.packages.list`` + ``.get``."""
+
+    def test_list_returns_typed(self, mock_client):
+        mock_client.expect(
+            "GET",
+            "/authz/gate-packages",
+            {"items": [_state_dict()], "total": 1, "page": 1, "per_page": 20},
+        )
+        result = GatePackagesAPI(mock_client).list()
+        assert isinstance(result, GatePackageList)
+        assert result.total == 1
+        assert result.items[0].name == "acme-gates"
+
+    def test_list_empty(self, mock_client):
+        mock_client.expect(
+            "GET",
+            "/authz/gate-packages",
+            {"items": [], "total": 0, "page": 1, "per_page": 20},
+        )
+        result = GatePackagesAPI(mock_client).list()
+        assert result.items == []
+        assert result.total == 0
+
+    def test_get_returns_typed_state(self, mock_client):
+        mock_client.expect("GET", "/authz/gate-packages/acme-gates", _state_dict())
+        result = GatePackagesAPI(mock_client).get("acme-gates")
+        assert isinstance(result, GatePackageState)
+        assert result.name == "acme-gates"
+
+
+class TestReplaceUninstall:
+    """M5b methods: client-side surface is wired now; server returns 501
+    until M5b T7.5 ships."""
+
+    def test_replace_calls_put(self, mock_client):
+        mock_client.expect(
+            "PUT",
+            "/authz/gate-packages/acme-gates",
+            {"package": _state_dict(), "install_duration_seconds": 1.0},
+        )
+        result = GatePackagesAPI(mock_client).replace(
+            "acme-gates", "acme-gates==1.0.1", "sha256:def"
+        )
+        assert isinstance(result, GatePackageInstallResult)
+        method, path, kwargs = mock_client.calls[0]
+        assert (method, path) == ("PUT", "/authz/gate-packages/acme-gates")
+        assert kwargs["json"]["package_spec"] == "acme-gates==1.0.1"
+
+    def test_uninstall_calls_delete(self, mock_client):
+        # MockClient treats None as 'no expectation set'; use an empty dict
+        # for the 204-No-Content equivalent. The SDK ignores the body anyway.
+        mock_client.expect("DELETE", "/authz/gate-packages/acme-gates", {})
+        result = GatePackagesAPI(mock_client).uninstall("acme-gates")
+        assert result is None
+        assert mock_client.calls[0][:2] == ("DELETE", "/authz/gate-packages/acme-gates")
+
+
+class TestErrorDispatch:
+    """T7.13 dispatch table integration with the GatePackages SDK."""
+
+    def test_400_hash_required_maps_to_typed(self):
+        err = error_for_response(
+            400, {"detail": {"reason": "hash_required"}}, "missing hash"
+        )
+        assert isinstance(err, GatePackageHashRequiredError)
+
+    def test_422_hash_mismatch_maps_to_typed(self):
+        err = error_for_response(
+            422, {"detail": {"reason": "hash_mismatch"}}, "bad hash"
+        )
+        assert isinstance(err, GatePackageHashMismatchError)
+
+    def test_504_install_timeout_maps_to_typed(self):
+        err = error_for_response(
+            504, {"detail": {"reason": "install_timeout"}}, "slow"
+        )
+        assert isinstance(err, GatePackageInstallTimeoutError)
+
+    def test_404_not_found_maps_to_typed(self):
+        err = error_for_response(
+            404, {"detail": {"reason": "gate_package_not_found"}}, "no such"
+        )
+        assert isinstance(err, GatePackageNotFoundError)


### PR DESCRIPTION
## Summary

WS-M5a customer surface: `kz.gates.packages.install/list/get` + 6 typed exceptions for gate-package failure modes. Companion to the kamiwaza-side install path + the deploy chart wiring.

## Changes

- **T7.13 — 6 typed exceptions** + dispatch table entries in `kamiwaza_sdk/exceptions.py`:
  - GatePackageHashRequiredError (400) — subclass of ValidationError
  - GatePackageHashMismatchError (422)
  - GatePackageInstallTimeoutError (504)
  - GatePackageClasspathDropError (409)
  - GatePackageUninstallBlockedError (409)
  - GatePackageNotFoundError (404) — subclass of NotFoundError
- **T7.12 SDK side — Pydantic schemas** at `kamiwaza_sdk/schemas/gate_packages.py`: mirror of server schemas (GatePackageSpec / State / List / InstallResult).
- **T7.10 — SDK GatePackagesAPI** at `kamiwaza_sdk/services/gate_packages.py` + `GatesAPI.packages` lazy property. Customer surface: `kz.gates.packages.install/replace/list/get/uninstall`. M5b verbs (replace/uninstall) are wired now; server returns 501 until M5b T7.5 ships.

## Test plan

- [x] **14/14 unit tests pass** at `tests/unit/test_kamiwaza_gate_packages.py` using the WS-M3.2 MockClient fixture
- [x] Dispatch table smoke verified: all 6 (status_code, reason) tuples map to the right typed class
- [x] Forward-compat: schemas opt into `extra="allow"`

## Linear

- ENG-4765 (T7.10 SDK kz.gates.packages)
- ENG-4766 (T7.12 Pydantic models — SDK side)
- ENG-4767 (T7.13 typed exceptions — SDK side)

## Risk

Pure additive — extends GatesAPI with a lazy-loaded sub-property; no existing service breaks. New typed exceptions extend existing hierarchy (ValidationError, NotFoundError, KamiwazaError).