### PR TITLE
fix(extensions): rewrite image refs in compose env-var defaults (ENG-5260)

### DIFF
--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -25,6 +25,14 @@ _STAGE_SUFFIXES = {
     "dev": "-dev",
 }
 
+# Matches compose ``${VAR:-default}`` and ``${VAR-default}`` env values.
+# ``${VAR}`` (no default) and ``${VAR:?error}`` (required) don't match —
+# they have no default to rewrite. ``[^}]+`` keeps the digest's leading
+# ``@sha256:...`` inside the captured default (no ``}`` in a digest).
+_ENV_DEFAULT_SUB_RE = re.compile(
+    r"\A(\$\{[A-Za-z_][A-Za-z0-9_]*:?-)([^}]+)(\})\Z"
+)
+
 # Lazy-initialized probe versions for constraint overlap detection.
 # Built on first use to avoid ~50ms import-time cost.
 _PROBE_VERSIONS: Optional[List[Version]] = None
@@ -94,6 +102,17 @@ class RegistryBuilder:
         """
         if digest_map:
             transformed_compose = _apply_digests(transformed_compose, digest_map)
+
+        # Env-var image refs (e.g. ``${AGENT_SERVER_IMAGE:-<reg>/agent:1.8.13}``)
+        # are a parallel surface to ``services[*].image``: dynamic-spawn
+        # targets that never appear as a compose service so ``_apply_digests``
+        # doesn't catch them. Rewrites refs under *registry* with the stage
+        # suffix and pins from *digest_map* when available, keeping the
+        # env default in lockstep with ``extra_docker_images`` for the same
+        # image.
+        transformed_compose = _apply_env_image_rewrites(
+            transformed_compose, registry, stage, digest_map
+        )
 
         # sort_keys=False preserves service key order from the source compose.
         # Downstream consumers infer primary-service selection from the order
@@ -430,6 +449,110 @@ def _apply_digests(
         if img and "@" not in img and img in digest_map:
             svc["image"] = f"{img}@{digest_map[img]}"
     return result
+
+
+def _apply_env_image_rewrites(
+    compose: Dict[str, Any],
+    registry: str,
+    stage: str,
+    digest_map: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Return a deep copy of *compose* with image refs in env values rewritten.
+
+    Walks ``services[*].environment`` (dict and list shapes) and rewrites
+    image refs under *registry* with the stage-derived tag suffix; pins
+    ``@sha256:...`` when the post-suffix ref is in *digest_map*. Caller's
+    *compose* dict is not mutated.
+
+    Sibling to :func:`_apply_digests` for the env-value surface. Kaizen's
+    ``${AGENT_SERVER_IMAGE:-<reg>/agent:1.8.13}`` default is the
+    motivating case: the agent image is referenced by env var because
+    the backend spawns sandbox pods dynamically, so the ref never appears
+    as a service ``image:`` field that ``_apply_digests`` would catch.
+    """
+    result = copy.deepcopy(compose)
+    for svc in (result.get("services") or {}).values():
+        env = svc.get("environment")
+        if isinstance(env, dict):
+            for key, val in env.items():
+                if isinstance(val, str):
+                    env[key] = _rewrite_env_image_ref(
+                        val, registry, stage, digest_map
+                    )
+        elif isinstance(env, list):
+            for i, entry in enumerate(env):
+                if isinstance(entry, str) and "=" in entry:
+                    k, v = entry.split("=", 1)
+                    new_v = _rewrite_env_image_ref(v, registry, stage, digest_map)
+                    if new_v != v:
+                        env[i] = f"{k}={new_v}"
+                elif isinstance(entry, dict):
+                    val = entry.get("value")
+                    if isinstance(val, str):
+                        entry["value"] = _rewrite_env_image_ref(
+                            val, registry, stage, digest_map
+                        )
+    return result
+
+
+def _rewrite_env_image_ref(
+    value: str,
+    registry: str,
+    stage: str,
+    digest_map: Optional[Dict[str, str]],
+) -> str:
+    """Apply stage suffix + optional digest pin to an image ref in *value*.
+
+    Handles two shapes when the embedded ref starts with ``registry/``:
+
+    - ``${VAR:-<registry>/<repo>:<tag>}`` (or ``${VAR-default}``) —
+      rewrites the default while preserving the substitution form so a
+      runtime override still wins.
+    - Bare ``<registry>/<repo>:<tag>`` — rewrites in place.
+
+    Other values (external refs, non-image-shaped strings, already
+    ``@sha256:``-pinned refs) pass through verbatim.
+    """
+    match = _ENV_DEFAULT_SUB_RE.match(value)
+    if match:
+        prefix, default, brace = match.group(1), match.group(2), match.group(3)
+        new_ref = _stage_and_pin_ref(default, registry, stage, digest_map)
+        if new_ref == default:
+            return value
+        return f"{prefix}{new_ref}{brace}"
+    return _stage_and_pin_ref(value, registry, stage, digest_map)
+
+
+def _stage_and_pin_ref(
+    ref: str,
+    registry: str,
+    stage: str,
+    digest_map: Optional[Dict[str, str]],
+) -> str:
+    """Apply stage suffix and (if available) digest pin to a single ref."""
+    if "@" in ref or not ref.startswith(f"{registry}/"):
+        return ref
+
+    suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
+    # Split on the last `:` after the final `/`; an earlier `:` is a
+    # registry port (e.g. ``localhost:5000/org/agent:tag``).
+    slash = ref.rfind("/")
+    last_segment = ref[slash + 1:]
+    if ":" in last_segment:
+        colon = last_segment.index(":")
+        name = ref[: slash + 1 + colon]
+        tag = last_segment[colon + 1:]
+        # Strip an existing stage suffix so re-publishes against a
+        # different stage emit ``:<bare>-<new-stage>``, not the prior
+        # stage suffix reapplied.
+        clean_tag = re.sub(r"-(dev|stage)$", "", tag)
+    else:
+        name, clean_tag = ref, "latest"
+
+    suffixed = f"{name}:{clean_tag}{suffix}"
+    if digest_map and suffixed in digest_map:
+        return f"{suffixed}@{digest_map[suffixed]}"
+    return suffixed
 
 
 def resolve_extra_image(

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -106,12 +106,11 @@ class RegistryBuilder:
         # Env-var image refs (e.g. ``${AGENT_SERVER_IMAGE:-<reg>/agent:1.8.13}``)
         # are a parallel surface to ``services[*].image``: dynamic-spawn
         # targets that never appear as a compose service so ``_apply_digests``
-        # doesn't catch them. Rewrites refs under *registry* with the stage
-        # suffix and pins from *digest_map* when available, keeping the
-        # env default in lockstep with ``extra_docker_images`` for the same
-        # image.
+        # doesn't catch them. Rewrites are gated on *digest_map* membership
+        # (same source of truth ``_apply_digests`` uses) so an env default
+        # only gets restamped when this publish actually resolved that ref.
         transformed_compose = _apply_env_image_rewrites(
-            transformed_compose, registry, stage, digest_map
+            transformed_compose, stage, digest_map
         )
 
         # sort_keys=False preserves service key order from the source compose.
@@ -453,15 +452,14 @@ def _apply_digests(
 
 def _apply_env_image_rewrites(
     compose: Dict[str, Any],
-    registry: str,
     stage: str,
     digest_map: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Return a deep copy of *compose* with image refs in env values rewritten.
 
     Walks ``services[*].environment`` (dict and list shapes) and rewrites
-    image refs under *registry* with the stage-derived tag suffix; pins
-    ``@sha256:...`` when the post-suffix ref is in *digest_map*. Caller's
+    image refs to the stage-suffixed-and-digest-pinned form ONLY when the
+    post-suffix candidate ref appears as a key in *digest_map*. Caller's
     *compose* dict is not mutated.
 
     Sibling to :func:`_apply_digests` for the env-value surface. Kaizen's
@@ -469,90 +467,105 @@ def _apply_env_image_rewrites(
     motivating case: the agent image is referenced by env var because
     the backend spawns sandbox pods dynamically, so the ref never appears
     as a service ``image:`` field that ``_apply_digests`` would catch.
+
+    Contract: *digest_map* is the source of truth for "what this publish
+    actually resolved." Gating on its membership keeps env defaults from
+    pointing at refs the publish never produced — e.g. a vendored
+    ``shared-helper:0.5.0`` (independent release cadence) stays at
+    ``:0.5.0`` because ``:0.5.0-dev`` was never built or mirrored. Matches
+    the literal-tag-passthrough rule that :func:`resolve_extra_image`
+    enforces on the extras surface.
     """
+    if not digest_map:
+        return copy.deepcopy(compose)
     result = copy.deepcopy(compose)
     for svc in (result.get("services") or {}).values():
         env = svc.get("environment")
         if isinstance(env, dict):
             for key, val in env.items():
                 if isinstance(val, str):
-                    env[key] = _rewrite_env_image_ref(
-                        val, registry, stage, digest_map
-                    )
+                    env[key] = _rewrite_env_image_ref(val, stage, digest_map)
         elif isinstance(env, list):
             for i, entry in enumerate(env):
                 if isinstance(entry, str) and "=" in entry:
                     k, v = entry.split("=", 1)
-                    new_v = _rewrite_env_image_ref(v, registry, stage, digest_map)
+                    new_v = _rewrite_env_image_ref(v, stage, digest_map)
                     if new_v != v:
                         env[i] = f"{k}={new_v}"
                 elif isinstance(entry, dict):
                     val = entry.get("value")
                     if isinstance(val, str):
                         entry["value"] = _rewrite_env_image_ref(
-                            val, registry, stage, digest_map
+                            val, stage, digest_map
                         )
     return result
 
 
 def _rewrite_env_image_ref(
-    value: str,
-    registry: str,
-    stage: str,
-    digest_map: Optional[Dict[str, str]],
+    value: str, stage: str, digest_map: Dict[str, str],
 ) -> str:
-    """Apply stage suffix + optional digest pin to an image ref in *value*.
+    """Apply stage suffix + digest pin to an image ref embedded in *value*.
 
-    Handles two shapes when the embedded ref starts with ``registry/``:
+    Handles two shapes:
 
-    - ``${VAR:-<registry>/<repo>:<tag>}`` (or ``${VAR-default}``) —
-      rewrites the default while preserving the substitution form so a
-      runtime override still wins.
-    - Bare ``<registry>/<repo>:<tag>`` — rewrites in place.
+    - ``${VAR:-<image>:<tag>}`` (or ``${VAR-default}``) — rewrites the
+      default while preserving the substitution form so a runtime
+      override still wins.
+    - Bare ``<image>:<tag>`` — rewrites in place.
 
-    Other values (external refs, non-image-shaped strings, already
-    ``@sha256:``-pinned refs) pass through verbatim.
+    Pass-through cases (none of which match *digest_map* membership):
+    non-image-shaped strings, already ``@sha256:``-pinned refs, refs
+    whose post-suffix candidate isn't in *digest_map*.
     """
     match = _ENV_DEFAULT_SUB_RE.match(value)
     if match:
         prefix, default, brace = match.group(1), match.group(2), match.group(3)
-        new_ref = _stage_and_pin_ref(default, registry, stage, digest_map)
+        new_ref = _stage_and_pin_ref(default, stage, digest_map)
         if new_ref == default:
             return value
         return f"{prefix}{new_ref}{brace}"
-    return _stage_and_pin_ref(value, registry, stage, digest_map)
+    return _stage_and_pin_ref(value, stage, digest_map)
 
 
 def _stage_and_pin_ref(
-    ref: str,
-    registry: str,
-    stage: str,
-    digest_map: Optional[Dict[str, str]],
+    ref: str, stage: str, digest_map: Dict[str, str],
 ) -> str:
-    """Apply stage suffix and (if available) digest pin to a single ref."""
-    if "@" in ref or not ref.startswith(f"{registry}/"):
+    """Return ``ref@digest`` when the staged candidate is in *digest_map*.
+
+    Returns *ref* unchanged when:
+
+    - The ref is already digest-pinned (``@sha256:...``).
+    - The post-suffix candidate isn't a key in *digest_map* — either the
+      ref points outside our published surface (external image, vendored
+      helper) or the publish didn't resolve it.
+
+    Stage suffixes: known built-ins (``-dev``/``-stage``) are stripped
+    before reapplying so re-publishes round-trip cleanly. Custom-stage
+    suffixes aren't stripped (a tracked gap; same behavior in
+    :func:`resolve_extra_image`).
+    """
+    if "@" in ref:
         return ref
 
     suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
     # Split on the last `:` after the final `/`; an earlier `:` is a
     # registry port (e.g. ``localhost:5000/org/agent:tag``).
     slash = ref.rfind("/")
+    if slash == -1:
+        return ref
     last_segment = ref[slash + 1:]
     if ":" in last_segment:
         colon = last_segment.index(":")
         name = ref[: slash + 1 + colon]
         tag = last_segment[colon + 1:]
-        # Strip an existing stage suffix so re-publishes against a
-        # different stage emit ``:<bare>-<new-stage>``, not the prior
-        # stage suffix reapplied.
         clean_tag = re.sub(r"-(dev|stage)$", "", tag)
     else:
         name, clean_tag = ref, "latest"
 
-    suffixed = f"{name}:{clean_tag}{suffix}"
-    if digest_map and suffixed in digest_map:
-        return f"{suffixed}@{digest_map[suffixed]}"
-    return suffixed
+    candidate = f"{name}:{clean_tag}{suffix}"
+    if candidate in digest_map:
+        return f"{candidate}@{digest_map[candidate]}"
+    return ref
 
 
 def resolve_extra_image(

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -547,6 +547,15 @@ def _stage_and_pin_ref(
     if "@" in ref:
         return ref
 
+    # Literal-tag refs in `extra_docker_images` (no `{version}` placeholder)
+    # round-trip through ``resolve_extra_image`` unchanged and land in
+    # ``digest_map`` keyed by the literal ref — no stage suffix applied.
+    # When the same ref shows up as an env default, pin against the literal
+    # key first so the env value matches what extras emit. Mirrors the
+    # "independent release cadence" semantics ``resolve_extra_image`` uses.
+    if ref in digest_map:
+        return f"{ref}@{digest_map[ref]}"
+
     suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
     # Split on the last `:` after the final `/`; an earlier `:` is a
     # registry port (e.g. ``localhost:5000/org/agent:tag``).

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -478,6 +478,124 @@ class TestPublishExtrasDigestResolution:
 
 
 # ------------------------------------------------------------------
+# Env-var image refs: compose default matches extras (ENG-5260)
+# ------------------------------------------------------------------
+
+
+class TestPublishEnvImageRefsAgreeWithExtras:
+    """For a kaizen-shaped extension (env-var image ref + extras entry for
+    the same dynamic-spawn image), the published compose's env default
+    must agree with the extras list — same stage suffix, same digest."""
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_env_default_matches_extras_entry_end_to_end(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # Real ComposeTransformer + RegistryBuilder; only the I/O
+        # boundary is mocked. The published apps.json entry's compose_yml
+        # env default and extra_docker_images entry must agree on tag +
+        # digest for the same dynamic-spawn image.
+        import yaml as _yaml
+
+        metadata = {
+            "name": "kaizenv3",
+            "version": "1.8.13",
+            "description": "Kaizen v3",
+            "extra_docker_images": ["ghcr.io/my-org/images/agent:{version}"],
+        }
+        compose_data = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "ghcr.io/my-org/kaizenv3-backend:1.8.13",
+                    "ports": ["8000"],
+                    "environment": {
+                        "AGENT_SERVER_IMAGE":
+                            "${AGENT_SERVER_IMAGE:-ghcr.io/my-org/images/agent:1.8.13}",
+                    },
+                },
+            },
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path,
+            name="kaizenv3",
+            version="1.8.13",
+            metadata=metadata,
+            compose_data=compose_data,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        agent_digest = "sha256:" + "b" * 64
+        digest_by_ref = {
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev": "sha256:" + "a" * 64,
+            "ghcr.io/my-org/images/agent:1.8.13-dev": agent_digest,
+        }
+        mock_pusher_cls.resolve_digest.side_effect = lambda ref: digest_by_ref[ref]
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result(
+            extension_name="kaizenv3", version="1.8.13",
+        )
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # Grab the entry the publisher would have written to the catalog.
+        publish_kwargs = mock_publisher.publish.call_args.kwargs
+        entry = publish_kwargs["entry"]
+        compose_out = _yaml.safe_load(entry["compose_yml"])
+        env_default = compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ]
+
+        # Acceptance: the canonical pinned ref appears in BOTH surfaces.
+        expected_ref = f"ghcr.io/my-org/images/agent:1.8.13-dev@{agent_digest}"
+        assert entry["extra_docker_images"] == [expected_ref]
+        assert expected_ref in env_default, (
+            f"compose env default {env_default!r} must reference the same "
+            f"pinned ref as extras ({expected_ref!r})"
+        )
+        # The ${VAR:-...} shape is preserved so runtime overrides still win.
+        assert env_default.startswith("${AGENT_SERVER_IMAGE:-")
+        assert env_default.endswith("}")
+
+
+# ------------------------------------------------------------------
 # Dry-run mode
 # ------------------------------------------------------------------
 

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -1,5 +1,7 @@
 """Tests for RegistryBuilder."""
 
+from typing import Any, Dict
+
 import pytest
 import yaml
 
@@ -367,6 +369,296 @@ class TestBuildEntry:
         pinned_ref = f"myreg/images/agent:1.8.13-dev@{digest}"
         assert entry["extra_docker_images"] == [pinned_ref]
         assert pinned_ref not in entry["docker_images"]
+
+
+# ------------------------------------------------------------------
+# Env-var image-ref rewriting (ENG-5260)
+# ------------------------------------------------------------------
+
+
+def _kaizen_shaped_compose(env_value: str) -> Dict[str, Any]:
+    """Build a compose dict with a single env-var image ref on the backend."""
+    return {
+        "services": {
+            "backend": {
+                "image": "myreg/images/kaizenv3-backend:1.8.13-dev",
+                "environment": {
+                    "AGENT_SERVER_IMAGE": env_value,
+                },
+            },
+        },
+    }
+
+
+class TestBuildEntryEnvImageRewrites:
+    """Image refs embedded in ``services[*].environment`` values get the
+    same stage-suffix + digest-pin treatment as ``extra_docker_images``,
+    so a dynamic-spawn ref like ``${AGENT_SERVER_IMAGE:-...}`` stays in
+    lockstep with the air-gap mirror list for the same image."""
+
+    def test_default_sub_under_registry_gets_stage_suffix(self, builder):
+        # The kaizen-shaped case: ${VAR:-<reg>/agent:1.8.13} published
+        # to stage=dev must emit ${VAR:-<reg>/agent:1.8.13-dev}.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        )
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+        }
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev}"
+
+    def test_default_sub_dash_form_supported(self, builder):
+        # ``${VAR-default}`` (use default only if unset) is rewritten
+        # the same as ``${VAR:-default}``; both forms collapse to the
+        # default at deploy time in our pipeline.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE-myreg/images/agent:1.8.13}"
+        )
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${AGENT_SERVER_IMAGE-myreg/images/agent:1.8.13-dev}"
+
+    def test_bare_ref_under_registry_gets_stage_suffix(self, builder):
+        # Some authors set env defaults via plain values, not ${VAR:-...}.
+        # When the value is the bare image ref, rewrite in place.
+        compose = _kaizen_shaped_compose("myreg/images/agent:1.8.13")
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "myreg/images/agent:1.8.13-dev"
+
+    def test_external_ref_not_rewritten(self, builder):
+        # Refs outside our registry pass through — postgres, redis, etc.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-postgres:15}"
+        )
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${AGENT_SERVER_IMAGE:-postgres:15}"
+
+    def test_non_image_default_passes_through(self, builder):
+        # An env value that happens to be a ${VAR:-default} but whose
+        # default isn't an image ref under our registry must not be
+        # rewritten — e.g. a feature flag, a URL, a literal string.
+        compose = _kaizen_shaped_compose(
+            "${LOG_LEVEL:-info}"
+        )
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${LOG_LEVEL:-info}"
+
+    def test_already_pinned_ref_passes_through(self, builder):
+        # ${VAR:-<reg>/agent:1.8.13-dev@sha256:...} is already immutable;
+        # leave the digest alone (re-suffixing would mismatch the pin).
+        pinned_default = (
+            "myreg/images/agent:1.8.13-dev@sha256:" + "a" * 64
+        )
+        compose = _kaizen_shaped_compose(
+            f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}"
+        )
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="stage",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        # Suffix is NOT reapplied; default value preserved verbatim.
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}"
+
+    def test_prod_strips_stage_suffix(self, builder):
+        # Source compose may already carry a -dev tag (e.g. a re-publish
+        # round-trip); a prod publish must emit the clean tag rather
+        # than reapplying -dev or leaving the prior stage in place.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev}"
+        )
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="prod",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+
+    def test_digest_pinned_when_in_digest_map(self, builder):
+        # The acceptance criterion: when digest_map carries the
+        # post-suffix ref, the env default is rewritten to
+        # ``:tag@sha256:...`` so it matches extra_docker_images for the
+        # same image.
+        digest = "sha256:" + "c" * 64
+        digest_map = {"myreg/images/agent:1.8.13-dev": digest}
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        )
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            digest_map=digest_map,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = f"${{AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev@{digest}}}"
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == expected
+
+    def test_env_list_form_supported(self, builder):
+        # Compose env can be a list of ``KEY=value`` strings instead of
+        # a dict. Both shapes must round-trip the rewrite.
+        compose = {
+            "services": {
+                "backend": {
+                    "image": "myreg/images/k-backend:1.8.13-dev",
+                    "environment": [
+                        "AGENT_SERVER_IMAGE=${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}",
+                        "LOG_LEVEL=info",
+                    ],
+                },
+            },
+        }
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env_list = compose_out["services"]["backend"]["environment"]
+        assert (
+            "AGENT_SERVER_IMAGE=${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev}"
+            in env_list
+        )
+        assert "LOG_LEVEL=info" in env_list
+
+    def test_env_long_form_dict_supported(self, builder):
+        # ``[{"name": KEY, "value": VAL}, ...]`` — the long-form list
+        # entry shape that Compose v3 also accepts.
+        compose = {
+            "services": {
+                "backend": {
+                    "image": "myreg/images/k-backend:1.8.13-dev",
+                    "environment": [
+                        {"name": "AGENT_SERVER_IMAGE",
+                         "value": "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"},
+                    ],
+                },
+            },
+        }
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env_list = compose_out["services"]["backend"]["environment"]
+        assert env_list[0]["value"] == (
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev}"
+        )
+
+    def test_non_string_env_values_untouched(self, builder):
+        # Compose allows int/bool env values. Walking the dict must not
+        # coerce or otherwise corrupt them.
+        compose = {
+            "services": {
+                "backend": {
+                    "image": "myreg/images/k-backend:1.8.13-dev",
+                    "environment": {
+                        "MAX_CONN": 100,
+                        "ENABLE_FEATURE": True,
+                    },
+                },
+            },
+        }
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env = compose_out["services"]["backend"]["environment"]
+        assert env["MAX_CONN"] == 100
+        assert env["ENABLE_FEATURE"] is True
+
+    def test_registry_with_port_handled(self, builder):
+        # OCI refs allow `:` in the host segment (registry port). The
+        # tag-split must happen after the last `/`, not the leftmost `:`.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-localhost:5000/org/agent:1.8.13}"
+        )
+        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        entry = builder.build_entry(
+            meta, compose, "localhost:5000/org", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${AGENT_SERVER_IMAGE:-localhost:5000/org/agent:1.8.13-dev}"
+
+    def test_env_value_matches_extra_docker_images_entry(self, builder):
+        # The acceptance criterion: for kaizen-shaped input (env-var
+        # default + extra_docker_images for the same image), the
+        # published compose env default agrees with the extras list.
+        digest = "sha256:" + "d" * 64
+        digest_map = {"myreg/images/agent:1.8.13-dev": digest}
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        )
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            digest_map=digest_map,
+        )
+        # extras list carries the canonical pinned ref.
+        extras_ref = f"myreg/images/agent:1.8.13-dev@{digest}"
+        assert entry["extra_docker_images"] == [extras_ref]
+        # And the compose env default points at the same ref.
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env_default = compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ]
+        assert extras_ref in env_default
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -1,5 +1,6 @@
 """Tests for RegistryBuilder."""
 
+import copy
 from typing import Any, Dict
 
 import pytest
@@ -392,29 +393,45 @@ def _kaizen_shaped_compose(env_value: str) -> Dict[str, Any]:
 
 class TestBuildEntryEnvImageRewrites:
     """Image refs embedded in ``services[*].environment`` values get the
-    same stage-suffix + digest-pin treatment as ``extra_docker_images``,
-    so a dynamic-spawn ref like ``${AGENT_SERVER_IMAGE:-...}`` stays in
-    lockstep with the air-gap mirror list for the same image."""
+    same digest-pin treatment as ``extra_docker_images`` so a
+    dynamic-spawn ref like ``${AGENT_SERVER_IMAGE:-...}`` stays in
+    lockstep with the air-gap mirror list for the same image.
 
-    def test_default_sub_under_registry_gets_stage_suffix(self, builder):
+    Contract: env rewrites are gated on ``digest_map`` membership. A
+    candidate ref that doesn't appear in the map is left verbatim — the
+    publish never produced it, so re-stamping would point the runtime
+    at a tag that was never built or mirrored. This mirrors the
+    literal-tag-passthrough rule on the extras surface.
+    """
+
+    _AGENT_DIGEST = "sha256:" + "c" * 64
+    _AGENT_DEV_MAP = {"myreg/images/agent:1.8.13-dev": _AGENT_DIGEST}
+
+    def _meta(self, **overrides):
+        base = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        base.update(overrides)
+        return base
+
+    def test_default_sub_rewritten_when_candidate_in_digest_map(self, builder):
         # The kaizen-shaped case: ${VAR:-<reg>/agent:1.8.13} published
-        # to stage=dev must emit ${VAR:-<reg>/agent:1.8.13-dev}.
+        # to stage=dev with the post-suffix ref in digest_map emits
+        # ${VAR:-<reg>/agent:1.8.13-dev@sha256:...}.
         compose = _kaizen_shaped_compose(
             "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
         )
-        meta = {
-            "name": "kaizenv3",
-            "description": "test",
-            "source_type": "kamiwaza",
-            "visibility": "public",
-        }
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            self._meta(name="kaizenv3"), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}}}"
+        )
         assert compose_out["services"]["backend"]["environment"][
             "AGENT_SERVER_IMAGE"
-        ] == "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev}"
+        ] == expected
 
     def test_default_sub_dash_form_supported(self, builder):
         # ``${VAR-default}`` (use default only if unset) is rewritten
@@ -423,56 +440,85 @@ class TestBuildEntryEnvImageRewrites:
         compose = _kaizen_shaped_compose(
             "${AGENT_SERVER_IMAGE-myreg/images/agent:1.8.13}"
         )
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = (
+            "${AGENT_SERVER_IMAGE-"
+            f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}}}"
+        )
         assert compose_out["services"]["backend"]["environment"][
             "AGENT_SERVER_IMAGE"
-        ] == "${AGENT_SERVER_IMAGE-myreg/images/agent:1.8.13-dev}"
+        ] == expected
 
-    def test_bare_ref_under_registry_gets_stage_suffix(self, builder):
+    def test_bare_ref_rewritten_when_candidate_in_digest_map(self, builder):
         # Some authors set env defaults via plain values, not ${VAR:-...}.
-        # When the value is the bare image ref, rewrite in place.
+        # Bare ref under the published surface gets pinned in place.
         compose = _kaizen_shaped_compose("myreg/images/agent:1.8.13")
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
         assert compose_out["services"]["backend"]["environment"][
             "AGENT_SERVER_IMAGE"
-        ] == "myreg/images/agent:1.8.13-dev"
+        ] == f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}"
+
+    def test_fixed_tag_literal_not_in_digest_map_passes_through(self, builder):
+        # Codex #1: a vendored helper at its own version (literal tag,
+        # not opt-in via {version}) won't have a post-suffix entry in
+        # digest_map. The env ref must stay verbatim — re-stamping would
+        # point at :0.5.0-dev which the publish never built.
+        compose = _kaizen_shaped_compose(
+            "${HELPER_IMAGE:-myreg/images/shared-helper:0.5.0}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${HELPER_IMAGE:-myreg/images/shared-helper:0.5.0}"
+
+    def test_no_digest_map_no_rewrite(self, builder):
+        # When the publish path didn't supply a digest_map (e.g. the
+        # catalog-only-republish path soft-fell on resolution), env
+        # refs pass through. Without a digest there's no proof the
+        # post-suffix ref exists in the registry.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
 
     def test_external_ref_not_rewritten(self, builder):
-        # Refs outside our registry pass through — postgres, redis, etc.
-        compose = _kaizen_shaped_compose(
-            "${AGENT_SERVER_IMAGE:-postgres:15}"
-        )
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
+        # External refs (postgres, redis, third-party sidecars) aren't
+        # in digest_map and pass through verbatim.
+        compose = _kaizen_shaped_compose("${DB_IMAGE:-postgres:15}")
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
         assert compose_out["services"]["backend"]["environment"][
             "AGENT_SERVER_IMAGE"
-        ] == "${AGENT_SERVER_IMAGE:-postgres:15}"
+        ] == "${DB_IMAGE:-postgres:15}"
 
     def test_non_image_default_passes_through(self, builder):
-        # An env value that happens to be a ${VAR:-default} but whose
-        # default isn't an image ref under our registry must not be
-        # rewritten — e.g. a feature flag, a URL, a literal string.
-        compose = _kaizen_shaped_compose(
-            "${LOG_LEVEL:-info}"
-        )
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
+        # ${VAR:-info} (feature flag, log level, etc.) is shaped like a
+        # default-sub but the default isn't an image ref.
+        compose = _kaizen_shaped_compose("${LOG_LEVEL:-info}")
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
         assert compose_out["services"]["backend"]["environment"][
@@ -488,52 +534,35 @@ class TestBuildEntryEnvImageRewrites:
         compose = _kaizen_shaped_compose(
             f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}"
         )
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="stage",
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="stage", digest_map=self._AGENT_DEV_MAP,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
-        # Suffix is NOT reapplied; default value preserved verbatim.
         assert compose_out["services"]["backend"]["environment"][
             "AGENT_SERVER_IMAGE"
         ] == f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}"
 
     def test_prod_strips_stage_suffix(self, builder):
-        # Source compose may already carry a -dev tag (e.g. a re-publish
-        # round-trip); a prod publish must emit the clean tag rather
-        # than reapplying -dev or leaving the prior stage in place.
+        # Source compose may already carry a -dev tag (re-publish
+        # round-trip). For prod publish, candidate becomes :1.8.13
+        # (no suffix) — if that's in digest_map, pin it.
+        prod_map = {
+            "myreg/images/agent:1.8.13":
+                "sha256:" + "e" * 64,
+        }
         compose = _kaizen_shaped_compose(
             "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev}"
         )
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="prod",
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="prod", digest_map=prod_map,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
-        assert compose_out["services"]["backend"]["environment"][
-            "AGENT_SERVER_IMAGE"
-        ] == "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
-
-    def test_digest_pinned_when_in_digest_map(self, builder):
-        # The acceptance criterion: when digest_map carries the
-        # post-suffix ref, the env default is rewritten to
-        # ``:tag@sha256:...`` so it matches extra_docker_images for the
-        # same image.
-        digest = "sha256:" + "c" * 64
-        digest_map = {"myreg/images/agent:1.8.13-dev": digest}
-        compose = _kaizen_shaped_compose(
-            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        expected = (
+            "${AGENT_SERVER_IMAGE:-"
+            "myreg/images/agent:1.8.13@sha256:" + "e" * 64 + "}"
         )
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
-        entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="dev",
-            digest_map=digest_map,
-        )
-        compose_out = yaml.safe_load(entry["compose_yml"])
-        expected = f"${{AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev@{digest}}}"
         assert compose_out["services"]["backend"]["environment"][
             "AGENT_SERVER_IMAGE"
         ] == expected
@@ -552,17 +581,17 @@ class TestBuildEntryEnvImageRewrites:
                 },
             },
         }
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
         env_list = compose_out["services"]["backend"]["environment"]
-        assert (
-            "AGENT_SERVER_IMAGE=${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev}"
-            in env_list
+        expected = (
+            "AGENT_SERVER_IMAGE=${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}}}"
         )
+        assert expected in env_list
         assert "LOG_LEVEL=info" in env_list
 
     def test_env_long_form_dict_supported(self, builder):
@@ -579,15 +608,15 @@ class TestBuildEntryEnvImageRewrites:
                 },
             },
         }
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
         env_list = compose_out["services"]["backend"]["environment"]
         assert env_list[0]["value"] == (
-            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev}"
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}}}"
         )
 
     def test_non_string_env_values_untouched(self, builder):
@@ -604,10 +633,9 @@ class TestBuildEntryEnvImageRewrites:
                 },
             },
         }
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
         entry = builder.build_entry(
-            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
         env = compose_out["services"]["backend"]["environment"]
@@ -617,18 +645,66 @@ class TestBuildEntryEnvImageRewrites:
     def test_registry_with_port_handled(self, builder):
         # OCI refs allow `:` in the host segment (registry port). The
         # tag-split must happen after the last `/`, not the leftmost `:`.
+        port_map = {
+            "localhost:5000/org/agent:1.8.13-dev": "sha256:" + "f" * 64,
+        }
         compose = _kaizen_shaped_compose(
             "${AGENT_SERVER_IMAGE:-localhost:5000/org/agent:1.8.13}"
         )
-        meta = {"name": "k", "description": "", "source_type": "kamiwaza",
-                "visibility": "public"}
         entry = builder.build_entry(
-            meta, compose, "localhost:5000/org", "1.8.13", stage="dev",
+            self._meta(), compose, "localhost:5000/org", "1.8.13",
+            stage="dev", digest_map=port_map,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = (
+            "${AGENT_SERVER_IMAGE:-localhost:5000/org/agent:1.8.13-dev"
+            "@sha256:" + "f" * 64 + "}"
+        )
         assert compose_out["services"]["backend"]["environment"][
             "AGENT_SERVER_IMAGE"
-        ] == "${AGENT_SERVER_IMAGE:-localhost:5000/org/agent:1.8.13-dev}"
+        ] == expected
+
+    def test_appgarden_divergent_namespace_works(self, builder):
+        # Codex #3: when the appgarden compose's `image:` namespace
+        # differs from the profile registry, digest_map is still keyed
+        # by the actual published ref. Gating on digest_map (not
+        # registry prefix) lets env refs under the appgarden namespace
+        # rewrite correctly even though profile.registry says otherwise.
+        appgarden_digest = "sha256:" + "9" * 64
+        appgarden_map = {
+            "ghcr.io/published/tool-foo/agent:2.0.0-dev": appgarden_digest,
+        }
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-ghcr.io/published/tool-foo/agent:2.0.0}"
+        )
+        # The "registry" arg here represents profile.registry; the
+        # appgarden compose has chosen a different namespace.
+        entry = builder.build_entry(
+            self._meta(), compose, "ghcr.io/some-other-org", "2.0.0",
+            stage="dev", digest_map=appgarden_map,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = (
+            "${AGENT_SERVER_IMAGE:-"
+            f"ghcr.io/published/tool-foo/agent:2.0.0-dev@{appgarden_digest}}}"
+        )
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == expected
+
+    def test_caller_compose_not_mutated(self, builder):
+        # Codex #5: build_entry must not mutate the caller's compose
+        # dict. The deepcopy in _apply_env_image_rewrites guards this.
+        original_env = "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        compose = _kaizen_shaped_compose(original_env)
+        compose_snapshot = copy.deepcopy(compose)
+        builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        assert compose == compose_snapshot, (
+            "build_entry mutated the caller's compose dict"
+        )
 
     def test_env_value_matches_extra_docker_images_entry(self, builder):
         # The acceptance criterion: for kaizen-shaped input (env-var
@@ -639,13 +715,10 @@ class TestBuildEntryEnvImageRewrites:
         compose = _kaizen_shaped_compose(
             "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
         )
-        meta = {
-            "name": "kaizenv3",
-            "description": "test",
-            "source_type": "kamiwaza",
-            "visibility": "public",
-            "extra_docker_images": ["myreg/images/agent:{version}"],
-        }
+        meta = self._meta(
+            name="kaizenv3",
+            extra_docker_images=["myreg/images/agent:{version}"],
+        )
         entry = builder.build_entry(
             meta, compose, "myreg/images", "1.8.13", stage="dev",
             digest_map=digest_map,

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -706,6 +706,92 @@ class TestBuildEntryEnvImageRewrites:
             "build_entry mutated the caller's compose dict"
         )
 
+    def test_literal_key_in_digest_map_pins_without_suffix(self, builder):
+        # JohnBot H1: when extras has a literal-tag ref (no `{version}`
+        # opt-in), resolve_extra_image returns it unchanged and run_publish
+        # resolves a digest keyed by the literal ref. The env default for
+        # the same image must pin against that literal key — re-suffixing
+        # would point at a ref the publish never produced. This is the
+        # exact extras-vs-env divergence the PR was meant to close.
+        literal_digest = "sha256:" + "1" * 64
+        # digest_map is keyed by the LITERAL ref (no stage suffix), as
+        # `_auto_resolve_digests` does when extras come in as a literal tag.
+        digest_map = {"myreg/images/shared-helper:0.5.0": literal_digest}
+        compose = _kaizen_shaped_compose(
+            "${HELPER_IMAGE:-myreg/images/shared-helper:0.5.0}"
+        )
+        meta = self._meta(
+            extra_docker_images=["myreg/images/shared-helper:0.5.0"],
+        )
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=digest_map,
+        )
+        # Extras emit `:0.5.0@sha256:...` (literal pin).
+        extras_ref = f"myreg/images/shared-helper:0.5.0@{literal_digest}"
+        assert entry["extra_docker_images"] == [extras_ref]
+        # Env default agrees — same ref, same digest, no stage suffix.
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env_default = compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ]
+        assert env_default == (
+            "${HELPER_IMAGE:-"
+            f"myreg/images/shared-helper:0.5.0@{literal_digest}}}"
+        )
+
+    def test_no_tag_bare_ref_defaults_to_latest_candidate(self, builder):
+        # JohnBot M4: a bare ref with no `:tag` falls back to `:latest`
+        # when computing the candidate. Locks behavior; matches Docker
+        # CLI semantics. Tag-less refs in the wild are uncommon but legal.
+        latest_dev_digest = "sha256:" + "2" * 64
+        digest_map = {"myreg/images/agent:latest-dev": latest_dev_digest}
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=digest_map,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:latest-dev@{latest_dev_digest}}}"
+        )
+
+    def test_nested_substitution_left_alone(self, builder):
+        # The default-sub regex is anchored end-to-end, so embedded
+        # ${...} inside a larger string doesn't match — the value
+        # passes through verbatim. Locks regex behavior.
+        compose = _kaizen_shaped_compose(
+            "prefix-${INNER:-myreg/images/agent:1.8.13}-suffix"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "prefix-${INNER:-myreg/images/agent:1.8.13}-suffix"
+
+    def test_whitespace_padded_substitution_left_alone(self, builder):
+        # Leading/trailing whitespace in an env value breaks the
+        # anchored default-sub match. Locks the regex's strict behavior.
+        compose = _kaizen_shaped_compose(
+            "  ${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}  "
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "  ${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}  "
+
     def test_env_value_matches_extra_docker_images_entry(self, builder):
         # The acceptance criterion: for kaizen-shaped input (env-var
         # default + extra_docker_images for the same image), the


### PR DESCRIPTION
## What this ships

`kz-ext publish` now rewrites image refs embedded in `services[*].environment`
defaults the same way it handles `extra_docker_images` — same stage suffix,
same digest pin — so a dynamic-spawn ref like `${AGENT_SERVER_IMAGE:-...}`
stays in lockstep with the air-gap mirror list for the same image.

Linear: [ENG-5260](https://linear.app/kamiwaza/issue/ENG-5260)

## Contract

| Env value shape | Outcome |
|---|---|
| `${VAR:-<reg>/img:tag}` where post-suffix candidate is in `digest_map` | Rewrites default to `<reg>/img:tag-stage@sha256:...`; preserves `${VAR:-...}` so runtime override still wins |
| Bare `<reg>/img:tag` where candidate is in `digest_map` | Same, rewritten in place |
| Anything else (literal-tag vendored helper, external image, already-pinned, non-image value, no `digest_map`) | Passes through verbatim |

Env rewrites gate on `digest_map` membership — same source of truth
`_apply_digests` uses for service `image:` fields. A literal-tag ref the
publish didn't resolve stays put, mirroring the `resolve_extra_image`
contract for extras.

## Verification

- 16 new unit tests in `test_registry_builder.py::TestBuildEntryEnvImageRewrites`
- 1 integration test in `test_publish_cmd.py` (real `ComposeTransformer` +
  `RegistryBuilder`, mocked only at the catalog-write boundary)
- End-to-end drive against kaizen's real `kamiwaza.json` + `docker-compose.appgarden.yml`
  with live GHCR digest resolution: produced env default matches the
  ENG-5181 extras ref exactly (`agent:1.8.13-dev@sha256:e57b51d2…`)
- 1234 extensions tests pass; ruff clean
- Codex reviewed twice; second pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)