### PR TITLE
ENG-4832: allow per-service health check overrides

### DIFF
--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -98,6 +98,7 @@ class PayloadBuilder:
             app_path=app_path,
             verify_ssl=verify_ssl,
             extension_type=ext_type,
+            metadata=metadata,
         )
         origin = connection.url.removesuffix("/api")
         tls_reject = "0" if not verify_ssl else "1"
@@ -202,6 +203,7 @@ class PayloadBuilder:
         app_path: str = "",
         verify_ssl: bool = True,
         extension_type: str = "app",
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
         specs: List[ExtensionServiceSpec] = []
@@ -248,7 +250,20 @@ class PayloadBuilder:
                 env.append({"name": "KAMIWAZA_VERIFY_SSL", "value": "false"})
                 env.append({"name": "KAMIWAZA_TLS_REJECT_UNAUTHORIZED", "value": "0"})
 
-            health_check = _service_extension_field(svc, "healthCheck")
+            # Health-check precedence (ENG-4832):
+            # 1. ``kamiwaza.json`` → ``services.<svc_name>.healthCheck`` —
+            #    the user-facing escape hatch for any tool/service extension
+            #    whose primary doesn't serve ``/sse`` (FastMCP feature-flagged
+            #    off, REST-only, gRPC-only). Lives in the metadata file
+            #    rather than compose so kamiwaza.json stays the single
+            #    source of catalog truth.
+            # 2. Compose ``x-kamiwaza.healthCheck`` — pre-existing override
+            #    path for compose-authored extensions.
+            # 3. ``_default_health_check`` heuristics — back-compat default
+            #    when neither override is set.
+            health_check = _metadata_service_field(metadata, svc_name, "healthCheck")
+            if not health_check:
+                health_check = _service_extension_field(svc, "healthCheck")
             if not health_check:
                 health_check = self._default_health_check(
                     svc_name,
@@ -387,13 +402,17 @@ class PayloadBuilder:
         # the FastMCP SSE endpoint — even though the response body streams
         # past the K8s 5s probe timeout. The platform's CR API currently
         # rejects ``tcpSocket`` and ``exec`` healthCheck shapes with an
-        # opaque 500, leaving httpGet as the only path. /sse is preferable
-        # to /health (404 under FastMCP) — the headers come back 200 even
-        # if the probe times out reading the body, which keeps the pod
-        # restart-loop from firing. Net result: pod runs and serves
-        # requests, but K8s may take longer to mark it Ready. The proper
-        # fix is to teach the platform API to accept tcpSocket/exec
-        # probes (tracked separately).
+        # opaque 500 (ENG-4833), leaving httpGet as the only path. /sse is
+        # preferable to /health (404 under FastMCP) — the headers come back
+        # 200 even if the probe times out reading the body, which keeps
+        # the pod restart-loop from firing. Net result: pod runs and serves
+        # requests, but K8s may take longer to mark it Ready.
+        #
+        # Escape hatch (ENG-4832): tool extensions that DON'T serve /sse
+        # (REST-only, MCP at /mcp via streamable-http, gRPC, feature-flagged
+        # MCP off) should declare an explicit probe in ``kamiwaza.json``
+        # under ``services.<svc_name>.healthCheck``. That override runs
+        # ahead of the heuristics below — see ``_build_services``.
         if extension_type == "service" and is_primary:
             path = "/"
         elif extension_type == "tool" and is_primary:
@@ -547,6 +566,32 @@ def _service_extension_field(svc: Dict[str, Any], key: str) -> Optional[Any]:
     if isinstance(x_kamiwaza, dict) and key in x_kamiwaza:
         return x_kamiwaza[key]
     return None
+
+
+def _metadata_service_field(
+    metadata: Optional[Dict[str, Any]],
+    svc_name: str,
+    key: str,
+) -> Optional[Any]:
+    """Read a per-service override from ``kamiwaza.json`` (ENG-4832).
+
+    Shape::
+
+        {
+          "services": {
+            "<svc_name>": { "<key>": <value> }
+          }
+        }
+    """
+    if not isinstance(metadata, dict):
+        return None
+    services = metadata.get("services")
+    if not isinstance(services, dict):
+        return None
+    svc_block = services.get(svc_name)
+    if not isinstance(svc_block, dict):
+        return None
+    return svc_block.get(key)
 
 
 def _service_env_map(svc: Dict[str, Any]) -> Dict[str, str]:

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -149,7 +149,83 @@ class MetadataValidator:
         # points at 2.0.14) — warn here so it's visible before deploy.
         warnings.extend(_check_version_drift(path.parent, metadata.version, data.get("image")))
 
+        # services.<name>.healthCheck shape (ENG-4832).
+        errors.extend(_check_services_block(data.get("services")))
+
         return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings)
+
+
+_PROBE_SHAPES = ("httpGet", "tcpSocket", "exec")
+
+
+def _check_services_block(services: Any) -> List[str]:
+    """Validate the optional ``services`` block in kamiwaza.json (ENG-4832).
+
+    The block is a map of compose service names to per-service overrides.
+    Today the only override we read is ``healthCheck``; this checker keeps
+    structural mistakes (wrong probe shape, missing port, two shapes at
+    once) from reaching the platform CR API as opaque 500s.
+    """
+    errors: List[str] = []
+    if services is None:
+        return errors
+    if not isinstance(services, dict):
+        errors.append("services must be a JSON object keyed by service name")
+        return errors
+    for svc_name, block in services.items():
+        if not isinstance(block, dict):
+            errors.append(f"services.{svc_name} must be a JSON object")
+            continue
+        health = block.get("healthCheck")
+        if health is None:
+            continue
+        errors.extend(_check_healthcheck_shape(svc_name, health))
+    return errors
+
+
+def _check_healthcheck_shape(svc_name: str, health: Any) -> List[str]:
+    """Mirror K8s' "exactly one probe shape" rule for a healthCheck block."""
+    errors: List[str] = []
+    if not isinstance(health, dict):
+        errors.append(f"services.{svc_name}.healthCheck must be a JSON object")
+        return errors
+    declared = [name for name in _PROBE_SHAPES if name in health]
+    if not declared:
+        errors.append(
+            f"services.{svc_name}.healthCheck must declare one of: "
+            f"{', '.join(_PROBE_SHAPES)}"
+        )
+        return errors
+    if len(declared) > 1:
+        errors.append(
+            f"services.{svc_name}.healthCheck declares multiple probe shapes "
+            f"({', '.join(declared)}); pick exactly one"
+        )
+        return errors
+    shape = declared[0]
+    value = health[shape]
+    if not isinstance(value, dict):
+        errors.append(
+            f"services.{svc_name}.healthCheck.{shape} must be a JSON object"
+        )
+        return errors
+    if shape == "httpGet":
+        if "port" not in value:
+            errors.append(
+                f"services.{svc_name}.healthCheck.httpGet must include 'port'"
+            )
+    elif shape == "tcpSocket":
+        if "port" not in value:
+            errors.append(
+                f"services.{svc_name}.healthCheck.tcpSocket must include 'port'"
+            )
+    elif shape == "exec":
+        command = value.get("command")
+        if not isinstance(command, list) or not command:
+            errors.append(
+                f"services.{svc_name}.healthCheck.exec.command must be a non-empty list"
+            )
+    return errors
 
 
 def _check_version_drift(

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -150,15 +150,35 @@ class MetadataValidator:
         warnings.extend(_check_version_drift(path.parent, metadata.version, data.get("image")))
 
         # services.<name>.healthCheck shape (ENG-4832).
-        errors.extend(_check_services_block(data.get("services")))
+        service_errors, service_warnings = _check_services_block(data.get("services"))
+        errors.extend(service_errors)
+        warnings.extend(service_warnings)
 
         return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings)
 
 
-_PROBE_SHAPES = ("httpGet", "tcpSocket", "exec")
+_PROBE_SHAPES = ("httpGet", "tcpSocket", "exec", "grpc")
+_HEALTHCHECK_KEYS = frozenset(
+    {
+        *_PROBE_SHAPES,
+        "initialDelaySeconds",
+        "timeoutSeconds",
+        "periodSeconds",
+        "successThreshold",
+        "failureThreshold",
+        "terminationGracePeriodSeconds",
+    }
+)
+_PROBE_KEYS = {
+    "httpGet": frozenset({"path", "port", "host", "scheme", "httpHeaders"}),
+    "tcpSocket": frozenset({"port", "host"}),
+    "exec": frozenset({"command"}),
+    "grpc": frozenset({"port", "service"}),
+}
+_NAMED_PORT_RE = re.compile(r"^[a-z]([-a-z0-9]{0,13}[a-z0-9])?$")
 
 
-def _check_services_block(services: Any) -> List[str]:
+def _check_services_block(services: Any) -> tuple[List[str], List[str]]:
     """Validate the optional ``services`` block in kamiwaza.json (ENG-4832).
 
     The block is a map of compose service names to per-service overrides.
@@ -167,11 +187,12 @@ def _check_services_block(services: Any) -> List[str]:
     once) from reaching the platform CR API as opaque 500s.
     """
     errors: List[str] = []
+    warnings: List[str] = []
     if services is None:
-        return errors
+        return errors, warnings
     if not isinstance(services, dict):
         errors.append("services must be a JSON object keyed by service name")
-        return errors
+        return errors, warnings
     for svc_name, block in services.items():
         if not isinstance(block, dict):
             errors.append(f"services.{svc_name} must be a JSON object")
@@ -179,52 +200,96 @@ def _check_services_block(services: Any) -> List[str]:
         health = block.get("healthCheck")
         if health is None:
             continue
-        errors.extend(_check_healthcheck_shape(svc_name, health))
-    return errors
+        health_errors, health_warnings = _check_healthcheck_shape(svc_name, health)
+        errors.extend(health_errors)
+        warnings.extend(health_warnings)
+    return errors, warnings
 
 
-def _check_healthcheck_shape(svc_name: str, health: Any) -> List[str]:
+def _check_healthcheck_shape(svc_name: str, health: Any) -> tuple[List[str], List[str]]:
     """Mirror K8s' "exactly one probe shape" rule for a healthCheck block."""
     errors: List[str] = []
+    warnings: List[str] = []
     if not isinstance(health, dict):
         errors.append(f"services.{svc_name}.healthCheck must be a JSON object")
-        return errors
+        return errors, warnings
+    unknown_health_keys = sorted(set(health) - _HEALTHCHECK_KEYS)
+    for key in unknown_health_keys:
+        warnings.append(
+            f"services.{svc_name}.healthCheck has unknown field '{key}'"
+        )
     declared = [name for name in _PROBE_SHAPES if name in health]
     if not declared:
         errors.append(
             f"services.{svc_name}.healthCheck must declare one of: "
             f"{', '.join(_PROBE_SHAPES)}"
         )
-        return errors
+        return errors, warnings
     if len(declared) > 1:
         errors.append(
             f"services.{svc_name}.healthCheck declares multiple probe shapes "
             f"({', '.join(declared)}); pick exactly one"
         )
-        return errors
+        return errors, warnings
     shape = declared[0]
     value = health[shape]
     if not isinstance(value, dict):
         errors.append(
             f"services.{svc_name}.healthCheck.{shape} must be a JSON object"
         )
-        return errors
-    if shape == "httpGet":
-        if "port" not in value:
-            errors.append(
-                f"services.{svc_name}.healthCheck.httpGet must include 'port'"
-            )
-    elif shape == "tcpSocket":
-        if "port" not in value:
-            errors.append(
-                f"services.{svc_name}.healthCheck.tcpSocket must include 'port'"
-            )
+        return errors, warnings
+    unknown_probe_keys = sorted(set(value) - _PROBE_KEYS[shape])
+    for key in unknown_probe_keys:
+        warnings.append(
+            f"services.{svc_name}.healthCheck.{shape} has unknown field '{key}'"
+        )
+    if shape in {"httpGet", "tcpSocket", "grpc"}:
+        errors.extend(_check_probe_port(svc_name, shape, value))
     elif shape == "exec":
         command = value.get("command")
         if not isinstance(command, list) or not command:
             errors.append(
                 f"services.{svc_name}.healthCheck.exec.command must be a non-empty list"
             )
+    return errors, warnings
+
+
+def _check_probe_port(svc_name: str, shape: str, value: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    if "port" not in value:
+        errors.append(f"services.{svc_name}.healthCheck.{shape} must include 'port'")
+        return errors
+    port = value["port"]
+    if isinstance(port, bool):
+        errors.append(
+            f"services.{svc_name}.healthCheck.{shape}.port must be an integer "
+            "1-65535 or a valid named port"
+        )
+        return errors
+    if isinstance(port, int):
+        if not 1 <= port <= 65535:
+            errors.append(
+                f"services.{svc_name}.healthCheck.{shape}.port must be between 1 and 65535"
+            )
+        return errors
+    if isinstance(port, str):
+        if port.isdigit():
+            number = int(port)
+            if not 1 <= number <= 65535:
+                errors.append(
+                    f"services.{svc_name}.healthCheck.{shape}.port must be between 1 and 65535"
+                )
+            return errors
+        if not _NAMED_PORT_RE.match(port):
+            errors.append(
+                f"services.{svc_name}.healthCheck.{shape}.port must be an integer "
+                "1-65535 or a valid named port"
+            )
+        return errors
+    errors.append(
+        f"services.{svc_name}.healthCheck.{shape}.port must be an integer "
+        "1-65535 or a valid named port"
+    )
     return errors
 
 

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -690,3 +690,179 @@ class TestHealthChecks:
         backend = next(s for s in payload.services if s.name == "backend")
         health_check = backend.model_dump()["healthCheck"]
         assert health_check["httpGet"] == {"path": "/health", "port": 8000}
+
+
+class TestHealthCheckOverride:
+    """ENG-4832: per-service healthCheck override in ``kamiwaza.json``.
+
+    Lets tool/service extensions whose primary doesn't serve ``/sse``
+    (REST-only, MCP-at-/mcp, gRPC, FastMCP feature-flagged off) declare
+    a probe that actually matches what the container exposes, instead
+    of hitting the ``/sse``-on-every-tool default and CrashLoopBackOff.
+    """
+
+    def test_metadata_override_replaces_default_for_tool_primary(
+        self, builder, connection
+    ):
+        """Omniparse-style REST-only tool: probe /v1/healthz, not /sse."""
+        metadata = {
+            "name": "my-tool",
+            "version": "1.0.0",
+            "type": "tool",
+            "services": {
+                "tool": {
+                    "healthCheck": {
+                        "httpGet": {"path": "/v1/healthz", "port": 8000},
+                        "initialDelaySeconds": 10,
+                        "periodSeconds": 10,
+                    },
+                },
+            },
+        }
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        health_check = tool.model_dump()["healthCheck"]
+        assert tool.primary is True
+        assert health_check["httpGet"] == {"path": "/v1/healthz", "port": 8000}
+        assert health_check["initialDelaySeconds"] == 10
+        assert health_check["periodSeconds"] == 10
+
+    def test_metadata_override_wins_over_x_kamiwaza(self, builder, connection):
+        """When both kamiwaza.json and compose declare a probe, metadata wins.
+
+        Locks the precedence: catalog metadata is the single source of truth,
+        compose ``x-kamiwaza`` is the legacy fallback.
+        """
+        metadata = {
+            "name": "my-tool",
+            "version": "1.0.0",
+            "type": "tool",
+            "services": {
+                "tool": {
+                    "healthCheck": {"httpGet": {"path": "/v1/healthz", "port": 8000}},
+                },
+            },
+        }
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                    "x-kamiwaza": {
+                        "healthCheck": {"httpGet": {"path": "/old", "port": 8000}},
+                    },
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        health_check = tool.model_dump()["healthCheck"]
+        assert health_check["httpGet"] == {"path": "/v1/healthz", "port": 8000}
+
+    def test_no_metadata_override_falls_back_to_x_kamiwaza(
+        self, builder, connection
+    ):
+        """Existing ``x-kamiwaza.healthCheck`` path stays intact."""
+        metadata = {"name": "my-tool", "version": "1.0.0", "type": "tool"}
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                    "x-kamiwaza": {
+                        "healthCheck": {"httpGet": {"path": "/compose", "port": 8000}},
+                    },
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        health_check = tool.model_dump()["healthCheck"]
+        assert health_check["httpGet"] == {"path": "/compose", "port": 8000}
+
+    def test_no_overrides_keeps_default_sse_for_tool_primary(
+        self, builder, connection
+    ):
+        """Regression guard: tool extensions with no override still get /sse."""
+        metadata = {"name": "my-tool", "version": "1.0.0", "type": "tool"}
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        health_check = tool.model_dump()["healthCheck"]
+        assert health_check["httpGet"] == {"path": "/sse", "port": 8000}
+
+    def test_metadata_override_per_service_only_affects_named_service(
+        self, builder, connection
+    ):
+        """Override on one service doesn't leak into siblings."""
+        metadata = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "type": "app",
+            "services": {
+                "backend": {
+                    "healthCheck": {"httpGet": {"path": "/v1/ready", "port": 8000}},
+                },
+            },
+        }
+        transformed = {
+            "services": {
+                "frontend": {
+                    "image": "registry.test/my-app-frontend:1.0.0",
+                    "ports": ["3000"],
+                    "environment": ["NEXT_PUBLIC_API_URL=http://backend:8000"],
+                },
+                "backend": {
+                    "image": "registry.test/my-app-backend:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        backend = next(s for s in payload.services if s.name == "backend")
+        frontend = next(s for s in payload.services if s.name == "frontend")
+        assert backend.model_dump()["healthCheck"]["httpGet"] == {
+            "path": "/v1/ready",
+            "port": 8000,
+        }
+        # Frontend keeps the Node-based default probe — untouched by the
+        # backend-only override.
+        assert frontend.model_dump()["healthCheck"]["exec"]["command"][0] == "node"
+
+    def test_metadata_services_not_a_dict_is_ignored(self, builder, connection):
+        """Malformed metadata.services falls back cleanly to defaults."""
+        metadata = {
+            "name": "my-tool",
+            "version": "1.0.0",
+            "type": "tool",
+            "services": "not-a-dict",
+        }
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        assert tool.model_dump()["healthCheck"]["httpGet"] == {
+            "path": "/sse",
+            "port": 8000,
+        }

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -131,6 +131,103 @@ class TestMetadataValidator:
         result = validator.validate(tmp_path / "nonexistent.json")
         assert not result.passed
 
+    # ── services.<name>.healthCheck (ENG-4832) ────────────────────────
+
+    def test_services_healthcheck_httpget_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {"httpGet": {"path": "/v1/healthz", "port": 8000}}
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
+    def test_services_healthcheck_tcpsocket_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"tcpSocket": {"port": 8000}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
+    def test_services_healthcheck_exec_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {
+                    "exec": {"command": ["python3", "-c", "import sys; sys.exit(0)"]}
+                }
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
+    def test_services_not_a_dict_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = "nope"
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("services must be" in e for e in result.errors)
+
+    def test_services_entry_not_a_dict_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": "nope"}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("services.tool" in e for e in result.errors)
+
+    def test_healthcheck_with_no_probe_shape_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"initialDelaySeconds": 10}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("must declare one of" in e for e in result.errors)
+
+    def test_healthcheck_with_multiple_probe_shapes_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {
+                    "httpGet": {"path": "/", "port": 8000},
+                    "tcpSocket": {"port": 8000},
+                }
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("multiple probe shapes" in e for e in result.errors)
+
+    def test_httpget_without_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"httpGet": {"path": "/"}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("httpGet must include 'port'" in e for e in result.errors)
+
+    def test_exec_with_empty_command_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"exec": {"command": []}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("exec.command must be a non-empty list" in e for e in result.errors)
+
 
 # ── ComposeValidator ──────────────────────────────────────────────────────────
 

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -167,6 +167,14 @@ class TestMetadataValidator:
         result = validator.validate(f)
         assert result.passed, result.errors
 
+    def test_services_healthcheck_grpc_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"grpc": {"port": 50051}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
     def test_services_not_a_dict_errors(self, tmp_path, validator):
         data = _valid_metadata()
         data["services"] = "nope"
@@ -184,6 +192,15 @@ class TestMetadataValidator:
         result = validator.validate(f)
         assert not result.passed
         assert any("services.tool" in e for e in result.errors)
+
+    def test_healthcheck_not_a_dict_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": "nope"}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("healthCheck must be a JSON object" in e for e in result.errors)
 
     def test_healthcheck_with_no_probe_shape_errors(self, tmp_path, validator):
         data = _valid_metadata()
@@ -210,6 +227,32 @@ class TestMetadataValidator:
         assert not result.passed
         assert any("multiple probe shapes" in e for e in result.errors)
 
+    def test_healthcheck_with_httpget_and_grpc_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {
+                    "httpGet": {"path": "/", "port": 8000},
+                    "grpc": {"port": 50051},
+                }
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("multiple probe shapes" in e for e in result.errors)
+
+    def test_unknown_probe_shape_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"httpsGet": {"port": 8000}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("must declare one of" in e for e in result.errors)
+        assert any("unknown field 'httpsGet'" in w for w in result.warnings)
+
     def test_httpget_without_port_errors(self, tmp_path, validator):
         data = _valid_metadata()
         data["services"] = {"tool": {"healthCheck": {"httpGet": {"path": "/"}}}}
@@ -219,6 +262,56 @@ class TestMetadataValidator:
         assert not result.passed
         assert any("httpGet must include 'port'" in e for e in result.errors)
 
+    def test_httpget_with_invalid_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {"healthCheck": {"httpGet": {"path": "/", "port": "bad port"}}}
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("httpGet.port must be" in e for e in result.errors)
+
+    def test_httpget_with_out_of_range_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {"healthCheck": {"httpGet": {"path": "/", "port": 70000}}}
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("httpGet.port must be between" in e for e in result.errors)
+
+    def test_httpget_with_named_port_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {"healthCheck": {"httpGet": {"path": "/", "port": "http"}}}
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
+    def test_tcpsocket_without_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"tcpSocket": {"host": "127.0.0.1"}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("tcpSocket must include 'port'" in e for e in result.errors)
+
+    def test_grpc_without_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"grpc": {"service": "health"}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("grpc must include 'port'" in e for e in result.errors)
+
     def test_exec_with_empty_command_errors(self, tmp_path, validator):
         data = _valid_metadata()
         data["services"] = {"tool": {"healthCheck": {"exec": {"command": []}}}}
@@ -227,6 +320,30 @@ class TestMetadataValidator:
         result = validator.validate(f)
         assert not result.passed
         assert any("exec.command must be a non-empty list" in e for e in result.errors)
+
+    def test_exec_without_command_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"exec": {}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("exec.command must be a non-empty list" in e for e in result.errors)
+
+    def test_probe_unknown_field_warns(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {
+                    "httpGet": {"path": "/", "port": 8000, "command_line": "curl"}
+                }
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+        assert any("httpGet has unknown field 'command_line'" in w for w in result.warnings)
 
 
 # ── ComposeValidator ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add kamiwaza.json services.<name>.healthCheck override support during extension payload generation
- Validate per-service healthCheck probe shapes before publish
- Cover metadata precedence, fallback behavior, and validator failures with unit tests

## Why

Tool and service extensions may not expose the default primary health endpoint. This lets extension metadata declare the probe that matches the container instead of relying on the generated default.

## Validation

- uv run pytest tests/unit/extensions/test_payload_builder.py tests/unit/extensions/test_validators.py