### PR TITLE
[codex] Fix compose volume payload generation

### DIFF
--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -61,9 +61,11 @@ def _build_patch_kwargs(
     sandbox = extra.get("sandbox")
     if sandbox:
         kwargs["sandbox"] = sandbox
-    volumes = extra.get("volumes")
-    if volumes:
-        kwargs["volumes"] = volumes
+    # Always forward ``volumes`` (even when empty) so removing a named
+    # volume from compose actually clears the stale top-level volume on
+    # the persisted CR. Same iterative-dev contract that drives the
+    # ``kamiwaza``/annotations forwarding above.
+    kwargs["volumes"] = extra.get("volumes") or []
     return kwargs
 
 
@@ -105,10 +107,14 @@ def _build_patch_service_specs(payload: Any) -> List[Any]:
             "healthCheck",
             "automountServiceAccountToken",
             "containerSecurityContext",
-            "volumeMounts",
         ):
             if field in svc_extra and svc_extra[field] is not None:
                 setattr(spec, field, svc_extra[field])
+        # Always forward ``volumeMounts`` (even when empty) so removing
+        # a volume from compose clears the stale per-service mount on
+        # the persisted CR; consistent with the top-level ``volumes``
+        # forwarding in ``_build_patch_kwargs``.
+        spec.volumeMounts = svc_extra.get("volumeMounts") or []
         patch_services.append(spec)
     return patch_services
 

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -61,6 +61,9 @@ def _build_patch_kwargs(
     sandbox = extra.get("sandbox")
     if sandbox:
         kwargs["sandbox"] = sandbox
+    volumes = extra.get("volumes")
+    if volumes:
+        kwargs["volumes"] = volumes
     return kwargs
 
 
@@ -102,6 +105,7 @@ def _build_patch_service_specs(payload: Any) -> List[Any]:
             "healthCheck",
             "automountServiceAccountToken",
             "containerSecurityContext",
+            "volumeMounts",
         ):
             if field in svc_extra and svc_extra[field] is not None:
                 setattr(spec, field, svc_extra[field])

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -65,6 +65,13 @@ def _build_patch_kwargs(
     # volume from compose actually clears the stale top-level volume on
     # the persisted CR. Same iterative-dev contract that drives the
     # ``kamiwaza``/annotations forwarding above.
+    #
+    # Safe against operator-managed mounts: the kamiwaza-extension-
+    # operator rebuilds each Deployment's volume list every reconcile as
+    # ``[tmp emptyDir] + (data PVC if persistence) + svc.Volumes``. The
+    # ``tmp``/``data`` volumes are injected at reconcile time and are
+    # never stored in ``svc.Volumes``, so PATCHing ``volumes: []`` clears
+    # only user-declared volumes and cannot wipe operator-managed ones.
     kwargs["volumes"] = extra.get("volumes") or []
     return kwargs
 
@@ -113,7 +120,9 @@ def _build_patch_service_specs(payload: Any) -> List[Any]:
         # Always forward ``volumeMounts`` (even when empty) so removing
         # a volume from compose clears the stale per-service mount on
         # the persisted CR; consistent with the top-level ``volumes``
-        # forwarding in ``_build_patch_kwargs``.
+        # forwarding in ``_build_patch_kwargs``. The operator appends
+        # ``svc.VolumeMounts`` after its own ``tmp``/``data`` mounts, so
+        # an empty list clears only user-declared mounts.
         spec.volumeMounts = svc_extra.get("volumeMounts") or []
         patch_services.append(spec)
     return patch_services

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -77,7 +77,14 @@ def _build_volume_specs(
     volumes: List[Dict[str, Any]] = []
     mounts_by_service: Dict[str, List[Dict[str, Any]]] = {}
     source_to_name: Dict[str, str] = {}
-    used_names: set[str] = set()
+    # Pre-reserve the operator-injected volume names. The kamiwaza-
+    # extension-operator rebuilds each Deployment's volume list as
+    # ``[tmp emptyDir] + (data PVC if persistence) + svc.Volumes``; if a
+    # user's compose volume normalizes to ``tmp`` or ``data``, the
+    # reconciled pod would carry duplicate volume names and the K8s API
+    # would reject the spec. Seeding the set forces such a volume to a
+    # collision-suffixed name (``tmp-2``/``data-2``).
+    used_names: set[str] = {"tmp", "data"}
 
     for svc_name, svc in (transformed.get("services") or {}).items():
         if not isinstance(svc, dict):

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -21,6 +21,7 @@ from kamiwaza_sdk.schemas.extensions import (
 
 from kamiwaza_extensions.compose_transformer import detect_service_url_rewrites
 from kamiwaza_extensions.connections import ConnectionInfo
+from kamiwaza_extensions.volume_utils import looks_like_host_path
 
 # CRD annotation keys — namespace is ``kamiwaza.io/*`` (NOT ``kamiwaza.ai/*``).
 # The platform's annotation persister filters incoming Extension CR annotations
@@ -119,7 +120,7 @@ def _parse_named_volume_mount(raw_volume: Any) -> Optional[tuple[str, str, bool]
             return None
         source_str = str(source)
         target_str = str(target)
-        if _looks_like_host_path(source_str) or not target_str.startswith("/"):
+        if looks_like_host_path(source_str) or not target_str.startswith("/"):
             return None
         read_only = bool(raw_volume.get("read_only") or raw_volume.get("readOnly"))
         return source_str, target_str, read_only
@@ -133,7 +134,7 @@ def _parse_named_volume_mount(raw_volume: Any) -> Optional[tuple[str, str, bool]
     source, target = parts[0], parts[1]
     if not source or not target or not target.startswith("/"):
         return None
-    if _looks_like_host_path(source):
+    if looks_like_host_path(source):
         return None
 
     modes = ",".join(parts[2:]).split(",") if len(parts) > 2 else []
@@ -155,14 +156,6 @@ def _unique_k8s_volume_name(source: str, used_names: set[str]) -> str:
         counter += 1
     used_names.add(name)
     return name
-
-
-def _looks_like_host_path(source: str) -> bool:
-    return (
-        source.startswith(("/", "./", "../", "~"))
-        or source in {".", ".."}
-        or bool(re.match(r"^[A-Za-z]:[\\/]", source))
-    )
 
 
 class PayloadBuilder:

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import socket
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -65,6 +66,105 @@ def _compose_resources_to_k8s(resources: Dict[str, str]) -> Dict[str, str]:
     return out
 
 
+_DNS_LABEL_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def _build_volume_specs(
+    transformed: Dict[str, Any],
+) -> tuple[List[Dict[str, Any]], Dict[str, List[Dict[str, Any]]]]:
+    """Translate named compose volumes to K8s emptyDir volumes and mounts."""
+    volumes: List[Dict[str, Any]] = []
+    mounts_by_service: Dict[str, List[Dict[str, Any]]] = {}
+    source_to_name: Dict[str, str] = {}
+    used_names: set[str] = set()
+
+    for svc_name, svc in (transformed.get("services") or {}).items():
+        if not isinstance(svc, dict):
+            continue
+        mounts: List[Dict[str, Any]] = []
+        for raw_volume in svc.get("volumes", []) or []:
+            parsed = _parse_named_volume_mount(raw_volume)
+            if not parsed:
+                continue
+            source, target, read_only = parsed
+            if source not in source_to_name:
+                name = _unique_k8s_volume_name(source, used_names)
+                source_to_name[source] = name
+                volumes.append({"name": name, "emptyDir": {}})
+
+            mount: Dict[str, Any] = {
+                "name": source_to_name[source],
+                "mountPath": target,
+            }
+            if read_only:
+                mount["readOnly"] = True
+            mounts.append(mount)
+        if mounts:
+            mounts_by_service[svc_name] = mounts
+
+    return volumes, mounts_by_service
+
+
+def _parse_named_volume_mount(raw_volume: Any) -> Optional[tuple[str, str, bool]]:
+    """Return ``(source, target, read_only)`` for named compose volumes."""
+    if isinstance(raw_volume, dict):
+        volume_type = raw_volume.get("type", "volume")
+        source = raw_volume.get("source") or raw_volume.get("src")
+        target = (
+            raw_volume.get("target")
+            or raw_volume.get("destination")
+            or raw_volume.get("dst")
+        )
+        if volume_type != "volume" or not source or not target:
+            return None
+        source_str = str(source)
+        target_str = str(target)
+        if _looks_like_host_path(source_str) or not target_str.startswith("/"):
+            return None
+        read_only = bool(raw_volume.get("read_only") or raw_volume.get("readOnly"))
+        return source_str, target_str, read_only
+
+    if not isinstance(raw_volume, str):
+        return None
+
+    parts = raw_volume.split(":")
+    if len(parts) < 2:
+        return None
+    source, target = parts[0], parts[1]
+    if not source or not target or not target.startswith("/"):
+        return None
+    if _looks_like_host_path(source):
+        return None
+
+    modes = ",".join(parts[2:]).split(",") if len(parts) > 2 else []
+    read_only = any(mode.strip().lower() == "ro" for mode in modes)
+    return source, target, read_only
+
+
+def _unique_k8s_volume_name(source: str, used_names: set[str]) -> str:
+    base = _DNS_LABEL_RE.sub("-", source.lower()).strip("-")
+    if not base:
+        base = "volume"
+    base = base[:63].strip("-") or "volume"
+    name = base
+    counter = 2
+    while name in used_names:
+        suffix = f"-{counter}"
+        prefix_len = 63 - len(suffix)
+        name = f"{base[:prefix_len].rstrip('-')}{suffix}"
+        counter += 1
+    used_names.add(name)
+    return name
+
+
+def _looks_like_host_path(source: str) -> bool:
+    return (
+        source.startswith(("/", "./", "../", "~"))
+        or source in {".", ".."}
+        or bool(re.match(r"^[A-Za-z]:[\\/]", source))
+    )
+
+
 class PayloadBuilder:
     """Build a ``CreateExtension`` request from extension metadata and
     a transformed compose dict."""
@@ -92,6 +192,7 @@ class PayloadBuilder:
         # ``tlsRejectUnauthorized`` spec field so the deployed
         # extension's in-cluster callbacks match the developer's intent.
         verify_ssl = connection.effective_verify_ssl()
+        volumes, service_volume_mounts = _build_volume_specs(transformed_compose)
 
         services = self._build_services(
             transformed_compose,
@@ -99,6 +200,7 @@ class PayloadBuilder:
             verify_ssl=verify_ssl,
             extension_type=ext_type,
             metadata=metadata,
+            service_volume_mounts=service_volume_mounts,
         )
         origin = connection.url.removesuffix("/api")
         tls_reject = "0" if not verify_ssl else "1"
@@ -125,6 +227,8 @@ class PayloadBuilder:
         sandbox = self._build_sandbox_spec(metadata, transformed_compose)
         if sandbox:
             kwargs["sandbox"] = sandbox
+        if volumes:
+            kwargs["volumes"] = volumes
 
         annotations = self.build_annotations(deployer=deployer, revision=revision)
 
@@ -204,8 +308,10 @@ class PayloadBuilder:
         verify_ssl: bool = True,
         extension_type: str = "app",
         metadata: Optional[Dict[str, Any]] = None,
+        service_volume_mounts: Optional[Dict[str, List[Dict[str, Any]]]] = None,
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
+        service_volume_mounts = service_volume_mounts or {}
         specs: List[ExtensionServiceSpec] = []
 
         # Determine primary service: prefer "frontend", fall back to first with ports
@@ -292,6 +398,9 @@ class PayloadBuilder:
             )
             if container_security_context is not None:
                 spec_kwargs["containerSecurityContext"] = container_security_context
+            volume_mounts = service_volume_mounts.get(svc_name)
+            if volume_mounts:
+                spec_kwargs["volumeMounts"] = volume_mounts
 
             specs.append(ExtensionServiceSpec(**spec_kwargs))
 

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import re
+from collections import defaultdict
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import yaml
 
 from kamiwaza_extensions.validators.result import ValidationResult
+from kamiwaza_extensions.volume_utils import looks_like_host_path
 
 MISSING_RESOURCE_LIMITS_TEXT = "no resource limits defined"
 
@@ -41,6 +42,13 @@ class ComposeValidator:
             warnings.append("No services defined in compose file")
             return ValidationResult(passed=True, warnings=warnings)
 
+        # ENG-4834: named volumes back to ``emptyDir`` at deploy. emptyDir
+        # is Pod-scoped, so a single named volume referenced by >1 service
+        # does NOT share data at runtime — each pod gets its own scratch
+        # dir. Track usage across services and warn after the per-service
+        # pass below so the user knows the contract before deploy.
+        named_volume_users: Dict[str, List[str]] = defaultdict(list)
+
         for svc_name, svc_config in services.items():
             if not isinstance(svc_config, dict):
                 continue
@@ -52,15 +60,44 @@ class ComposeValidator:
                 if ":" in port_str:
                     warnings.append(f"Service '{svc_name}': host port binding '{port_str}' — may conflict in deployment")
 
-            # Bind mounts
-            volumes = svc_config.get("volumes", [])
-            for vol in volumes:
-                if _is_bind_mount(vol):
+            # Bind mounts and tmpfs. Bind mounts in a service with a
+            # ``build:`` context are a normal local-dev hot-reload pattern
+            # (the file lives in the build context and the running image
+            # already has it baked in); ``ComposeTransformer`` strips
+            # these at deploy time. For services without ``build:`` —
+            # prebuilt images — a bind mount has no transform path and
+            # the deployed pod would silently miss the files, which is
+            # the failure mode this validator exists to prevent.
+            has_build = "build" in svc_config
+            for vol in svc_config.get("volumes") or []:
+                if _is_tmpfs_mount(vol):
                     errors.append(
-                        f"Service '{svc_name}': bind mount '{_format_volume(vol)}' "
-                        "is not supported in deployment; use a named volume "
-                        "like 'data:/path' or write to /tmp"
+                        f"Service '{svc_name}': tmpfs mount '{_format_volume(vol)}' "
+                        "is not supported in deployment; write to /tmp directly "
+                        "or use a named volume like 'data:/path'"
                     )
+                    continue
+                if _is_bind_mount(vol):
+                    formatted = _format_volume(vol)
+                    if has_build:
+                        warnings.append(
+                            f"Service '{svc_name}': bind mount '{formatted}' "
+                            "will be stripped at deploy (local-dev only). "
+                            "Use a named volume for persistence, or 'develop.watch' "
+                            "for hot-reload."
+                        )
+                    else:
+                        errors.append(
+                            f"Service '{svc_name}': bind mount '{formatted}' "
+                            "is not supported in deployment; use a named volume "
+                            "like 'data:/path' or write to /tmp. Note: named "
+                            "volumes deploy as emptyDir, so data is lost on pod "
+                            "restart and not shared across services."
+                        )
+                    continue
+                source = _named_volume_source(vol)
+                if source is not None:
+                    named_volume_users[source].append(svc_name)
 
             # Missing resource limits
             deploy = svc_config.get("deploy", {})
@@ -89,6 +126,15 @@ class ComposeValidator:
                     if not dockerfile_path.exists():
                         errors.append(f"Service '{svc_name}': Dockerfile not found at {build}/Dockerfile")
 
+        for source, users in named_volume_users.items():
+            if len(users) > 1:
+                joined = ", ".join(sorted(set(users)))
+                warnings.append(
+                    f"Named volume '{source}' referenced by multiple services "
+                    f"({joined}) — emptyDir is pod-scoped, so each service "
+                    "gets its own copy and data is not shared at runtime."
+                )
+
         # Custom networks
         networks = data.get("networks", {})
         if networks:
@@ -103,29 +149,48 @@ def _is_bind_mount(volume: object) -> bool:
         source = volume.get("source") or volume.get("src")
         if volume_type == "bind":
             return True
-        return bool(source and _looks_like_host_path(str(source)))
+        if volume_type in {"tmpfs", "volume"}:
+            return False
+        return bool(source and looks_like_host_path(str(source)))
 
     if not isinstance(volume, str):
         return False
 
-    if re.match(r"^[A-Za-z]:[\\/]", volume):
-        return True
-    if volume.startswith(("./", "../", "/", "~")):
+    if looks_like_host_path(volume):
         return True
     if ":./" in volume or ":../" in volume:
         return True
     if ":" not in volume:
         return False
     source, _, _ = volume.partition(":")
-    return _looks_like_host_path(source)
+    return looks_like_host_path(source)
 
 
-def _looks_like_host_path(source: str) -> bool:
-    return (
-        source.startswith(("/", "./", "../", "~"))
-        or source in {".", ".."}
-        or bool(re.match(r"^[A-Za-z]:[\\/]", source))
-    )
+def _is_tmpfs_mount(volume: object) -> bool:
+    if isinstance(volume, dict):
+        return volume.get("type") == "tmpfs"
+    return False
+
+
+def _named_volume_source(volume: object) -> str | None:
+    """Return the source name for a true named compose volume, else None."""
+    if isinstance(volume, dict):
+        if volume.get("type") not in (None, "volume"):
+            return None
+        source = volume.get("source") or volume.get("src")
+        if not source:
+            return None
+        source_str = str(source)
+        if looks_like_host_path(source_str):
+            return None
+        return source_str
+
+    if not isinstance(volume, str) or ":" not in volume:
+        return None
+    source, _, _ = volume.partition(":")
+    if not source or looks_like_host_path(source):
+        return None
+    return source
 
 
 def _format_volume(volume: object) -> str:

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -99,6 +99,21 @@ class ComposeValidator:
                 if source is not None:
                     named_volume_users[source].append(svc_name)
 
+            # Service-level ``tmpfs:`` key — a distinct compose field from
+            # ``volumes:``. ``ComposeTransformer`` only strips long-form
+            # tmpfs entries that appear inside ``volumes:``, so a service
+            # declaring the more common top-level ``tmpfs: [...]`` slips
+            # past the transformer and silently loses the mount at deploy.
+            tmpfs = svc_config.get("tmpfs")
+            if tmpfs:
+                entries = tmpfs if isinstance(tmpfs, list) else [tmpfs]
+                for entry in entries:
+                    errors.append(
+                        f"Service '{svc_name}': tmpfs mount '{entry}' is not "
+                        "supported in deployment; write to /tmp directly or "
+                        "use a named volume like 'data:/path'"
+                    )
+
             # Missing resource limits
             deploy = svc_config.get("deploy", {})
             if isinstance(deploy, dict):

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -55,9 +55,12 @@ class ComposeValidator:
             # Bind mounts
             volumes = svc_config.get("volumes", [])
             for vol in volumes:
-                vol_str = str(vol)
-                if isinstance(vol, str) and (":./" in vol_str or vol_str.startswith("./") or vol_str.startswith("../") or re.match(r"^/[^$]", vol_str)):
-                    warnings.append(f"Service '{svc_name}': bind mount '{vol_str}' — not available in deployment")
+                if _is_bind_mount(vol):
+                    errors.append(
+                        f"Service '{svc_name}': bind mount '{_format_volume(vol)}' "
+                        "is not supported in deployment; use a named volume "
+                        "like 'data:/path' or write to /tmp"
+                    )
 
             # Missing resource limits
             deploy = svc_config.get("deploy", {})
@@ -92,3 +95,45 @@ class ComposeValidator:
             warnings.append("Custom networks defined — platform manages networking")
 
         return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings)
+
+
+def _is_bind_mount(volume: object) -> bool:
+    if isinstance(volume, dict):
+        volume_type = volume.get("type")
+        source = volume.get("source") or volume.get("src")
+        if volume_type == "bind":
+            return True
+        return bool(source and _looks_like_host_path(str(source)))
+
+    if not isinstance(volume, str):
+        return False
+
+    if re.match(r"^[A-Za-z]:[\\/]", volume):
+        return True
+    if volume.startswith(("./", "../", "/", "~")):
+        return True
+    if ":./" in volume or ":../" in volume:
+        return True
+    if ":" not in volume:
+        return False
+    source, _, _ = volume.partition(":")
+    return _looks_like_host_path(source)
+
+
+def _looks_like_host_path(source: str) -> bool:
+    return (
+        source.startswith(("/", "./", "../", "~"))
+        or source in {".", ".."}
+        or bool(re.match(r"^[A-Za-z]:[\\/]", source))
+    )
+
+
+def _format_volume(volume: object) -> str:
+    if isinstance(volume, dict):
+        source = volume.get("source") or volume.get("src") or ""
+        target = (
+            volume.get("target") or volume.get("destination") or volume.get("dst") or ""
+        )
+        if source or target:
+            return f"{source}:{target}".rstrip(":")
+    return str(volume)

--- a/kamiwaza_extensions/volume_utils.py
+++ b/kamiwaza_extensions/volume_utils.py
@@ -1,0 +1,22 @@
+"""Shared classifiers for compose volume entries.
+
+Both ``payload_builder`` and ``validators.compose`` need to recognise host
+paths so they can either translate or reject them. Keeping the rules in
+one module avoids the validator and payload builder drifting on what
+counts as a bind mount.
+"""
+
+from __future__ import annotations
+
+import re
+
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def looks_like_host_path(source: str) -> bool:
+    """Return True if *source* names a host-side path (not a named volume)."""
+    return (
+        source.startswith(("/", "./", "../", "~"))
+        or source in {".", ".."}
+        or bool(_WINDOWS_DRIVE_RE.match(source))
+    )

--- a/kamiwaza_extensions/volume_utils.py
+++ b/kamiwaza_extensions/volume_utils.py
@@ -14,9 +14,19 @@ _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
 
 
 def looks_like_host_path(source: str) -> bool:
-    """Return True if *source* names a host-side path (not a named volume)."""
+    """Return True if *source* names a host-side path (not a named volume).
+
+    A ``$`` anywhere in the source means shell/compose variable
+    interpolation (``${PWD}/src``, ``$HOME/.cache``). Such a source
+    resolves to a host path at runtime and can never be a valid named
+    volume — compose volume names are restricted to ``[A-Za-z0-9._-]``.
+    Treating it as a host path makes the validator reject it instead of
+    the payload builder silently turning ``${PWD}/src`` into an
+    ``emptyDir`` over the image's baked application files.
+    """
     return (
         source.startswith(("/", "./", "../", "~"))
         or source in {".", ".."}
+        or "$" in source
         or bool(_WINDOWS_DRIVE_RE.match(source))
     )

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -757,6 +757,35 @@ class TestBuildPatchKwargsCarriesAnnotations:
         assert (specs[0].model_extra or {})["volumeMounts"] == volume_mounts
         assert specs[0].model_dump()["volumeMounts"] == volume_mounts
 
+    def test_volumes_cleared_when_payload_has_none(self):
+        """ENG-4834 follow-up: removing a named volume from compose
+        must clear the stale top-level volume on the persisted CR.
+        Omitting the field on PATCH leaves the operator with no signal
+        to clear, so always send an explicit (possibly empty) list."""
+        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
+
+        kwargs = _build_patch_kwargs(
+            patch_services=["svc"],
+            payload=self._payload_with_annotations(None),
+        )
+        assert kwargs["volumes"] == []
+
+    def test_volume_mounts_cleared_when_svc_has_none(self):
+        """ENG-4834 follow-up: per-service mounts must also clear on
+        PATCH when removed from compose. Mirrors the top-level clear
+        behavior in ``_build_patch_kwargs``."""
+        from kamiwaza_sdk.schemas.extensions import ExtensionServiceSpec
+
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        class _FakePayload:
+            services = [
+                ExtensionServiceSpec(name="tool", image="reg/tool:dev"),
+            ]
+
+        specs = _build_patch_service_specs(_FakePayload())
+        assert (specs[0].model_extra or {}).get("volumeMounts") == []
+
     def test_patchextension_accepts_sandbox_via_extra_allow(self):
         """Sanity: PatchExtension must accept the sandbox kwarg via
         ``extra="allow"``."""

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
@@ -633,6 +632,41 @@ class TestBuildPatchKwargsCarriesAnnotations:
         )
         assert "sandbox" not in kwargs
 
+    def test_carries_volumes_so_patch_refreshes_mount_contract(self):
+        """ENG-4834: existing dev CRs are updated by PATCH after first
+        create, so top-level volume declarations must ride PATCH too."""
+        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
+
+        volumes = [{"name": "omniparse-data", "emptyDir": {}}]
+
+        class _FakePayload:
+            model_extra = {"volumes": volumes}
+            kamiwaza = None
+
+        kwargs = _build_patch_kwargs(patch_services=["svc"], payload=_FakePayload())
+        assert kwargs["volumes"] == volumes
+
+    def test_patchextension_accepts_volumes_via_extra_allow(self):
+        """Sanity: PatchExtension must accept top-level volumes via
+        ``extra="allow"``."""
+        from kamiwaza_sdk.schemas.extensions import PatchExtension, PatchServiceSpec
+
+        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
+
+        volumes = [{"name": "data", "emptyDir": {}}]
+
+        class _FakePayload:
+            model_extra = {"volumes": volumes}
+            kamiwaza = None
+
+        kwargs = _build_patch_kwargs(
+            patch_services=[PatchServiceSpec(name="x")],
+            payload=_FakePayload(),
+        )
+        patch = PatchExtension(**kwargs)
+        assert (patch.model_extra or {}).get("volumes") == volumes
+        assert patch.model_dump()["volumes"] == volumes
+
     def test_patch_service_specs_forwards_x_kamiwaza_overrides(self):
         """jxstanford PR #97 review H2: per-service overrides
         (healthCheck, automountServiceAccountToken,
@@ -701,6 +735,27 @@ class TestBuildPatchKwargsCarriesAnnotations:
 
         specs = _build_patch_service_specs(_FakePayload())
         assert (specs[0].model_extra or {})["automountServiceAccountToken"] is False
+
+    def test_patch_service_specs_forwards_volume_mounts(self):
+        """ENG-4834: service-level mounts must also refresh on PATCH."""
+        from kamiwaza_sdk.schemas.extensions import ExtensionServiceSpec
+
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        volume_mounts = [{"name": "data", "mountPath": "/data"}]
+
+        class _FakePayload:
+            services = [
+                ExtensionServiceSpec(
+                    name="tool",
+                    image="reg/tool:dev",
+                    volumeMounts=volume_mounts,
+                ),
+            ]
+
+        specs = _build_patch_service_specs(_FakePayload())
+        assert (specs[0].model_extra or {})["volumeMounts"] == volume_mounts
+        assert specs[0].model_dump()["volumeMounts"] == volume_mounts
 
     def test_patchextension_accepts_sandbox_via_extra_allow(self):
         """Sanity: PatchExtension must accept the sandbox kwarg via

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -423,6 +423,60 @@ class TestComposeVolumes:
             "volumeMounts" not in (svc.model_extra or {}) for svc in payload.services
         )
 
+    def test_interpolated_host_path_is_not_emitted_as_empty_dir(
+        self, builder, metadata, connection
+    ):
+        """PR-113 review High #1: a shell-interpolated bind source
+        (``${PWD}/src``) must NOT be normalized into a named volume and
+        emitted as an emptyDir over the image's baked files. It is a
+        host path and the validator rejects it; the payload builder must
+        agree and drop it."""
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/tool:dev",
+                    "ports": ["8000"],
+                    "volumes": [
+                        "${PWD}/src:/app/src",
+                        "$HOME/.cache:/cache",
+                    ],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "tool-dev-abc")
+        tool = payload.services[0].model_dump()
+
+        assert "volumes" not in (payload.model_extra or {})
+        assert "volumeMounts" not in tool
+
+    def test_user_volume_named_tmp_avoids_operator_collision(
+        self, builder, metadata, connection
+    ):
+        """PR-113 review High #2: the operator injects volumes named
+        ``tmp`` and ``data``. A user compose volume that normalizes to
+        either must be renamed so the reconciled Deployment has no
+        duplicate volume names (K8s rejects duplicates)."""
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/tool:dev",
+                    "ports": ["8000"],
+                    "volumes": ["tmp:/scratch", "data:/store"],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "tool-dev-abc")
+        tool = payload.services[0].model_dump()
+
+        emitted = {v["name"] for v in (payload.model_extra or {})["volumes"]}
+        assert emitted.isdisjoint({"tmp", "data"})
+        mount_names = {m["name"] for m in tool["volumeMounts"]}
+        # Mounts must reference the renamed volumes, not the reserved ones.
+        assert mount_names == emitted
+        assert mount_names.isdisjoint({"tmp", "data"})
+
 
 class TestEnvParsing:
     def test_list_format(self, builder):

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -319,6 +319,111 @@ class TestServiceRefRewritesAnnotation:
         assert ANNOTATION_SERVICE_REF_REWRITES not in annotations
 
 
+class TestComposeVolumes:
+    """ENG-4834: named compose volumes must reach the kext payload."""
+
+    def test_named_volume_becomes_empty_dir_and_volume_mount(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/tool:dev",
+                    "ports": ["8000"],
+                    "volumes": ["omniparse-data:/data"],
+                },
+            },
+            "volumes": {"omniparse-data": None},
+        }
+
+        payload = builder.build(metadata, transformed, connection, "tool-dev-abc")
+        tool = payload.services[0].model_dump()
+
+        assert (payload.model_extra or {})["volumes"] == [
+            {"name": "omniparse-data", "emptyDir": {}}
+        ]
+        assert payload.model_dump()["volumes"] == [
+            {"name": "omniparse-data", "emptyDir": {}}
+        ]
+        assert tool["volumeMounts"] == [
+            {"name": "omniparse-data", "mountPath": "/data"}
+        ]
+
+    def test_shared_named_volume_is_declared_once(self, builder, metadata, connection):
+        transformed = {
+            "services": {
+                "api": {
+                    "image": "registry.test/api:dev",
+                    "ports": ["8000"],
+                    "volumes": ["shared-data:/cache"],
+                },
+                "worker": {
+                    "image": "registry.test/worker:dev",
+                    "volumes": ["shared-data:/cache"],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "app-dev-abc")
+        services = {svc.name: svc.model_dump() for svc in payload.services}
+
+        assert (payload.model_extra or {})["volumes"] == [
+            {"name": "shared-data", "emptyDir": {}}
+        ]
+        assert services["api"]["volumeMounts"] == [
+            {"name": "shared-data", "mountPath": "/cache"}
+        ]
+        assert services["worker"]["volumeMounts"] == [
+            {"name": "shared-data", "mountPath": "/cache"}
+        ]
+
+    def test_long_form_volume_is_supported_and_read_only(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "backend": {
+                    "image": "registry.test/backend:dev",
+                    "ports": ["8000"],
+                    "volumes": [
+                        {
+                            "type": "volume",
+                            "source": "backend_data",
+                            "target": "/app/persist",
+                            "read_only": True,
+                        }
+                    ],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "app-dev-abc")
+        backend = payload.services[0].model_dump()
+
+        assert (payload.model_extra or {})["volumes"] == [
+            {"name": "backend-data", "emptyDir": {}}
+        ]
+        assert backend["volumeMounts"] == [
+            {
+                "name": "backend-data",
+                "mountPath": "/app/persist",
+                "readOnly": True,
+            }
+        ]
+
+    def test_no_volumes_keeps_payload_unchanged(
+        self, builder, metadata, transformed_compose, connection
+    ):
+        payload = builder.build(
+            metadata, transformed_compose, connection, "app-dev-abc"
+        )
+
+        assert "volumes" not in (payload.model_extra or {})
+        assert all(
+            "volumeMounts" not in (svc.model_extra or {}) for svc in payload.services
+        )
+
+
 class TestEnvParsing:
     def test_list_format(self, builder):
         result = builder._parse_env(["KEY=value", "BARE_KEY"])

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -91,6 +91,33 @@ class TestRunValidate:
         assert output["errors"] == []
         assert output["warnings"]
 
+    def test_validate_fails_on_bind_mount(self, tmp_path, capsys):
+        import typer
+
+        from kamiwaza_extensions.commands.validate import run_validate
+
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginxinc/nginx-unprivileged:stable-alpine",
+                    "ports": ["8080:8080"],
+                    "volumes": ["./data:/app/data"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "1.0", "memory": "1G"}}
+                    },
+                },
+            },
+        }
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(_valid_metadata()))
+        (tmp_path / "docker-compose.yml").write_text(yaml.dump(compose))
+
+        with pytest.raises(typer.Exit):
+            run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["passed"] is False
+        assert any("bind mount './data:/app/data'" in err for err in output["errors"])
+
     def test_validate_fails_on_image_only_rootful_nginx_runtime(self, tmp_path, capsys):
         import typer
 

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -578,6 +578,27 @@ class TestComposeValidator:
         assert not result.passed
         assert any("tmpfs mount" in e for e in result.errors)
 
+    def test_interpolated_bind_source_is_rejected(self, tmp_path, validator):
+        """PR-113 review High #1: a shell-interpolated bind source
+        (``${PWD}/src``, ``$HOME/.cache``) resolves to a host path at
+        runtime and can never be a named volume. The validator must
+        reject it on a prebuilt-image service rather than letting the
+        payload builder turn it into an emptyDir."""
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "volumes": ["${PWD}/src:/app/src", "$HOME/.cache:/cache"],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        bind_errors = [e for e in result.errors if "bind mount" in e]
+        assert len(bind_errors) == 2
+
     def test_service_level_tmpfs_key_is_rejected(self, tmp_path, validator):
         """Compose's top-level ``tmpfs:`` service key is distinct from
         ``volumes:``. ``ComposeTransformer`` only strips long-form tmpfs

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -578,6 +578,39 @@ class TestComposeValidator:
         assert not result.passed
         assert any("tmpfs mount" in e for e in result.errors)
 
+    def test_service_level_tmpfs_key_is_rejected(self, tmp_path, validator):
+        """Compose's top-level ``tmpfs:`` service key is distinct from
+        ``volumes:``. ``ComposeTransformer`` only strips long-form tmpfs
+        entries inside ``volumes:``, so a service-level ``tmpfs:`` slips
+        through and silently loses the mount at deploy — reject it."""
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "tmpfs": ["/run/cache", "/var/cache:size=64m"],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        tmpfs_errors = [e for e in result.errors if "tmpfs mount" in e]
+        assert len(tmpfs_errors) == 2
+
+    def test_service_level_tmpfs_string_form_is_rejected(self, tmp_path, validator):
+        """The ``tmpfs:`` key also accepts a bare string."""
+        compose = {
+            "services": {
+                "web": {"image": "nginx", "tmpfs": "/run/cache"},
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        assert any("tmpfs mount '/run/cache'" in e for e in result.errors)
+
     def test_null_volumes_key_does_not_crash(self, tmp_path, validator):
         """A YAML ``volumes:`` key with no value parses to ``None``;
         the per-service loop must not crash trying to iterate it."""

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -388,7 +388,7 @@ class TestComposeValidator:
         assert result.passed  # warning, not error
         assert any("port" in w.lower() for w in result.warnings)
 
-    def test_bind_mount_warning(self, tmp_path, validator):
+    def test_bind_mount_error(self, tmp_path, validator):
         compose = {
             "services": {
                 "web": {"image": "nginx", "volumes": ["./src:/app"]},
@@ -397,8 +397,42 @@ class TestComposeValidator:
         f = tmp_path / "docker-compose.yml"
         self._write_compose(f, compose)
         result = validator.validate(f, tmp_path)
+        assert not result.passed
+        assert any("bind mount './src:/app'" in e for e in result.errors)
+
+    def test_long_form_bind_mount_error(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "volumes": [{"type": "bind", "source": "./src", "target": "/app"}],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        assert any("bind mount './src:/app'" in e for e in result.errors)
+
+    def test_named_volume_passes_compose_validation(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "volumes": ["data:/app/data"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "0.5", "memory": "512M"}}
+                    },
+                },
+            },
+            "volumes": {"data": None},
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
         assert result.passed
-        assert any("bind mount" in w.lower() for w in result.warnings)
+        assert not any("bind mount" in e.lower() for e in result.errors)
 
     def test_missing_resource_limits_warning(self, tmp_path, validator):
         compose = {

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -481,6 +481,117 @@ class TestComposeValidator:
         assert result.passed
         assert any("network" in w.lower() for w in result.warnings)
 
+    def test_scaffold_templates_pass_validation(self, validator):
+        """ENG-4834 regression: ``kz-ext create`` ships templates that
+        carry bind mounts on ``build:`` services for local-dev hot
+        reload. Promoting bind mounts to a hard error breaks every fresh
+        scaffold's ``kz-ext validate`` and ``kz-ext publish``. Lock in
+        that the shipped templates validate cleanly."""
+        from pathlib import Path
+
+        import kamiwaza_extensions
+
+        templates_root = Path(kamiwaza_extensions.__file__).parent / "templates"
+        for kind in ("app", "tool"):
+            ext_dir = templates_root / kind
+            compose = ext_dir / "docker-compose.yml"
+            if not compose.exists():
+                continue
+            result = validator.validate(compose, ext_dir)
+            # Templates may legitimately surface warnings (no resource
+            # limits, bind-mounts-as-local-dev). They must NOT produce
+            # validation errors that block create→validate→publish.
+            assert result.passed, (
+                f"{kind} template failed validation: {result.errors}"
+            )
+
+    def test_bind_mount_in_build_service_warns_not_errors(self, tmp_path, validator):
+        """ENG-4834: scaffolded extensions (``kz-ext create``) ship a
+        ``build:`` service with bind mounts for hot-reload. ``ComposeTransformer``
+        strips them at deploy, so the validator must NOT error on this
+        local-dev pattern — otherwise every fresh scaffold fails
+        ``kz-ext validate`` / ``kz-ext publish``."""
+        (tmp_path / "Dockerfile").write_text("FROM python:3.10")
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "volumes": ["./src:/app/src"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "0.5", "memory": "512M"}}
+                    },
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert result.passed, result.errors
+        assert any("stripped at deploy" in w for w in result.warnings)
+
+    def test_shared_named_volume_warns_about_emptydir(self, tmp_path, validator):
+        """ENG-4834: named volumes deploy as pod-scoped ``emptyDir``, so
+        two services referencing the same name do NOT share data at
+        runtime. Surface this before the user is surprised post-deploy."""
+        compose = {
+            "services": {
+                "api": {
+                    "image": "nginx",
+                    "volumes": ["shared:/app/data"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "0.5", "memory": "512M"}}
+                    },
+                },
+                "worker": {
+                    "image": "nginx",
+                    "volumes": ["shared:/app/data"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "0.5", "memory": "512M"}}
+                    },
+                },
+            },
+            "volumes": {"shared": None},
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert result.passed
+        assert any(
+            "emptyDir is pod-scoped" in w and "shared" in w for w in result.warnings
+        )
+
+    def test_tmpfs_long_form_is_rejected(self, tmp_path, validator):
+        """``ComposeTransformer._strip_bind_mounts`` silently drops tmpfs
+        mounts — same failure mode as the pre-ENG-4834 named-volume drop.
+        Surface explicitly so the user can fix the compose."""
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "volumes": [{"type": "tmpfs", "target": "/run/cache"}],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        assert any("tmpfs mount" in e for e in result.errors)
+
+    def test_null_volumes_key_does_not_crash(self, tmp_path, validator):
+        """A YAML ``volumes:`` key with no value parses to ``None``;
+        the per-service loop must not crash trying to iterate it."""
+        compose = {
+            "services": {
+                "web": {"image": "nginx", "volumes": None},
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        # Should not raise; service has no volumes -> no bind-mount findings
+        assert not any("bind mount" in e for e in result.errors)
+
     def test_invalid_yaml(self, tmp_path, validator):
         f = tmp_path / "docker-compose.yml"
         f.write_text(": invalid: yaml: {{{}}")


### PR DESCRIPTION
## Summary

Fix ENG-4834 by preserving named Docker Compose volumes in the generated KamiwazaExtension payload.

## What changed

- Translate named compose volumes into top-level `emptyDir` volumes and per-service `volumeMounts`.
- Preserve volume mounts during `kz-ext dev` PATCH redeploys so existing dev CRs refresh correctly.
- Reject bind mounts during compose validation with a clear error instead of allowing them to be silently stripped.
- Add unit coverage for payload generation, patch serialization, validator behavior, and `kz-ext validate` output.

## Root cause

`payload_builder.py` was reading image, ports, env, resources, and health checks from transformed compose services, but ignored `volumes`. The compose transformer preserved named volumes, but the deploy payload dropped them, leaving only the implicit writable `/tmp` mount in pods with read-only root filesystems.

## Validation

- `uv run pytest tests/unit/extensions/test_payload_builder.py tests/unit/extensions/test_dev_state.py tests/unit/extensions/test_dev_patch.py tests/unit/extensions/test_validators.py tests/unit/extensions/test_validate_cmd.py tests/unit/test_extension_service.py`
- `uv run ruff check kamiwaza_extensions/payload_builder.py kamiwaza_extensions/commands/dev.py kamiwaza_extensions/validators/compose.py tests/unit/extensions/test_payload_builder.py tests/unit/extensions/test_dev_state.py tests/unit/extensions/test_validators.py tests/unit/extensions/test_validate_cmd.py`