### PR TITLE
ENG-4956: Reduce scaffold validation warnings

### DIFF
--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -385,7 +385,14 @@ def run_publish(
     meta_result = meta_validator.validate(info.path / "kamiwaza.json")
 
     compose_validator = ComposeValidator()
-    compose_result = compose_validator.validate(publish_compose_path, info.path)
+    # An authored appgarden compose is published via `_retag_appgarden_compose`,
+    # which bypasses `ComposeTransformer` — so bind mounts and missing resource
+    # limits are NOT stripped/backfilled and must surface as warnings, not info.
+    compose_result = compose_validator.validate(
+        publish_compose_path,
+        info.path,
+        transformer_handled=appgarden_data is None,
+    )
 
     all_errors = meta_result.errors[:]
     all_warnings = meta_result.warnings[:]

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -407,8 +407,8 @@ def run_publish(
             console.print(f"    [yellow]![/yellow] {warn}")
     else:
         console.print("          [green]\u2713[/green] passed")
-    for info in all_info:
-        console.print(f"    [cyan]i[/cyan] {info}")
+    for info_msg in all_info:
+        console.print(f"    [cyan]i[/cyan] {info_msg}")
 
     # 3. Resolve publish profile
     profile_mgr = ProfileManager()

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -389,9 +389,11 @@ def run_publish(
 
     all_errors = meta_result.errors[:]
     all_warnings = meta_result.warnings[:]
+    all_info = meta_result.info[:]
     if compose_result:
         all_errors.extend(compose_result.errors)
         all_warnings.extend(compose_result.warnings)
+        all_info.extend(compose_result.info)
 
     if all_errors:
         console.print("          [red]\u2717 failed[/red]")
@@ -405,6 +407,8 @@ def run_publish(
             console.print(f"    [yellow]![/yellow] {warn}")
     else:
         console.print("          [green]\u2713[/green] passed")
+    for info in all_info:
+        console.print(f"    [cyan]i[/cyan] {info}")
 
     # 3. Resolve publish profile
     profile_mgr = ProfileManager()

--- a/kamiwaza_extensions/commands/validate.py
+++ b/kamiwaza_extensions/commands/validate.py
@@ -35,7 +35,16 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
         ext_dir = ExtensionDetector().find_root(start_dir)
     except (ExtensionNotFoundError, MultipleExtensionsError) as exc:
         if json_output:
-            typer.echo(json_mod.dumps({"passed": False, "errors": [str(exc)], "warnings": []}))
+            typer.echo(
+                json_mod.dumps(
+                    {
+                        "passed": False,
+                        "errors": [str(exc)],
+                        "warnings": [],
+                        "info": [],
+                    }
+                )
+            )
         else:
             console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(code=1) from exc
@@ -72,12 +81,15 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
     # Merge results
     all_errors = meta_result.errors[:]
     all_warnings = meta_result.warnings[:]
+    all_info = meta_result.info[:]
     if compose_result:
         all_errors.extend(compose_result.errors)
         all_warnings.extend(compose_result.warnings)
+        all_info.extend(compose_result.info)
     if runtime_result:
         all_errors.extend(runtime_result.errors)
         all_warnings.extend(runtime_result.warnings)
+        all_info.extend(runtime_result.info)
 
     passed = len(all_errors) == 0
 
@@ -86,6 +98,7 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
             "passed": passed,
             "errors": all_errors,
             "warnings": all_warnings,
+            "info": all_info,
         }
         typer.echo(json_mod.dumps(output, indent=2))
     else:
@@ -95,6 +108,9 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
         if all_warnings:
             for warn in all_warnings:
                 console.print(f"  [yellow]![/yellow] {warn}")
+        if all_info:
+            for info in all_info:
+                console.print(f"  [cyan]i[/cyan] {info}")
         if passed:
             console.print("[green]✓ Validation passed[/green]", highlight=False)
             if all_warnings:

--- a/kamiwaza_extensions/commands/validate.py
+++ b/kamiwaza_extensions/commands/validate.py
@@ -109,8 +109,8 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
             for warn in all_warnings:
                 console.print(f"  [yellow]![/yellow] {warn}")
         if all_info:
-            for info in all_info:
-                console.print(f"  [cyan]i[/cyan] {info}")
+            for info_msg in all_info:
+                console.print(f"  [cyan]i[/cyan] {info_msg}")
         if passed:
             console.print("[green]✓ Validation passed[/green]", highlight=False)
             if all_warnings:

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple
 # Reuse the validator's bind-mount detection so the "stripped at deploy"
 # info message ComposeValidator emits stays in sync with what the
 # transformer actually strips (ENG-4956).
-from kamiwaza_extensions.validators.compose import _is_bind_mount
+from kamiwaza_extensions.validators.compose import is_bind_mount
 
 
 def _replace_image_tag(image_ref: str, new_tag: str) -> str:
@@ -549,7 +549,7 @@ def _strip_bind_mounts(volumes: List[Any]) -> List[str]:
     """Keep named volumes, remove bind mounts.
 
     String bind-mount detection is delegated to the validator's
-    ``_is_bind_mount`` so every host-path form ``ComposeValidator``
+    ``is_bind_mount`` so every host-path form ``ComposeValidator``
     flags as "stripped at deploy" (absolute/relative paths, ``~``, and
     Windows drive letters) is actually stripped here. See ENG-4956.
     """
@@ -561,7 +561,7 @@ def _strip_bind_mounts(volumes: List[Any]) -> List[str]:
                 kept.append(vol)
             continue
         s = str(vol)
-        if _is_bind_mount(s):
+        if is_bind_mount(s):
             continue
         kept.append(s)
     return kept

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -6,6 +6,11 @@ import copy
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+# Reuse the validator's bind-mount detection so the "stripped at deploy"
+# info message ComposeValidator emits stays in sync with what the
+# transformer actually strips (ENG-4956).
+from kamiwaza_extensions.validators.compose import _is_bind_mount
+
 
 def _replace_image_tag(image_ref: str, new_tag: str) -> str:
     """Return *image_ref* with its tag (and any digest) replaced by *new_tag*.
@@ -541,22 +546,23 @@ def _strip_host_ports(ports: List[Any]) -> List[str]:
 
 
 def _strip_bind_mounts(volumes: List[Any]) -> List[str]:
-    """Keep named volumes, remove bind mounts (``./``, ``../``, absolute paths)."""
-    kept = []
+    """Keep named volumes, remove bind mounts.
+
+    String bind-mount detection is delegated to the validator's
+    ``_is_bind_mount`` so every host-path form ``ComposeValidator``
+    flags as "stripped at deploy" (absolute/relative paths, ``~``, and
+    Windows drive letters) is actually stripped here. See ENG-4956.
+    """
+    kept: List[Any] = []
     for vol in volumes:
         if isinstance(vol, dict):
-            # Long-form volume — check type
+            # Long-form volume — keep named volumes; bind/tmpfs are stripped.
             if vol.get("type") == "volume":
                 kept.append(vol)
-            # bind / tmpfs types are stripped
             continue
         s = str(vol)
-        if s.startswith("/") or s.startswith("./") or s.startswith("../"):
+        if _is_bind_mount(s):
             continue
-        if ":" in s:
-            host_part = s.split(":", 1)[0]
-            if host_part.startswith("/") or host_part.startswith("./") or host_part.startswith("../"):
-                continue
         kept.append(s)
     return kept
 

--- a/kamiwaza_extensions/convert_agent/agent.py
+++ b/kamiwaza_extensions/convert_agent/agent.py
@@ -301,6 +301,7 @@ def _validate_plan_in_staging(
 
         errors: List[str] = []
         warnings: List[str] = []
+        info: List[str] = []
 
         metadata_path = staged_root / "kamiwaza.json"
         if not metadata_path.exists():
@@ -309,6 +310,7 @@ def _validate_plan_in_staging(
             meta_result = MetadataValidator().validate(metadata_path)
             errors.extend(meta_result.errors)
             warnings.extend(meta_result.warnings)
+            info.extend(meta_result.info)
 
         compose_path = _find_compose_file(staged_root)
         if compose_path is None:
@@ -317,18 +319,25 @@ def _validate_plan_in_staging(
             compose_result = ComposeValidator().validate(compose_path, staged_root)
             errors.extend(compose_result.errors)
             warnings.extend(compose_result.warnings)
-            for warning in compose_result.warnings:
-                if is_missing_resource_limits_warning(warning):
-                    errors.append(f"Blocking conversion warning: {warning}")
+            info.extend(compose_result.info)
+            for message in compose_result.warnings + compose_result.info:
+                if is_missing_resource_limits_warning(message):
+                    errors.append(f"Blocking conversion warning: {message}")
             if compose_result.passed:
                 runtime_result = PlatformRuntimeValidator().validate(compose_path, staged_root)
                 errors.extend(runtime_result.errors)
                 warnings.extend(runtime_result.warnings)
+                info.extend(runtime_result.info)
 
         if not (staged_root / "CONVERT_NOTES.md").exists():
             errors.append("CONVERT_NOTES.md was not generated.")
 
-        return ValidationSummary(passed=len(errors) == 0, errors=errors, warnings=warnings)
+        return ValidationSummary(
+            passed=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+            info=info,
+        )
 
 
 def _strip_outward_symlinks(staged_root: Path) -> None:

--- a/kamiwaza_extensions/convert_agent/agent.py
+++ b/kamiwaza_extensions/convert_agent/agent.py
@@ -266,7 +266,7 @@ def _validate_plan_in_staging(
     """Materialize the plan in a temp copy and run the validators against it."""
     from kamiwaza_extensions.validators.compose import (
         ComposeValidator,
-        is_missing_resource_limits_warning,
+        is_missing_resource_limits_finding,
     )
     from kamiwaza_extensions.validators.metadata import MetadataValidator
     from kamiwaza_extensions.validators.platform_runtime import PlatformRuntimeValidator
@@ -320,9 +320,14 @@ def _validate_plan_in_staging(
             errors.extend(compose_result.errors)
             warnings.extend(compose_result.warnings)
             info.extend(compose_result.info)
+            # Conversion is intentionally stricter than `validate`/`publish`:
+            # those surface missing resource limits as benign `info` because
+            # deploy applies defaults, but a converted app should ship explicit
+            # limits, so we promote the finding to a blocking conversion error.
+            # Scan both channels since the finding may land in either.
             for message in compose_result.warnings + compose_result.info:
-                if is_missing_resource_limits_warning(message):
-                    errors.append(f"Blocking conversion warning: {message}")
+                if is_missing_resource_limits_finding(message):
+                    errors.append(f"Blocking conversion finding: {message}")
             if compose_result.passed:
                 runtime_result = PlatformRuntimeValidator().validate(compose_path, staged_root)
                 errors.extend(runtime_result.errors)

--- a/kamiwaza_extensions/convert_agent/models.py
+++ b/kamiwaza_extensions/convert_agent/models.py
@@ -46,6 +46,7 @@ class ValidationSummary:
     passed: bool = False
     errors: List[str] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
+    info: List[str] = field(default_factory=list)
 
 
 @dataclass

--- a/kamiwaza_extensions/convert_agent/prompts.py
+++ b/kamiwaza_extensions/convert_agent/prompts.py
@@ -270,6 +270,7 @@ def _render_validation_feedback(validation: Optional[ValidationSummary]) -> str:
         return ""
     error_lines = "\n".join(f"- {err}" for err in validation.errors) or "- None"
     warning_lines = "\n".join(f"- {warn}" for warn in validation.warnings) or "- None"
+    info_lines = "\n".join(f"- {info}" for info in validation.info) or "- None"
     return f"""
 ## Validation Feedback From Previous Attempt
 Errors:
@@ -277,6 +278,9 @@ Errors:
 
 Warnings:
 {warning_lines}
+
+Info:
+{info_lines}
 """
 
 

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -24,6 +24,7 @@ class ComposeValidator:
     def validate(self, compose_path: Path, ext_dir: Path) -> ValidationResult:
         errors: List[str] = []
         warnings: List[str] = []
+        info: List[str] = []
 
         try:
             with compose_path.open("r", encoding="utf-8") as f:
@@ -55,18 +56,26 @@ class ComposeValidator:
             # Bind mounts
             volumes = svc_config.get("volumes", [])
             for vol in volumes:
-                vol_str = str(vol)
-                if isinstance(vol, str) and (":./" in vol_str or vol_str.startswith("./") or vol_str.startswith("../") or re.match(r"^/[^$]", vol_str)):
-                    warnings.append(f"Service '{svc_name}': bind mount '{vol_str}' — not available in deployment")
+                if _is_bind_mount(vol):
+                    info.append(
+                        f"Service '{svc_name}': bind mount '{_format_volume(vol)}' "
+                        "— local-dev only (stripped at deploy)"
+                    )
 
             # Missing resource limits
             deploy = svc_config.get("deploy", {})
             if isinstance(deploy, dict):
                 resources = deploy.get("resources", {})
                 if not resources or not isinstance(resources, dict) or not resources.get("limits"):
-                    warnings.append(f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}")
+                    info.append(
+                        f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT} "
+                        "— defaults will be applied at deploy"
+                    )
             else:
-                warnings.append(f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}")
+                info.append(
+                    f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT} "
+                    "— defaults will be applied at deploy"
+                )
 
             # Explicit container_name
             if "container_name" in svc_config:
@@ -91,4 +100,51 @@ class ComposeValidator:
         if networks:
             warnings.append("Custom networks defined — platform manages networking")
 
-        return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings)
+        return ValidationResult(
+            passed=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+            info=info,
+        )
+
+
+def _is_bind_mount(volume: object) -> bool:
+    if isinstance(volume, dict):
+        volume_type = volume.get("type")
+        source = volume.get("source") or volume.get("src")
+        if volume_type == "bind":
+            return True
+        return bool(source and _looks_like_host_path(str(source)))
+
+    if not isinstance(volume, str):
+        return False
+
+    if re.match(r"^[A-Za-z]:[\\/]", volume):
+        return True
+    if volume.startswith(("./", "../", "/", "~")):
+        return True
+    if ":./" in volume or ":../" in volume:
+        return True
+    if ":" not in volume:
+        return False
+    source, _, _ = volume.partition(":")
+    return _looks_like_host_path(source)
+
+
+def _looks_like_host_path(source: str) -> bool:
+    return (
+        source.startswith(("/", "./", "../", "~"))
+        or source in {".", ".."}
+        or bool(re.match(r"^[A-Za-z]:[\\/]", source))
+    )
+
+
+def _format_volume(volume: object) -> str:
+    if isinstance(volume, dict):
+        source = volume.get("source") or volume.get("src") or ""
+        target = (
+            volume.get("target") or volume.get("destination") or volume.get("dst") or ""
+        )
+        if source or target:
+            return f"{source}:{target}".rstrip(":")
+    return str(volume)

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -13,8 +13,13 @@ from kamiwaza_extensions.validators.result import ValidationResult
 MISSING_RESOURCE_LIMITS_TEXT = "no resource limits defined"
 
 
-def is_missing_resource_limits_warning(message: str) -> bool:
-    """Return True when *message* is the compose missing-limits warning."""
+def is_missing_resource_limits_finding(message: str) -> bool:
+    """Return True when *message* is the compose missing-limits finding.
+
+    As of ENG-4956 this finding is emitted on the ``info`` channel for
+    ``validate``/``publish`` (deploy applies defaults), but conversion
+    still treats it as blocking — see ``ConversionAgent`` for why.
+    """
     return MISSING_RESOURCE_LIMITS_TEXT in message.lower()
 
 

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -16,17 +16,43 @@ MISSING_RESOURCE_LIMITS_TEXT = "no resource limits defined"
 def is_missing_resource_limits_finding(message: str) -> bool:
     """Return True when *message* is the compose missing-limits finding.
 
-    As of ENG-4956 this finding is emitted on the ``info`` channel for
-    ``validate``/``publish`` (deploy applies defaults), but conversion
-    still treats it as blocking — see ``ConversionAgent`` for why.
+    As of ENG-4956 this finding is emitted on the ``info`` channel when
+    the generic ``ComposeTransformer`` will run (deploy applies
+    defaults), and as a ``warning`` otherwise; conversion still treats
+    it as blocking — see ``ConversionAgent`` for why. The match is
+    channel-agnostic, so callers should scan ``warnings + info``.
     """
     return MISSING_RESOURCE_LIMITS_TEXT in message.lower()
+
+
+# Deprecated alias: ``is_missing_resource_limits_warning`` was the
+# pre-ENG-4956 name (the finding was always a warning then). Kept so
+# external importers don't break; prefer the ``_finding`` name.
+is_missing_resource_limits_warning = is_missing_resource_limits_finding
 
 
 class ComposeValidator:
     """Validates docker-compose.yml for deployment compatibility."""
 
-    def validate(self, compose_path: Path, ext_dir: Path) -> ValidationResult:
+    def validate(
+        self,
+        compose_path: Path,
+        ext_dir: Path,
+        *,
+        transformer_handled: bool = True,
+    ) -> ValidationResult:
+        """Validate a compose file for deployment compatibility.
+
+        ``transformer_handled`` controls how findings that the generic
+        ``ComposeTransformer`` would normally fix are reported. When
+        True (the default — ``kz-ext validate`` and publishes that go
+        through the generic transform), bind mounts and missing
+        resource limits are emitted on the ``info`` channel because
+        deploy strips/backfills them. When False — e.g. publishing an
+        authored ``docker-compose.appgarden.yml``, which bypasses the
+        transformer — the same findings are emitted as actionable
+        warnings because no deploy-time stripping or defaulting occurs.
+        """
         errors: List[str] = []
         warnings: List[str] = []
         info: List[str] = []
@@ -61,26 +87,31 @@ class ComposeValidator:
             # Bind mounts
             volumes = svc_config.get("volumes", [])
             for vol in volumes:
-                if _is_bind_mount(vol):
-                    info.append(
-                        f"Service '{svc_name}': bind mount '{_format_volume(vol)}' "
-                        "— local-dev only (stripped at deploy)"
+                if is_bind_mount(vol):
+                    finding = (
+                        f"Service '{svc_name}': bind mount "
+                        f"'{_format_volume(vol)}'"
                     )
+                    if transformer_handled:
+                        info.append(f"{finding} — local-dev only (stripped at deploy)")
+                    else:
+                        warnings.append(
+                            f"{finding} — ships to the catalog as-is "
+                            "(this publish path does not strip bind mounts)"
+                        )
 
             # Missing resource limits
             deploy = svc_config.get("deploy", {})
-            if isinstance(deploy, dict):
-                resources = deploy.get("resources", {})
-                if not resources or not isinstance(resources, dict) or not resources.get("limits"):
-                    info.append(
-                        f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT} "
-                        "— defaults will be applied at deploy"
+            resources = deploy.get("resources", {}) if isinstance(deploy, dict) else {}
+            if not isinstance(resources, dict) or not resources.get("limits"):
+                finding = f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}"
+                if transformer_handled:
+                    info.append(f"{finding} — defaults will be applied at deploy")
+                else:
+                    warnings.append(
+                        f"{finding} — add explicit limits "
+                        "(this publish path does not apply deploy-time defaults)"
                     )
-            else:
-                info.append(
-                    f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT} "
-                    "— defaults will be applied at deploy"
-                )
 
             # Explicit container_name
             if "container_name" in svc_config:
@@ -113,7 +144,13 @@ class ComposeValidator:
         )
 
 
-def _is_bind_mount(volume: object) -> bool:
+def is_bind_mount(volume: object) -> bool:
+    """Return True when *volume* is a host bind mount (not a named volume).
+
+    Public so ``ComposeTransformer`` can share the exact detection the
+    validator uses, keeping "stripped at deploy" findings in sync with
+    what the transformer actually strips.
+    """
     if isinstance(volume, dict):
         volume_type = volume.get("type")
         source = volume.get("source") or volume.get("src")

--- a/kamiwaza_extensions/validators/result.py
+++ b/kamiwaza_extensions/validators/result.py
@@ -11,3 +11,4 @@ class ValidationResult:
     passed: bool
     errors: List[str] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
+    info: List[str] = field(default_factory=list)

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -86,6 +86,24 @@ class TestStripBindMounts:
         result = transformer.transform(compose, "test", "v1", "reg")
         assert result["services"]["web"]["volumes"] == ["data:/app/data"]
 
+    def test_strips_home_dir_bind_mount(self, transformer):
+        """ENG-4956: ~ paths are flagged by the validator, so deploy must strip them."""
+        compose = {"services": {"web": {"volumes": ["~/data:/app/data", "named:/app/persist"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["web"]["volumes"] == ["named:/app/persist"]
+
+    def test_strips_windows_drive_bind_mount(self, transformer):
+        """ENG-4956: Windows drive-letter paths are flagged by the validator."""
+        compose = {"services": {"web": {"volumes": [r"C:\host\data:/app/data"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert "volumes" not in result["services"]["web"]
+
+    def test_strips_cwd_bind_mount(self, transformer):
+        """ENG-4956: a bare '.' source is flagged by the validator."""
+        compose = {"services": {"web": {"volumes": [".:/app"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert "volumes" not in result["services"]["web"]
+
 
 class TestBuildContextRemoval:
     def test_removes_build_adds_image(self, transformer):

--- a/tests/unit/extensions/test_e2e_flows.py
+++ b/tests/unit/extensions/test_e2e_flows.py
@@ -30,8 +30,10 @@ class TestCreateThenValidateFlow:
         assert "Created" in result.output
 
         result = runner.invoke(app, ["validate", str(d)])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert "passed" in result.output.lower()
+        assert "!" not in result.output
+        assert "warning" not in result.output.lower()
 
     def test_create_tool_then_validate(self, tmp_path, monkeypatch):
         d = _empty_dir(tmp_path)
@@ -64,6 +66,11 @@ class TestCreateThenValidateFlow:
         data = json.loads(result.output)
         assert data["passed"] is True
         assert data["errors"] == []
+        assert data["warnings"] == []
+        assert len(data["info"]) == 4
+        assert any("bind mount './frontend/src:/app/src'" in i for i in data["info"])
+        assert any("bind mount './backend/app:/app/app'" in i for i in data["info"])
+        assert sum("no resource limits defined" in i for i in data["info"]) == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/extensions/test_e2e_flows.py
+++ b/tests/unit/extensions/test_e2e_flows.py
@@ -67,10 +67,16 @@ class TestCreateThenValidateFlow:
         assert data["passed"] is True
         assert data["errors"] == []
         assert data["warnings"] == []
-        assert len(data["info"]) == 4
-        assert any("bind mount './frontend/src:/app/src'" in i for i in data["info"])
-        assert any("bind mount './backend/app:/app/app'" in i for i in data["info"])
-        assert sum("no resource limits defined" in i for i in data["info"]) == 2
+        # Assert by category rather than a brittle total count, so an
+        # unrelated scaffold tweak doesn't silently break this test.
+        bind_infos = [i for i in data["info"] if "bind mount" in i]
+        limit_infos = [i for i in data["info"] if "no resource limits defined" in i]
+        assert len(bind_infos) == 2
+        assert len(limit_infos) == 2
+        # Every info entry is one of the two expected categories.
+        assert len(bind_infos) + len(limit_infos) == len(data["info"])
+        assert any("bind mount './frontend/src:/app/src'" in i for i in bind_infos)
+        assert any("bind mount './backend/app:/app/app'" in i for i in bind_infos)
 
 
 @pytest.mark.unit

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -271,6 +271,85 @@ class TestPublishWithInfoFindings:
         mock_publisher.publish.assert_called_once()
 
 
+class TestPublishAppgardenValidationChannel:
+    """ENG-4956: an authored appgarden compose bypasses ComposeTransformer, so
+    `run_publish` must validate it with `transformer_handled=False` — otherwise
+    bind mounts / missing limits are reported as benign info even though deploy
+    will not strip or backfill them.
+    """
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_appgarden_publish_validates_with_transformer_handled_false(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # An authored appgarden compose makes run_publish take the
+        # _retag_appgarden_compose path instead of the generic transform.
+        (tmp_path / "docker-compose.appgarden.yml").write_text(
+            "services:\n"
+            "  backend:\n"
+            "    image: ghcr.io/my-org/my-app-backend:1.0.0\n"
+        )
+
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(tmp_path)
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer_cls.return_value = MagicMock()
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = ["ghcr.io/my-org/my-app-backend:1.0.0"]
+        mock_builder_cls.return_value = mock_image_builder
+
+        mock_pusher_cls.return_value = MagicMock()
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result()
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # The compose validator must be told the transformer is bypassed.
+        assert mock_compose_validator.validate.call_args.kwargs[
+            "transformer_handled"
+        ] is False
+
+
 # ------------------------------------------------------------------
 # extra_docker_images: digest resolution
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -44,7 +44,7 @@ def _make_extension_info(
     )
 
 
-def _make_validation_result(passed=True, errors=None, warnings=None):
+def _make_validation_result(passed=True, errors=None, warnings=None, info=None):
     """Create a mock ValidationResult."""
     from kamiwaza_extensions.validators.result import ValidationResult
 
@@ -52,6 +52,7 @@ def _make_validation_result(passed=True, errors=None, warnings=None):
         passed=passed,
         errors=errors or [],
         warnings=warnings or [],
+        info=info or [],
     )
 
 
@@ -180,6 +181,93 @@ class TestPublishHappyPath:
         mock_image_builder.build.assert_called_once()
         mock_pusher.push.assert_called_once()
         mock_reg_builder.build_entry.assert_called_once()
+        mock_publisher.publish.assert_called_once()
+
+
+class TestPublishWithInfoFindings:
+    """ENG-4956 regression: info findings must not break the publish flow.
+
+    The info-printing loop previously rebound the `info` variable (the
+    ExtensionInfo object) to a message string, so `info.path` later raised
+    `AttributeError: 'str' object has no attribute 'path'` whenever
+    validation emitted any info entry.
+    """
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_publish_succeeds_with_info_findings(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(tmp_path)
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        # Compose validation emits scaffold-default info entries.
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result(
+            info=[
+                "Service 'backend' uses bind mount './data:/app' — stripped at deploy.",
+                "Service 'backend' has no resource limits — defaults applied at deploy.",
+            ]
+        )
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer = MagicMock()
+        mock_transformer.transform.return_value = {
+            "services": {"backend": {"image": "ghcr.io/my-org/my-app-backend:1.0.0"}}
+        }
+        mock_transformer_cls.return_value = mock_transformer
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = ["ghcr.io/my-org/my-app-backend:1.0.0"]
+        mock_builder_cls.return_value = mock_image_builder
+
+        mock_pusher_cls.return_value = MagicMock()
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result()
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        # Must not raise AttributeError — the ExtensionInfo binding survives
+        # the info-printing loop.
+        run_publish(stage="dev")
+
+        # resolve_profile is the call site that crashed: it needs the real
+        # ExtensionInfo's `path`, proving `info` was not clobbered.
+        mock_profile_mgr.resolve_profile.assert_called_once_with(
+            "dev", extension_dir=tmp_path
+        )
         mock_publisher.publish.assert_called_once()
 
 

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -5,7 +5,12 @@ import json
 import pytest
 
 from kamiwaza_extensions.validators.metadata import MetadataValidator
-from kamiwaza_extensions.validators.compose import ComposeValidator
+from kamiwaza_extensions.validators.compose import (
+    ComposeValidator,
+    is_bind_mount,
+    is_missing_resource_limits_finding,
+    is_missing_resource_limits_warning,
+)
 from kamiwaza_extensions.validators.platform_runtime import PlatformRuntimeValidator
 
 
@@ -481,6 +486,87 @@ class TestComposeValidator:
         result = validator.validate(f, tmp_path)
         # yaml.safe_load might not error on all bad yaml; check it doesn't crash
         assert isinstance(result, ComposeValidator.__init__.__class__) or True
+
+    def test_bind_mount_is_warning_when_transformer_bypassed(self, tmp_path, validator):
+        """ENG-4956: on a publish path that bypasses ComposeTransformer (e.g. an
+        authored appgarden compose), bind mounts are NOT stripped, so the finding
+        must be an actionable warning rather than benign info."""
+        compose = {
+            "services": {"web": {"image": "nginx", "volumes": ["./src:/app"]}},
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path, transformer_handled=False)
+        assert result.passed
+        assert not any("bind mount" in i.lower() for i in result.info)
+        assert any(
+            "bind mount './src:/app'" in w and "stripped at deploy" not in w
+            for w in result.warnings
+        )
+
+    def test_missing_limits_is_warning_when_transformer_bypassed(self, tmp_path, validator):
+        """ENG-4956: when the transformer is bypassed, deploy-time resource
+        defaults are not applied, so the finding must be a warning."""
+        compose = {"services": {"web": {"image": "nginx"}}}
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path, transformer_handled=False)
+        assert result.passed
+        assert not any("resource limits" in i.lower() for i in result.info)
+        assert any(
+            "no resource limits defined" in w and "at deploy" not in w
+            for w in result.warnings
+        )
+
+
+@pytest.mark.unit
+class TestIsBindMount:
+    """Direct coverage for the validator/transformer shared bind-mount detector."""
+
+    @pytest.mark.parametrize(
+        "volume",
+        [
+            "/abs/host:/app",
+            "./rel:/app",
+            "../rel:/app",
+            "~/home:/app",
+            r"C:\host\data:/app",
+            ".:/app",
+            "..:/app",
+            {"type": "bind", "source": "./src", "target": "/app"},
+            {"source": "/abs/host", "target": "/app"},
+        ],
+    )
+    def test_detects_bind_mounts(self, volume):
+        assert is_bind_mount(volume) is True
+
+    @pytest.mark.parametrize(
+        "volume",
+        [
+            "data:/app",
+            "logs:/var/log:rw",
+            "named_volume:/data",
+            {"type": "volume", "source": "data", "target": "/app"},
+            {"source": "data", "target": "/app"},
+        ],
+    )
+    def test_ignores_named_volumes(self, volume):
+        assert is_bind_mount(volume) is False
+
+
+@pytest.mark.unit
+class TestResourceLimitsFinding:
+    """The renamed helper and its backward-compatible alias."""
+
+    def test_finding_matcher(self):
+        assert is_missing_resource_limits_finding(
+            "Service 'web': no resource limits defined — defaults applied"
+        )
+        assert not is_missing_resource_limits_finding("Service 'web': all good")
+
+    def test_deprecated_alias_is_same_callable(self):
+        # External importers of the pre-ENG-4956 name must keep working.
+        assert is_missing_resource_limits_warning is is_missing_resource_limits_finding
 
 
 @pytest.mark.unit

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -388,7 +388,7 @@ class TestComposeValidator:
         assert result.passed  # warning, not error
         assert any("port" in w.lower() for w in result.warnings)
 
-    def test_bind_mount_warning(self, tmp_path, validator):
+    def test_bind_mount_info(self, tmp_path, validator):
         compose = {
             "services": {
                 "web": {"image": "nginx", "volumes": ["./src:/app"]},
@@ -398,9 +398,32 @@ class TestComposeValidator:
         self._write_compose(f, compose)
         result = validator.validate(f, tmp_path)
         assert result.passed
-        assert any("bind mount" in w.lower() for w in result.warnings)
+        assert not any("bind mount" in w.lower() for w in result.warnings)
+        assert any(
+            "bind mount './src:/app'" in i and "stripped at deploy" in i
+            for i in result.info
+        )
 
-    def test_missing_resource_limits_warning(self, tmp_path, validator):
+    def test_long_form_bind_mount_info(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "volumes": [{"type": "bind", "source": "./src", "target": "/app"}],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert result.passed
+        assert not any("bind mount" in w.lower() for w in result.warnings)
+        assert any(
+            "bind mount './src:/app'" in i and "stripped at deploy" in i
+            for i in result.info
+        )
+
+    def test_missing_resource_limits_info(self, tmp_path, validator):
         compose = {
             "services": {
                 "web": {"image": "nginx"},
@@ -410,7 +433,12 @@ class TestComposeValidator:
         self._write_compose(f, compose)
         result = validator.validate(f, tmp_path)
         assert result.passed
-        assert any("resource" in w.lower() for w in result.warnings)
+        assert not any("resource" in w.lower() for w in result.warnings)
+        assert any(
+            "no resource limits defined" in i
+            and "defaults will be applied at deploy" in i
+            for i in result.info
+        )
 
     def test_missing_dockerfile_error(self, tmp_path, validator):
         compose = {


### PR DESCRIPTION
## Summary

Fixes ENG-4956 by reclassifying transformer-handled compose findings as informational instead of warnings. A fresh app scaffold still reports what deploy will handle, but `kz-ext validate` no longer shows `!` warning lines or a warning count for starter defaults.

## Root Cause

The vanilla app scaffold intentionally includes local-dev bind mounts and omits explicit resource limits because the deploy transformer strips bind mounts and applies resource defaults. `ComposeValidator` was still classifying those transformer-handled patterns as warnings, making a fresh scaffold look questionable on first validation.

## Changes

- Added an additive `info` channel to `ValidationResult` and `kz-ext validate --json`.
- Moved compose bind mounts and missing resource limits from warnings to info, with messages that explain deploy-time handling.
- Kept user-actionable compatibility findings as warnings/errors, including host port mappings, custom networks, explicit `container_name`, and missing Dockerfiles.
- Threaded info through publish and conversion validation paths so the new channel is preserved.
- Added regression coverage for warning-free fresh app scaffold validation.

## Validation

- `uv run ruff check kamiwaza_extensions/validators/result.py kamiwaza_extensions/validators/compose.py kamiwaza_extensions/commands/validate.py kamiwaza_extensions/commands/publish.py kamiwaza_extensions/convert_agent/models.py kamiwaza_extensions/convert_agent/prompts.py kamiwaza_extensions/convert_agent/agent.py tests/unit/extensions/test_e2e_flows.py tests/unit/extensions/test_validators.py`
- `uv run pytest tests/unit/extensions/test_validators.py tests/unit/extensions/test_e2e_flows.py tests/unit/extensions/test_validate_cmd.py tests/unit/extensions/test_publish_cmd.py tests/unit/extensions/test_convert_agent.py -q` (`205 passed`)
- Manual smoke: `kz-ext create --type app --name demo-app`, `kz-ext validate`, and `kz-ext validate --json` show `warnings: []` and four scaffold-default `info` entries.