### PR TITLE
chore: bring integration branch HEAD into kamiwaza-mesh-v1.0.0 (PR #115 follow-on)

### DIFF
--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -345,15 +345,52 @@ def test_context_required_llm_available(context_required_llm: str) -> None:
     assert context_required_llm
 
 
-def test_context_vectordb_lifecycle_global(live_kamiwaza_client) -> None:
+def test_context_vectordb_create_in_global_workroom_is_read_only(
+    live_kamiwaza_client,
+) -> None:
+    """Global Workroom is read-only for VectorDB creation (ENG-4352, PR #1635).
+
+    Verifies the server-side gate at
+    ``kamiwaza/services/context/lifecycle.py:_raise_if_global_workroom_write``
+    rejects ``create_vectordb`` without an explicit workroom_id (which
+    defaults to the Global Workroom UUID). Returns 403 regardless of
+    caller role, matching commit 73071d5d1's stated intent:
+    "Keeps Global Workroom read paths available to members and blocks
+    Global write paths in both ReBAC-on and RBAC-off modes."
+    """
+    service = _context_service(live_kamiwaza_client)
+
+    with pytest.raises(APIError) as exc_info:
+        service.create_vectordb(
+            name=f"sdk-context-vdb-global-{uuid4().hex[:8]}",
+            engine="milvus",
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "Global Workroom is read-only" in str(exc_info.value)
+
+
+def test_context_vectordb_lifecycle_in_workroom(live_kamiwaza_client) -> None:
+    """Full VectorDB lifecycle (create / get / update / scale / delete)
+    succeeds when scoped to a non-global workroom.
+
+    The Global Workroom is read-only for VectorDB creation
+    (see test_context_vectordb_create_in_global_workroom_is_read_only).
+    A dedicated test workroom is the canonical write target — matches
+    how SDK consumers create vectordbs in production.
+    """
     service = _context_service(live_kamiwaza_client)
 
     name = f"sdk-context-vdb-{uuid4().hex[:8]}"
-    created = service.create_vectordb(name=name, engine="milvus")
+    created = service.create_vectordb(
+        name=name,
+        engine="milvus",
+        workroom_id=DEFAULT_WORKROOM_ID,
+    )
     vectordb_id = created["id"]
 
     try:
-        fetched = service.get_vectordb(vectordb_id)
+        fetched = service.get_vectordb(vectordb_id, workroom_id=DEFAULT_WORKROOM_ID)
         assert fetched["id"] == vectordb_id
         assert fetched["name"] == name
 
@@ -361,13 +398,20 @@ def test_context_vectordb_lifecycle_global(live_kamiwaza_client) -> None:
             vectordb_id,
             config={"SDK_CONTEXT_TEST": "1"},
             replicas=1,
+            workroom_id=DEFAULT_WORKROOM_ID,
         )
         assert updated["id"] == vectordb_id
 
-        scaled = service.scale_vectordb(vectordb_id, replicas=1)
+        scaled = service.scale_vectordb(
+            vectordb_id,
+            replicas=1,
+            workroom_id=DEFAULT_WORKROOM_ID,
+        )
         assert scaled["id"] == vectordb_id
     finally:
-        _safe_delete_vectordb(service, vectordb_id)
+        _safe_delete_vectordb(
+            service, vectordb_id, workroom_id=DEFAULT_WORKROOM_ID
+        )
 
 
 def test_context_vectordb_insert_vectors_instance(

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -370,67 +370,14 @@ def test_context_vectordb_create_in_global_workroom_is_read_only(
     assert "Global Workroom is read-only" in str(exc_info.value)
 
 
-def test_context_vectordb_lifecycle_in_workroom(live_kamiwaza_client) -> None:
-    """Full VectorDB lifecycle (create / get / update / scale / delete)
-    succeeds when scoped to a non-global workroom.
-
-    The Global Workroom is read-only for VectorDB creation
-    (see test_context_vectordb_create_in_global_workroom_is_read_only).
-    A dedicated test workroom is the canonical write target — matches
-    how SDK consumers create vectordbs in production.
-
-    Creates a fresh workroom for the test rather than reusing
-    ``DEFAULT_WORKROOM_ID`` — the module-level default resolves to the
-    Global Workroom UUID when no env override is set, which would
-    trigger the same 403 contract the negative test asserts. The fresh
-    workroom is torn down in the ``finally`` block.
-    """
-    service = _context_service(live_kamiwaza_client)
-
-    workroom_payload = {
-        "name": f"sdk-vdb-test-{uuid4().hex[:8]}",
-        "type": "ephemeral",
-    }
-    workroom = live_kamiwaza_client.post("/workrooms/", json=workroom_payload)
-    test_workroom_id = str(workroom["id"])
-
-    name = f"sdk-context-vdb-{uuid4().hex[:8]}"
-    vectordb_id: str | None = None
-    try:
-        created = service.create_vectordb(
-            name=name,
-            engine="milvus",
-            workroom_id=test_workroom_id,
-        )
-        vectordb_id = created["id"]
-
-        fetched = service.get_vectordb(vectordb_id, workroom_id=test_workroom_id)
-        assert fetched["id"] == vectordb_id
-        assert fetched["name"] == name
-
-        updated = service.update_vectordb(
-            vectordb_id,
-            config={"SDK_CONTEXT_TEST": "1"},
-            replicas=1,
-            workroom_id=test_workroom_id,
-        )
-        assert updated["id"] == vectordb_id
-
-        scaled = service.scale_vectordb(
-            vectordb_id,
-            replicas=1,
-            workroom_id=test_workroom_id,
-        )
-        assert scaled["id"] == vectordb_id
-    finally:
-        if vectordb_id:
-            _safe_delete_vectordb(
-                service, vectordb_id, workroom_id=test_workroom_id
-            )
-        try:
-            live_kamiwaza_client.delete(f"/workrooms/{test_workroom_id}")
-        except APIError:
-            pass
+# Non-Global VectorDB lifecycle test omitted: the SDK scopes writes via
+# the X-Workroom-Id header, but the istio ingress strip-identity-headers
+# EnvoyFilter (deploy network chart, ENG-5310-mesh-v1.0.0) drops that
+# header along with x-user-* spoofing defenses. The Global-readonly
+# assertion above already covers the negative side of the contract;
+# end-to-end lifecycle coverage stays in the kamiwaza repo's
+# tests/integration/services/context until the SDK gains a non-header
+# workroom-scoping path.
 
 
 def test_context_vectordb_insert_vectors_instance(

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -378,19 +378,33 @@ def test_context_vectordb_lifecycle_in_workroom(live_kamiwaza_client) -> None:
     (see test_context_vectordb_create_in_global_workroom_is_read_only).
     A dedicated test workroom is the canonical write target — matches
     how SDK consumers create vectordbs in production.
+
+    Creates a fresh workroom for the test rather than reusing
+    ``DEFAULT_WORKROOM_ID`` — the module-level default resolves to the
+    Global Workroom UUID when no env override is set, which would
+    trigger the same 403 contract the negative test asserts. The fresh
+    workroom is torn down in the ``finally`` block.
     """
     service = _context_service(live_kamiwaza_client)
 
-    name = f"sdk-context-vdb-{uuid4().hex[:8]}"
-    created = service.create_vectordb(
-        name=name,
-        engine="milvus",
-        workroom_id=DEFAULT_WORKROOM_ID,
-    )
-    vectordb_id = created["id"]
+    workroom_payload = {
+        "name": f"sdk-vdb-test-{uuid4().hex[:8]}",
+        "type": "ephemeral",
+    }
+    workroom = live_kamiwaza_client.post("/workrooms/", json=workroom_payload)
+    test_workroom_id = str(workroom["id"])
 
+    name = f"sdk-context-vdb-{uuid4().hex[:8]}"
+    vectordb_id: str | None = None
     try:
-        fetched = service.get_vectordb(vectordb_id, workroom_id=DEFAULT_WORKROOM_ID)
+        created = service.create_vectordb(
+            name=name,
+            engine="milvus",
+            workroom_id=test_workroom_id,
+        )
+        vectordb_id = created["id"]
+
+        fetched = service.get_vectordb(vectordb_id, workroom_id=test_workroom_id)
         assert fetched["id"] == vectordb_id
         assert fetched["name"] == name
 
@@ -398,20 +412,25 @@ def test_context_vectordb_lifecycle_in_workroom(live_kamiwaza_client) -> None:
             vectordb_id,
             config={"SDK_CONTEXT_TEST": "1"},
             replicas=1,
-            workroom_id=DEFAULT_WORKROOM_ID,
+            workroom_id=test_workroom_id,
         )
         assert updated["id"] == vectordb_id
 
         scaled = service.scale_vectordb(
             vectordb_id,
             replicas=1,
-            workroom_id=DEFAULT_WORKROOM_ID,
+            workroom_id=test_workroom_id,
         )
         assert scaled["id"] == vectordb_id
     finally:
-        _safe_delete_vectordb(
-            service, vectordb_id, workroom_id=DEFAULT_WORKROOM_ID
-        )
+        if vectordb_id:
+            _safe_delete_vectordb(
+                service, vectordb_id, workroom_id=test_workroom_id
+            )
+        try:
+            live_kamiwaza_client.delete(f"/workrooms/{test_workroom_id}")
+        except APIError:
+            pass
 
 
 def test_context_vectordb_insert_vectors_instance(


### PR DESCRIPTION
PR #115 merged into integration/kamiwaza-mesh-v1.0.0-release-0.13.0 (its base branch) after PR #111 had already landed in kamiwaza-mesh-v1.0.0. This means the integration branch carries 4 commits that aren't yet in mesh-v1.0.0:

- 36f9488 Merge pull request #115 (vectordb test split + cleanup)
- 409977e test(context): drop non-Global VectorDB lifecycle test (ENG-5320 documented gap)
- 69e79c9 test(context): use freshly-created workroom for vectordb lifecycle test
- 32c6e16 test(context): split vectordb lifecycle into global-readonly + workroom-scoped

This fast-forward / merge brings them into mesh-v1.0.0 so the SDK on-host repos pick up the test changes when running live smoke against the upcoming kamiwaza-mesh-v1.0.0 container build.

ENG-5310 close-out / mechanical port.