### PR TITLE
M7: Accumulating reconciliation work — kamiwaza-sdk (mesh-v1.0.0)

### DIFF
--- a/.github/workflows/python-complexity.yml
+++ b/.github/workflows/python-complexity.yml
@@ -60,6 +60,12 @@ jobs:
             "kamiwaza_extensions/commands/publish.py"
             "kamiwaza_extensions/commands/dev.py"
             "kamiwaza_extensions/registry_builder.py"
+            # M7-B (ENG-5380) reconciliation: develop commit 87e5a71 (ENG-5260
+            # rewrite image refs in compose env-var defaults) pushed compose.py
+            # over the CC threshold. Grandfather pending refactor — same pattern
+            # as the other extension files. Refactor follow-up tracked in
+            # D210 Bugs & Carryovers (see ENG-5310 M8 backlog).
+            "kamiwaza_extensions/validators/compose.py"
           )
 
           is_grandfathered() {

--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -323,10 +323,11 @@ def port_forward(
 @run_with_error_handling
 def bump(
     level: str = typer.Option("patch", "--level", "-l", help="Bump level: major, minor, or patch"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview file changes without writing"),
 ) -> None:
-    """Bump extension version in kamiwaza.json."""
+    """Bump extension version across kamiwaza.json, compose, Dockerfile, pyproject, package.json."""
     from kamiwaza_extensions.commands.bump import run_bump
-    run_bump(level=level)
+    run_bump(level=level, dry_run=dry_run)
 
 
 @app.command()

--- a/kamiwaza_extensions/commands/bump.py
+++ b/kamiwaza_extensions/commands/bump.py
@@ -1,19 +1,41 @@
-"""Bump command — increment extension version in kamiwaza.json."""
+"""Bump command — propagate an extension's new version across well-known files.
+
+Updates ``kamiwaza.json`` plus image tags in compose files, ``ARG`` defaults
+in ``Dockerfile``, and the ``[project] version`` line in ``pyproject.toml`` /
+``package.json`` so the manifest doesn't drift from the rest of the tree.
+"""
 
 from __future__ import annotations
 
+import difflib
 import json
+import re
+import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import typer
 from rich.console import Console
 
+if TYPE_CHECKING:
+    from packaging.version import Version
+
 console = Console(stderr=True)
 
 
-def run_bump(*, level: str = "patch") -> None:
-    """Bump the version in kamiwaza.json."""
+@dataclass
+class FileUpdate:
+    """A pending rewrite of a single file."""
+
+    path: Path
+    before: str
+    after: str
+    summary: str
+
+
+def run_bump(*, level: str = "patch", dry_run: bool = False) -> None:
+    """Bump the version in kamiwaza.json and propagate to sibling files."""
     from packaging.version import Version
 
     from kamiwaza_extensions.extension_detector import ExtensionDetector
@@ -21,12 +43,12 @@ def run_bump(*, level: str = "patch") -> None:
     detector = ExtensionDetector()
     info = detector.detect()
 
-    kamiwaza_json_path = info.path / "kamiwaza.json"
+    ext_dir = info.path
+    kamiwaza_json_path = ext_dir / "kamiwaza.json"
     if not kamiwaza_json_path.exists():
         console.print("[red]Error:[/red] kamiwaza.json not found.")
         raise typer.Exit(code=1)
 
-    # Parse current version
     try:
         current = Version(info.version)
     except Exception:
@@ -35,35 +57,447 @@ def run_bump(*, level: str = "patch") -> None:
         )
         raise typer.Exit(code=1)
 
-    # Compute new version
-    major, minor, patch = current.major, current.minor, current.micro
-    if level == "major":
-        new_version = f"{major + 1}.0.0"
-    elif level == "minor":
-        new_version = f"{major}.{minor + 1}.0"
-    elif level == "patch":
-        new_version = f"{major}.{minor}.{patch + 1}"
-    else:
+    old_version = info.version
+    new_version = _compute_new_version(current, level)
+    if new_version is None:
         console.print(
             f"[red]Error:[/red] Unknown level '{level}'. Use: major, minor, patch"
         )
         raise typer.Exit(code=1)
 
-    # Update kamiwaza.json
-    with kamiwaza_json_path.open("r", encoding="utf-8") as f:
-        data = json.load(f)
+    # Scope compose/drift rewrites to the extension's own image repo so we
+    # don't accidentally retag a sidecar that happens to share `old`
+    # (e.g. `vendor/sidecar:2.0.14` while bumping our `app` to 2.1.0).
+    manifest = json.loads(kamiwaza_json_path.read_text(encoding="utf-8"))
+    ext_repo = extension_image_repo(manifest.get("image"))
 
-    old_version = data.get("version", info.version)
-    data["version"] = new_version
+    updates: List[FileUpdate] = []
+    for update in (
+        _update_kamiwaza_json(kamiwaza_json_path, old_version, new_version),
+        *_update_compose_files(ext_dir, old_version, new_version, ext_repo),
+        _update_dockerfile(ext_dir / "Dockerfile", old_version, new_version),
+        _update_pyproject(ext_dir / "pyproject.toml", old_version, new_version),
+        *_update_package_json_files(ext_dir, old_version, new_version),
+    ):
+        if update is not None:
+            updates.append(update)
 
-    # Atomic write via temp file + rename
-    tmp_path = kamiwaza_json_path.with_suffix(".tmp")
-    with tmp_path.open("w", encoding="utf-8") as f:
-        json.dump(data, f, indent=4)
-        f.write("\n")
-    tmp_path.replace(kamiwaza_json_path)
+    if dry_run:
+        for update in updates:
+            rel = _relative(update.path, ext_dir)
+            diff = "".join(
+                difflib.unified_diff(
+                    update.before.splitlines(keepends=True),
+                    update.after.splitlines(keepends=True),
+                    fromfile=f"a/{rel}",
+                    tofile=f"b/{rel}",
+                )
+            )
+            # Diff body goes to stdout (so `kz-ext bump --dry-run > patch.diff`
+            # captures it) and bypasses Rich markup so TOML/Dockerfile syntax
+            # like `[project]` isn't parsed as a style tag.
+            sys.stdout.write(diff)
+        sys.stdout.flush()
+        console.print(
+            f"[yellow]Would bump:[/yellow] "
+            f"[bold]{old_version}[/bold] → [bold]{new_version}[/bold] "
+            f"({level}) — {len(updates)} file(s)"
+        )
+        return
 
+    _commit_updates(updates)
+
+    extras = [u for u in updates if u.path != kamiwaza_json_path]
     console.print(
-        f"[green]\u2713[/green] Bumped version: "
+        f"[green]✓[/green] Bumped version: "
         f"[bold]{old_version}[/bold] → [bold]{new_version}[/bold] ({level})"
     )
+    for update in extras:
+        console.print(f"  [dim]→[/dim] {_relative(update.path, ext_dir)}: {update.summary}")
+
+
+def _compute_new_version(current: "Version", level: str) -> Optional[str]:
+    major, minor, patch = current.major, current.minor, current.micro
+    if level == "major":
+        return f"{major + 1}.0.0"
+    if level == "minor":
+        return f"{major}.{minor + 1}.0"
+    if level == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    return None
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _commit_updates(updates: List[FileUpdate]) -> None:
+    """Two-phase write: stage every tmp file first, then rename all.
+
+    Single-file atomicity is preserved by ``Path.replace``; the two-phase
+    ordering reduces the window in which a half-bumped tree is observable.
+    If any tmp write fails, no rename has happened yet, so the tree is
+    unchanged and the caller sees the original exception.
+    """
+    staged: List[Tuple[Path, Path]] = []
+    try:
+        for update in updates:
+            # Use ``with_name`` instead of ``with_suffix(suffix + ".tmp")``
+            # — Python 3.13 tightened ``with_suffix`` to reject suffixes
+            # that contain internal dots (e.g. ``.json.tmp``).
+            tmp = update.path.with_name(update.path.name + ".tmp")
+            with tmp.open("w", encoding="utf-8") as f:
+                f.write(update.after)
+            staged.append((tmp, update.path))
+    except Exception:
+        # Best-effort cleanup of already-staged tmp files.
+        for tmp, _ in staged:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise
+
+    for tmp, dest in staged:
+        tmp.replace(dest)
+
+
+# ---------------------------------------------------------------------------
+# Image-ref parsing
+# ---------------------------------------------------------------------------
+
+
+def _split_image_ref(ref: str) -> Tuple[str, Optional[str], Optional[str]]:
+    """Split a Docker image reference into ``(repo, tag, digest)``.
+
+    Handles registry ports (``localhost:5000/app``) by splitting tag from
+    repo on the **last** ``:`` that isn't inside the digest suffix, and
+    preserves any trailing ``@sha256:...`` digest so callers can re-attach
+    it after rewriting the tag.
+    """
+    digest: Optional[str] = None
+    if "@" in ref:
+        ref, _, digest = ref.partition("@")
+        digest = "@" + digest
+
+    # If there's a `/`, tag (if any) lives after the last `/`'s segment.
+    if "/" in ref:
+        head, _, last = ref.rpartition("/")
+        if ":" in last:
+            name, _, tag = last.rpartition(":")
+            return f"{head}/{name}", tag, digest
+        return ref, None, digest
+    # No `/` — single-segment image like `app:2.0.14` or `postgres:16`.
+    if ":" in ref:
+        repo, _, tag = ref.rpartition(":")
+        return repo, tag, digest
+    return ref, None, digest
+
+
+# ---------------------------------------------------------------------------
+# Per-file updaters
+# ---------------------------------------------------------------------------
+
+
+def _update_kamiwaza_json(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    before = path.read_text(encoding="utf-8")
+    data = json.loads(before)
+    if data.get("version") != old:
+        # Manifest already drifted (or its detector value was different);
+        # fall back to writing through json.dumps so the file is at least
+        # internally consistent post-bump.
+        data["version"] = new
+        return FileUpdate(
+            path=path,
+            before=before,
+            after=json.dumps(data, indent=4) + "\n",
+            summary="version",
+        )
+
+    # Targeted rewrite of the top-level ``"version"`` string. Mirrors the
+    # package.json approach so a manifest with non-default indentation,
+    # key order, or non-ASCII content doesn't get a full-file reformat
+    # diff on bump.
+    span = _find_top_level_string_value_span(before, "version")
+    if span is None or before[span[0] : span[1]] != old:
+        # Pathological: top-level version isn't a string. Re-serialize.
+        data["version"] = new
+        return FileUpdate(
+            path=path,
+            before=before,
+            after=json.dumps(data, indent=4) + "\n",
+            summary="version",
+        )
+    after = before[: span[0]] + new + before[span[1] :]
+
+    # Conditional image-tag rewrite.
+    image = data.get("image")
+    image_changed = False
+    if isinstance(image, str):
+        repo, tag, digest = _split_image_ref(image)
+        if tag == old:
+            new_image = f"{repo}:{new}{digest or ''}"
+            image_span = _find_top_level_string_value_span(after, "image")
+            if image_span is not None and after[image_span[0] : image_span[1]] == image:
+                after = after[: image_span[0]] + new_image + after[image_span[1] :]
+                image_changed = True
+
+    if after == before:
+        return None
+    summary = "version" + (" + image tag" if image_changed else "")
+    return FileUpdate(path=path, before=before, after=after, summary=summary)
+
+
+def extension_image_repo(manifest_image: object) -> Optional[str]:
+    """Return the manifest image's repo (e.g. ``ghcr.io/x/y``) or ``None``.
+
+    Used to scope compose rewrites and drift warnings to images that belong
+    to the extension, so a sidecar with a coincidentally matching tag isn't
+    silently retagged.
+    """
+    if not isinstance(manifest_image, str):
+        return None
+    repo, _, _ = _split_image_ref(manifest_image)
+    return repo or None
+
+
+def _update_compose_files(
+    ext_dir: Path, old: str, new: str, ext_repo: Optional[str]
+) -> List[Optional[FileUpdate]]:
+    from kamiwaza_extensions.constants import ALL_COMPOSE_FILENAMES
+
+    seen: set = set()
+    results: List[Optional[FileUpdate]] = []
+    for name in ALL_COMPOSE_FILENAMES:
+        path = ext_dir / name
+        if not path.exists() or path in seen:
+            continue
+        seen.add(path)
+        results.append(_update_compose_file(path, old, new, ext_repo))
+    return results
+
+
+# Capture the full image reference token (everything between optional quotes
+# and any trailing whitespace/comment) so a ref like
+# `localhost:5000/app:2.0.14@sha256:...` is handed off to `_split_image_ref`
+# intact rather than mangled by a regex that doesn't understand digests or
+# registry ports.
+_COMPOSE_IMAGE_RE = re.compile(
+    r"""(?P<prefix>^\s*image\s*:\s*)(?P<quote>['"]?)(?P<ref>\S+?)(?P=quote)(?P<suffix>\s*(?:\#.*)?)$""",
+    re.MULTILINE,
+)
+
+
+def _update_compose_file(
+    path: Path, old: str, new: str, ext_repo: Optional[str]
+) -> Optional[FileUpdate]:
+    before = path.read_text(encoding="utf-8")
+
+    count = 0
+
+    def repl(match: re.Match) -> str:
+        nonlocal count
+        ref = match.group("ref")
+        repo, tag, digest = _split_image_ref(ref)
+        if tag != old:
+            return match.group(0)
+        # If the manifest declares an image repo, only retag images that
+        # belong to the extension. Without a manifest repo we fall back to
+        # tag-equality alone (the original behavior, exercised by tests
+        # for manifests that omit `image`).
+        if ext_repo is not None and repo != ext_repo:
+            return match.group(0)
+        count += 1
+        new_ref = f"{repo}:{new}{digest or ''}"
+        return (
+            f"{match.group('prefix')}{match.group('quote')}"
+            f"{new_ref}{match.group('quote')}{match.group('suffix')}"
+        )
+
+    after = _COMPOSE_IMAGE_RE.sub(repl, before)
+    if count == 0 or after == before:
+        return None
+    return FileUpdate(
+        path=path,
+        before=before,
+        after=after,
+        summary=f"{count} image tag(s)",
+    )
+
+
+def _update_dockerfile(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    if not path.exists():
+        return None
+    before = path.read_text(encoding="utf-8")
+
+    # ARG <NAME>_VERSION=<old> — only retag ARGs whose name ends in
+    # ``_VERSION`` so we don't silently rewrite an unrelated pin like
+    # ``ARG PYTHON_VERSION=3.11.9`` when the extension itself is at
+    # ``3.11.9``. Matches the drift detector's heuristic and keeps the
+    # blast radius narrow.
+    arg_re = re.compile(
+        rf"""(?m)^(?P<prefix>\s*ARG\s+[A-Za-z_][A-Za-z0-9_]*_VERSION\s*=\s*)(?P<q>["']?){re.escape(old)}(?P=q)(?P<suffix>\s*(?:\#.*)?)$"""
+    )
+
+    count = 0
+
+    def repl(match: re.Match) -> str:
+        nonlocal count
+        count += 1
+        q = match.group("q")
+        return f"{match.group('prefix')}{q}{new}{q}{match.group('suffix')}"
+
+    after = arg_re.sub(repl, before)
+    if count == 0 or after == before:
+        return None
+    return FileUpdate(
+        path=path,
+        before=before,
+        after=after,
+        summary=f"{count} ARG default(s)",
+    )
+
+
+def _update_pyproject(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    """Rewrite ``[project] version`` while preserving comments and formatting.
+
+    Locates the ``[project]`` table by header line, then scans only that
+    table's body for the ``version`` key — sidesteps the lazy-regex trap
+    where a TOML array like ``classifiers = [...]`` before the version
+    line defeats a single anchored pattern.
+    """
+    if not path.exists():
+        return None
+    before = path.read_text(encoding="utf-8")
+    span = _find_project_table_span(before)
+    if span is None:
+        return None
+    start, end = span
+    version_re = re.compile(
+        r"""(?m)^(?P<prefix>version\s*=\s*["'])(?P<value>[^"']+)(?P<tail>["'])"""
+    )
+    body = before[start:end]
+    match = version_re.search(body)
+    if not match or match.group("value") != old:
+        return None
+    new_body = body[: match.start("value")] + new + body[match.end("value") :]
+    after = before[:start] + new_body + before[end:]
+    return FileUpdate(path=path, before=before, after=after, summary="[project] version")
+
+
+# TOML allows a comment after a table header (`[project]  # main metadata`),
+# so match `]` followed by optional whitespace and an optional `# comment`.
+_TOML_SECTION_RE = re.compile(r"(?m)^\[([^\]\n]+)\]\s*(?:#.*)?$")
+
+
+def _find_project_table_span(text: str) -> Optional[Tuple[int, int]]:
+    """Return ``(start, end)`` indices of the ``[project]`` table body."""
+    for header in _TOML_SECTION_RE.finditer(text):
+        if header.group(1).strip() != "project":
+            continue
+        body_start = header.end()
+        next_header = _TOML_SECTION_RE.search(text, body_start)
+        body_end = next_header.start() if next_header else len(text)
+        return body_start, body_end
+    return None
+
+
+def _update_package_json_files(
+    ext_dir: Path, old: str, new: str
+) -> List[Optional[FileUpdate]]:
+    """Update root and any first-level ``package.json`` (e.g. ``frontend/``).
+
+    Scaffolded app extensions keep their JS package file under
+    ``frontend/package.json``; a root-only check would silently leave it
+    stale. Restricting to depth 1 keeps the scan bounded and avoids
+    crawling ``node_modules``.
+    """
+    candidates: List[Path] = []
+    root = ext_dir / "package.json"
+    if root.exists():
+        candidates.append(root)
+    for child in sorted(ext_dir.iterdir() if ext_dir.exists() else []):
+        if not child.is_dir() or child.name in {"node_modules", ".git"} or child.name.startswith("."):
+            continue
+        nested = child / "package.json"
+        if nested.exists():
+            candidates.append(nested)
+    return [_update_package_json(p, old, new) for p in candidates]
+
+
+def _update_package_json(path: Path, old: str, new: str) -> Optional[FileUpdate]:
+    before = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(before)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict) or data.get("version") != old:
+        return None
+    # Targeted rewrite of the **top-level** `"version"` key. A bare regex
+    # match-first would rewrite the first textual `"version"` — which could
+    # be a nested one like `engines.version` or `config.version` — and
+    # leave the real package version stale. Walk the source with brace
+    # depth + string awareness to locate the depth-1 value span and splice
+    # in the new version, preserving the file's indentation and key order.
+    span = _find_top_level_string_value_span(before, "version")
+    if span is None or before[span[0] : span[1]] != old:
+        return None
+    after = before[: span[0]] + new + before[span[1] :]
+    if after == before:
+        return None
+    return FileUpdate(path=path, before=before, after=after, summary='"version"')
+
+
+def _find_top_level_string_value_span(text: str, key: str) -> Optional[Tuple[int, int]]:
+    """Return ``(start, end)`` of the string value bound to top-level *key*.
+
+    Walks the JSON text tracking brace/bracket depth so nested objects
+    that happen to use the same key name (e.g. ``engines.version``) are
+    ignored. Returns ``None`` if the key isn't found at depth 1 with a
+    string value.
+    """
+    depth = 0
+    i = 0
+    n = len(text)
+    in_string = False
+    string_start = -1
+    pending_key: Optional[str] = None
+    awaiting_value = False
+    while i < n:
+        ch = text[i]
+        if in_string:
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == '"':
+                token = text[string_start + 1 : i]
+                in_string = False
+                if awaiting_value and depth == 1:
+                    if pending_key == key:
+                        return string_start + 1, i
+                    awaiting_value = False
+                    pending_key = None
+                else:
+                    pending_key = token
+            i += 1
+            continue
+        if ch == '"':
+            in_string = True
+            string_start = i
+        elif ch in "{[":
+            depth += 1
+        elif ch in "}]":
+            depth -= 1
+            awaiting_value = False
+            pending_key = None
+        elif ch == ":":
+            if depth == 1 and pending_key is not None:
+                awaiting_value = True
+        elif ch == ",":
+            awaiting_value = False
+            pending_key = None
+        i += 1
+    return None

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -61,6 +61,18 @@ def _build_patch_kwargs(
     sandbox = extra.get("sandbox")
     if sandbox:
         kwargs["sandbox"] = sandbox
+    # Always forward ``volumes`` (even when empty) so removing a named
+    # volume from compose actually clears the stale top-level volume on
+    # the persisted CR. Same iterative-dev contract that drives the
+    # ``kamiwaza``/annotations forwarding above.
+    #
+    # Safe against operator-managed mounts: the kamiwaza-extension-
+    # operator rebuilds each Deployment's volume list every reconcile as
+    # ``[tmp emptyDir] + (data PVC if persistence) + svc.Volumes``. The
+    # ``tmp``/``data`` volumes are injected at reconcile time and are
+    # never stored in ``svc.Volumes``, so PATCHing ``volumes: []`` clears
+    # only user-declared volumes and cannot wipe operator-managed ones.
+    kwargs["volumes"] = extra.get("volumes") or []
     return kwargs
 
 
@@ -105,6 +117,13 @@ def _build_patch_service_specs(payload: Any) -> List[Any]:
         ):
             if field in svc_extra and svc_extra[field] is not None:
                 setattr(spec, field, svc_extra[field])
+        # Always forward ``volumeMounts`` (even when empty) so removing
+        # a volume from compose clears the stale per-service mount on
+        # the persisted CR; consistent with the top-level ``volumes``
+        # forwarding in ``_build_patch_kwargs``. The operator appends
+        # ``svc.VolumeMounts`` after its own ``tmp``/``data`` mounts, so
+        # an empty list clears only user-declared mounts.
+        spec.volumeMounts = svc_extra.get("volumeMounts") or []
         patch_services.append(spec)
     return patch_services
 

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -270,7 +270,10 @@ def run_publish(
         validate_digest,
     )
     from kamiwaza_extensions.profile_manager import ProfileManager
-    from kamiwaza_extensions.registry_builder import RegistryBuilder
+    from kamiwaza_extensions.registry_builder import (
+        RegistryBuilder,
+        resolve_extra_image,
+    )
     from kamiwaza_extensions.validators.compose import ComposeValidator
     from kamiwaza_extensions.validators.metadata import MetadataValidator
 
@@ -623,6 +626,25 @@ def run_publish(
                 _verify_supplied_digest(ref, digest)
         else:
             digest_map = _auto_resolve_digests(published_refs)
+
+    # Extras under our registry get the same tag-and-digest pinning as
+    # compose buildable services. External refs and author-pinned
+    # `@sha256:...` refs pass through untouched. Refs already in
+    # digest_map (e.g. the buildable service redundantly listed in extras
+    # when the user supplied `--digest`) are left alone — re-resolving
+    # would hit the registry and could overwrite an explicit user pin.
+    resolved_extras = [
+        resolve_extra_image(img, registry, version, stage)
+        for img in (info.metadata.get("extra_docker_images") or [])
+    ]
+    extras_to_resolve = [
+        r for r in resolved_extras
+        if r.startswith(f"{registry}/")
+        and "@" not in r
+        and r not in digest_map
+    ]
+    if extras_to_resolve:
+        digest_map.update(_auto_resolve_digests(extras_to_resolve))
 
     # 7. Build catalog entry
     reg_builder = RegistryBuilder()

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -385,13 +385,22 @@ def run_publish(
     meta_result = meta_validator.validate(info.path / "kamiwaza.json")
 
     compose_validator = ComposeValidator()
-    compose_result = compose_validator.validate(publish_compose_path, info.path)
+    # An authored appgarden compose is published via `_retag_appgarden_compose`,
+    # which bypasses `ComposeTransformer` — so bind mounts and missing resource
+    # limits are NOT stripped/backfilled and must surface as warnings, not info.
+    compose_result = compose_validator.validate(
+        publish_compose_path,
+        info.path,
+        transformer_handled=appgarden_data is None,
+    )
 
     all_errors = meta_result.errors[:]
     all_warnings = meta_result.warnings[:]
+    all_info = meta_result.info[:]
     if compose_result:
         all_errors.extend(compose_result.errors)
         all_warnings.extend(compose_result.warnings)
+        all_info.extend(compose_result.info)
 
     if all_errors:
         console.print("          [red]\u2717 failed[/red]")
@@ -405,6 +414,8 @@ def run_publish(
             console.print(f"    [yellow]![/yellow] {warn}")
     else:
         console.print("          [green]\u2713[/green] passed")
+    for info_msg in all_info:
+        console.print(f"    [cyan]i[/cyan] {info_msg}")
 
     # 3. Resolve publish profile
     profile_mgr = ProfileManager()

--- a/kamiwaza_extensions/commands/validate.py
+++ b/kamiwaza_extensions/commands/validate.py
@@ -35,7 +35,16 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
         ext_dir = ExtensionDetector().find_root(start_dir)
     except (ExtensionNotFoundError, MultipleExtensionsError) as exc:
         if json_output:
-            typer.echo(json_mod.dumps({"passed": False, "errors": [str(exc)], "warnings": []}))
+            typer.echo(
+                json_mod.dumps(
+                    {
+                        "passed": False,
+                        "errors": [str(exc)],
+                        "warnings": [],
+                        "info": [],
+                    }
+                )
+            )
         else:
             console.print(f"[red]Error:[/red] {exc}")
         raise typer.Exit(code=1) from exc
@@ -72,12 +81,15 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
     # Merge results
     all_errors = meta_result.errors[:]
     all_warnings = meta_result.warnings[:]
+    all_info = meta_result.info[:]
     if compose_result:
         all_errors.extend(compose_result.errors)
         all_warnings.extend(compose_result.warnings)
+        all_info.extend(compose_result.info)
     if runtime_result:
         all_errors.extend(runtime_result.errors)
         all_warnings.extend(runtime_result.warnings)
+        all_info.extend(runtime_result.info)
 
     passed = len(all_errors) == 0
 
@@ -86,6 +98,7 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
             "passed": passed,
             "errors": all_errors,
             "warnings": all_warnings,
+            "info": all_info,
         }
         typer.echo(json_mod.dumps(output, indent=2))
     else:
@@ -95,6 +108,9 @@ def run_validate(*, path: Optional[str], json_output: bool) -> None:
         if all_warnings:
             for warn in all_warnings:
                 console.print(f"  [yellow]![/yellow] {warn}")
+        if all_info:
+            for info_msg in all_info:
+                console.print(f"  [cyan]i[/cyan] {info_msg}")
         if passed:
             console.print("[green]✓ Validation passed[/green]", highlight=False)
             if all_warnings:

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -6,6 +6,11 @@ import copy
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+# Reuse the validator's bind-mount detection so the "stripped at deploy"
+# info message ComposeValidator emits stays in sync with what the
+# transformer actually strips (ENG-4956).
+from kamiwaza_extensions.validators.compose import is_bind_mount
+
 
 def _replace_image_tag(image_ref: str, new_tag: str) -> str:
     """Return *image_ref* with its tag (and any digest) replaced by *new_tag*.
@@ -541,22 +546,23 @@ def _strip_host_ports(ports: List[Any]) -> List[str]:
 
 
 def _strip_bind_mounts(volumes: List[Any]) -> List[str]:
-    """Keep named volumes, remove bind mounts (``./``, ``../``, absolute paths)."""
-    kept = []
+    """Keep named volumes, remove bind mounts.
+
+    String bind-mount detection is delegated to the validator's
+    ``is_bind_mount`` so every host-path form ``ComposeValidator``
+    flags as "stripped at deploy" (absolute/relative paths, ``~``, and
+    Windows drive letters) is actually stripped here. See ENG-4956.
+    """
+    kept: List[Any] = []
     for vol in volumes:
         if isinstance(vol, dict):
-            # Long-form volume — check type
+            # Long-form volume — keep named volumes; bind/tmpfs are stripped.
             if vol.get("type") == "volume":
                 kept.append(vol)
-            # bind / tmpfs types are stripped
             continue
         s = str(vol)
-        if s.startswith("/") or s.startswith("./") or s.startswith("../"):
+        if is_bind_mount(s):
             continue
-        if ":" in s:
-            host_part = s.split(":", 1)[0]
-            if host_part.startswith("/") or host_part.startswith("./") or host_part.startswith("../"):
-                continue
         kept.append(s)
     return kept
 

--- a/kamiwaza_extensions/constants.py
+++ b/kamiwaza_extensions/constants.py
@@ -16,6 +16,13 @@ COMPOSE_FILENAMES = (
     "compose.yaml",
 )
 
+# All compose-file names a version bump / drift check should inspect. Includes
+# the appgarden deployment overlay alongside the canonical compose names.
+ALL_COMPOSE_FILENAMES = COMPOSE_FILENAMES + (
+    "docker-compose.appgarden.yml",
+    "docker-compose.appgarden.yaml",
+)
+
 EXTENSIONS_NAMESPACE = "kamiwaza-extensions"
 
 

--- a/kamiwaza_extensions/convert_agent/agent.py
+++ b/kamiwaza_extensions/convert_agent/agent.py
@@ -266,7 +266,7 @@ def _validate_plan_in_staging(
     """Materialize the plan in a temp copy and run the validators against it."""
     from kamiwaza_extensions.validators.compose import (
         ComposeValidator,
-        is_missing_resource_limits_warning,
+        is_missing_resource_limits_finding,
     )
     from kamiwaza_extensions.validators.metadata import MetadataValidator
     from kamiwaza_extensions.validators.platform_runtime import PlatformRuntimeValidator
@@ -301,6 +301,7 @@ def _validate_plan_in_staging(
 
         errors: List[str] = []
         warnings: List[str] = []
+        info: List[str] = []
 
         metadata_path = staged_root / "kamiwaza.json"
         if not metadata_path.exists():
@@ -309,6 +310,7 @@ def _validate_plan_in_staging(
             meta_result = MetadataValidator().validate(metadata_path)
             errors.extend(meta_result.errors)
             warnings.extend(meta_result.warnings)
+            info.extend(meta_result.info)
 
         compose_path = _find_compose_file(staged_root)
         if compose_path is None:
@@ -317,18 +319,30 @@ def _validate_plan_in_staging(
             compose_result = ComposeValidator().validate(compose_path, staged_root)
             errors.extend(compose_result.errors)
             warnings.extend(compose_result.warnings)
-            for warning in compose_result.warnings:
-                if is_missing_resource_limits_warning(warning):
-                    errors.append(f"Blocking conversion warning: {warning}")
+            info.extend(compose_result.info)
+            # Conversion is intentionally stricter than `validate`/`publish`:
+            # those surface missing resource limits as benign `info` because
+            # deploy applies defaults, but a converted app should ship explicit
+            # limits, so we promote the finding to a blocking conversion error.
+            # Scan both channels since the finding may land in either.
+            for message in compose_result.warnings + compose_result.info:
+                if is_missing_resource_limits_finding(message):
+                    errors.append(f"Blocking conversion finding: {message}")
             if compose_result.passed:
                 runtime_result = PlatformRuntimeValidator().validate(compose_path, staged_root)
                 errors.extend(runtime_result.errors)
                 warnings.extend(runtime_result.warnings)
+                info.extend(runtime_result.info)
 
         if not (staged_root / "CONVERT_NOTES.md").exists():
             errors.append("CONVERT_NOTES.md was not generated.")
 
-        return ValidationSummary(passed=len(errors) == 0, errors=errors, warnings=warnings)
+        return ValidationSummary(
+            passed=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+            info=info,
+        )
 
 
 def _strip_outward_symlinks(staged_root: Path) -> None:

--- a/kamiwaza_extensions/convert_agent/models.py
+++ b/kamiwaza_extensions/convert_agent/models.py
@@ -46,6 +46,7 @@ class ValidationSummary:
     passed: bool = False
     errors: List[str] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
+    info: List[str] = field(default_factory=list)
 
 
 @dataclass

--- a/kamiwaza_extensions/convert_agent/prompts.py
+++ b/kamiwaza_extensions/convert_agent/prompts.py
@@ -270,6 +270,7 @@ def _render_validation_feedback(validation: Optional[ValidationSummary]) -> str:
         return ""
     error_lines = "\n".join(f"- {err}" for err in validation.errors) or "- None"
     warning_lines = "\n".join(f"- {warn}" for warn in validation.warnings) or "- None"
+    info_lines = "\n".join(f"- {info}" for info in validation.info) or "- None"
     return f"""
 ## Validation Feedback From Previous Attempt
 Errors:
@@ -277,6 +278,9 @@ Errors:
 
 Warnings:
 {warning_lines}
+
+Info:
+{info_lines}
 """
 
 

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import socket
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -20,6 +21,7 @@ from kamiwaza_sdk.schemas.extensions import (
 
 from kamiwaza_extensions.compose_transformer import detect_service_url_rewrites
 from kamiwaza_extensions.connections import ConnectionInfo
+from kamiwaza_extensions.volume_utils import looks_like_host_path
 
 # CRD annotation keys — namespace is ``kamiwaza.io/*`` (NOT ``kamiwaza.ai/*``).
 # The platform's annotation persister filters incoming Extension CR annotations
@@ -65,6 +67,104 @@ def _compose_resources_to_k8s(resources: Dict[str, str]) -> Dict[str, str]:
     return out
 
 
+_DNS_LABEL_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def _build_volume_specs(
+    transformed: Dict[str, Any],
+) -> tuple[List[Dict[str, Any]], Dict[str, List[Dict[str, Any]]]]:
+    """Translate named compose volumes to K8s emptyDir volumes and mounts."""
+    volumes: List[Dict[str, Any]] = []
+    mounts_by_service: Dict[str, List[Dict[str, Any]]] = {}
+    source_to_name: Dict[str, str] = {}
+    # Pre-reserve the operator-injected volume names. The kamiwaza-
+    # extension-operator rebuilds each Deployment's volume list as
+    # ``[tmp emptyDir] + (data PVC if persistence) + svc.Volumes``; if a
+    # user's compose volume normalizes to ``tmp`` or ``data``, the
+    # reconciled pod would carry duplicate volume names and the K8s API
+    # would reject the spec. Seeding the set forces such a volume to a
+    # collision-suffixed name (``tmp-2``/``data-2``).
+    used_names: set[str] = {"tmp", "data"}
+
+    for svc_name, svc in (transformed.get("services") or {}).items():
+        if not isinstance(svc, dict):
+            continue
+        mounts: List[Dict[str, Any]] = []
+        for raw_volume in svc.get("volumes", []) or []:
+            parsed = _parse_named_volume_mount(raw_volume)
+            if not parsed:
+                continue
+            source, target, read_only = parsed
+            if source not in source_to_name:
+                name = _unique_k8s_volume_name(source, used_names)
+                source_to_name[source] = name
+                volumes.append({"name": name, "emptyDir": {}})
+
+            mount: Dict[str, Any] = {
+                "name": source_to_name[source],
+                "mountPath": target,
+            }
+            if read_only:
+                mount["readOnly"] = True
+            mounts.append(mount)
+        if mounts:
+            mounts_by_service[svc_name] = mounts
+
+    return volumes, mounts_by_service
+
+
+def _parse_named_volume_mount(raw_volume: Any) -> Optional[tuple[str, str, bool]]:
+    """Return ``(source, target, read_only)`` for named compose volumes."""
+    if isinstance(raw_volume, dict):
+        volume_type = raw_volume.get("type", "volume")
+        source = raw_volume.get("source") or raw_volume.get("src")
+        target = (
+            raw_volume.get("target")
+            or raw_volume.get("destination")
+            or raw_volume.get("dst")
+        )
+        if volume_type != "volume" or not source or not target:
+            return None
+        source_str = str(source)
+        target_str = str(target)
+        if looks_like_host_path(source_str) or not target_str.startswith("/"):
+            return None
+        read_only = bool(raw_volume.get("read_only") or raw_volume.get("readOnly"))
+        return source_str, target_str, read_only
+
+    if not isinstance(raw_volume, str):
+        return None
+
+    parts = raw_volume.split(":")
+    if len(parts) < 2:
+        return None
+    source, target = parts[0], parts[1]
+    if not source or not target or not target.startswith("/"):
+        return None
+    if looks_like_host_path(source):
+        return None
+
+    modes = ",".join(parts[2:]).split(",") if len(parts) > 2 else []
+    read_only = any(mode.strip().lower() == "ro" for mode in modes)
+    return source, target, read_only
+
+
+def _unique_k8s_volume_name(source: str, used_names: set[str]) -> str:
+    base = _DNS_LABEL_RE.sub("-", source.lower()).strip("-")
+    if not base:
+        base = "volume"
+    base = base[:63].strip("-") or "volume"
+    name = base
+    counter = 2
+    while name in used_names:
+        suffix = f"-{counter}"
+        prefix_len = 63 - len(suffix)
+        name = f"{base[:prefix_len].rstrip('-')}{suffix}"
+        counter += 1
+    used_names.add(name)
+    return name
+
+
 class PayloadBuilder:
     """Build a ``CreateExtension`` request from extension metadata and
     a transformed compose dict."""
@@ -92,6 +192,7 @@ class PayloadBuilder:
         # ``tlsRejectUnauthorized`` spec field so the deployed
         # extension's in-cluster callbacks match the developer's intent.
         verify_ssl = connection.effective_verify_ssl()
+        volumes, service_volume_mounts = _build_volume_specs(transformed_compose)
 
         services = self._build_services(
             transformed_compose,
@@ -99,6 +200,7 @@ class PayloadBuilder:
             verify_ssl=verify_ssl,
             extension_type=ext_type,
             metadata=metadata,
+            service_volume_mounts=service_volume_mounts,
         )
         origin = connection.url.removesuffix("/api")
         tls_reject = "0" if not verify_ssl else "1"
@@ -125,6 +227,8 @@ class PayloadBuilder:
         sandbox = self._build_sandbox_spec(metadata, transformed_compose)
         if sandbox:
             kwargs["sandbox"] = sandbox
+        if volumes:
+            kwargs["volumes"] = volumes
 
         annotations = self.build_annotations(deployer=deployer, revision=revision)
 
@@ -204,8 +308,10 @@ class PayloadBuilder:
         verify_ssl: bool = True,
         extension_type: str = "app",
         metadata: Optional[Dict[str, Any]] = None,
+        service_volume_mounts: Optional[Dict[str, List[Dict[str, Any]]]] = None,
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
+        service_volume_mounts = service_volume_mounts or {}
         specs: List[ExtensionServiceSpec] = []
 
         # Determine primary service: prefer "frontend", fall back to first with ports
@@ -292,6 +398,9 @@ class PayloadBuilder:
             )
             if container_security_context is not None:
                 spec_kwargs["containerSecurityContext"] = container_security_context
+            volume_mounts = service_volume_mounts.get(svc_name)
+            if volume_mounts:
+                spec_kwargs["volumeMounts"] = volume_mounts
 
             specs.append(ExtensionServiceSpec(**spec_kwargs))
 

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -98,6 +98,7 @@ class PayloadBuilder:
             app_path=app_path,
             verify_ssl=verify_ssl,
             extension_type=ext_type,
+            metadata=metadata,
         )
         origin = connection.url.removesuffix("/api")
         tls_reject = "0" if not verify_ssl else "1"
@@ -202,6 +203,7 @@ class PayloadBuilder:
         app_path: str = "",
         verify_ssl: bool = True,
         extension_type: str = "app",
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
         specs: List[ExtensionServiceSpec] = []
@@ -248,7 +250,20 @@ class PayloadBuilder:
                 env.append({"name": "KAMIWAZA_VERIFY_SSL", "value": "false"})
                 env.append({"name": "KAMIWAZA_TLS_REJECT_UNAUTHORIZED", "value": "0"})
 
-            health_check = _service_extension_field(svc, "healthCheck")
+            # Health-check precedence (ENG-4832):
+            # 1. ``kamiwaza.json`` → ``services.<svc_name>.healthCheck`` —
+            #    the user-facing escape hatch for any tool/service extension
+            #    whose primary doesn't serve ``/sse`` (FastMCP feature-flagged
+            #    off, REST-only, gRPC-only). Lives in the metadata file
+            #    rather than compose so kamiwaza.json stays the single
+            #    source of catalog truth.
+            # 2. Compose ``x-kamiwaza.healthCheck`` — pre-existing override
+            #    path for compose-authored extensions.
+            # 3. ``_default_health_check`` heuristics — back-compat default
+            #    when neither override is set.
+            health_check = _metadata_service_field(metadata, svc_name, "healthCheck")
+            if not health_check:
+                health_check = _service_extension_field(svc, "healthCheck")
             if not health_check:
                 health_check = self._default_health_check(
                     svc_name,
@@ -387,13 +402,17 @@ class PayloadBuilder:
         # the FastMCP SSE endpoint — even though the response body streams
         # past the K8s 5s probe timeout. The platform's CR API currently
         # rejects ``tcpSocket`` and ``exec`` healthCheck shapes with an
-        # opaque 500, leaving httpGet as the only path. /sse is preferable
-        # to /health (404 under FastMCP) — the headers come back 200 even
-        # if the probe times out reading the body, which keeps the pod
-        # restart-loop from firing. Net result: pod runs and serves
-        # requests, but K8s may take longer to mark it Ready. The proper
-        # fix is to teach the platform API to accept tcpSocket/exec
-        # probes (tracked separately).
+        # opaque 500 (ENG-4833), leaving httpGet as the only path. /sse is
+        # preferable to /health (404 under FastMCP) — the headers come back
+        # 200 even if the probe times out reading the body, which keeps
+        # the pod restart-loop from firing. Net result: pod runs and serves
+        # requests, but K8s may take longer to mark it Ready.
+        #
+        # Escape hatch (ENG-4832): tool extensions that DON'T serve /sse
+        # (REST-only, MCP at /mcp via streamable-http, gRPC, feature-flagged
+        # MCP off) should declare an explicit probe in ``kamiwaza.json``
+        # under ``services.<svc_name>.healthCheck``. That override runs
+        # ahead of the heuristics below — see ``_build_services``.
         if extension_type == "service" and is_primary:
             path = "/"
         elif extension_type == "tool" and is_primary:
@@ -547,6 +566,32 @@ def _service_extension_field(svc: Dict[str, Any], key: str) -> Optional[Any]:
     if isinstance(x_kamiwaza, dict) and key in x_kamiwaza:
         return x_kamiwaza[key]
     return None
+
+
+def _metadata_service_field(
+    metadata: Optional[Dict[str, Any]],
+    svc_name: str,
+    key: str,
+) -> Optional[Any]:
+    """Read a per-service override from ``kamiwaza.json`` (ENG-4832).
+
+    Shape::
+
+        {
+          "services": {
+            "<svc_name>": { "<key>": <value> }
+          }
+        }
+    """
+    if not isinstance(metadata, dict):
+        return None
+    services = metadata.get("services")
+    if not isinstance(services, dict):
+        return None
+    svc_block = services.get(svc_name)
+    if not isinstance(svc_block, dict):
+        return None
+    return svc_block.get(key)
 
 
 def _service_env_map(svc: Dict[str, Any]) -> Dict[str, str]:

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -70,12 +70,13 @@ class RegistryBuilder:
                 are tagged with publish's revision; services without one
                 keep their declared image ref verbatim).
             registry: Docker registry prefix (e.g. ``"kamiwazaai"``).
-            version: Semver version string for this release.
+            version: Semver version string for this release. Substituted
+                into ``{version}`` placeholders in ``extra_docker_images``
+                entries.
             stage: One of ``"prod"``, ``"stage"``, ``"dev"``, or any custom name.
-                Currently unused in the body — ``ComposeTransformer`` already
-                applied the stage-derived tag to buildable services. Kept on
-                the signature for call-site compatibility with prior callers
-                of ``RegistryBuilder``.
+                Applied as a tag suffix to ``extra_docker_images`` entries
+                under *registry* that carried a ``{version}`` placeholder.
+                Author-pinned literal tags pass through untouched.
             revision: Optional revision identifier. When provided, included
                 as a top-level ``revision`` field on the entry; consumed by
                 ``CatalogDedupGuard`` to make CI re-publishes idempotent.
@@ -103,26 +104,20 @@ class RegistryBuilder:
         )
         docker_images = self.extract_docker_images(transformed_compose)
 
-        extra_images = metadata.get("extra_docker_images") or []
-        if extra_images:
-            # Apply the same digest-pinning rule to extras so a service
-            # ref that's redundantly listed in `extra_docker_images`
-            # collapses against its already-pinned compose copy during
-            # dedup, instead of leaking an unpinned duplicate.
-            #
-            # Match is exact-string against the post-stage-suffix ref
-            # (e.g. `<reg>/<ext>-<svc>:<version>-dev`); a pre-suffix
-            # entry like `<reg>/<ext>-<svc>:<version>` won't collapse.
-            # Author the entry to match what compose carries after
-            # transform.
-            if digest_map:
-                extra_images = [
-                    f"{img}@{digest_map[img]}"
-                    if img in digest_map and "@" not in img
-                    else img
-                    for img in extra_images
-                ]
-            docker_images = list(dict.fromkeys(docker_images + extra_images))
+        # `docker_images` and `extra_docker_images` are disjoint catalog
+        # fields: compose-derived vs. author-declared. Downstream consumers
+        # iterate each list separately; do not merge.
+        extra_images = [
+            resolve_extra_image(img, registry, version, stage)
+            for img in (metadata.get("extra_docker_images") or [])
+        ]
+        if extra_images and digest_map:
+            extra_images = [
+                f"{img}@{digest_map[img]}"
+                if img in digest_map and "@" not in img
+                else img
+                for img in extra_images
+            ]
 
         # Source kamiwaza.json is the catalog contract: every top-level
         # field the developer authored reaches the catalog entry. The
@@ -142,6 +137,14 @@ class RegistryBuilder:
         entry.setdefault("visibility", "public")
         entry["compose_yml"] = compose_yml
         entry["docker_images"] = docker_images
+        # Overwrite the deepcopy carryover with the resolved list (source
+        # entries are in author format; the catalog needs post-substitution
+        # refs). Drop the field entirely when metadata declared no extras
+        # so the catalog field is absent rather than an empty array.
+        if extra_images:
+            entry["extra_docker_images"] = extra_images
+        else:
+            entry.pop("extra_docker_images", None)
 
         # `revision` is owned exclusively by the publish-time parameter,
         # never by source kamiwaza.json. Pop first so a stale value in
@@ -427,6 +430,47 @@ def _apply_digests(
         if img and "@" not in img and img in digest_map:
             svc["image"] = f"{img}@{digest_map[img]}"
     return result
+
+
+def resolve_extra_image(
+    image: str, registry: str, version: str, stage: str,
+) -> str:
+    """Apply ``{version}`` substitution and stage suffix to one ref.
+
+    Substitutes ``{version}`` literally, then applies the stage-derived
+    suffix only to substituted refs under *registry*. Returns *image*
+    unchanged when:
+
+    - The ref carried no ``{version}`` placeholder (author-pinned tag).
+    - The ref is already digest-pinned (``@sha256:...``).
+    - The ref is outside *registry* (external pass-through).
+    """
+    substituted = image.replace("{version}", version)
+
+    if (
+        substituted == image
+        or "@" in substituted
+        or not substituted.startswith(f"{registry}/")
+    ):
+        return substituted
+
+    # The tag, if any, lives after the last `/`. Splitting on the leftmost
+    # `:` would catch a registry port (e.g. `localhost:5000/...`) instead.
+    suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
+    slash = substituted.rfind("/")
+    last_segment = substituted[slash + 1:]
+    if ":" in last_segment:
+        colon = last_segment.index(":")
+        name = substituted[: slash + 1 + colon]
+        tag = last_segment[colon + 1:]
+        # Strip an existing stage suffix so `agent:{version}-dev` published
+        # against a prod stage emits the unsuffixed tag rather than
+        # `agent:1.8.13-dev` reapplied.
+        clean_tag = re.sub(r"-(dev|stage)$", "", tag)
+    else:
+        name, clean_tag = substituted, "latest"
+
+    return f"{name}:{clean_tag}{suffix}"
 
 
 def _normalize_preview_image(path: str) -> str:

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -25,6 +25,14 @@ _STAGE_SUFFIXES = {
     "dev": "-dev",
 }
 
+# Matches compose ``${VAR:-default}`` and ``${VAR-default}`` env values.
+# ``${VAR}`` (no default) and ``${VAR:?error}`` (required) don't match —
+# they have no default to rewrite. ``[^}]+`` keeps the digest's leading
+# ``@sha256:...`` inside the captured default (no ``}`` in a digest).
+_ENV_DEFAULT_SUB_RE = re.compile(
+    r"\A(\$\{[A-Za-z_][A-Za-z0-9_]*:?-)([^}]+)(\})\Z"
+)
+
 # Lazy-initialized probe versions for constraint overlap detection.
 # Built on first use to avoid ~50ms import-time cost.
 _PROBE_VERSIONS: Optional[List[Version]] = None
@@ -94,6 +102,16 @@ class RegistryBuilder:
         """
         if digest_map:
             transformed_compose = _apply_digests(transformed_compose, digest_map)
+
+        # Env-var image refs (e.g. ``${AGENT_SERVER_IMAGE:-<reg>/agent:1.8.13}``)
+        # are a parallel surface to ``services[*].image``: dynamic-spawn
+        # targets that never appear as a compose service so ``_apply_digests``
+        # doesn't catch them. Rewrites are gated on *digest_map* membership
+        # (same source of truth ``_apply_digests`` uses) so an env default
+        # only gets restamped when this publish actually resolved that ref.
+        transformed_compose = _apply_env_image_rewrites(
+            transformed_compose, stage, digest_map
+        )
 
         # sort_keys=False preserves service key order from the source compose.
         # Downstream consumers infer primary-service selection from the order
@@ -430,6 +448,133 @@ def _apply_digests(
         if img and "@" not in img and img in digest_map:
             svc["image"] = f"{img}@{digest_map[img]}"
     return result
+
+
+def _apply_env_image_rewrites(
+    compose: Dict[str, Any],
+    stage: str,
+    digest_map: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Return a deep copy of *compose* with image refs in env values rewritten.
+
+    Walks ``services[*].environment`` (dict and list shapes) and rewrites
+    image refs to the stage-suffixed-and-digest-pinned form ONLY when the
+    post-suffix candidate ref appears as a key in *digest_map*. Caller's
+    *compose* dict is not mutated.
+
+    Sibling to :func:`_apply_digests` for the env-value surface. Kaizen's
+    ``${AGENT_SERVER_IMAGE:-<reg>/agent:1.8.13}`` default is the
+    motivating case: the agent image is referenced by env var because
+    the backend spawns sandbox pods dynamically, so the ref never appears
+    as a service ``image:`` field that ``_apply_digests`` would catch.
+
+    Contract: *digest_map* is the source of truth for "what this publish
+    actually resolved." Gating on its membership keeps env defaults from
+    pointing at refs the publish never produced — e.g. a vendored
+    ``shared-helper:0.5.0`` (independent release cadence) stays at
+    ``:0.5.0`` because ``:0.5.0-dev`` was never built or mirrored. Matches
+    the literal-tag-passthrough rule that :func:`resolve_extra_image`
+    enforces on the extras surface.
+    """
+    if not digest_map:
+        return copy.deepcopy(compose)
+    result = copy.deepcopy(compose)
+    for svc in (result.get("services") or {}).values():
+        env = svc.get("environment")
+        if isinstance(env, dict):
+            for key, val in env.items():
+                if isinstance(val, str):
+                    env[key] = _rewrite_env_image_ref(val, stage, digest_map)
+        elif isinstance(env, list):
+            for i, entry in enumerate(env):
+                if isinstance(entry, str) and "=" in entry:
+                    k, v = entry.split("=", 1)
+                    new_v = _rewrite_env_image_ref(v, stage, digest_map)
+                    if new_v != v:
+                        env[i] = f"{k}={new_v}"
+                elif isinstance(entry, dict):
+                    val = entry.get("value")
+                    if isinstance(val, str):
+                        entry["value"] = _rewrite_env_image_ref(
+                            val, stage, digest_map
+                        )
+    return result
+
+
+def _rewrite_env_image_ref(
+    value: str, stage: str, digest_map: Dict[str, str],
+) -> str:
+    """Apply stage suffix + digest pin to an image ref embedded in *value*.
+
+    Handles two shapes:
+
+    - ``${VAR:-<image>:<tag>}`` (or ``${VAR-default}``) — rewrites the
+      default while preserving the substitution form so a runtime
+      override still wins.
+    - Bare ``<image>:<tag>`` — rewrites in place.
+
+    Pass-through cases (none of which match *digest_map* membership):
+    non-image-shaped strings, already ``@sha256:``-pinned refs, refs
+    whose post-suffix candidate isn't in *digest_map*.
+    """
+    match = _ENV_DEFAULT_SUB_RE.match(value)
+    if match:
+        prefix, default, brace = match.group(1), match.group(2), match.group(3)
+        new_ref = _stage_and_pin_ref(default, stage, digest_map)
+        if new_ref == default:
+            return value
+        return f"{prefix}{new_ref}{brace}"
+    return _stage_and_pin_ref(value, stage, digest_map)
+
+
+def _stage_and_pin_ref(
+    ref: str, stage: str, digest_map: Dict[str, str],
+) -> str:
+    """Return ``ref@digest`` when the staged candidate is in *digest_map*.
+
+    Returns *ref* unchanged when:
+
+    - The ref is already digest-pinned (``@sha256:...``).
+    - The post-suffix candidate isn't a key in *digest_map* — either the
+      ref points outside our published surface (external image, vendored
+      helper) or the publish didn't resolve it.
+
+    Stage suffixes: known built-ins (``-dev``/``-stage``) are stripped
+    before reapplying so re-publishes round-trip cleanly. Custom-stage
+    suffixes aren't stripped (a tracked gap; same behavior in
+    :func:`resolve_extra_image`).
+    """
+    if "@" in ref:
+        return ref
+
+    # Literal-tag refs in `extra_docker_images` (no `{version}` placeholder)
+    # round-trip through ``resolve_extra_image`` unchanged and land in
+    # ``digest_map`` keyed by the literal ref — no stage suffix applied.
+    # When the same ref shows up as an env default, pin against the literal
+    # key first so the env value matches what extras emit. Mirrors the
+    # "independent release cadence" semantics ``resolve_extra_image`` uses.
+    if ref in digest_map:
+        return f"{ref}@{digest_map[ref]}"
+
+    suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
+    # Split on the last `:` after the final `/`; an earlier `:` is a
+    # registry port (e.g. ``localhost:5000/org/agent:tag``).
+    slash = ref.rfind("/")
+    if slash == -1:
+        return ref
+    last_segment = ref[slash + 1:]
+    if ":" in last_segment:
+        colon = last_segment.index(":")
+        name = ref[: slash + 1 + colon]
+        tag = last_segment[colon + 1:]
+        clean_tag = re.sub(r"-(dev|stage)$", "", tag)
+    else:
+        name, clean_tag = ref, "latest"
+
+    candidate = f"{name}:{clean_tag}{suffix}"
+    if candidate in digest_map:
+        return f"{candidate}@{digest_map[candidate]}"
+    return ref
 
 
 def resolve_extra_image(

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import re
+from collections import defaultdict
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 import yaml
 
 from kamiwaza_extensions.validators.result import ValidationResult
+from kamiwaza_extensions.volume_utils import looks_like_host_path
 
 MISSING_RESOURCE_LIMITS_TEXT = "no resource limits defined"
 
@@ -41,6 +42,13 @@ class ComposeValidator:
             warnings.append("No services defined in compose file")
             return ValidationResult(passed=True, warnings=warnings)
 
+        # ENG-4834: named volumes back to ``emptyDir`` at deploy. emptyDir
+        # is Pod-scoped, so a single named volume referenced by >1 service
+        # does NOT share data at runtime — each pod gets its own scratch
+        # dir. Track usage across services and warn after the per-service
+        # pass below so the user knows the contract before deploy.
+        named_volume_users: Dict[str, List[str]] = defaultdict(list)
+
         for svc_name, svc_config in services.items():
             if not isinstance(svc_config, dict):
                 continue
@@ -52,12 +60,59 @@ class ComposeValidator:
                 if ":" in port_str:
                     warnings.append(f"Service '{svc_name}': host port binding '{port_str}' — may conflict in deployment")
 
-            # Bind mounts
-            volumes = svc_config.get("volumes", [])
-            for vol in volumes:
-                vol_str = str(vol)
-                if isinstance(vol, str) and (":./" in vol_str or vol_str.startswith("./") or vol_str.startswith("../") or re.match(r"^/[^$]", vol_str)):
-                    warnings.append(f"Service '{svc_name}': bind mount '{vol_str}' — not available in deployment")
+            # Bind mounts and tmpfs. Bind mounts in a service with a
+            # ``build:`` context are a normal local-dev hot-reload pattern
+            # (the file lives in the build context and the running image
+            # already has it baked in); ``ComposeTransformer`` strips
+            # these at deploy time. For services without ``build:`` —
+            # prebuilt images — a bind mount has no transform path and
+            # the deployed pod would silently miss the files, which is
+            # the failure mode this validator exists to prevent.
+            has_build = "build" in svc_config
+            for vol in svc_config.get("volumes") or []:
+                if _is_tmpfs_mount(vol):
+                    errors.append(
+                        f"Service '{svc_name}': tmpfs mount '{_format_volume(vol)}' "
+                        "is not supported in deployment; write to /tmp directly "
+                        "or use a named volume like 'data:/path'"
+                    )
+                    continue
+                if _is_bind_mount(vol):
+                    formatted = _format_volume(vol)
+                    if has_build:
+                        warnings.append(
+                            f"Service '{svc_name}': bind mount '{formatted}' "
+                            "will be stripped at deploy (local-dev only). "
+                            "Use a named volume for persistence, or 'develop.watch' "
+                            "for hot-reload."
+                        )
+                    else:
+                        errors.append(
+                            f"Service '{svc_name}': bind mount '{formatted}' "
+                            "is not supported in deployment; use a named volume "
+                            "like 'data:/path' or write to /tmp. Note: named "
+                            "volumes deploy as emptyDir, so data is lost on pod "
+                            "restart and not shared across services."
+                        )
+                    continue
+                source = _named_volume_source(vol)
+                if source is not None:
+                    named_volume_users[source].append(svc_name)
+
+            # Service-level ``tmpfs:`` key — a distinct compose field from
+            # ``volumes:``. ``ComposeTransformer`` only strips long-form
+            # tmpfs entries that appear inside ``volumes:``, so a service
+            # declaring the more common top-level ``tmpfs: [...]`` slips
+            # past the transformer and silently loses the mount at deploy.
+            tmpfs = svc_config.get("tmpfs")
+            if tmpfs:
+                entries = tmpfs if isinstance(tmpfs, list) else [tmpfs]
+                for entry in entries:
+                    errors.append(
+                        f"Service '{svc_name}': tmpfs mount '{entry}' is not "
+                        "supported in deployment; write to /tmp directly or "
+                        "use a named volume like 'data:/path'"
+                    )
 
             # Missing resource limits
             deploy = svc_config.get("deploy", {})
@@ -86,9 +141,79 @@ class ComposeValidator:
                     if not dockerfile_path.exists():
                         errors.append(f"Service '{svc_name}': Dockerfile not found at {build}/Dockerfile")
 
+        for source, users in named_volume_users.items():
+            if len(users) > 1:
+                joined = ", ".join(sorted(set(users)))
+                warnings.append(
+                    f"Named volume '{source}' referenced by multiple services "
+                    f"({joined}) — emptyDir is pod-scoped, so each service "
+                    "gets its own copy and data is not shared at runtime."
+                )
+
         # Custom networks
         networks = data.get("networks", {})
         if networks:
             warnings.append("Custom networks defined — platform manages networking")
 
         return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings)
+
+
+def _is_bind_mount(volume: object) -> bool:
+    if isinstance(volume, dict):
+        volume_type = volume.get("type")
+        source = volume.get("source") or volume.get("src")
+        if volume_type == "bind":
+            return True
+        if volume_type in {"tmpfs", "volume"}:
+            return False
+        return bool(source and looks_like_host_path(str(source)))
+
+    if not isinstance(volume, str):
+        return False
+
+    if looks_like_host_path(volume):
+        return True
+    if ":./" in volume or ":../" in volume:
+        return True
+    if ":" not in volume:
+        return False
+    source, _, _ = volume.partition(":")
+    return looks_like_host_path(source)
+
+
+def _is_tmpfs_mount(volume: object) -> bool:
+    if isinstance(volume, dict):
+        return volume.get("type") == "tmpfs"
+    return False
+
+
+def _named_volume_source(volume: object) -> str | None:
+    """Return the source name for a true named compose volume, else None."""
+    if isinstance(volume, dict):
+        if volume.get("type") not in (None, "volume"):
+            return None
+        source = volume.get("source") or volume.get("src")
+        if not source:
+            return None
+        source_str = str(source)
+        if looks_like_host_path(source_str):
+            return None
+        return source_str
+
+    if not isinstance(volume, str) or ":" not in volume:
+        return None
+    source, _, _ = volume.partition(":")
+    if not source or looks_like_host_path(source):
+        return None
+    return source
+
+
+def _format_volume(volume: object) -> str:
+    if isinstance(volume, dict):
+        source = volume.get("source") or volume.get("src") or ""
+        target = (
+            volume.get("target") or volume.get("destination") or volume.get("dst") or ""
+        )
+        if source or target:
+            return f"{source}:{target}".rstrip(":")
+    return str(volume)

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -14,17 +14,49 @@ from kamiwaza_extensions.volume_utils import looks_like_host_path
 MISSING_RESOURCE_LIMITS_TEXT = "no resource limits defined"
 
 
-def is_missing_resource_limits_warning(message: str) -> bool:
-    """Return True when *message* is the compose missing-limits warning."""
+def is_missing_resource_limits_finding(message: str) -> bool:
+    """Return True when *message* is the compose missing-limits finding.
+
+    As of ENG-4956 this finding is emitted on the ``info`` channel when
+    the generic ``ComposeTransformer`` will run (deploy applies
+    defaults), and as a ``warning`` otherwise; conversion still treats
+    it as blocking — see ``ConversionAgent`` for why. The match is
+    channel-agnostic, so callers should scan ``warnings + info``.
+    """
     return MISSING_RESOURCE_LIMITS_TEXT in message.lower()
+
+
+# Deprecated alias: ``is_missing_resource_limits_warning`` was the
+# pre-ENG-4956 name (the finding was always a warning then). Kept so
+# external importers don't break; prefer the ``_finding`` name.
+is_missing_resource_limits_warning = is_missing_resource_limits_finding
 
 
 class ComposeValidator:
     """Validates docker-compose.yml for deployment compatibility."""
 
-    def validate(self, compose_path: Path, ext_dir: Path) -> ValidationResult:
+    def validate(
+        self,
+        compose_path: Path,
+        ext_dir: Path,
+        *,
+        transformer_handled: bool = True,
+    ) -> ValidationResult:
+        """Validate a compose file for deployment compatibility.
+
+        ``transformer_handled`` controls how findings that the generic
+        ``ComposeTransformer`` would normally fix are reported. When
+        True (the default — ``kz-ext validate`` and publishes that go
+        through the generic transform), bind mounts and missing
+        resource limits are emitted on the ``info`` channel because
+        deploy strips/backfills them. When False — e.g. publishing an
+        authored ``docker-compose.appgarden.yml``, which bypasses the
+        transformer — the same findings are emitted as actionable
+        warnings because no deploy-time stripping or defaulting occurs.
+        """
         errors: List[str] = []
         warnings: List[str] = []
+        info: List[str] = []
 
         try:
             with compose_path.open("r", encoding="utf-8") as f:
@@ -77,22 +109,33 @@ class ComposeValidator:
                         "or use a named volume like 'data:/path'"
                     )
                     continue
-                if _is_bind_mount(vol):
+                if is_bind_mount(vol):
                     formatted = _format_volume(vol)
-                    if has_build:
-                        warnings.append(
-                            f"Service '{svc_name}': bind mount '{formatted}' "
-                            "will be stripped at deploy (local-dev only). "
-                            "Use a named volume for persistence, or 'develop.watch' "
-                            "for hot-reload."
-                        )
-                    else:
+                    if not has_build:
                         errors.append(
                             f"Service '{svc_name}': bind mount '{formatted}' "
                             "is not supported in deployment; use a named volume "
                             "like 'data:/path' or write to /tmp. Note: named "
                             "volumes deploy as emptyDir, so data is lost on pod "
                             "restart and not shared across services."
+                        )
+                    elif transformer_handled:
+                        # ENG-4956: a build-service bind mount is the local-dev
+                        # hot-reload pattern ComposeTransformer strips at deploy,
+                        # so a fresh scaffold reports it as info, not a warning.
+                        info.append(
+                            f"Service '{svc_name}': bind mount '{formatted}' "
+                            "— local-dev only (stripped at deploy). Use a named "
+                            "volume for persistence, or 'develop.watch' for hot-reload."
+                        )
+                    else:
+                        # Publish path that bypasses ComposeTransformer (an
+                        # authored appgarden compose): the bind mount is NOT
+                        # stripped, so surface it as an actionable warning.
+                        warnings.append(
+                            f"Service '{svc_name}': bind mount '{formatted}' "
+                            "— ships to the catalog as-is "
+                            "(this publish path does not strip bind mounts)"
                         )
                     continue
                 source = _named_volume_source(vol)
@@ -116,12 +159,16 @@ class ComposeValidator:
 
             # Missing resource limits
             deploy = svc_config.get("deploy", {})
-            if isinstance(deploy, dict):
-                resources = deploy.get("resources", {})
-                if not resources or not isinstance(resources, dict) or not resources.get("limits"):
-                    warnings.append(f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}")
-            else:
-                warnings.append(f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}")
+            resources = deploy.get("resources", {}) if isinstance(deploy, dict) else {}
+            if not isinstance(resources, dict) or not resources.get("limits"):
+                finding = f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}"
+                if transformer_handled:
+                    info.append(f"{finding} — defaults will be applied at deploy")
+                else:
+                    warnings.append(
+                        f"{finding} — add explicit limits "
+                        "(this publish path does not apply deploy-time defaults)"
+                    )
 
             # Explicit container_name
             if "container_name" in svc_config:
@@ -155,10 +202,21 @@ class ComposeValidator:
         if networks:
             warnings.append("Custom networks defined — platform manages networking")
 
-        return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings)
+        return ValidationResult(
+            passed=len(errors) == 0,
+            errors=errors,
+            warnings=warnings,
+            info=info,
+        )
 
 
-def _is_bind_mount(volume: object) -> bool:
+def is_bind_mount(volume: object) -> bool:
+    """Return True when *volume* is a host bind mount (not a named volume).
+
+    Public so ``ComposeTransformer`` can share the exact detection the
+    validator uses, keeping "stripped at deploy" findings in sync with
+    what the transformer actually strips.
+    """
     if isinstance(volume, dict):
         volume_type = volume.get("type")
         source = volume.get("source") or volume.get("src")

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field
 
 from kamiwaza_extensions import __version__
 from kamiwaza_extensions.validators.result import ValidationResult
@@ -25,6 +25,23 @@ _SEMVER_RE = re.compile(
 
 # Valid image extensions for preview_image
 _IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+
+# Dockerfile ARGs that pin third-party runtime / base-image versions and
+# intentionally don't track the extension's own semver. Excluded from drift
+# checks so a clean Dockerfile doesn't emit noisy warnings.
+_RUNTIME_VERSION_ARGS = frozenset({
+    "NODE_VERSION",
+    "PYTHON_VERSION",
+    "ALPINE_VERSION",
+    "DEBIAN_VERSION",
+    "UBUNTU_VERSION",
+    "GO_VERSION",
+    "BUN_VERSION",
+    "RUBY_VERSION",
+    "RUST_VERSION",
+    "JAVA_VERSION",
+    "BASE_IMAGE_VERSION",
+})
 
 
 class KamiwazaMetadata(BaseModel):
@@ -126,7 +143,171 @@ class MetadataValidator:
             if not image_path.exists():
                 warnings.append(f"preview_image file not found: {metadata.preview_image}")
 
+        # Version-drift checks: surface mismatches between kamiwaza.json
+        # version and the same version recorded in sibling files. Drift
+        # silently breaks publishes (manifest claims 2.1.0, image tag still
+        # points at 2.0.14) — warn here so it's visible before deploy.
+        warnings.extend(_check_version_drift(path.parent, metadata.version, data.get("image")))
+
         return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings)
+
+
+def _check_version_drift(
+    ext_dir: Path, version: str, manifest_image: Optional[Any]
+) -> List[str]:
+    # Import locally to share the canonical image-ref parser with the bump
+    # command — keeps the updater and the drift detector from diverging on
+    # what counts as a "tag" (registry ports, digest suffixes, etc.).
+    from kamiwaza_extensions.commands.bump import (
+        _split_image_ref,
+        extension_image_repo,
+    )
+    from kamiwaza_extensions.constants import ALL_COMPOSE_FILENAMES
+
+    warnings: List[str] = []
+    ext_repo = extension_image_repo(manifest_image)
+
+    # kamiwaza.json image tag
+    if isinstance(manifest_image, str):
+        _, tag, _ = _split_image_ref(manifest_image)
+        if tag is not None and tag != version and _looks_like_semver(tag):
+            warnings.append(
+                f"Version drift: kamiwaza.json version='{version}' but image tag='{tag}'"
+            )
+
+    image_re = re.compile(
+        r"""^\s*image\s*:\s*['"]?(?P<ref>\S+?)['"]?\s*(?:\#.*)?$""",
+        re.MULTILINE,
+    )
+    for name in ALL_COMPOSE_FILENAMES:
+        compose = ext_dir / name
+        if not compose.exists():
+            continue
+        try:
+            content = compose.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for match in image_re.finditer(content):
+            repo, tag, _ = _split_image_ref(match.group("ref"))
+            # Only flag images that belong to the extension. Without a
+            # manifest image repo we fall back to "semver tag != manifest
+            # version" alone, which keeps drift detection useful for
+            # manifests that omit `image` but risks noise for unrelated
+            # third-party services (e.g. redis:7.2.4); scoping eliminates
+            # that noise when the manifest declares its repo.
+            if tag is None or tag == version or not _looks_like_semver(tag):
+                continue
+            if ext_repo is not None and repo != ext_repo:
+                continue
+            warnings.append(
+                f"Version drift: {name} has image tag='{tag}' but kamiwaza.json version='{version}'"
+            )
+            break  # one warning per compose file is enough signal
+
+    # Dockerfile *_VERSION ARG defaults
+    dockerfile = ext_dir / "Dockerfile"
+    if dockerfile.exists():
+        try:
+            content = dockerfile.read_text(encoding="utf-8")
+        except OSError:
+            content = ""
+        arg_re = re.compile(
+            r"""^\s*ARG\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*_VERSION)\s*=\s*["']?(?P<value>[^\s"']+)["']?""",
+            re.MULTILINE,
+        )
+        for match in arg_re.finditer(content):
+            name = match.group("name")
+            value = match.group("value")
+            # Skip well-known third-party runtime ARGs — they pin
+            # interpreter/base-image versions that intentionally don't
+            # track the extension's own semver, so any "drift" against
+            # the manifest is noise.
+            if name in _RUNTIME_VERSION_ARGS:
+                continue
+            if value != version and _looks_like_semver(value):
+                warnings.append(
+                    f"Version drift: Dockerfile ARG {name}='{value}' "
+                    f"but kamiwaza.json version='{version}'"
+                )
+
+    # pyproject.toml [project] version — scan only inside the [project]
+    # table to survive arrays (e.g. `classifiers = [...]`) before the
+    # version line.
+    pyproject = ext_dir / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            content = pyproject.read_text(encoding="utf-8")
+        except OSError:
+            content = ""
+        pyproject_version = _find_pyproject_version(content)
+        if pyproject_version is not None and pyproject_version != version:
+            warnings.append(
+                f"Version drift: pyproject.toml version='{pyproject_version}' "
+                f"but kamiwaza.json version='{version}'"
+            )
+
+    # package.json — root and any first-level subdir (e.g. frontend/),
+    # mirroring what `kz-ext bump` propagates so the validator can spot
+    # the same drift the bumper handles.
+    for pkg in _candidate_package_jsons(ext_dir):
+        try:
+            data = json.loads(pkg.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        pkg_version = data.get("version")
+        if isinstance(pkg_version, str) and pkg_version != version:
+            try:
+                rel = pkg.relative_to(ext_dir)
+            except ValueError:
+                rel = pkg
+            warnings.append(
+                f"Version drift: {rel} version='{pkg_version}' "
+                f"but kamiwaza.json version='{version}'"
+            )
+
+    return warnings
+
+
+def _candidate_package_jsons(ext_dir: Path) -> List[Path]:
+    candidates: List[Path] = []
+    root = ext_dir / "package.json"
+    if root.exists():
+        candidates.append(root)
+    try:
+        children = sorted(ext_dir.iterdir())
+    except OSError:
+        return candidates
+    for child in children:
+        if (
+            not child.is_dir()
+            or child.name in {"node_modules", ".git"}
+            or child.name.startswith(".")
+        ):
+            continue
+        nested = child / "package.json"
+        if nested.exists():
+            candidates.append(nested)
+    return candidates
+
+
+def _find_pyproject_version(text: str) -> Optional[str]:
+    from kamiwaza_extensions.commands.bump import _find_project_table_span
+
+    span = _find_project_table_span(text)
+    if span is None:
+        return None
+    start, end = span
+    match = re.search(
+        r"""(?m)^version\s*=\s*["'](?P<value>[^"']+)["']""",
+        text[start:end],
+    )
+    return match.group("value") if match else None
+
+
+def _looks_like_semver(value: str) -> bool:
+    return bool(_SEMVER_RE.match(value))
 
 
 def _is_valid_specifier_set(value: str) -> bool:

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -149,7 +149,148 @@ class MetadataValidator:
         # points at 2.0.14) — warn here so it's visible before deploy.
         warnings.extend(_check_version_drift(path.parent, metadata.version, data.get("image")))
 
+        # services.<name>.healthCheck shape (ENG-4832).
+        service_errors, service_warnings = _check_services_block(data.get("services"))
+        errors.extend(service_errors)
+        warnings.extend(service_warnings)
+
         return ValidationResult(passed=len(errors) == 0, errors=errors, warnings=warnings)
+
+
+_PROBE_SHAPES = ("httpGet", "tcpSocket", "exec", "grpc")
+_HEALTHCHECK_KEYS = frozenset(
+    {
+        *_PROBE_SHAPES,
+        "initialDelaySeconds",
+        "timeoutSeconds",
+        "periodSeconds",
+        "successThreshold",
+        "failureThreshold",
+        "terminationGracePeriodSeconds",
+    }
+)
+_PROBE_KEYS = {
+    "httpGet": frozenset({"path", "port", "host", "scheme", "httpHeaders"}),
+    "tcpSocket": frozenset({"port", "host"}),
+    "exec": frozenset({"command"}),
+    "grpc": frozenset({"port", "service"}),
+}
+_NAMED_PORT_RE = re.compile(r"^[a-z]([-a-z0-9]{0,13}[a-z0-9])?$")
+
+
+def _check_services_block(services: Any) -> tuple[List[str], List[str]]:
+    """Validate the optional ``services`` block in kamiwaza.json (ENG-4832).
+
+    The block is a map of compose service names to per-service overrides.
+    Today the only override we read is ``healthCheck``; this checker keeps
+    structural mistakes (wrong probe shape, missing port, two shapes at
+    once) from reaching the platform CR API as opaque 500s.
+    """
+    errors: List[str] = []
+    warnings: List[str] = []
+    if services is None:
+        return errors, warnings
+    if not isinstance(services, dict):
+        errors.append("services must be a JSON object keyed by service name")
+        return errors, warnings
+    for svc_name, block in services.items():
+        if not isinstance(block, dict):
+            errors.append(f"services.{svc_name} must be a JSON object")
+            continue
+        health = block.get("healthCheck")
+        if health is None:
+            continue
+        health_errors, health_warnings = _check_healthcheck_shape(svc_name, health)
+        errors.extend(health_errors)
+        warnings.extend(health_warnings)
+    return errors, warnings
+
+
+def _check_healthcheck_shape(svc_name: str, health: Any) -> tuple[List[str], List[str]]:
+    """Mirror K8s' "exactly one probe shape" rule for a healthCheck block."""
+    errors: List[str] = []
+    warnings: List[str] = []
+    if not isinstance(health, dict):
+        errors.append(f"services.{svc_name}.healthCheck must be a JSON object")
+        return errors, warnings
+    unknown_health_keys = sorted(set(health) - _HEALTHCHECK_KEYS)
+    for key in unknown_health_keys:
+        warnings.append(
+            f"services.{svc_name}.healthCheck has unknown field '{key}'"
+        )
+    declared = [name for name in _PROBE_SHAPES if name in health]
+    if not declared:
+        errors.append(
+            f"services.{svc_name}.healthCheck must declare one of: "
+            f"{', '.join(_PROBE_SHAPES)}"
+        )
+        return errors, warnings
+    if len(declared) > 1:
+        errors.append(
+            f"services.{svc_name}.healthCheck declares multiple probe shapes "
+            f"({', '.join(declared)}); pick exactly one"
+        )
+        return errors, warnings
+    shape = declared[0]
+    value = health[shape]
+    if not isinstance(value, dict):
+        errors.append(
+            f"services.{svc_name}.healthCheck.{shape} must be a JSON object"
+        )
+        return errors, warnings
+    unknown_probe_keys = sorted(set(value) - _PROBE_KEYS[shape])
+    for key in unknown_probe_keys:
+        warnings.append(
+            f"services.{svc_name}.healthCheck.{shape} has unknown field '{key}'"
+        )
+    if shape in {"httpGet", "tcpSocket", "grpc"}:
+        errors.extend(_check_probe_port(svc_name, shape, value))
+    elif shape == "exec":
+        command = value.get("command")
+        if not isinstance(command, list) or not command:
+            errors.append(
+                f"services.{svc_name}.healthCheck.exec.command must be a non-empty list"
+            )
+    return errors, warnings
+
+
+def _check_probe_port(svc_name: str, shape: str, value: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    if "port" not in value:
+        errors.append(f"services.{svc_name}.healthCheck.{shape} must include 'port'")
+        return errors
+    port = value["port"]
+    if isinstance(port, bool):
+        errors.append(
+            f"services.{svc_name}.healthCheck.{shape}.port must be an integer "
+            "1-65535 or a valid named port"
+        )
+        return errors
+    if isinstance(port, int):
+        if not 1 <= port <= 65535:
+            errors.append(
+                f"services.{svc_name}.healthCheck.{shape}.port must be between 1 and 65535"
+            )
+        return errors
+    if isinstance(port, str):
+        if port.isdigit():
+            number = int(port)
+            if not 1 <= number <= 65535:
+                errors.append(
+                    f"services.{svc_name}.healthCheck.{shape}.port must be between 1 and 65535"
+                )
+            return errors
+        if not _NAMED_PORT_RE.match(port):
+            errors.append(
+                f"services.{svc_name}.healthCheck.{shape}.port must be an integer "
+                "1-65535 or a valid named port"
+            )
+        return errors
+    errors.append(
+        f"services.{svc_name}.healthCheck.{shape}.port must be an integer "
+        "1-65535 or a valid named port"
+    )
+    return errors
 
 
 def _check_version_drift(

--- a/kamiwaza_extensions/validators/result.py
+++ b/kamiwaza_extensions/validators/result.py
@@ -11,3 +11,4 @@ class ValidationResult:
     passed: bool
     errors: List[str] = field(default_factory=list)
     warnings: List[str] = field(default_factory=list)
+    info: List[str] = field(default_factory=list)

--- a/kamiwaza_extensions/volume_utils.py
+++ b/kamiwaza_extensions/volume_utils.py
@@ -1,0 +1,32 @@
+"""Shared classifiers for compose volume entries.
+
+Both ``payload_builder`` and ``validators.compose`` need to recognise host
+paths so they can either translate or reject them. Keeping the rules in
+one module avoids the validator and payload builder drifting on what
+counts as a bind mount.
+"""
+
+from __future__ import annotations
+
+import re
+
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+def looks_like_host_path(source: str) -> bool:
+    """Return True if *source* names a host-side path (not a named volume).
+
+    A ``$`` anywhere in the source means shell/compose variable
+    interpolation (``${PWD}/src``, ``$HOME/.cache``). Such a source
+    resolves to a host path at runtime and can never be a valid named
+    volume — compose volume names are restricted to ``[A-Za-z0-9._-]``.
+    Treating it as a host path makes the validator reject it instead of
+    the payload builder silently turning ``${PWD}/src`` into an
+    ``emptyDir`` over the image's baked application files.
+    """
+    return (
+        source.startswith(("/", "./", "../", "~"))
+        or source in {".", ".."}
+        or "$" in source
+        or bool(_WINDOWS_DRIVE_RE.match(source))
+    )

--- a/tests/unit/extensions/test_bump_cmd.py
+++ b/tests/unit/extensions/test_bump_cmd.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -92,6 +92,397 @@ class TestBump:
         assert data["version"] == "1.0.1"
         assert data["description"] == "keep me"
         assert data["tags"] == ["ai"]
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_image_tag(self, mock_detector_cls, tmp_path):
+        kj = tmp_path / "kamiwaza.json"
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": "ghcr.io/kamiwaza/omniparse:2.0.14",
+        }, indent=4) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        data = json.loads(kj.read_text())
+        assert data["version"] == "2.1.0"
+        assert data["image"] == "ghcr.io/kamiwaza/omniparse:2.1.0"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_leaves_latest_tag_alone(self, mock_detector_cls, tmp_path):
+        kj = tmp_path / "kamiwaza.json"
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": "ghcr.io/kamiwaza/omniparse:latest",
+        }, indent=4) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")
+
+        data = json.loads(kj.read_text())
+        assert data["image"] == "ghcr.io/kamiwaza/omniparse:latest"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_compose_files(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: ghcr.io/kamiwaza/omniparse:2.0.14\n"
+            "  db:\n"
+            "    image: postgres:16\n"
+        )
+        appgarden = tmp_path / "docker-compose.appgarden.yml"
+        appgarden.write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: ghcr.io/kamiwaza/omniparse:2.0.14\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        assert "ghcr.io/kamiwaza/omniparse:2.1.0" in compose.read_text()
+        assert "postgres:16" in compose.read_text()
+        assert "ghcr.io/kamiwaza/omniparse:2.1.0" in appgarden.read_text()
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_dockerfile_arg(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text(
+            "FROM python:3.11\n"
+            "ARG OMNIPARSE_VERSION=2.0.14\n"
+            "ARG UNRELATED=something-else\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = dockerfile.read_text()
+        assert "ARG OMNIPARSE_VERSION=2.1.0" in content
+        assert "ARG UNRELATED=something-else" in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_pyproject(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "# top comment\n"
+            "[project]\n"
+            'name = "omniparse"\n'
+            'version = "2.0.14"  # bumped by kz-ext\n'
+            "\n"
+            "[tool.ruff]\n"
+            "line-length = 88\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")
+
+        content = pyproject.read_text()
+        assert 'version = "2.0.15"' in content
+        assert "# bumped by kz-ext" in content  # comment preserved
+        assert "# top comment" in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_package_json(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pkg = tmp_path / "package.json"
+        pkg.write_text(json.dumps({"name": "x", "version": "2.0.14"}, indent=2) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="major")
+
+        data = json.loads(pkg.read_text())
+        assert data["version"] == "3.0.0"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_only_kamiwaza_json_present(self, mock_detector_cls, tmp_path):
+        kj = _write_kamiwaza_json(tmp_path, "1.0.0")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "1.0.0")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")
+
+        # No sibling files means only kamiwaza.json should change.
+        assert json.loads(kj.read_text())["version"] == "1.0.1"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_dry_run_does_not_write(self, mock_detector_cls, tmp_path):
+        kj = tmp_path / "kamiwaza.json"
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": "ghcr.io/x/y:2.0.14",
+        }, indent=4) + "\n")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text("services:\n  app:\n    image: ghcr.io/x/y:2.0.14\n")
+        before_kj = kj.read_text()
+        before_compose = compose.read_text()
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor", dry_run=True)
+
+        assert kj.read_text() == before_kj
+        assert compose.read_text() == before_compose
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_compose_handles_registry_port(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: localhost:5000/omniparse:2.0.14\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        assert "localhost:5000/omniparse:2.1.0" in compose.read_text()
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_compose_preserves_digest_suffix(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        compose = tmp_path / "docker-compose.yml"
+        digest = "sha256:" + "a" * 64
+        compose.write_text(
+            f"services:\n  app:\n    image: ghcr.io/x/y:2.0.14@{digest}\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")
+
+        content = compose.read_text()
+        assert f"ghcr.io/x/y:2.0.15@{digest}" in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_compose_handles_quoted_image(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text(
+            'services:\n  app:\n    image: "ghcr.io/x/y:2.0.14"\n'
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        assert '"ghcr.io/x/y:2.1.0"' in compose.read_text()
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_pyproject_with_arrays_before_version(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            "[project]\n"
+            'name = "omniparse"\n'
+            'classifiers = [\n'
+            '    "Topic :: Software Development",\n'
+            '    "License :: OSI Approved",\n'
+            ']\n'
+            'dependencies = ["requests", "typer"]\n'
+            'version = "2.0.14"\n'
+            "\n"
+            "[tool.ruff]\n"
+            "line-length = 88\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        assert 'version = "2.1.0"' in pyproject.read_text()
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_propagates_nested_package_json(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        frontend = tmp_path / "frontend"
+        frontend.mkdir()
+        pkg = frontend / "package.json"
+        pkg.write_text(json.dumps({"name": "x", "version": "2.0.14"}, indent=2) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        data = json.loads(pkg.read_text())
+        assert data["version"] == "2.1.0"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_package_json_preserves_indent(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pkg = tmp_path / "package.json"
+        # Use 4-space indent; expect it to survive.
+        original = (
+            '{\n'
+            '    "name": "x",\n'
+            '    "version": "2.0.14",\n'
+            '    "scripts": {\n'
+            '        "build": "next build"\n'
+            '    }\n'
+            '}\n'
+        )
+        pkg.write_text(original)
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="patch")
+
+        content = pkg.read_text()
+        assert '"version": "2.0.15"' in content
+        assert '    "name": "x"' in content  # 4-space indent preserved
+        assert '"scripts"' in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_dockerfile_arg_with_trailing_comment(self, mock_detector_cls, tmp_path):
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text(
+            "FROM python:3.11\n"
+            "ARG OMNIPARSE_VERSION=2.0.14  # injected at build\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = dockerfile.read_text()
+        assert "ARG OMNIPARSE_VERSION=2.1.0" in content
+        assert "# injected at build" in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_image_with_digest_in_kamiwaza_json(self, mock_detector_cls, tmp_path):
+        kj = tmp_path / "kamiwaza.json"
+        digest = "sha256:" + "b" * 64
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": f"ghcr.io/x/y:2.0.14@{digest}",
+        }, indent=4) + "\n")
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        data = json.loads(kj.read_text())
+        assert data["image"] == f"ghcr.io/x/y:2.1.0@{digest}"
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_compose_scopes_to_extension_repo(self, mock_detector_cls, tmp_path):
+        """A sidecar whose tag happens to equal `old` must not be retagged
+        when the manifest declares its own image repo."""
+        kj = tmp_path / "kamiwaza.json"
+        kj.write_text(json.dumps({
+            "name": "test-app",
+            "version": "2.0.14",
+            "image": "ghcr.io/kamiwaza/app:2.0.14",
+        }, indent=4) + "\n")
+        compose = tmp_path / "docker-compose.yml"
+        compose.write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: ghcr.io/kamiwaza/app:2.0.14\n"
+            "  sidecar:\n"
+            "    image: vendor/sidecar:2.0.14\n"
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = compose.read_text()
+        assert "ghcr.io/kamiwaza/app:2.1.0" in content
+        assert "vendor/sidecar:2.0.14" in content  # untouched
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_package_json_targets_top_level_version(self, mock_detector_cls, tmp_path):
+        """Nested `"version"` keys (engines, config, …) must not be
+        rewritten when the top-level version is the bump target."""
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pkg = tmp_path / "package.json"
+        # `engines.version` appears textually before top-level `version`
+        # and shares the same string value — a naive first-match regex
+        # would rewrite the wrong one.
+        original = (
+            '{\n'
+            '  "name": "x",\n'
+            '  "engines": {\n'
+            '    "version": "2.0.14"\n'
+            '  },\n'
+            '  "version": "2.0.14"\n'
+            '}\n'
+        )
+        pkg.write_text(original)
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        data = json.loads(pkg.read_text())
+        assert data["version"] == "2.1.0"
+        assert data["engines"]["version"] == "2.0.14"  # untouched
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_kamiwaza_json_preserves_indent_and_unicode(
+        self, mock_detector_cls, tmp_path
+    ):
+        """A hand-authored manifest with 2-space indent and Unicode
+        description should not be reformatted by bump."""
+        kj = tmp_path / "kamiwaza.json"
+        original = (
+            '{\n'
+            '  "name": "test-app",\n'
+            '  "version": "2.0.14",\n'
+            '  "description": "Café ☕ tooling",\n'
+            '  "image": "ghcr.io/x/y:2.0.14"\n'
+            '}\n'
+        )
+        kj.write_text(original)
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = kj.read_text()
+        # Targeted rewrite — 2-space indent and the Unicode char survive.
+        assert '  "name": "test-app"' in content
+        assert "Café ☕ tooling" in content
+        assert '"version": "2.1.0"' in content
+        assert '"image": "ghcr.io/x/y:2.1.0"' in content
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_pyproject_header_with_comment(self, mock_detector_cls, tmp_path):
+        """A `[project]` header followed by a TOML comment should still
+        be located by the table-span scanner."""
+        _write_kamiwaza_json(tmp_path, "2.0.14")
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]  # main metadata\n'
+            'name = "x"\n'
+            'version = "2.0.14"\n'
+        )
+        mock_detector_cls.return_value.detect.return_value = _make_extension_info(tmp_path, "2.0.14")
+
+        from kamiwaza_extensions.commands.bump import run_bump
+        run_bump(level="minor")
+
+        content = pyproject.read_text()
+        assert 'version = "2.1.0"' in content
+        assert "[project]  # main metadata" in content
 
     @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
     def test_invalid_level_exits(self, mock_detector_cls, tmp_path):

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -86,6 +86,24 @@ class TestStripBindMounts:
         result = transformer.transform(compose, "test", "v1", "reg")
         assert result["services"]["web"]["volumes"] == ["data:/app/data"]
 
+    def test_strips_home_dir_bind_mount(self, transformer):
+        """ENG-4956: ~ paths are flagged by the validator, so deploy must strip them."""
+        compose = {"services": {"web": {"volumes": ["~/data:/app/data", "named:/app/persist"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["web"]["volumes"] == ["named:/app/persist"]
+
+    def test_strips_windows_drive_bind_mount(self, transformer):
+        """ENG-4956: Windows drive-letter paths are flagged by the validator."""
+        compose = {"services": {"web": {"volumes": [r"C:\host\data:/app/data"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert "volumes" not in result["services"]["web"]
+
+    def test_strips_cwd_bind_mount(self, transformer):
+        """ENG-4956: a bare '.' source is flagged by the validator."""
+        compose = {"services": {"web": {"volumes": [".:/app"]}}}
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert "volumes" not in result["services"]["web"]
+
 
 class TestBuildContextRemoval:
     def test_removes_build_adds_image(self, transformer):

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
@@ -633,6 +632,41 @@ class TestBuildPatchKwargsCarriesAnnotations:
         )
         assert "sandbox" not in kwargs
 
+    def test_carries_volumes_so_patch_refreshes_mount_contract(self):
+        """ENG-4834: existing dev CRs are updated by PATCH after first
+        create, so top-level volume declarations must ride PATCH too."""
+        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
+
+        volumes = [{"name": "omniparse-data", "emptyDir": {}}]
+
+        class _FakePayload:
+            model_extra = {"volumes": volumes}
+            kamiwaza = None
+
+        kwargs = _build_patch_kwargs(patch_services=["svc"], payload=_FakePayload())
+        assert kwargs["volumes"] == volumes
+
+    def test_patchextension_accepts_volumes_via_extra_allow(self):
+        """Sanity: PatchExtension must accept top-level volumes via
+        ``extra="allow"``."""
+        from kamiwaza_sdk.schemas.extensions import PatchExtension, PatchServiceSpec
+
+        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
+
+        volumes = [{"name": "data", "emptyDir": {}}]
+
+        class _FakePayload:
+            model_extra = {"volumes": volumes}
+            kamiwaza = None
+
+        kwargs = _build_patch_kwargs(
+            patch_services=[PatchServiceSpec(name="x")],
+            payload=_FakePayload(),
+        )
+        patch = PatchExtension(**kwargs)
+        assert (patch.model_extra or {}).get("volumes") == volumes
+        assert patch.model_dump()["volumes"] == volumes
+
     def test_patch_service_specs_forwards_x_kamiwaza_overrides(self):
         """jxstanford PR #97 review H2: per-service overrides
         (healthCheck, automountServiceAccountToken,
@@ -701,6 +735,56 @@ class TestBuildPatchKwargsCarriesAnnotations:
 
         specs = _build_patch_service_specs(_FakePayload())
         assert (specs[0].model_extra or {})["automountServiceAccountToken"] is False
+
+    def test_patch_service_specs_forwards_volume_mounts(self):
+        """ENG-4834: service-level mounts must also refresh on PATCH."""
+        from kamiwaza_sdk.schemas.extensions import ExtensionServiceSpec
+
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        volume_mounts = [{"name": "data", "mountPath": "/data"}]
+
+        class _FakePayload:
+            services = [
+                ExtensionServiceSpec(
+                    name="tool",
+                    image="reg/tool:dev",
+                    volumeMounts=volume_mounts,
+                ),
+            ]
+
+        specs = _build_patch_service_specs(_FakePayload())
+        assert (specs[0].model_extra or {})["volumeMounts"] == volume_mounts
+        assert specs[0].model_dump()["volumeMounts"] == volume_mounts
+
+    def test_volumes_cleared_when_payload_has_none(self):
+        """ENG-4834 follow-up: removing a named volume from compose
+        must clear the stale top-level volume on the persisted CR.
+        Omitting the field on PATCH leaves the operator with no signal
+        to clear, so always send an explicit (possibly empty) list."""
+        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
+
+        kwargs = _build_patch_kwargs(
+            patch_services=["svc"],
+            payload=self._payload_with_annotations(None),
+        )
+        assert kwargs["volumes"] == []
+
+    def test_volume_mounts_cleared_when_svc_has_none(self):
+        """ENG-4834 follow-up: per-service mounts must also clear on
+        PATCH when removed from compose. Mirrors the top-level clear
+        behavior in ``_build_patch_kwargs``."""
+        from kamiwaza_sdk.schemas.extensions import ExtensionServiceSpec
+
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        class _FakePayload:
+            services = [
+                ExtensionServiceSpec(name="tool", image="reg/tool:dev"),
+            ]
+
+        specs = _build_patch_service_specs(_FakePayload())
+        assert (specs[0].model_extra or {}).get("volumeMounts") == []
 
     def test_patchextension_accepts_sandbox_via_extra_allow(self):
         """Sanity: PatchExtension must accept the sandbox kwarg via

--- a/tests/unit/extensions/test_e2e_flows.py
+++ b/tests/unit/extensions/test_e2e_flows.py
@@ -30,8 +30,10 @@ class TestCreateThenValidateFlow:
         assert "Created" in result.output
 
         result = runner.invoke(app, ["validate", str(d)])
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.output
         assert "passed" in result.output.lower()
+        assert "!" not in result.output
+        assert "warning" not in result.output.lower()
 
     def test_create_tool_then_validate(self, tmp_path, monkeypatch):
         d = _empty_dir(tmp_path)
@@ -64,6 +66,17 @@ class TestCreateThenValidateFlow:
         data = json.loads(result.output)
         assert data["passed"] is True
         assert data["errors"] == []
+        assert data["warnings"] == []
+        # Assert by category rather than a brittle total count, so an
+        # unrelated scaffold tweak doesn't silently break this test.
+        bind_infos = [i for i in data["info"] if "bind mount" in i]
+        limit_infos = [i for i in data["info"] if "no resource limits defined" in i]
+        assert len(bind_infos) == 2
+        assert len(limit_infos) == 2
+        # Every info entry is one of the two expected categories.
+        assert len(bind_infos) + len(limit_infos) == len(data["info"])
+        assert any("bind mount './frontend/src:/app/src'" in i for i in bind_infos)
+        assert any("bind mount './backend/app:/app/app'" in i for i in bind_infos)
 
 
 @pytest.mark.unit

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -690,3 +690,179 @@ class TestHealthChecks:
         backend = next(s for s in payload.services if s.name == "backend")
         health_check = backend.model_dump()["healthCheck"]
         assert health_check["httpGet"] == {"path": "/health", "port": 8000}
+
+
+class TestHealthCheckOverride:
+    """ENG-4832: per-service healthCheck override in ``kamiwaza.json``.
+
+    Lets tool/service extensions whose primary doesn't serve ``/sse``
+    (REST-only, MCP-at-/mcp, gRPC, FastMCP feature-flagged off) declare
+    a probe that actually matches what the container exposes, instead
+    of hitting the ``/sse``-on-every-tool default and CrashLoopBackOff.
+    """
+
+    def test_metadata_override_replaces_default_for_tool_primary(
+        self, builder, connection
+    ):
+        """Omniparse-style REST-only tool: probe /v1/healthz, not /sse."""
+        metadata = {
+            "name": "my-tool",
+            "version": "1.0.0",
+            "type": "tool",
+            "services": {
+                "tool": {
+                    "healthCheck": {
+                        "httpGet": {"path": "/v1/healthz", "port": 8000},
+                        "initialDelaySeconds": 10,
+                        "periodSeconds": 10,
+                    },
+                },
+            },
+        }
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        health_check = tool.model_dump()["healthCheck"]
+        assert tool.primary is True
+        assert health_check["httpGet"] == {"path": "/v1/healthz", "port": 8000}
+        assert health_check["initialDelaySeconds"] == 10
+        assert health_check["periodSeconds"] == 10
+
+    def test_metadata_override_wins_over_x_kamiwaza(self, builder, connection):
+        """When both kamiwaza.json and compose declare a probe, metadata wins.
+
+        Locks the precedence: catalog metadata is the single source of truth,
+        compose ``x-kamiwaza`` is the legacy fallback.
+        """
+        metadata = {
+            "name": "my-tool",
+            "version": "1.0.0",
+            "type": "tool",
+            "services": {
+                "tool": {
+                    "healthCheck": {"httpGet": {"path": "/v1/healthz", "port": 8000}},
+                },
+            },
+        }
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                    "x-kamiwaza": {
+                        "healthCheck": {"httpGet": {"path": "/old", "port": 8000}},
+                    },
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        health_check = tool.model_dump()["healthCheck"]
+        assert health_check["httpGet"] == {"path": "/v1/healthz", "port": 8000}
+
+    def test_no_metadata_override_falls_back_to_x_kamiwaza(
+        self, builder, connection
+    ):
+        """Existing ``x-kamiwaza.healthCheck`` path stays intact."""
+        metadata = {"name": "my-tool", "version": "1.0.0", "type": "tool"}
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                    "x-kamiwaza": {
+                        "healthCheck": {"httpGet": {"path": "/compose", "port": 8000}},
+                    },
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        health_check = tool.model_dump()["healthCheck"]
+        assert health_check["httpGet"] == {"path": "/compose", "port": 8000}
+
+    def test_no_overrides_keeps_default_sse_for_tool_primary(
+        self, builder, connection
+    ):
+        """Regression guard: tool extensions with no override still get /sse."""
+        metadata = {"name": "my-tool", "version": "1.0.0", "type": "tool"}
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        health_check = tool.model_dump()["healthCheck"]
+        assert health_check["httpGet"] == {"path": "/sse", "port": 8000}
+
+    def test_metadata_override_per_service_only_affects_named_service(
+        self, builder, connection
+    ):
+        """Override on one service doesn't leak into siblings."""
+        metadata = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "type": "app",
+            "services": {
+                "backend": {
+                    "healthCheck": {"httpGet": {"path": "/v1/ready", "port": 8000}},
+                },
+            },
+        }
+        transformed = {
+            "services": {
+                "frontend": {
+                    "image": "registry.test/my-app-frontend:1.0.0",
+                    "ports": ["3000"],
+                    "environment": ["NEXT_PUBLIC_API_URL=http://backend:8000"],
+                },
+                "backend": {
+                    "image": "registry.test/my-app-backend:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        backend = next(s for s in payload.services if s.name == "backend")
+        frontend = next(s for s in payload.services if s.name == "frontend")
+        assert backend.model_dump()["healthCheck"]["httpGet"] == {
+            "path": "/v1/ready",
+            "port": 8000,
+        }
+        # Frontend keeps the Node-based default probe — untouched by the
+        # backend-only override.
+        assert frontend.model_dump()["healthCheck"]["exec"]["command"][0] == "node"
+
+    def test_metadata_services_not_a_dict_is_ignored(self, builder, connection):
+        """Malformed metadata.services falls back cleanly to defaults."""
+        metadata = {
+            "name": "my-tool",
+            "version": "1.0.0",
+            "type": "tool",
+            "services": "not-a-dict",
+        }
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/my-tool:1.0.0",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        payload = builder.build(metadata, transformed, connection, "test")
+        tool = payload.services[0]
+        assert tool.model_dump()["healthCheck"]["httpGet"] == {
+            "path": "/sse",
+            "port": 8000,
+        }

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -319,6 +319,165 @@ class TestServiceRefRewritesAnnotation:
         assert ANNOTATION_SERVICE_REF_REWRITES not in annotations
 
 
+class TestComposeVolumes:
+    """ENG-4834: named compose volumes must reach the kext payload."""
+
+    def test_named_volume_becomes_empty_dir_and_volume_mount(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/tool:dev",
+                    "ports": ["8000"],
+                    "volumes": ["omniparse-data:/data"],
+                },
+            },
+            "volumes": {"omniparse-data": None},
+        }
+
+        payload = builder.build(metadata, transformed, connection, "tool-dev-abc")
+        tool = payload.services[0].model_dump()
+
+        assert (payload.model_extra or {})["volumes"] == [
+            {"name": "omniparse-data", "emptyDir": {}}
+        ]
+        assert payload.model_dump()["volumes"] == [
+            {"name": "omniparse-data", "emptyDir": {}}
+        ]
+        assert tool["volumeMounts"] == [
+            {"name": "omniparse-data", "mountPath": "/data"}
+        ]
+
+    def test_shared_named_volume_is_declared_once(self, builder, metadata, connection):
+        transformed = {
+            "services": {
+                "api": {
+                    "image": "registry.test/api:dev",
+                    "ports": ["8000"],
+                    "volumes": ["shared-data:/cache"],
+                },
+                "worker": {
+                    "image": "registry.test/worker:dev",
+                    "volumes": ["shared-data:/cache"],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "app-dev-abc")
+        services = {svc.name: svc.model_dump() for svc in payload.services}
+
+        assert (payload.model_extra or {})["volumes"] == [
+            {"name": "shared-data", "emptyDir": {}}
+        ]
+        assert services["api"]["volumeMounts"] == [
+            {"name": "shared-data", "mountPath": "/cache"}
+        ]
+        assert services["worker"]["volumeMounts"] == [
+            {"name": "shared-data", "mountPath": "/cache"}
+        ]
+
+    def test_long_form_volume_is_supported_and_read_only(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "backend": {
+                    "image": "registry.test/backend:dev",
+                    "ports": ["8000"],
+                    "volumes": [
+                        {
+                            "type": "volume",
+                            "source": "backend_data",
+                            "target": "/app/persist",
+                            "read_only": True,
+                        }
+                    ],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "app-dev-abc")
+        backend = payload.services[0].model_dump()
+
+        assert (payload.model_extra or {})["volumes"] == [
+            {"name": "backend-data", "emptyDir": {}}
+        ]
+        assert backend["volumeMounts"] == [
+            {
+                "name": "backend-data",
+                "mountPath": "/app/persist",
+                "readOnly": True,
+            }
+        ]
+
+    def test_no_volumes_keeps_payload_unchanged(
+        self, builder, metadata, transformed_compose, connection
+    ):
+        payload = builder.build(
+            metadata, transformed_compose, connection, "app-dev-abc"
+        )
+
+        assert "volumes" not in (payload.model_extra or {})
+        assert all(
+            "volumeMounts" not in (svc.model_extra or {}) for svc in payload.services
+        )
+
+    def test_interpolated_host_path_is_not_emitted_as_empty_dir(
+        self, builder, metadata, connection
+    ):
+        """PR-113 review High #1: a shell-interpolated bind source
+        (``${PWD}/src``) must NOT be normalized into a named volume and
+        emitted as an emptyDir over the image's baked files. It is a
+        host path and the validator rejects it; the payload builder must
+        agree and drop it."""
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/tool:dev",
+                    "ports": ["8000"],
+                    "volumes": [
+                        "${PWD}/src:/app/src",
+                        "$HOME/.cache:/cache",
+                    ],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "tool-dev-abc")
+        tool = payload.services[0].model_dump()
+
+        assert "volumes" not in (payload.model_extra or {})
+        assert "volumeMounts" not in tool
+
+    def test_user_volume_named_tmp_avoids_operator_collision(
+        self, builder, metadata, connection
+    ):
+        """PR-113 review High #2: the operator injects volumes named
+        ``tmp`` and ``data``. A user compose volume that normalizes to
+        either must be renamed so the reconciled Deployment has no
+        duplicate volume names (K8s rejects duplicates)."""
+        transformed = {
+            "services": {
+                "tool": {
+                    "image": "registry.test/tool:dev",
+                    "ports": ["8000"],
+                    "volumes": ["tmp:/scratch", "data:/store"],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "tool-dev-abc")
+        tool = payload.services[0].model_dump()
+
+        emitted = {v["name"] for v in (payload.model_extra or {})["volumes"]}
+        assert emitted.isdisjoint({"tmp", "data"})
+        mount_names = {m["name"] for m in tool["volumeMounts"]}
+        # Mounts must reference the renamed volumes, not the reserved ones.
+        assert mount_names == emitted
+        assert mount_names.isdisjoint({"tmp", "data"})
+
+
 class TestEnvParsing:
     def test_list_format(self, builder):
         result = builder._parse_env(["KEY=value", "BARE_KEY"])

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -478,6 +478,124 @@ class TestPublishExtrasDigestResolution:
 
 
 # ------------------------------------------------------------------
+# Env-var image refs: compose default matches extras (ENG-5260)
+# ------------------------------------------------------------------
+
+
+class TestPublishEnvImageRefsAgreeWithExtras:
+    """For a kaizen-shaped extension (env-var image ref + extras entry for
+    the same dynamic-spawn image), the published compose's env default
+    must agree with the extras list — same stage suffix, same digest."""
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_env_default_matches_extras_entry_end_to_end(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # Real ComposeTransformer + RegistryBuilder; only the I/O
+        # boundary is mocked. The published apps.json entry's compose_yml
+        # env default and extra_docker_images entry must agree on tag +
+        # digest for the same dynamic-spawn image.
+        import yaml as _yaml
+
+        metadata = {
+            "name": "kaizenv3",
+            "version": "1.8.13",
+            "description": "Kaizen v3",
+            "extra_docker_images": ["ghcr.io/my-org/images/agent:{version}"],
+        }
+        compose_data = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "ghcr.io/my-org/kaizenv3-backend:1.8.13",
+                    "ports": ["8000"],
+                    "environment": {
+                        "AGENT_SERVER_IMAGE":
+                            "${AGENT_SERVER_IMAGE:-ghcr.io/my-org/images/agent:1.8.13}",
+                    },
+                },
+            },
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path,
+            name="kaizenv3",
+            version="1.8.13",
+            metadata=metadata,
+            compose_data=compose_data,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        agent_digest = "sha256:" + "b" * 64
+        digest_by_ref = {
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev": "sha256:" + "a" * 64,
+            "ghcr.io/my-org/images/agent:1.8.13-dev": agent_digest,
+        }
+        mock_pusher_cls.resolve_digest.side_effect = lambda ref: digest_by_ref[ref]
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result(
+            extension_name="kaizenv3", version="1.8.13",
+        )
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # Grab the entry the publisher would have written to the catalog.
+        publish_kwargs = mock_publisher.publish.call_args.kwargs
+        entry = publish_kwargs["entry"]
+        compose_out = _yaml.safe_load(entry["compose_yml"])
+        env_default = compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ]
+
+        # Acceptance: the canonical pinned ref appears in BOTH surfaces.
+        expected_ref = f"ghcr.io/my-org/images/agent:1.8.13-dev@{agent_digest}"
+        assert entry["extra_docker_images"] == [expected_ref]
+        assert expected_ref in env_default, (
+            f"compose env default {env_default!r} must reference the same "
+            f"pinned ref as extras ({expected_ref!r})"
+        )
+        # The ${VAR:-...} shape is preserved so runtime overrides still win.
+        assert env_default.startswith("${AGENT_SERVER_IMAGE:-")
+        assert env_default.endswith("}")
+
+
+# ------------------------------------------------------------------
 # Dry-run mode
 # ------------------------------------------------------------------
 

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -184,6 +184,300 @@ class TestPublishHappyPath:
 
 
 # ------------------------------------------------------------------
+# extra_docker_images: digest resolution
+# ------------------------------------------------------------------
+
+
+class TestPublishExtrasDigestResolution:
+    """`kz-ext publish` resolves digests for extra_docker_images."""
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_extras_under_registry_get_digest_resolved_and_passed_to_build_entry(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # An extra_docker_images entry with `{version}` under the
+        # configured registry must be substituted, stage-suffixed, and
+        # digest-pinned via the same registry-resolution path compose
+        # buildable services use.
+        metadata = {
+            "name": "kaizenv3",
+            "version": "1.8.13",
+            "description": "Kaizen v3",
+            "extra_docker_images": [
+                "ghcr.io/my-org/images/agent:{version}",
+            ],
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path, name="kaizenv3", version="1.8.13", metadata=metadata,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer = MagicMock()
+        mock_transformer.transform.return_value = {
+            "services": {
+                "backend": {"image": "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev"},
+            },
+        }
+        mock_transformer_cls.return_value = mock_transformer
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        # Distinct digests per ref so the assertion can pin which ref
+        # got which digest.
+        digest_by_ref = {
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev": "sha256:" + "a" * 64,
+            "ghcr.io/my-org/images/agent:1.8.13-dev": "sha256:" + "b" * 64,
+        }
+        mock_pusher_cls.resolve_digest.side_effect = lambda ref: digest_by_ref[ref]
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {
+            "name": "kaizenv3",
+            "version": "1.8.13",
+        }
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result(
+            extension_name="kaizenv3", version="1.8.13",
+        )
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        resolved_refs = [
+            call.args[0] for call in mock_pusher_cls.resolve_digest.call_args_list
+        ]
+        assert "ghcr.io/my-org/images/agent:1.8.13-dev" in resolved_refs
+        assert "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev" in resolved_refs
+
+        # Both digests reach digest_map.
+        build_entry_kwargs = mock_reg_builder.build_entry.call_args.kwargs
+        digest_map = build_entry_kwargs["digest_map"]
+        assert digest_map["ghcr.io/my-org/images/agent:1.8.13-dev"] == (
+            "sha256:" + "b" * 64
+        )
+        assert digest_map["ghcr.io/my-org/kaizenv3-backend:1.8.13-dev"] == (
+            "sha256:" + "a" * 64
+        )
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_extras_already_in_digest_map_skipped_from_auto_resolve(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # When `--digest` pins a buildable ref and that same ref is
+        # redundantly listed in extras, the explicit pin must survive:
+        # no registry lookup, no overwrite.
+        metadata = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "Test",
+            "extra_docker_images": ["ghcr.io/my-org/my-app-backend:{version}"],
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path, metadata=metadata,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer = MagicMock()
+        mock_transformer.transform.return_value = {
+            "services": {
+                "backend": {"image": "ghcr.io/my-org/my-app-backend:1.0.0-dev"},
+            },
+        }
+        mock_transformer_cls.return_value = mock_transformer
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        # If anything calls resolve_digest, fail the test loudly — the
+        # user-supplied digest must be the only source of truth here.
+        mock_pusher_cls.resolve_digest.side_effect = AssertionError(
+            "resolve_digest should not be called when --digest pins the ref"
+        )
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result()
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        supplied_digest = "sha256:" + "e" * 64
+        # --digest implies --no-push so the supplied digest is trusted
+        # without a post-push verification round-trip.
+        run_publish(stage="dev", digest=supplied_digest, no_push=True)
+
+        # The supplied digest survived end-to-end into build_entry's map.
+        build_entry_kwargs = mock_reg_builder.build_entry.call_args.kwargs
+        digest_map = build_entry_kwargs["digest_map"]
+        assert digest_map["ghcr.io/my-org/my-app-backend:1.0.0-dev"] == supplied_digest
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_external_extras_skipped_from_digest_resolution(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # External refs and already-pinned refs skip the digest lookup:
+        # external images aren't ours to pin, and re-tagging a pinned ref
+        # would break its immutable identity.
+        metadata = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "Test",
+            "extra_docker_images": [
+                "postgres:15",                              # external
+                "ghcr.io/external/sidecar:2.0",             # external
+                "ghcr.io/my-org/images/util@sha256:" + "c" * 64,  # already pinned
+            ],
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path, metadata=metadata,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer = MagicMock()
+        mock_transformer.transform.return_value = {
+            "services": {
+                "backend": {"image": "ghcr.io/my-org/my-app-backend:1.0.0-dev"},
+            },
+        }
+        mock_transformer_cls.return_value = mock_transformer
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/my-app-backend:1.0.0-dev",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        compose_digest = "sha256:" + "d" * 64
+        mock_pusher_cls.resolve_digest.return_value = compose_digest
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result()
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # Only the compose backend hits the registry; the three extras
+        # are filtered out before resolution.
+        resolved_refs = [
+            call.args[0] for call in mock_pusher_cls.resolve_digest.call_args_list
+        ]
+        assert resolved_refs == ["ghcr.io/my-org/my-app-backend:1.0.0-dev"]
+
+
+# ------------------------------------------------------------------
 # Dry-run mode
 # ------------------------------------------------------------------
 

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -44,7 +44,7 @@ def _make_extension_info(
     )
 
 
-def _make_validation_result(passed=True, errors=None, warnings=None):
+def _make_validation_result(passed=True, errors=None, warnings=None, info=None):
     """Create a mock ValidationResult."""
     from kamiwaza_extensions.validators.result import ValidationResult
 
@@ -52,6 +52,7 @@ def _make_validation_result(passed=True, errors=None, warnings=None):
         passed=passed,
         errors=errors or [],
         warnings=warnings or [],
+        info=info or [],
     )
 
 
@@ -181,6 +182,172 @@ class TestPublishHappyPath:
         mock_pusher.push.assert_called_once()
         mock_reg_builder.build_entry.assert_called_once()
         mock_publisher.publish.assert_called_once()
+
+
+class TestPublishWithInfoFindings:
+    """ENG-4956 regression: info findings must not break the publish flow.
+
+    The info-printing loop previously rebound the `info` variable (the
+    ExtensionInfo object) to a message string, so `info.path` later raised
+    `AttributeError: 'str' object has no attribute 'path'` whenever
+    validation emitted any info entry.
+    """
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_publish_succeeds_with_info_findings(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(tmp_path)
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        # Compose validation emits scaffold-default info entries.
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result(
+            info=[
+                "Service 'backend' uses bind mount './data:/app' — stripped at deploy.",
+                "Service 'backend' has no resource limits — defaults applied at deploy.",
+            ]
+        )
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer = MagicMock()
+        mock_transformer.transform.return_value = {
+            "services": {"backend": {"image": "ghcr.io/my-org/my-app-backend:1.0.0"}}
+        }
+        mock_transformer_cls.return_value = mock_transformer
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = ["ghcr.io/my-org/my-app-backend:1.0.0"]
+        mock_builder_cls.return_value = mock_image_builder
+
+        mock_pusher_cls.return_value = MagicMock()
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result()
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        # Must not raise AttributeError — the ExtensionInfo binding survives
+        # the info-printing loop.
+        run_publish(stage="dev")
+
+        # resolve_profile is the call site that crashed: it needs the real
+        # ExtensionInfo's `path`, proving `info` was not clobbered.
+        mock_profile_mgr.resolve_profile.assert_called_once_with(
+            "dev", extension_dir=tmp_path
+        )
+        mock_publisher.publish.assert_called_once()
+
+
+class TestPublishAppgardenValidationChannel:
+    """ENG-4956: an authored appgarden compose bypasses ComposeTransformer, so
+    `run_publish` must validate it with `transformer_handled=False` — otherwise
+    bind mounts / missing limits are reported as benign info even though deploy
+    will not strip or backfill them.
+    """
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.registry_builder.RegistryBuilder")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.compose_transformer.ComposeTransformer")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_appgarden_publish_validates_with_transformer_handled_false(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_transformer_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_reg_builder_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # An authored appgarden compose makes run_publish take the
+        # _retag_appgarden_compose path instead of the generic transform.
+        (tmp_path / "docker-compose.appgarden.yml").write_text(
+            "services:\n"
+            "  backend:\n"
+            "    image: ghcr.io/my-org/my-app-backend:1.0.0\n"
+        )
+
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(tmp_path)
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_transformer_cls.return_value = MagicMock()
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = ["ghcr.io/my-org/my-app-backend:1.0.0"]
+        mock_builder_cls.return_value = mock_image_builder
+
+        mock_pusher_cls.return_value = MagicMock()
+
+        mock_reg_builder = MagicMock()
+        mock_reg_builder.build_entry.return_value = {"name": "my-app", "version": "1.0.0"}
+        mock_reg_builder_cls.return_value = mock_reg_builder
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result()
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        # The compose validator must be told the transformer is bypassed.
+        assert mock_compose_validator.validate.call_args.kwargs[
+            "transformer_handled"
+        ] is False
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -167,7 +167,11 @@ class TestBuildEntry:
         assert entry["category"] == "chatbot"
         assert entry["verified"] is True
 
-    def test_extra_docker_images_appended(self, builder, transformed_compose):
+    def test_extra_docker_images_emitted_on_their_own_field(
+        self, builder, transformed_compose,
+    ):
+        # Extras live in their own catalog field; docker_images is
+        # compose-derived only. The two lists never merge.
         meta = {
             "name": "my-app",
             "description": "test",
@@ -176,9 +180,15 @@ class TestBuildEntry:
             "extra_docker_images": ["custom/sidecar:latest"],
         }
         entry = builder.build_entry(meta, transformed_compose, "reg", "1.0.0")
-        assert "custom/sidecar:latest" in entry["docker_images"]
+        assert entry["extra_docker_images"] == ["custom/sidecar:latest"]
+        # docker_images stays compose-derived only.
+        assert "custom/sidecar:latest" not in entry["docker_images"]
 
-    def test_extra_docker_images_deduped(self, builder):
+    def test_extra_docker_images_disjoint_from_docker_images(self, builder):
+        # If the same ref appears in compose AND extras, each list retains
+        # its own copy — no dedup across the two fields. They represent
+        # different intents (runtime service vs. additional pull manifest)
+        # and downstream consumers iterate them separately.
         compose = {"services": {"web": {"image": "custom/sidecar:latest"}}}
         meta = {
             "name": "my-app",
@@ -188,7 +198,175 @@ class TestBuildEntry:
             "extra_docker_images": ["custom/sidecar:latest"],
         }
         entry = builder.build_entry(meta, compose, "reg", "1.0.0")
-        assert entry["docker_images"].count("custom/sidecar:latest") == 1
+        assert entry["docker_images"] == ["custom/sidecar:latest"]
+        assert entry["extra_docker_images"] == ["custom/sidecar:latest"]
+
+    def test_no_extra_docker_images_field_when_metadata_omits_it(
+        self, builder, metadata, transformed_compose,
+    ):
+        entry = builder.build_entry(metadata, transformed_compose, "reg", "1.0.0")
+        assert "extra_docker_images" not in entry
+
+    # `{version}` in extra_docker_images entries must be substituted
+    # before reaching the catalog — same rewrite ComposeTransformer
+    # applies to compose service images.
+    def test_extra_docker_images_version_placeholder_substituted(
+        self, builder, transformed_compose,
+    ):
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13", stage="prod",
+        )
+        # No raw `{version}` placeholder reaches the catalog.
+        assert "myreg/images/agent:{version}" not in entry["extra_docker_images"]
+        assert "myreg/images/agent:1.8.13" in entry["extra_docker_images"]
+        # Extras stay out of docker_images.
+        assert all(
+            "agent" not in ref for ref in entry["docker_images"]
+        ), entry["docker_images"]
+
+    def test_extra_docker_images_stage_suffix_applied(
+        self, builder, transformed_compose,
+    ):
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        for stage, expected_tag in [
+            ("prod", "1.8.13"),
+            ("dev", "1.8.13-dev"),
+            ("stage", "1.8.13-stage"),
+        ]:
+            entry = builder.build_entry(
+                meta, transformed_compose, "myreg/images", "1.8.13", stage=stage,
+            )
+            expected_ref = f"myreg/images/agent:{expected_tag}"
+            assert expected_ref in entry["extra_docker_images"], (
+                f"stage={stage}: expected {expected_ref} in extras, "
+                f"got {entry['extra_docker_images']}"
+            )
+            # Extras don't leak into docker_images regardless of stage.
+            assert expected_ref not in entry["docker_images"]
+
+    def test_extra_docker_images_external_ref_not_suffixed(
+        self, builder, transformed_compose,
+    ):
+        # Refs outside the configured registry namespace pass through
+        # untouched — postgres, redis, third-party sidecars, etc.
+        meta = {
+            "name": "my-app",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": [
+                "ghcr.io/external/sidecar:2.0",
+                "quay.io/org/util:{version}",
+            ],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        # External ref with no placeholder: untouched.
+        assert "ghcr.io/external/sidecar:2.0" in entry["extra_docker_images"]
+        # External ref with placeholder: substituted but NOT stage-suffixed.
+        # External tags aren't ours to rewrite.
+        assert "quay.io/org/util:1.8.13" in entry["extra_docker_images"]
+
+    def test_extra_docker_images_fixed_tag_under_registry_passthrough(
+        self, builder, transformed_compose,
+    ):
+        # A literal tag (no `{version}`) signals an independent release
+        # cadence — a vendored helper at its own version. Re-suffixing it
+        # would point at a tag this publish never built.
+        meta = {
+            "name": "my-app",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/shared-helper:0.5.0"],
+        }
+        for stage in ["dev", "stage", "prod"]:
+            entry = builder.build_entry(
+                meta, transformed_compose, "myreg/images", "1.8.13", stage=stage,
+            )
+            assert entry["extra_docker_images"] == [
+                "myreg/images/shared-helper:0.5.0"
+            ], f"stage={stage}: fixed tag should pass through verbatim"
+
+    def test_extra_docker_images_registry_with_port_untagged(
+        self, builder, transformed_compose,
+    ):
+        # OCI refs allow `:` in the host segment (registry port). For an
+        # untagged ref like `localhost:5000/org/agent`, the tag (if any)
+        # lives after the last `/`, not at the first `:`. Splitting on the
+        # leftmost colon would mangle the repository path.
+        meta = {
+            "name": "my-app",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["localhost:5000/org/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "localhost:5000/org", "1.8.13",
+            stage="dev",
+        )
+        assert entry["extra_docker_images"] == [
+            "localhost:5000/org/agent:1.8.13-dev"
+        ]
+
+    def test_extra_docker_images_digest_pinned_ref_passthrough(
+        self, builder, transformed_compose,
+    ):
+        # Already-digest-pinned refs are left exactly as-authored. Re-tagging
+        # would mismatch the digest and break the immutable-identity contract.
+        pinned = (
+            "myreg/images/agent:1.8.13-dev"
+            "@sha256:" + "a" * 64
+        )
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": [pinned],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13", stage="prod",
+        )
+        assert pinned in entry["extra_docker_images"]
+
+    def test_extra_docker_images_digest_pinned_when_in_digest_map(
+        self, builder, transformed_compose,
+    ):
+        # When the caller supplies a digest_map entry keyed by the
+        # post-substitution ref, build_entry pins the extra and emits it
+        # only via extra_docker_images.
+        digest = "sha256:" + "b" * 64
+        digest_map = {"myreg/images/agent:1.8.13-dev": digest}
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13", stage="dev",
+            digest_map=digest_map,
+        )
+        pinned_ref = f"myreg/images/agent:1.8.13-dev@{digest}"
+        assert entry["extra_docker_images"] == [pinned_ref]
+        assert pinned_ref not in entry["docker_images"]
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -1,5 +1,8 @@
 """Tests for RegistryBuilder."""
 
+import copy
+from typing import Any, Dict
+
 import pytest
 import yaml
 
@@ -367,6 +370,454 @@ class TestBuildEntry:
         pinned_ref = f"myreg/images/agent:1.8.13-dev@{digest}"
         assert entry["extra_docker_images"] == [pinned_ref]
         assert pinned_ref not in entry["docker_images"]
+
+
+# ------------------------------------------------------------------
+# Env-var image-ref rewriting (ENG-5260)
+# ------------------------------------------------------------------
+
+
+def _kaizen_shaped_compose(env_value: str) -> Dict[str, Any]:
+    """Build a compose dict with a single env-var image ref on the backend."""
+    return {
+        "services": {
+            "backend": {
+                "image": "myreg/images/kaizenv3-backend:1.8.13-dev",
+                "environment": {
+                    "AGENT_SERVER_IMAGE": env_value,
+                },
+            },
+        },
+    }
+
+
+class TestBuildEntryEnvImageRewrites:
+    """Image refs embedded in ``services[*].environment`` values get the
+    same digest-pin treatment as ``extra_docker_images`` so a
+    dynamic-spawn ref like ``${AGENT_SERVER_IMAGE:-...}`` stays in
+    lockstep with the air-gap mirror list for the same image.
+
+    Contract: env rewrites are gated on ``digest_map`` membership. A
+    candidate ref that doesn't appear in the map is left verbatim — the
+    publish never produced it, so re-stamping would point the runtime
+    at a tag that was never built or mirrored. This mirrors the
+    literal-tag-passthrough rule on the extras surface.
+    """
+
+    _AGENT_DIGEST = "sha256:" + "c" * 64
+    _AGENT_DEV_MAP = {"myreg/images/agent:1.8.13-dev": _AGENT_DIGEST}
+
+    def _meta(self, **overrides):
+        base = {"name": "k", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        base.update(overrides)
+        return base
+
+    def test_default_sub_rewritten_when_candidate_in_digest_map(self, builder):
+        # The kaizen-shaped case: ${VAR:-<reg>/agent:1.8.13} published
+        # to stage=dev with the post-suffix ref in digest_map emits
+        # ${VAR:-<reg>/agent:1.8.13-dev@sha256:...}.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        )
+        entry = builder.build_entry(
+            self._meta(name="kaizenv3"), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}}}"
+        )
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == expected
+
+    def test_default_sub_dash_form_supported(self, builder):
+        # ``${VAR-default}`` (use default only if unset) is rewritten
+        # the same as ``${VAR:-default}``; both forms collapse to the
+        # default at deploy time in our pipeline.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE-myreg/images/agent:1.8.13}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = (
+            "${AGENT_SERVER_IMAGE-"
+            f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}}}"
+        )
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == expected
+
+    def test_bare_ref_rewritten_when_candidate_in_digest_map(self, builder):
+        # Some authors set env defaults via plain values, not ${VAR:-...}.
+        # Bare ref under the published surface gets pinned in place.
+        compose = _kaizen_shaped_compose("myreg/images/agent:1.8.13")
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}"
+
+    def test_fixed_tag_literal_not_in_digest_map_passes_through(self, builder):
+        # Codex #1: a vendored helper at its own version (literal tag,
+        # not opt-in via {version}) won't have a post-suffix entry in
+        # digest_map. The env ref must stay verbatim — re-stamping would
+        # point at :0.5.0-dev which the publish never built.
+        compose = _kaizen_shaped_compose(
+            "${HELPER_IMAGE:-myreg/images/shared-helper:0.5.0}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${HELPER_IMAGE:-myreg/images/shared-helper:0.5.0}"
+
+    def test_no_digest_map_no_rewrite(self, builder):
+        # When the publish path didn't supply a digest_map (e.g. the
+        # catalog-only-republish path soft-fell on resolution), env
+        # refs pass through. Without a digest there's no proof the
+        # post-suffix ref exists in the registry.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13", stage="dev",
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+
+    def test_external_ref_not_rewritten(self, builder):
+        # External refs (postgres, redis, third-party sidecars) aren't
+        # in digest_map and pass through verbatim.
+        compose = _kaizen_shaped_compose("${DB_IMAGE:-postgres:15}")
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${DB_IMAGE:-postgres:15}"
+
+    def test_non_image_default_passes_through(self, builder):
+        # ${VAR:-info} (feature flag, log level, etc.) is shaped like a
+        # default-sub but the default isn't an image ref.
+        compose = _kaizen_shaped_compose("${LOG_LEVEL:-info}")
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${LOG_LEVEL:-info}"
+
+    def test_already_pinned_ref_passes_through(self, builder):
+        # ${VAR:-<reg>/agent:1.8.13-dev@sha256:...} is already immutable;
+        # leave the digest alone (re-suffixing would mismatch the pin).
+        pinned_default = (
+            "myreg/images/agent:1.8.13-dev@sha256:" + "a" * 64
+        )
+        compose = _kaizen_shaped_compose(
+            f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="stage", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}"
+
+    def test_prod_strips_stage_suffix(self, builder):
+        # Source compose may already carry a -dev tag (re-publish
+        # round-trip). For prod publish, candidate becomes :1.8.13
+        # (no suffix) — if that's in digest_map, pin it.
+        prod_map = {
+            "myreg/images/agent:1.8.13":
+                "sha256:" + "e" * 64,
+        }
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13-dev}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="prod", digest_map=prod_map,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = (
+            "${AGENT_SERVER_IMAGE:-"
+            "myreg/images/agent:1.8.13@sha256:" + "e" * 64 + "}"
+        )
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == expected
+
+    def test_env_list_form_supported(self, builder):
+        # Compose env can be a list of ``KEY=value`` strings instead of
+        # a dict. Both shapes must round-trip the rewrite.
+        compose = {
+            "services": {
+                "backend": {
+                    "image": "myreg/images/k-backend:1.8.13-dev",
+                    "environment": [
+                        "AGENT_SERVER_IMAGE=${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}",
+                        "LOG_LEVEL=info",
+                    ],
+                },
+            },
+        }
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env_list = compose_out["services"]["backend"]["environment"]
+        expected = (
+            "AGENT_SERVER_IMAGE=${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}}}"
+        )
+        assert expected in env_list
+        assert "LOG_LEVEL=info" in env_list
+
+    def test_env_long_form_dict_supported(self, builder):
+        # ``[{"name": KEY, "value": VAL}, ...]`` — the long-form list
+        # entry shape that Compose v3 also accepts.
+        compose = {
+            "services": {
+                "backend": {
+                    "image": "myreg/images/k-backend:1.8.13-dev",
+                    "environment": [
+                        {"name": "AGENT_SERVER_IMAGE",
+                         "value": "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"},
+                    ],
+                },
+            },
+        }
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env_list = compose_out["services"]["backend"]["environment"]
+        assert env_list[0]["value"] == (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:1.8.13-dev@{self._AGENT_DIGEST}}}"
+        )
+
+    def test_non_string_env_values_untouched(self, builder):
+        # Compose allows int/bool env values. Walking the dict must not
+        # coerce or otherwise corrupt them.
+        compose = {
+            "services": {
+                "backend": {
+                    "image": "myreg/images/k-backend:1.8.13-dev",
+                    "environment": {
+                        "MAX_CONN": 100,
+                        "ENABLE_FEATURE": True,
+                    },
+                },
+            },
+        }
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env = compose_out["services"]["backend"]["environment"]
+        assert env["MAX_CONN"] == 100
+        assert env["ENABLE_FEATURE"] is True
+
+    def test_registry_with_port_handled(self, builder):
+        # OCI refs allow `:` in the host segment (registry port). The
+        # tag-split must happen after the last `/`, not the leftmost `:`.
+        port_map = {
+            "localhost:5000/org/agent:1.8.13-dev": "sha256:" + "f" * 64,
+        }
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-localhost:5000/org/agent:1.8.13}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "localhost:5000/org", "1.8.13",
+            stage="dev", digest_map=port_map,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = (
+            "${AGENT_SERVER_IMAGE:-localhost:5000/org/agent:1.8.13-dev"
+            "@sha256:" + "f" * 64 + "}"
+        )
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == expected
+
+    def test_appgarden_divergent_namespace_works(self, builder):
+        # Codex #3: when the appgarden compose's `image:` namespace
+        # differs from the profile registry, digest_map is still keyed
+        # by the actual published ref. Gating on digest_map (not
+        # registry prefix) lets env refs under the appgarden namespace
+        # rewrite correctly even though profile.registry says otherwise.
+        appgarden_digest = "sha256:" + "9" * 64
+        appgarden_map = {
+            "ghcr.io/published/tool-foo/agent:2.0.0-dev": appgarden_digest,
+        }
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-ghcr.io/published/tool-foo/agent:2.0.0}"
+        )
+        # The "registry" arg here represents profile.registry; the
+        # appgarden compose has chosen a different namespace.
+        entry = builder.build_entry(
+            self._meta(), compose, "ghcr.io/some-other-org", "2.0.0",
+            stage="dev", digest_map=appgarden_map,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        expected = (
+            "${AGENT_SERVER_IMAGE:-"
+            f"ghcr.io/published/tool-foo/agent:2.0.0-dev@{appgarden_digest}}}"
+        )
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == expected
+
+    def test_caller_compose_not_mutated(self, builder):
+        # Codex #5: build_entry must not mutate the caller's compose
+        # dict. The deepcopy in _apply_env_image_rewrites guards this.
+        original_env = "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        compose = _kaizen_shaped_compose(original_env)
+        compose_snapshot = copy.deepcopy(compose)
+        builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        assert compose == compose_snapshot, (
+            "build_entry mutated the caller's compose dict"
+        )
+
+    def test_literal_key_in_digest_map_pins_without_suffix(self, builder):
+        # JohnBot H1: when extras has a literal-tag ref (no `{version}`
+        # opt-in), resolve_extra_image returns it unchanged and run_publish
+        # resolves a digest keyed by the literal ref. The env default for
+        # the same image must pin against that literal key — re-suffixing
+        # would point at a ref the publish never produced. This is the
+        # exact extras-vs-env divergence the PR was meant to close.
+        literal_digest = "sha256:" + "1" * 64
+        # digest_map is keyed by the LITERAL ref (no stage suffix), as
+        # `_auto_resolve_digests` does when extras come in as a literal tag.
+        digest_map = {"myreg/images/shared-helper:0.5.0": literal_digest}
+        compose = _kaizen_shaped_compose(
+            "${HELPER_IMAGE:-myreg/images/shared-helper:0.5.0}"
+        )
+        meta = self._meta(
+            extra_docker_images=["myreg/images/shared-helper:0.5.0"],
+        )
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=digest_map,
+        )
+        # Extras emit `:0.5.0@sha256:...` (literal pin).
+        extras_ref = f"myreg/images/shared-helper:0.5.0@{literal_digest}"
+        assert entry["extra_docker_images"] == [extras_ref]
+        # Env default agrees — same ref, same digest, no stage suffix.
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env_default = compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ]
+        assert env_default == (
+            "${HELPER_IMAGE:-"
+            f"myreg/images/shared-helper:0.5.0@{literal_digest}}}"
+        )
+
+    def test_no_tag_bare_ref_defaults_to_latest_candidate(self, builder):
+        # JohnBot M4: a bare ref with no `:tag` falls back to `:latest`
+        # when computing the candidate. Locks behavior; matches Docker
+        # CLI semantics. Tag-less refs in the wild are uncommon but legal.
+        latest_dev_digest = "sha256:" + "2" * 64
+        digest_map = {"myreg/images/agent:latest-dev": latest_dev_digest}
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=digest_map,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:latest-dev@{latest_dev_digest}}}"
+        )
+
+    def test_nested_substitution_left_alone(self, builder):
+        # The default-sub regex is anchored end-to-end, so embedded
+        # ${...} inside a larger string doesn't match — the value
+        # passes through verbatim. Locks regex behavior.
+        compose = _kaizen_shaped_compose(
+            "prefix-${INNER:-myreg/images/agent:1.8.13}-suffix"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "prefix-${INNER:-myreg/images/agent:1.8.13}-suffix"
+
+    def test_whitespace_padded_substitution_left_alone(self, builder):
+        # Leading/trailing whitespace in an env value breaks the
+        # anchored default-sub match. Locks the regex's strict behavior.
+        compose = _kaizen_shaped_compose(
+            "  ${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}  "
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.8.13",
+            stage="dev", digest_map=self._AGENT_DEV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "  ${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}  "
+
+    def test_env_value_matches_extra_docker_images_entry(self, builder):
+        # The acceptance criterion: for kaizen-shaped input (env-var
+        # default + extra_docker_images for the same image), the
+        # published compose env default agrees with the extras list.
+        digest = "sha256:" + "d" * 64
+        digest_map = {"myreg/images/agent:1.8.13-dev": digest}
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.8.13}"
+        )
+        meta = self._meta(
+            name="kaizenv3",
+            extra_docker_images=["myreg/images/agent:{version}"],
+        )
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.8.13", stage="dev",
+            digest_map=digest_map,
+        )
+        # extras list carries the canonical pinned ref.
+        extras_ref = f"myreg/images/agent:1.8.13-dev@{digest}"
+        assert entry["extra_docker_images"] == [extras_ref]
+        # And the compose env default points at the same ref.
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env_default = compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ]
+        assert extras_ref in env_default
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -222,3 +222,138 @@ class TestRunValidateMonorepo:
         assert output["passed"] is False
         joined = " ".join(output["errors"])
         assert "Multiple kamiwaza.json found" in joined
+
+
+class TestVersionDrift:
+    """ENG-4835: surface drift between kamiwaza.json version and sibling files."""
+
+    def _meta(self, version: str, image: str | None = None) -> dict:
+        m = _valid_metadata()
+        m["version"] = version
+        if image is not None:
+            m["image"] = image
+        return m
+
+    def test_image_tag_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(
+            json.dumps(self._meta("2.1.0", "ghcr.io/x/y:2.0.14"))
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert result.passed
+        assert any("image tag" in w and "2.0.14" in w for w in result.warnings)
+
+    def test_compose_image_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n  app:\n    image: ghcr.io/x/y:2.0.14\n"
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("docker-compose.yml" in w and "2.0.14" in w for w in result.warnings)
+
+    def test_dockerfile_arg_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "Dockerfile").write_text(
+            "FROM python:3.11\nARG OMNIPARSE_VERSION=2.0.14\n"
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("OMNIPARSE_VERSION" in w for w in result.warnings)
+
+    def test_runtime_arg_drift_not_warned(self, tmp_path):
+        """Common third-party runtime ARGs (NODE_VERSION, ALPINE_VERSION,
+        …) intentionally don't track the extension's semver, so they
+        must not trigger drift warnings."""
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "Dockerfile").write_text(
+            "FROM node:20-alpine\n"
+            "ARG NODE_VERSION=20.11.1\n"
+            "ARG ALPINE_VERSION=3.19.1\n"
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        drift = [w for w in result.warnings if "drift" in w.lower()]
+        assert drift == []
+
+    def test_pyproject_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "2.0.14"\n'
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("pyproject.toml" in w and "2.0.14" in w for w in result.warnings)
+
+    def test_aligned_versions_no_drift_warnings(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(
+            json.dumps(self._meta("2.1.0", "ghcr.io/x/y:2.1.0"))
+        )
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n  app:\n    image: ghcr.io/x/y:2.1.0\n"
+        )
+        (tmp_path / "Dockerfile").write_text(
+            "FROM python:3.11\nARG OMNIPARSE_VERSION=2.1.0\n"
+        )
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "2.1.0"\n'
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        drift = [w for w in result.warnings if "drift" in w.lower()]
+        assert drift == []
+
+    def test_package_json_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "package.json").write_text(
+            json.dumps({"name": "x", "version": "2.0.14"}, indent=2)
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("package.json" in w and "2.0.14" in w for w in result.warnings)
+
+    def test_nested_package_json_drift_warns(self, tmp_path):
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(self._meta("2.1.0")))
+        (tmp_path / "frontend").mkdir()
+        (tmp_path / "frontend" / "package.json").write_text(
+            json.dumps({"name": "x", "version": "2.0.14"}, indent=2)
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        assert any("frontend/package.json" in w and "2.0.14" in w for w in result.warnings)
+
+    def test_unrelated_thirdparty_image_no_drift_warning(self, tmp_path):
+        """A redis/postgres sidecar's semver tag must not trigger a drift
+        warning when the extension declares its own image repo."""
+        from pathlib import Path
+        from kamiwaza_extensions.validators.metadata import MetadataValidator
+
+        (tmp_path / "kamiwaza.json").write_text(
+            json.dumps(self._meta("2.1.0", "ghcr.io/kamiwaza/app:2.1.0"))
+        )
+        (tmp_path / "docker-compose.yml").write_text(
+            "services:\n"
+            "  app:\n"
+            "    image: ghcr.io/kamiwaza/app:2.1.0\n"
+            "  redis:\n"
+            "    image: redis:7.2.4\n"
+        )
+        result = MetadataValidator().validate(Path(tmp_path / "kamiwaza.json"))
+        drift = [w for w in result.warnings if "drift" in w.lower()]
+        assert drift == []

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -91,6 +91,33 @@ class TestRunValidate:
         assert output["errors"] == []
         assert output["warnings"]
 
+    def test_validate_fails_on_bind_mount(self, tmp_path, capsys):
+        import typer
+
+        from kamiwaza_extensions.commands.validate import run_validate
+
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginxinc/nginx-unprivileged:stable-alpine",
+                    "ports": ["8080:8080"],
+                    "volumes": ["./data:/app/data"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "1.0", "memory": "1G"}}
+                    },
+                },
+            },
+        }
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(_valid_metadata()))
+        (tmp_path / "docker-compose.yml").write_text(yaml.dump(compose))
+
+        with pytest.raises(typer.Exit):
+            run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["passed"] is False
+        assert any("bind mount './data:/app/data'" in err for err in output["errors"])
+
     def test_validate_fails_on_image_only_rootful_nginx_runtime(self, tmp_path, capsys):
         import typer
 

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -388,7 +388,7 @@ class TestComposeValidator:
         assert result.passed  # warning, not error
         assert any("port" in w.lower() for w in result.warnings)
 
-    def test_bind_mount_warning(self, tmp_path, validator):
+    def test_bind_mount_error(self, tmp_path, validator):
         compose = {
             "services": {
                 "web": {"image": "nginx", "volumes": ["./src:/app"]},
@@ -397,8 +397,42 @@ class TestComposeValidator:
         f = tmp_path / "docker-compose.yml"
         self._write_compose(f, compose)
         result = validator.validate(f, tmp_path)
+        assert not result.passed
+        assert any("bind mount './src:/app'" in e for e in result.errors)
+
+    def test_long_form_bind_mount_error(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "volumes": [{"type": "bind", "source": "./src", "target": "/app"}],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        assert any("bind mount './src:/app'" in e for e in result.errors)
+
+    def test_named_volume_passes_compose_validation(self, tmp_path, validator):
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "volumes": ["data:/app/data"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "0.5", "memory": "512M"}}
+                    },
+                },
+            },
+            "volumes": {"data": None},
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
         assert result.passed
-        assert any("bind mount" in w.lower() for w in result.warnings)
+        assert not any("bind mount" in e.lower() for e in result.errors)
 
     def test_missing_resource_limits_warning(self, tmp_path, validator):
         compose = {
@@ -446,6 +480,171 @@ class TestComposeValidator:
         result = validator.validate(f, tmp_path)
         assert result.passed
         assert any("network" in w.lower() for w in result.warnings)
+
+    def test_scaffold_templates_pass_validation(self, validator):
+        """ENG-4834 regression: ``kz-ext create`` ships templates that
+        carry bind mounts on ``build:`` services for local-dev hot
+        reload. Promoting bind mounts to a hard error breaks every fresh
+        scaffold's ``kz-ext validate`` and ``kz-ext publish``. Lock in
+        that the shipped templates validate cleanly."""
+        from pathlib import Path
+
+        import kamiwaza_extensions
+
+        templates_root = Path(kamiwaza_extensions.__file__).parent / "templates"
+        for kind in ("app", "tool"):
+            ext_dir = templates_root / kind
+            compose = ext_dir / "docker-compose.yml"
+            if not compose.exists():
+                continue
+            result = validator.validate(compose, ext_dir)
+            # Templates may legitimately surface warnings (no resource
+            # limits, bind-mounts-as-local-dev). They must NOT produce
+            # validation errors that block create→validate→publish.
+            assert result.passed, (
+                f"{kind} template failed validation: {result.errors}"
+            )
+
+    def test_bind_mount_in_build_service_warns_not_errors(self, tmp_path, validator):
+        """ENG-4834: scaffolded extensions (``kz-ext create``) ship a
+        ``build:`` service with bind mounts for hot-reload. ``ComposeTransformer``
+        strips them at deploy, so the validator must NOT error on this
+        local-dev pattern — otherwise every fresh scaffold fails
+        ``kz-ext validate`` / ``kz-ext publish``."""
+        (tmp_path / "Dockerfile").write_text("FROM python:3.10")
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "volumes": ["./src:/app/src"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "0.5", "memory": "512M"}}
+                    },
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert result.passed, result.errors
+        assert any("stripped at deploy" in w for w in result.warnings)
+
+    def test_shared_named_volume_warns_about_emptydir(self, tmp_path, validator):
+        """ENG-4834: named volumes deploy as pod-scoped ``emptyDir``, so
+        two services referencing the same name do NOT share data at
+        runtime. Surface this before the user is surprised post-deploy."""
+        compose = {
+            "services": {
+                "api": {
+                    "image": "nginx",
+                    "volumes": ["shared:/app/data"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "0.5", "memory": "512M"}}
+                    },
+                },
+                "worker": {
+                    "image": "nginx",
+                    "volumes": ["shared:/app/data"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "0.5", "memory": "512M"}}
+                    },
+                },
+            },
+            "volumes": {"shared": None},
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert result.passed
+        assert any(
+            "emptyDir is pod-scoped" in w and "shared" in w for w in result.warnings
+        )
+
+    def test_tmpfs_long_form_is_rejected(self, tmp_path, validator):
+        """``ComposeTransformer._strip_bind_mounts`` silently drops tmpfs
+        mounts — same failure mode as the pre-ENG-4834 named-volume drop.
+        Surface explicitly so the user can fix the compose."""
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "volumes": [{"type": "tmpfs", "target": "/run/cache"}],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        assert any("tmpfs mount" in e for e in result.errors)
+
+    def test_interpolated_bind_source_is_rejected(self, tmp_path, validator):
+        """PR-113 review High #1: a shell-interpolated bind source
+        (``${PWD}/src``, ``$HOME/.cache``) resolves to a host path at
+        runtime and can never be a named volume. The validator must
+        reject it on a prebuilt-image service rather than letting the
+        payload builder turn it into an emptyDir."""
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "volumes": ["${PWD}/src:/app/src", "$HOME/.cache:/cache"],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        bind_errors = [e for e in result.errors if "bind mount" in e]
+        assert len(bind_errors) == 2
+
+    def test_service_level_tmpfs_key_is_rejected(self, tmp_path, validator):
+        """Compose's top-level ``tmpfs:`` service key is distinct from
+        ``volumes:``. ``ComposeTransformer`` only strips long-form tmpfs
+        entries inside ``volumes:``, so a service-level ``tmpfs:`` slips
+        through and silently loses the mount at deploy — reject it."""
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "tmpfs": ["/run/cache", "/var/cache:size=64m"],
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        tmpfs_errors = [e for e in result.errors if "tmpfs mount" in e]
+        assert len(tmpfs_errors) == 2
+
+    def test_service_level_tmpfs_string_form_is_rejected(self, tmp_path, validator):
+        """The ``tmpfs:`` key also accepts a bare string."""
+        compose = {
+            "services": {
+                "web": {"image": "nginx", "tmpfs": "/run/cache"},
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        assert any("tmpfs mount '/run/cache'" in e for e in result.errors)
+
+    def test_null_volumes_key_does_not_crash(self, tmp_path, validator):
+        """A YAML ``volumes:`` key with no value parses to ``None``;
+        the per-service loop must not crash trying to iterate it."""
+        compose = {
+            "services": {
+                "web": {"image": "nginx", "volumes": None},
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        # Should not raise; service has no volumes -> no bind-mount findings
+        assert not any("bind mount" in e for e in result.errors)
 
     def test_invalid_yaml(self, tmp_path, validator):
         f = tmp_path / "docker-compose.yml"

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -5,7 +5,12 @@ import json
 import pytest
 
 from kamiwaza_extensions.validators.metadata import MetadataValidator
-from kamiwaza_extensions.validators.compose import ComposeValidator
+from kamiwaza_extensions.validators.compose import (
+    ComposeValidator,
+    is_bind_mount,
+    is_missing_resource_limits_finding,
+    is_missing_resource_limits_warning,
+)
 from kamiwaza_extensions.validators.platform_runtime import PlatformRuntimeValidator
 
 
@@ -434,7 +439,7 @@ class TestComposeValidator:
         assert result.passed
         assert not any("bind mount" in e.lower() for e in result.errors)
 
-    def test_missing_resource_limits_warning(self, tmp_path, validator):
+    def test_missing_resource_limits_info(self, tmp_path, validator):
         compose = {
             "services": {
                 "web": {"image": "nginx"},
@@ -444,7 +449,14 @@ class TestComposeValidator:
         self._write_compose(f, compose)
         result = validator.validate(f, tmp_path)
         assert result.passed
-        assert any("resource" in w.lower() for w in result.warnings)
+        # ENG-4956: deploy backfills resource limits, so the default
+        # (transformer-handled) path reports this as info, not a warning.
+        assert not any("resource" in w.lower() for w in result.warnings)
+        assert any(
+            "no resource limits defined" in i
+            and "defaults will be applied at deploy" in i
+            for i in result.info
+        )
 
     def test_missing_dockerfile_error(self, tmp_path, validator):
         compose = {
@@ -505,12 +517,13 @@ class TestComposeValidator:
                 f"{kind} template failed validation: {result.errors}"
             )
 
-    def test_bind_mount_in_build_service_warns_not_errors(self, tmp_path, validator):
-        """ENG-4834: scaffolded extensions (``kz-ext create``) ship a
+    def test_bind_mount_in_build_service_is_info(self, tmp_path, validator):
+        """ENG-4834/ENG-4956: scaffolded extensions (``kz-ext create``) ship a
         ``build:`` service with bind mounts for hot-reload. ``ComposeTransformer``
         strips them at deploy, so the validator must NOT error on this
-        local-dev pattern — otherwise every fresh scaffold fails
-        ``kz-ext validate`` / ``kz-ext publish``."""
+        local-dev pattern — and per ENG-4956 the default (transformer-handled)
+        path reports it as info rather than a warning so a fresh scaffold's
+        ``kz-ext validate`` is clean."""
         (tmp_path / "Dockerfile").write_text("FROM python:3.10")
         compose = {
             "services": {
@@ -527,7 +540,56 @@ class TestComposeValidator:
         self._write_compose(f, compose)
         result = validator.validate(f, tmp_path)
         assert result.passed, result.errors
-        assert any("stripped at deploy" in w for w in result.warnings)
+        assert not any("bind mount" in w.lower() for w in result.warnings)
+        assert any(
+            "bind mount './src:/app/src'" in i and "stripped at deploy" in i
+            for i in result.info
+        )
+
+    def test_bind_mount_in_build_service_is_warning_when_transformer_bypassed(
+        self, tmp_path, validator
+    ):
+        """ENG-4956: on a publish path that bypasses ComposeTransformer (an
+        authored appgarden compose), a build-service bind mount is NOT
+        stripped, so it must surface as an actionable warning, not info."""
+        (tmp_path / "Dockerfile").write_text("FROM python:3.10")
+        compose = {
+            "services": {
+                "web": {
+                    "build": ".",
+                    "volumes": ["./src:/app/src"],
+                    "deploy": {
+                        "resources": {"limits": {"cpus": "0.5", "memory": "512M"}}
+                    },
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path, transformer_handled=False)
+        assert result.passed, result.errors
+        assert not any("bind mount" in i.lower() for i in result.info)
+        assert any(
+            "bind mount './src:/app/src'" in w and "stripped at deploy" not in w
+            for w in result.warnings
+        )
+
+    def test_missing_limits_is_warning_when_transformer_bypassed(
+        self, tmp_path, validator
+    ):
+        """ENG-4956: when the transformer is bypassed, deploy-time resource
+        defaults are not applied, so the finding must be a warning."""
+        compose = {"services": {"web": {"image": "nginx", "build": "."}}}
+        (tmp_path / "Dockerfile").write_text("FROM python:3.10")
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path, transformer_handled=False)
+        assert result.passed
+        assert not any("resource limits" in i.lower() for i in result.info)
+        assert any(
+            "no resource limits defined" in w and "at deploy" not in w
+            for w in result.warnings
+        )
 
     def test_shared_named_volume_warns_about_emptydir(self, tmp_path, validator):
         """ENG-4834: named volumes deploy as pod-scoped ``emptyDir``, so
@@ -652,6 +714,58 @@ class TestComposeValidator:
         result = validator.validate(f, tmp_path)
         # yaml.safe_load might not error on all bad yaml; check it doesn't crash
         assert isinstance(result, ComposeValidator.__init__.__class__) or True
+
+
+@pytest.mark.unit
+class TestIsBindMount:
+    """Direct coverage for the validator/transformer shared bind-mount detector."""
+
+    @pytest.mark.parametrize(
+        "volume",
+        [
+            "/abs/host:/app",
+            "./rel:/app",
+            "../rel:/app",
+            "~/home:/app",
+            r"C:\host\data:/app",
+            ".:/app",
+            "..:/app",
+            "${PWD}/src:/app",
+            {"type": "bind", "source": "./src", "target": "/app"},
+            {"source": "/abs/host", "target": "/app"},
+        ],
+    )
+    def test_detects_bind_mounts(self, volume):
+        assert is_bind_mount(volume) is True
+
+    @pytest.mark.parametrize(
+        "volume",
+        [
+            "data:/app",
+            "logs:/var/log:rw",
+            "named_volume:/data",
+            {"type": "volume", "source": "data", "target": "/app"},
+            {"type": "tmpfs", "target": "/run/cache"},
+            {"source": "data", "target": "/app"},
+        ],
+    )
+    def test_ignores_named_volumes(self, volume):
+        assert is_bind_mount(volume) is False
+
+
+@pytest.mark.unit
+class TestResourceLimitsFinding:
+    """The renamed helper and its backward-compatible alias."""
+
+    def test_finding_matcher(self):
+        assert is_missing_resource_limits_finding(
+            "Service 'web': no resource limits defined — defaults applied"
+        )
+        assert not is_missing_resource_limits_finding("Service 'web': all good")
+
+    def test_deprecated_alias_is_same_callable(self):
+        # External importers of the pre-ENG-4956 name must keep working.
+        assert is_missing_resource_limits_warning is is_missing_resource_limits_finding
 
 
 @pytest.mark.unit

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -131,6 +131,220 @@ class TestMetadataValidator:
         result = validator.validate(tmp_path / "nonexistent.json")
         assert not result.passed
 
+    # ── services.<name>.healthCheck (ENG-4832) ────────────────────────
+
+    def test_services_healthcheck_httpget_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {"httpGet": {"path": "/v1/healthz", "port": 8000}}
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
+    def test_services_healthcheck_tcpsocket_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"tcpSocket": {"port": 8000}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
+    def test_services_healthcheck_exec_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {
+                    "exec": {"command": ["python3", "-c", "import sys; sys.exit(0)"]}
+                }
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
+    def test_services_healthcheck_grpc_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"grpc": {"port": 50051}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
+    def test_services_not_a_dict_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = "nope"
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("services must be" in e for e in result.errors)
+
+    def test_services_entry_not_a_dict_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": "nope"}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("services.tool" in e for e in result.errors)
+
+    def test_healthcheck_not_a_dict_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": "nope"}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("healthCheck must be a JSON object" in e for e in result.errors)
+
+    def test_healthcheck_with_no_probe_shape_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"initialDelaySeconds": 10}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("must declare one of" in e for e in result.errors)
+
+    def test_healthcheck_with_multiple_probe_shapes_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {
+                    "httpGet": {"path": "/", "port": 8000},
+                    "tcpSocket": {"port": 8000},
+                }
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("multiple probe shapes" in e for e in result.errors)
+
+    def test_healthcheck_with_httpget_and_grpc_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {
+                    "httpGet": {"path": "/", "port": 8000},
+                    "grpc": {"port": 50051},
+                }
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("multiple probe shapes" in e for e in result.errors)
+
+    def test_unknown_probe_shape_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"httpsGet": {"port": 8000}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("must declare one of" in e for e in result.errors)
+        assert any("unknown field 'httpsGet'" in w for w in result.warnings)
+
+    def test_httpget_without_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"httpGet": {"path": "/"}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("httpGet must include 'port'" in e for e in result.errors)
+
+    def test_httpget_with_invalid_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {"healthCheck": {"httpGet": {"path": "/", "port": "bad port"}}}
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("httpGet.port must be" in e for e in result.errors)
+
+    def test_httpget_with_out_of_range_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {"healthCheck": {"httpGet": {"path": "/", "port": 70000}}}
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("httpGet.port must be between" in e for e in result.errors)
+
+    def test_httpget_with_named_port_passes(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {"healthCheck": {"httpGet": {"path": "/", "port": "http"}}}
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+
+    def test_tcpsocket_without_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"tcpSocket": {"host": "127.0.0.1"}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("tcpSocket must include 'port'" in e for e in result.errors)
+
+    def test_grpc_without_port_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"grpc": {"service": "health"}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("grpc must include 'port'" in e for e in result.errors)
+
+    def test_exec_with_empty_command_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"exec": {"command": []}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("exec.command must be a non-empty list" in e for e in result.errors)
+
+    def test_exec_without_command_errors(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {"tool": {"healthCheck": {"exec": {}}}}
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("exec.command must be a non-empty list" in e for e in result.errors)
+
+    def test_probe_unknown_field_warns(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["services"] = {
+            "tool": {
+                "healthCheck": {
+                    "httpGet": {"path": "/", "port": 8000, "command_line": "curl"}
+                }
+            }
+        }
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, result.errors
+        assert any("httpGet has unknown field 'command_line'" in w for w in result.warnings)
+
 
 # ── ComposeValidator ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Purpose

**Accumulating PR for all M7 reconciliation work in this repo against `kamiwaza-mesh-v1.0.0`.**

Per M7 discipline: commits accumulate on this branch; no merge until M7-D 3-host smoke gate (ENG-5382) passes.

## Commits accumulated

### M7-B (ENG-5380)

Merge `origin/develop` (clean, no conflicts). Brings in 6 commits from develop:

- `0184315` ENG-4956: Reduce scaffold validation warnings (#114)
- `a144991` [codex] Fix compose volume payload generation (#113)
- `f721e46` ENG-4832: allow per-service health check overrides (#112)
- `87e5a71` fix(extensions): rewrite image refs in compose env-var defaults (ENG-5260) (#110)
- `44de64e` fix(extensions): resolve extra_docker_images tag + digest; stop merging into docker_images (ENG-5181) (#108)
- `29b9e38` fix(extensions): kz-ext bump propagates version everywhere (ENG-4835) (#106)

**Classification**: Action (1) Clean merge. All commits are docker-compose-as-extension-packaging-format work, platform-agnostic (mesh and develop both parse compose for App Garden extension authoring).

## Gating

- [ ] Per-PR CI green
- [ ] M7-D milestone smoke gate
- [ ] Cascade merge after M7-D PASS

## Reference

- Milestone: M7 (Reconciliation + back-merge to develop)
- Parent: ENG-5310 mesh-v1.0.0 reconciliation