### PR TITLE
ENG-4765/4766/4767: M5a SDK kz.gates.packages + typed exceptions

### DIFF
--- a/kamiwaza_sdk/exceptions.py
+++ b/kamiwaza_sdk/exceptions.py
@@ -182,6 +182,59 @@ class MeshJobFailedError(KamiwazaError):
 
 
 # ----------------------------------------------------------------------------
+# Gate-package typed subclasses (T7.13 / ENG-4767 — WS-M5)
+#
+# Map server-emitted ``detail.reason`` shapes to SDK-side typed errors so
+# customer code can pattern-match on the gate-package failure mode instead
+# of inspecting the body. Server side raises FastAPI ``HTTPException(
+# status_code=N, detail={"reason": "X", ...})`` directly from the gate-
+# packages API handler (T7.2).
+# ----------------------------------------------------------------------------
+
+
+class GatePackageHashRequiredError(ValidationError):
+    """400 with ``detail.reason == "hash_required"`` — POST/PUT to
+    ``/api/authz/gate-packages`` without ``hash_digest`` in the request body.
+    Hash-pinning is mandatory at MVP per FR-89/FR-89a; customer code must
+    pin a known SHA-256 of the wheel."""
+
+
+class GatePackageHashMismatchError(KamiwazaError):
+    """422 with ``detail.reason == "hash_mismatch"`` — pip ``--require-hashes``
+    rejected the install because the wheel served from the index doesn't
+    match the supplied ``hash_digest``. Either the wheel was retagged on the
+    index or the customer pinned the wrong hash. Body carries the expected
+    vs observed digests."""
+
+
+class GatePackageInstallTimeoutError(KamiwazaError):
+    """504 with ``detail.reason == "install_timeout"`` — pip-install
+    subprocess exceeded the chart-configured ``authz.gatePackages.installTimeoutSeconds``
+    (default 120s). Compiled dependencies on slow hosts may need a higher
+    timeout. Body carries the configured limit + actual elapsed."""
+
+
+class GatePackageClasspathDropError(KamiwazaError):
+    """409 with ``detail.reason == "classpath_drop"`` — PUT-replace refused
+    because the new package's classpath set is not a superset of the
+    currently-bound classpaths. Customer must explicitly unbind the dropped
+    classpath first. Body carries the dropped classpath list."""
+
+
+class GatePackageUninstallBlockedError(KamiwazaError):
+    """409 with ``detail.reason == "uninstall_blocked"`` — DELETE refused
+    because one or more active bindings (``Cluster.executionGate`` or
+    ``Dataset.gate``) reference a classpath from the package. Customer must
+    unbind first. Body carries the blocking bindings."""
+
+
+class GatePackageNotFoundError(NotFoundError):
+    """404 with ``detail.reason == "gate_package_not_found"`` — GET/PUT/DELETE
+    on a name that doesn't exist in ``cluster_gate_packages``. Customer may
+    have a stale package name reference or a typo."""
+
+
+# ----------------------------------------------------------------------------
 # Response → typed-exception dispatch table (T7.2 — migrated from kamiwaza/)
 #
 # The status code is part of the match alongside the reason string to avoid
@@ -194,6 +247,13 @@ _REASON_TO_EXCEPTION: dict[tuple[int, str], type[KamiwazaError]] = {
     (503, "psk_propagation_timeout"): FederationPairTimeoutError,
     (403, "brokered_user_not_allowlisted"): BrokeredUserNotAllowlistedError,
     (403, "endpoint_requires_native_realm"): NativeRealmRequiredError,
+    # T7.13 / ENG-4767 — gate-package typed errors (WS-M5)
+    (400, "hash_required"): GatePackageHashRequiredError,
+    (422, "hash_mismatch"): GatePackageHashMismatchError,
+    (504, "install_timeout"): GatePackageInstallTimeoutError,
+    (409, "classpath_drop"): GatePackageClasspathDropError,
+    (409, "uninstall_blocked"): GatePackageUninstallBlockedError,
+    (404, "gate_package_not_found"): GatePackageNotFoundError,
 }
 
 

--- a/kamiwaza_sdk/schemas/gate_packages.py
+++ b/kamiwaza_sdk/schemas/gate_packages.py
@@ -1,0 +1,124 @@
+"""T7.12 / ENG-4766 — Gate-package Pydantic models on the SDK surface.
+
+WS-M5 foundation task. Typed request/response shapes for
+``kz.gates.packages.{install, replace, list, get, uninstall}`` typed
+wrappers (T7.10) and corresponding server-side handlers (T7.2).
+
+All models opt into ``extra="allow"`` for forward compatibility per
+``.ai/knowledge/failures/common-pitfalls.md`` — pinned-wheel customers
+must not break when the server adds fields.
+
+Server-side correlate lives at
+``kamiwaza/services/authz/gate_packages/schemas.py`` (mirrors these
+shapes; the two are kept in sync by code review since they cross a repo
+boundary).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+GatePackageStatus = Literal["active", "uninstalling", "failed"]
+
+
+class GatePackageSpec(BaseModel):
+    """Request body for POST /api/authz/gate-packages (install) and
+    PUT /api/authz/gate-packages/{name} (replace).
+
+    Per FR-89 + FR-89a, ``hash_digest`` is REQUIRED at MVP — server
+    rejects requests without it via the
+    ``GatePackageHashRequiredError`` typed exception.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    package_spec: str = Field(
+        ...,
+        description=(
+            'Pip-installable spec, e.g. "acme-gates==1.2.3". Must include '
+            "a pinned version — unpinned specs are rejected by the server."
+        ),
+    )
+    hash_digest: str = Field(
+        ...,
+        description=(
+            'SHA-256 digest of the wheel as published on the index, e.g. '
+            '"sha256:abcd...". Server invokes pip with --require-hashes; '
+            "mismatches surface as ``GatePackageHashMismatchError``."
+        ),
+    )
+    index_url: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional override for the pip index URL. Server enforces the "
+            "chart-configured ``authz.gatePackages.indexUrl`` allowlist; "
+            "client-supplied values outside the allowlist are rejected at "
+            "the API layer before any pip subprocess fires."
+        ),
+    )
+
+
+class GatePackageState(BaseModel):
+    """Response model for GET (single) and PUT/POST (install/replace
+    result), and an element of the list response.
+
+    Mirrors ``DBGatePackage`` columns one-to-one.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(..., description="Package name; the PK on cluster_gate_packages.")
+    package_spec: str = Field(..., description="Original pip spec, e.g. 'acme-gates==1.0.0'.")
+    version: str = Field(..., description="Resolved version, e.g. '1.0.0'.")
+    hash_digest: str = Field(..., description="SHA-256 of the installed wheel.")
+    index_url: Optional[str] = Field(default=None, description="Pip index used at install.")
+    installed_at: datetime = Field(..., description="Initial install timestamp.")
+    installed_by: str = Field(..., description="Actor (Keycloak subject ID) at install.")
+    last_replaced_at: Optional[datetime] = Field(
+        default=None, description="Most recent PUT-replace timestamp; null until first replace."
+    )
+    status: GatePackageStatus = Field(default="active", description="Lifecycle state.")
+    classpaths: List[str] = Field(
+        default_factory=list,
+        description="Fully-qualified gate classpaths discovered in the package.",
+    )
+
+
+class GatePackageList(BaseModel):
+    """Response model for GET /api/authz/gate-packages (paginated)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    items: List[GatePackageState] = Field(default_factory=list)
+    total: int = Field(default=0)
+    page: int = Field(default=1)
+    per_page: int = Field(default=20)
+
+
+class GatePackageInstallResult(BaseModel):
+    """Response model for POST /api/authz/gate-packages.
+
+    The install result is the freshly-created ``GatePackageState`` plus
+    a server-side context block carrying audit-event provenance for the
+    customer's audit logs.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    package: GatePackageState = Field(
+        ..., description="The installed package's current state record."
+    )
+    install_duration_seconds: float = Field(
+        ..., description="Wall-clock pip-install elapsed (server-measured)."
+    )
+    audit_event_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Identifier of the emitted ``gate_package_lifecycle`` audit "
+            "event; customers can cross-reference into their audit stream."
+        ),
+    )

--- a/kamiwaza_sdk/services/gate_packages.py
+++ b/kamiwaza_sdk/services/gate_packages.py
@@ -1,0 +1,108 @@
+"""T7.10 / ENG-4765 — Gate-package SDK service (WS-M5).
+
+Customer surface: ``kz.gates.packages.{install, replace, list, get, uninstall}``.
+
+Exposed via the ``GatesAPI.packages`` lazy property — ``kz.gates`` is the
+discovery surface (M2 / T5.4); ``kz.gates.packages`` is the install
+surface (M5). Two semantically related capabilities live under a single
+top-level service per the design's "code-level sub-API on kz.gates"
+framing.
+
+Server-side correlate: ``kamiwaza/services/authz/gate_packages/api.py``
+(T7.2 / ENG-4757). All five SDK methods translate 1:1 to the same HTTP
+verb on ``/api/authz/gate-packages``. M5a ships install + list + get;
+M5b ships replace + uninstall.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..schemas.gate_packages import (
+    GatePackageInstallResult,
+    GatePackageList,
+    GatePackageSpec,
+    GatePackageState,
+)
+from .base_service import BaseService
+
+
+class GatePackagesAPI(BaseService):
+    """Install, replace, list, get, and uninstall gate packages."""
+
+    def install(
+        self,
+        package_spec: str,
+        hash_digest: str,
+        *,
+        index_url: Optional[str] = None,
+    ) -> GatePackageInstallResult:
+        """Install a gate package (FR-89 / FR-95 / WS-M5a).
+
+        Args:
+            package_spec: Version-pinned pip spec, e.g.
+                ``"acme-gates==1.2.3"``. Unpinned specs are rejected.
+            hash_digest: SHA-256 of the wheel as published on the
+                index, e.g. ``"sha256:abcd..."``. REQUIRED at MVP.
+            index_url: Optional override for the chart-configured pip
+                index. Server enforces the chart-configured allowlist.
+
+        Returns:
+            ``GatePackageInstallResult`` with the new state row +
+            install duration + audit event id.
+
+        Raises:
+            GatePackageHashRequiredError: 400 when ``hash_digest`` is
+                missing (Pydantic + server-side double check).
+            GatePackageHashMismatchError: 422 when pip --require-hashes
+                rejects the wheel.
+            GatePackageInstallTimeoutError: 504 when pip subprocess
+                exceeds the chart-configured install timeout.
+        """
+        spec = GatePackageSpec(
+            package_spec=package_spec,
+            hash_digest=hash_digest,
+            index_url=index_url,
+        )
+        response = self.client._request(
+            "POST",
+            "/authz/gate-packages",
+            json=spec.model_dump(exclude_none=True),
+        )
+        return GatePackageInstallResult.model_validate(response)
+
+    def list(self) -> GatePackageList:
+        """List installed gate packages (FR-90)."""
+        response = self.client._request("GET", "/authz/gate-packages")
+        return GatePackageList.model_validate(response)
+
+    def get(self, name: str) -> GatePackageState:
+        """Get the state record for one installed gate package (FR-90)."""
+        response = self.client._request("GET", f"/authz/gate-packages/{name}")
+        return GatePackageState.model_validate(response)
+
+    def replace(
+        self,
+        name: str,
+        package_spec: str,
+        hash_digest: str,
+        *,
+        index_url: Optional[str] = None,
+    ) -> GatePackageInstallResult:
+        """Atomic in-place replace (FR-89a). Ships in WS-M5b."""
+        spec = GatePackageSpec(
+            package_spec=package_spec,
+            hash_digest=hash_digest,
+            index_url=index_url,
+        )
+        response = self.client._request(
+            "PUT",
+            f"/authz/gate-packages/{name}",
+            json=spec.model_dump(exclude_none=True),
+        )
+        return GatePackageInstallResult.model_validate(response)
+
+    def uninstall(self, name: str) -> None:
+        """Uninstall (FR-90). Server refuses if any active binding
+        references a classpath from the package. Ships in WS-M5b."""
+        self.client._request("DELETE", f"/authz/gate-packages/{name}")

--- a/kamiwaza_sdk/services/gate_packages.py
+++ b/kamiwaza_sdk/services/gate_packages.py
@@ -89,7 +89,20 @@ class GatePackagesAPI(BaseService):
         *,
         index_url: Optional[str] = None,
     ) -> GatePackageInstallResult:
-        """Atomic in-place replace (FR-89a). Ships in WS-M5b."""
+        """Atomic in-place replace (FR-89a). Ships in WS-M5b.
+
+        Raises:
+            GatePackageHashRequiredError: 400 when ``hash_digest`` is missing.
+            GatePackageHashMismatchError: 422 when pip --require-hashes
+                rejects the wheel.
+            GatePackageInstallTimeoutError: 504 on pip-subprocess timeout.
+            GatePackageNotFoundError: 404 when no package named ``name`` is
+                currently installed.
+            GatePackageClasspathDropError: 409 when the candidate package's
+                classpaths are not a superset of the active package's
+                classpaths. Rebinding the dropped classpaths is operator
+                work; the error body names the diff.
+        """
         spec = GatePackageSpec(
             package_spec=package_spec,
             hash_digest=hash_digest,
@@ -104,5 +117,15 @@ class GatePackagesAPI(BaseService):
 
     def uninstall(self, name: str) -> None:
         """Uninstall (FR-90). Server refuses if any active binding
-        references a classpath from the package. Ships in WS-M5b."""
+        references a classpath from the package. Ships in WS-M5b.
+
+        Return value is reserved; M5b may surface the audit event id.
+
+        Raises:
+            GatePackageNotFoundError: 404 when no package named ``name``
+                is currently installed.
+            GatePackageUninstallBlockedError: 409 when at least one active
+                binding still references a classpath from the package.
+                The error body names the blocking bindings.
+        """
         self.client._request("DELETE", f"/authz/gate-packages/{name}")

--- a/kamiwaza_sdk/services/gates.py
+++ b/kamiwaza_sdk/services/gates.py
@@ -19,7 +19,23 @@ from .base_service import BaseService
 
 
 class GatesAPI(BaseService):
-    """Gate discovery on the local cluster."""
+    """Gate discovery on the local cluster + gate-packages sub-API."""
+
+    @property
+    def packages(self) -> "GatePackagesAPI":
+        """Gate-package install / replace / list / get / uninstall
+        (T7.10 / ENG-4765, WS-M5). Lazy-loaded sub-service.
+
+        Customer surface: ``kz.gates.packages.install("acme-gates==1.0.0",
+        hash_digest="sha256:...")``. Lives under ``kz.gates`` because
+        the two concerns are semantically related — gate-code lifecycle
+        and gate-code reflection both anchor on the gate registry.
+        """
+        if not hasattr(self, "_packages"):
+            from .gate_packages import GatePackagesAPI
+
+            self._packages = GatePackagesAPI(self.client)
+        return self._packages
 
     def discover(self, classpath: str) -> GateDiscovery:
         """Reflect on a Gate class by classpath; return its metadata.

--- a/kamiwaza_sdk/services/gates.py
+++ b/kamiwaza_sdk/services/gates.py
@@ -14,8 +14,13 @@ Server-side correlate: POST /api/authz/gates/discover (§4.2.3).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ..schemas.federation import GateDiscovery
 from .base_service import BaseService
+
+if TYPE_CHECKING:
+    from .gate_packages import GatePackagesAPI
 
 
 class GatesAPI(BaseService):

--- a/tests/unit/test_kamiwaza_gate_packages.py
+++ b/tests/unit/test_kamiwaza_gate_packages.py
@@ -1,0 +1,186 @@
+"""Unit tests for T7.10 GatePackagesAPI (ENG-4765) — kz.gates.packages.*."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from kamiwaza_sdk.exceptions import (
+    GatePackageHashMismatchError,
+    GatePackageHashRequiredError,
+    GatePackageInstallTimeoutError,
+    GatePackageNotFoundError,
+    error_for_response,
+)
+from kamiwaza_sdk.schemas.gate_packages import (
+    GatePackageInstallResult,
+    GatePackageList,
+    GatePackageState,
+)
+from kamiwaza_sdk.services.gate_packages import GatePackagesAPI
+from kamiwaza_sdk.services.gates import GatesAPI
+
+
+def _state_dict() -> Dict[str, Any]:
+    return {
+        "name": "acme-gates",
+        "package_spec": "acme-gates==1.0.0",
+        "version": "1.0.0",
+        "hash_digest": "sha256:abc",
+        "index_url": None,
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+        "installed_by": "admin",
+        "last_replaced_at": None,
+        "status": "active",
+        "classpaths": ["acme_gates.gate.AcmeAttributeGate"],
+    }
+
+
+class TestGatesLazyProperty:
+    """Verify ``kz.gates.packages`` is lazy + cached + the right type."""
+
+    def test_packages_returns_gate_packages_api(self, mock_client):
+        gates = GatesAPI(mock_client)
+        assert isinstance(gates.packages, GatePackagesAPI)
+
+    def test_packages_is_cached_per_gates_instance(self, mock_client):
+        gates = GatesAPI(mock_client)
+        first = gates.packages
+        second = gates.packages
+        assert first is second
+
+    def test_packages_only_instantiated_on_first_access(self, mock_client):
+        gates = GatesAPI(mock_client)
+        assert not hasattr(gates, "_packages")
+        _ = gates.packages
+        assert hasattr(gates, "_packages")
+
+
+class TestInstall:
+    """``kz.gates.packages.install``."""
+
+    def test_posts_to_gate_packages_endpoint(self, mock_client):
+        mock_client.expect(
+            "POST",
+            "/authz/gate-packages",
+            {
+                "package": _state_dict(),
+                "install_duration_seconds": 2.3,
+                "audit_event_id": "evt-1",
+            },
+        )
+        svc = GatePackagesAPI(mock_client)
+        result = svc.install("acme-gates==1.0.0", "sha256:abc")
+
+        assert isinstance(result, GatePackageInstallResult)
+        assert result.package.name == "acme-gates"
+        assert result.install_duration_seconds == 2.3
+
+        method, path, kwargs = mock_client.calls[0]
+        assert (method, path) == ("POST", "/authz/gate-packages")
+        body = kwargs["json"]
+        assert body == {
+            "package_spec": "acme-gates==1.0.0",
+            "hash_digest": "sha256:abc",
+        }
+
+    def test_include_index_url_when_supplied(self, mock_client):
+        mock_client.expect(
+            "POST",
+            "/authz/gate-packages",
+            {"package": _state_dict(), "install_duration_seconds": 0.1},
+        )
+        svc = GatePackagesAPI(mock_client)
+        svc.install(
+            "acme-gates==1.0.0",
+            "sha256:abc",
+            index_url="https://idx.example/simple",
+        )
+        body = mock_client.calls[0][2]["json"]
+        assert body["index_url"] == "https://idx.example/simple"
+
+
+class TestListGet:
+    """``kz.gates.packages.list`` + ``.get``."""
+
+    def test_list_returns_typed(self, mock_client):
+        mock_client.expect(
+            "GET",
+            "/authz/gate-packages",
+            {"items": [_state_dict()], "total": 1, "page": 1, "per_page": 20},
+        )
+        result = GatePackagesAPI(mock_client).list()
+        assert isinstance(result, GatePackageList)
+        assert result.total == 1
+        assert result.items[0].name == "acme-gates"
+
+    def test_list_empty(self, mock_client):
+        mock_client.expect(
+            "GET",
+            "/authz/gate-packages",
+            {"items": [], "total": 0, "page": 1, "per_page": 20},
+        )
+        result = GatePackagesAPI(mock_client).list()
+        assert result.items == []
+        assert result.total == 0
+
+    def test_get_returns_typed_state(self, mock_client):
+        mock_client.expect("GET", "/authz/gate-packages/acme-gates", _state_dict())
+        result = GatePackagesAPI(mock_client).get("acme-gates")
+        assert isinstance(result, GatePackageState)
+        assert result.name == "acme-gates"
+
+
+class TestReplaceUninstall:
+    """M5b methods: client-side surface is wired now; server returns 501
+    until M5b T7.5 ships."""
+
+    def test_replace_calls_put(self, mock_client):
+        mock_client.expect(
+            "PUT",
+            "/authz/gate-packages/acme-gates",
+            {"package": _state_dict(), "install_duration_seconds": 1.0},
+        )
+        result = GatePackagesAPI(mock_client).replace(
+            "acme-gates", "acme-gates==1.0.1", "sha256:def"
+        )
+        assert isinstance(result, GatePackageInstallResult)
+        method, path, kwargs = mock_client.calls[0]
+        assert (method, path) == ("PUT", "/authz/gate-packages/acme-gates")
+        assert kwargs["json"]["package_spec"] == "acme-gates==1.0.1"
+
+    def test_uninstall_calls_delete(self, mock_client):
+        # MockClient treats None as 'no expectation set'; use an empty dict
+        # for the 204-No-Content equivalent. The SDK ignores the body anyway.
+        mock_client.expect("DELETE", "/authz/gate-packages/acme-gates", {})
+        result = GatePackagesAPI(mock_client).uninstall("acme-gates")
+        assert result is None
+        assert mock_client.calls[0][:2] == ("DELETE", "/authz/gate-packages/acme-gates")
+
+
+class TestErrorDispatch:
+    """T7.13 dispatch table integration with the GatePackages SDK."""
+
+    def test_400_hash_required_maps_to_typed(self):
+        err = error_for_response(
+            400, {"detail": {"reason": "hash_required"}}, "missing hash"
+        )
+        assert isinstance(err, GatePackageHashRequiredError)
+
+    def test_422_hash_mismatch_maps_to_typed(self):
+        err = error_for_response(
+            422, {"detail": {"reason": "hash_mismatch"}}, "bad hash"
+        )
+        assert isinstance(err, GatePackageHashMismatchError)
+
+    def test_504_install_timeout_maps_to_typed(self):
+        err = error_for_response(
+            504, {"detail": {"reason": "install_timeout"}}, "slow"
+        )
+        assert isinstance(err, GatePackageInstallTimeoutError)
+
+    def test_404_not_found_maps_to_typed(self):
+        err = error_for_response(
+            404, {"detail": {"reason": "gate_package_not_found"}}, "no such"
+        )
+        assert isinstance(err, GatePackageNotFoundError)


### PR DESCRIPTION


Re-opens [kamiwaza-ai/kamiwaza-sdk#109](https://github.com/kamiwaza-ai/kamiwaza-sdk/pull/109) against `develop`. The original PR auto-closed when the `kamiwaza-mesh-v1.0.0` base branch was deleted post back-merge.

## Scope

WS-M5 SDK surface for gate-packages:
- `kamiwaza_sdk.gates.packages` submodule (install / list / get / replace / uninstall)
- Typed exception subclasses: `GatePackageHashMismatchError`, `GatePackageHashRequiredError`, `GatePackageClasspathDropError`, `GatePackageUninstallBlockedError`, `GatePackageInstallTimeoutError`, `GatePackageNotFoundError`
- Pydantic schemas: `GatePackageSpec`, `GatePackageState`, `GatePackageInstallResult`, `GatePackageList`

Head branch unchanged from the closed #109. All commits and content are identical.

## Refs

- Linear: **ENG-4765** (T7.10 SDK kz.gates.packages submodule), **ENG-4766** (T7.12 Pydantic models), **ENG-4767** (T7.13 GatePackageHashRequiredError typed exception)
- Linear project: [Federation API and SDK updates](https://linear.app/kamiwaza/project/federation-api-and-sdk-updates-00f00bf54d3a) WS-M5
- Previous PR: #109 (closed when mesh branch deleted)
- Sibling code PRs (now also on develop): kamiwaza-internal/kamiwaza#1754, kamiwaza-internal/deploy#247, kamiwaza-internal/kamiwaza-docs-engineering-internal#70
- CloseFeature companion PRs: kamiwaza-internal/kamiwaza-docs-engineering-internal#73 (Gate 1), #74 (Gate 2), this repo's Gate 4 (separate PR), kamiwaza-ai/kamiwaza-docs Gate 3 (separate PR)

<!-- pr-evidence-start -->
<details>
<summary>📋 <b>pr-evidence</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-05-24T13:21:24.556Z
manifest_hash: sha256:96bac4cf6541f007259749230dc8459f7ecf03f6518eb898230f8b5221f9581f
phase_a_complete: true
phase_b_complete: false
repos:
  - name: kamiwaza
    path: /Users/jxstanford/devel/kz/kamiwaza-stack/kamiwaza
    branch: fix/eng-5777-federation-pair-psk-barrier-initiator
    head_sha: 562f3f25ea2430c6666b9dae067e6324a0de207b
    head_sha_short: 562f3f25e
    dirty_files: 0
    ahead: 0
    behind: 0
    upstream: origin/fix/eng-5777-federation-pair-psk-barrier-initiator
    delivery:
      mode: source-mount
      verified: false
      details:
        bind_mount:
          host_path: /Users/jxstanford/devel/kz/kamiwaza-stack/kamiwaza
          container_path: /app/kamiwaza
          spot_check_file: kamiwaza/cluster/services.py
          host_sha256: 6c72601ad92c58b6bf67205e2402d3f451fc590405810ba0fbac5d1a19bec84d
  - name: kamiwaza-sdk
    path: /Users/jxstanford/devel/kz/kamiwaza-stack/kamiwaza-sdk
    branch: feat/ws-m5-code-packaging
    head_sha: a8b22de152ecacca4730841cb45da6255eb3d2c7
    head_sha_short: a8b22de15
    dirty_files: 0
    ahead: 0
    behind: 0
    upstream: origin/feat/ws-m5-code-packaging
    delivery:
      mode: source-mount
      verified: false
      details:
        bind_mount:
          host_path: /Users/jxstanford/devel/kz/kamiwaza-stack/kamiwaza-sdk
          container_path: /app/kamiwaza-sdk
          spot_check_file: kamiwaza_sdk/services/gate_packages.py
          host_sha256: caa7016b3583d26741d9f8d3493b2714a465b34b13b4694fb96b5418a6f14150
  - name: deploy
    path: /Users/jxstanford/devel/kz/kamiwaza-stack/deploy
    branch: develop
    head_sha: 92ed52721ced7a5f4631f5aa570a5255e1609d87
    head_sha_short: 92ed52721
    dirty_files: 0
    ahead: 0
    behind: 0
    upstream: origin/develop
    delivery:
      mode: not-applicable
      verified: true
  - name: kamiwaza-docs-engineering-internal
    path: /Users/jxstanford/devel/kz/kamiwaza-stack/kamiwaza-docs-engineering-internal
    branch: feat/ws-m5-code-packaging
    head_sha: 2bb0f1816bbc1cb076dfc6ef891cb0cb46abb36c
    head_sha_short: 2bb0f1816
    dirty_files: 1
    ahead: 0
    behind: 0
    upstream: origin/feat/ws-m5-code-packaging
    delivery:
      mode: not-applicable
      verified: true
```

</details>

# PR Evidence — generated 2026-05-24T13:21:24.556Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| kamiwaza | fix/eng-5777-federation-pair-psk-barrier-initiator | `562f3f25e` | clean | source-mount ⚠ |
| kamiwaza-sdk | feat/ws-m5-code-packaging | `a8b22de15` | clean | source-mount ⚠ |
| deploy | develop | `92ed52721` | clean | not-applicable ✓ |
| kamiwaza-docs-engineering-internal | feat/ws-m5-code-packaging | `2bb0f1816` | 1 dirty | not-applicable ✓ |

## Cross-references

- Linear: `ENG-5777`
- PR: kamiwaza-internal/kamiwaza#1805
- PR: kamiwaza-internal/kamiwaza#1754
- PR: kamiwaza-ai/kamiwaza-sdk#109
- PR: kamiwaza-internal/deploy#247
- PR: kamiwaza-internal/kamiwaza-docs-engineering-internal#70


## M5 Final Verification — Live End-to-End

**Trigger:** PR #1805 HEAD `562f3f25e` (ENG-5777: PSK barrier wiring + 3 self-review iterations to APPROVE)
**Operator:** jxstanford
**Verification log:** `~/.cache/kamiwaza/pr-evidence/m5-final-verification-20260524T131614Z.log` (operator workstation archive)

### Substrate

| Host | Hardware | Role | Source state |
|---|---|---|---|
| spark-1 (192.168.50.30) | NVIDIA GB10 aarch64 | Federation initiator | kamiwaza @ `562f3f25e` · deploy @ `d770348ba` · sdk @ `a8b22de15` |
| evo-x2-1 (192.168.50.20) | AMD Strix x86_64 | Federation receiver | (same) |

Both hosts on M5 chart (`make dev-full` on `deploy@feat/ws-m5-code-packaging`) — PVC `core-gate-packages-venv` Bound (10Gi RWO ceph-block), `KAMIWAZA_GATE_PACKAGES_*` env vars present on scheduler pod, `cluster_gate_packages` Postgres table created.

### Scope

1. **ENG-5777 PSK barrier** — exercised via federation pair from initiator (the failure mode the operator handoff reported).
2. **T7.21 gate-package lifecycle** — install → list → get → discover (both `AcmeAttributeGate` + `AcmeExecutionGate`) → uninstall → list (empty) → federation-still-PAIRED.

### Results

| Step | Outcome |
|---|---|
| Federation pair (spark-1 → evo-x2-1) | **PAIRED both sides**, edge=ORION, central=Default Cluster, fresh `last_ping` |
| T7.21 install `acme-gates==1.0.0` (sha256:`06c0d3bf3642...`) | **HTTP 200**, 0.22s install, 2 classpaths discovered, audit event `8ebd2aa4-…` |
| List | 1 item; `status: active`; classpaths populated |
| Get `acme-gates` | matches install response |
| Discover `acme_gates.gate.AcmeAttributeGate` | kind=attribute; required `tier`; min_tier enum schema |
| Discover `acme_gates.exec_gate.AcmeExecutionGate` | kind=execution; same required attribute shape |
| Uninstall `acme-gates` | **HTTP 204** No Content |
| List after uninstall | empty (`total: 0`) |
| Federation post-cycle | **still PAIRED both sides** |

### What this proves

- **ENG-5777 fix verified live.** The PSK barrier wiring (`services.py:2924 → _resolve_psk_with_barrier(federation_id_str, secret_urn)`) bridges the DataHub create→read propagation race on the initiator side, matching the receiver-side barrier ENG-4653 fixed.
- **T7.21 round-trip works on PR-shipped chart + PR-shipped code.** Install pipeline (T7.4 pip wrapper), persistence (T7.3 `cluster_gate_packages`), classpath discovery (T7.18 runtime integration), and PVC delivery (T7.8/T7.9) all green.
- **ENG-5266 + ENG-5267 + ENG-5269** (closed as duplicate-of-T7.21 in Linear today) — confirmed shipped: discover allowlist accepts the classpath, sys.path resolves the install dir, no proxy-fallback errors.
- **No regressions:** federation status unchanged across the full gate-package lifecycle.

### Linear / PR train

- **ENG-5777** — In Review (this PR's ticket; 3-iteration APPROVE per check-pr-self-review skill)
- **M5 merge train** (this PR is one of 5): kamiwaza#1754, kamiwaza-sdk#109, deploy#247, eng-docs#70, plus this PR
- **WS-M5 Linear milestone** — 23 issues, all In Review or `Duplicate` of T7.21; flips to Done when the train merges

<!-- pr-evidence-end -->
