### PR TITLE
ENG-5426: ComposeValidator rejects deploy.resources.requests key

### DIFF
--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -21,6 +21,7 @@ from kamiwaza_sdk.schemas.extensions import (
 
 from kamiwaza_extensions.compose_transformer import detect_service_url_rewrites
 from kamiwaza_extensions.connections import ConnectionInfo
+from kamiwaza_extensions.validators.compose import INVALID_DEPLOY_REQUESTS_TEXT
 from kamiwaza_extensions.volume_utils import looks_like_host_path
 
 # CRD annotation keys — namespace is ``kamiwaza.io/*`` (NOT ``kamiwaza.ai/*``).
@@ -543,6 +544,13 @@ class PayloadBuilder:
     def _parse_resources(svc: Dict[str, Any]) -> Optional[ResourceSpec]:
         deploy = svc.get("deploy", {})
         res = deploy.get("resources", {})
+        # ENG-5426: the validator rejects `deploy.resources.requests` at
+        # validate-time, but `kz-ext dev` (run_dev_remote) builds payloads
+        # without invoking ComposeValidator. Raise here so any code path that
+        # bypasses the validator still cannot silently drop the typo
+        # (which is the ENG-5424 over-reservation failure class).
+        if isinstance(res, dict) and "requests" in res:
+            raise ValueError(INVALID_DEPLOY_REQUESTS_TEXT)
         limits = res.get("limits")
         requests = res.get("reservations")
         if limits or requests:

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -544,7 +544,7 @@ class PayloadBuilder:
         deploy = svc.get("deploy", {})
         res = deploy.get("resources", {})
         limits = res.get("limits")
-        requests = res.get("requests") or res.get("reservations")
+        requests = res.get("reservations")
         if limits or requests:
             return ResourceSpec(
                 limits=_compose_resources_to_k8s(limits) if limits else None,

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -160,6 +160,26 @@ class ComposeValidator:
             # Missing resource limits
             deploy = svc_config.get("deploy", {})
             resources = deploy.get("resources", {}) if isinstance(deploy, dict) else {}
+
+            # ENG-5426: ``deploy.resources.requests`` is a Kubernetes term, not
+            # a Docker Compose key — Compose's schema only knows ``limits`` and
+            # ``reservations``. Authors writing ``requests:`` out of K8s habit
+            # have it silently dropped from the compose→catalog→CR pipeline,
+            # which then ships limits-only and lets Kubernetes default the
+            # request to equal the limit — silently over-reserving (ENG-5424).
+            # Fail-fast here so the typo never reaches deploy; do NOT auto-map
+            # to ``reservations``, because silently rewriting the author's
+            # intent is the failure class we're eliminating.
+            if isinstance(resources, dict) and "requests" in resources:
+                errors.append(
+                    f"Service '{svc_name}': "
+                    "deploy.resources.requests is not a valid Docker Compose key "
+                    "(only `limits` and `reservations` are valid). "
+                    "Did you mean `reservations`? "
+                    "`reservations` is the Compose term that maps to "
+                    "Kubernetes `requests` at deploy."
+                )
+
             if not isinstance(resources, dict) or not resources.get("limits"):
                 finding = f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}"
                 if transformer_handled:

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -13,6 +13,18 @@ from kamiwaza_extensions.volume_utils import looks_like_host_path
 
 MISSING_RESOURCE_LIMITS_TEXT = "no resource limits defined"
 
+# ENG-5426: shared with ``payload_builder._parse_resources`` so the validator's
+# fail-fast at validate-time and the parser's fail-fast at parse-time emit the
+# same user-facing message (one source of truth — wording drift would defeat
+# the per-PR assertions that pin this phrase).
+INVALID_DEPLOY_REQUESTS_TEXT = (
+    "deploy.resources.requests is not a valid Docker Compose key "
+    "(only `limits` and `reservations` are valid). "
+    "Did you mean `reservations`? "
+    "`reservations` is the Compose term that maps to "
+    "Kubernetes `requests` at deploy."
+)
+
 
 def is_missing_resource_limits_finding(message: str) -> bool:
     """Return True when *message* is the compose missing-limits finding.
@@ -163,14 +175,7 @@ class ComposeValidator:
 
             # ENG-5426: requests is a K8s term, not Compose — fail-fast (no auto-map to reservations).
             if isinstance(resources, dict) and "requests" in resources:
-                errors.append(
-                    f"Service '{svc_name}': "
-                    "deploy.resources.requests is not a valid Docker Compose key "
-                    "(only `limits` and `reservations` are valid). "
-                    "Did you mean `reservations`? "
-                    "`reservations` is the Compose term that maps to "
-                    "Kubernetes `requests` at deploy."
-                )
+                errors.append(f"Service '{svc_name}': {INVALID_DEPLOY_REQUESTS_TEXT}")
 
             if not isinstance(resources, dict) or not resources.get("limits"):
                 finding = f"Service '{svc_name}': {MISSING_RESOURCE_LIMITS_TEXT}"

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -161,15 +161,7 @@ class ComposeValidator:
             deploy = svc_config.get("deploy", {})
             resources = deploy.get("resources", {}) if isinstance(deploy, dict) else {}
 
-            # ENG-5426: ``deploy.resources.requests`` is a Kubernetes term, not
-            # a Docker Compose key — Compose's schema only knows ``limits`` and
-            # ``reservations``. Authors writing ``requests:`` out of K8s habit
-            # have it silently dropped from the compose→catalog→CR pipeline,
-            # which then ships limits-only and lets Kubernetes default the
-            # request to equal the limit — silently over-reserving (ENG-5424).
-            # Fail-fast here so the typo never reaches deploy; do NOT auto-map
-            # to ``reservations``, because silently rewriting the author's
-            # intent is the failure class we're eliminating.
+            # ENG-5426: requests is a K8s term, not Compose — fail-fast (no auto-map to reservations).
             if isinstance(resources, dict) and "requests" in resources:
                 errors.append(
                     f"Service '{svc_name}': "

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -700,6 +700,23 @@ class TestResourceParsing:
     def test_no_resources_returns_none(self, builder):
         assert builder._parse_resources({}) is None
 
+    def test_reservations_maps_to_requests(self, builder):
+        # ENG-5426: Compose `reservations` is the term that maps to K8s
+        # `requests`. The compose-side `requests` key is now rejected by
+        # ComposeValidator, so the parser only reads `reservations`.
+        svc = {
+            "deploy": {
+                "resources": {
+                    "limits": {"cpus": "1.0", "memory": "1G"},
+                    "reservations": {"cpus": "0.5", "memory": "512M"},
+                }
+            }
+        }
+        res = builder._parse_resources(svc)
+        assert res.limits["cpu"] == "1000m"
+        assert res.requests["cpu"] == "500m"
+        assert res.requests["memory"] == "512M"
+
 
 class TestResolveType:
     def test_default_app(self, builder):

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -717,6 +717,32 @@ class TestResourceParsing:
         assert res.requests["cpu"] == "500m"
         assert res.requests["memory"] == "512M"
 
+    def test_parse_resources_raises_on_requests_key(self, builder):
+        # ENG-5426 (Codex H1): `run_dev_remote` builds payloads without
+        # invoking ComposeValidator, so a parser that *silently* dropped
+        # an unknown `requests` key would reproduce the ENG-5424
+        # over-reservation incident on the `kz-ext dev` path. Pair the
+        # validator's fail-fast at validate-time with the parser's
+        # fail-fast at parse-time. Dev-path-level coverage is implicit:
+        # `run_dev_remote → payload_builder.build → _parse_resources` is
+        # a straight call chain (payload_builder.py:333), and the dev
+        # tests mock `PayloadBuilder` wholesale, so the parser layer is
+        # where this contract is most cleanly pinned.
+        svc = {
+            "deploy": {
+                "resources": {
+                    "limits": {"cpus": "1.0", "memory": "1G"},
+                    "requests": {"cpus": "0.5", "memory": "512M"},
+                }
+            }
+        }
+        with pytest.raises(ValueError) as exc_info:
+            builder._parse_resources(svc)
+        assert (
+            "deploy.resources.requests is not a valid Docker Compose key"
+            in str(exc_info.value)
+        )
+
 
 class TestResolveType:
     def test_default_app(self, builder):

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -458,6 +458,61 @@ class TestComposeValidator:
             for i in result.info
         )
 
+    def test_deploy_resources_requests_key_errors(self, tmp_path, validator):
+        """ENG-5426: ``deploy.resources.requests`` is a Kubernetes term, not
+        a Compose key. Authors writing it out of K8s habit had it silently
+        dropped, leaving the CR limits-only and Kubernetes defaulting the
+        request to equal the limit (the ENG-5424 over-reservation incident).
+        The validator must fail-fast on this typo."""
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "deploy": {
+                        "resources": {
+                            "limits": {"cpus": "1.0", "memory": "1G"},
+                            "requests": {"cpus": "0.5", "memory": "512M"},
+                        }
+                    },
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert not result.passed
+        assert any(
+            "deploy.resources.requests is not a valid Docker Compose key" in e
+            and "Did you mean `reservations`?" in e
+            for e in result.errors
+        )
+
+    def test_deploy_resources_reservations_no_requests_error(
+        self, tmp_path, validator
+    ):
+        """ENG-5426 negative coverage: valid ``deploy.resources.reservations``
+        must not trigger the new requests-key error."""
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginx",
+                    "deploy": {
+                        "resources": {
+                            "limits": {"cpus": "1.0", "memory": "1G"},
+                            "reservations": {"cpus": "0.5", "memory": "512M"},
+                        }
+                    },
+                },
+            },
+        }
+        f = tmp_path / "docker-compose.yml"
+        self._write_compose(f, compose)
+        result = validator.validate(f, tmp_path)
+        assert result.passed, result.errors
+        assert not any(
+            "deploy.resources.requests" in e for e in result.errors
+        )
+
     def test_missing_dockerfile_error(self, tmp_path, validator):
         compose = {
             "services": {


### PR DESCRIPTION
## Summary
- `deploy.resources.requests` is a Kubernetes term, not a Docker Compose key. Compose's `deploy.resources` schema supports only `limits` and `reservations`. Authors writing `requests:` out of K8s habit had it silently dropped from the compose→catalog→CR pipeline; Kubernetes then defaulted the request to equal the limit, silently over-reserving. This is the ENG-5424 incident class (omniparse, ~6 weeks, full reserved CPU core per instance).
- `ComposeValidator.validate()` now emits an *error* (blocks validation) when any service's `deploy.resources` contains a `requests` key, regardless of `transformer_handled`. The error message includes the literal phrase `deploy.resources.requests is not a valid Docker Compose key` and a "Did you mean `reservations`?" hint explaining that `reservations` is the Compose term that maps to Kubernetes `requests` at deploy.
- No auto-correct: we explicitly do NOT map `requests` → `reservations` silently, because silently changing the author's intent is the failure class we're trying to eliminate.

## Test plan
- [x] New unit test: compose with `services.web.deploy.resources.requests: {cpus: '1.0'}` → `result.passed is False` and error contains both required phrases.
- [x] Negative-coverage test: valid `deploy.resources.reservations` → no requests-related error and `result.passed` is True.
- [x] `uv run pytest tests/unit/extensions/test_validators.py -x -v` — 86 passed.
- [x] `make test` — 1889 passed, 0 failed.
- [x] `uv run ruff check` on changed files — clean.

Out of scope (per brief): ComposeTransformer, catalog/CR pipeline, other invalid-key validations under `deploy.resources`, missing-limits logic.

---
_Driven by Loial peer-process engineer (first tmux-based spawn). Brief: `~/.loial/engineers/ENG-5426/brief.md`._