### PR TITLE
ENG-5599: honor --revision in resolve_extra_image for {version} extras

### DIFF
--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -638,12 +638,11 @@ def run_publish(
         else:
             digest_map = _auto_resolve_digests(published_refs)
 
-    # Extras under our registry get the same tag-and-digest pinning as
-    # compose buildable services. External refs and author-pinned
-    # `@sha256:...` refs pass through untouched. Refs already in
-    # digest_map (e.g. the buildable service redundantly listed in extras
-    # when the user supplied `--digest`) are left alone — re-resolving
-    # would hit the registry and could overwrite an explicit user pin.
+    # `{version}` extras under our registry are retagged and digest-
+    # pinned. Literal extras under our registry keep their tag but may
+    # be digest-pinned. External refs and `@sha256:`-pinned refs keep
+    # their declared form. Refs already in digest_map are left alone —
+    # re-resolving would overwrite an explicit `--digest` user pin.
     resolved_extras = [
         resolve_extra_image(img, registry, version, stage, revision)
         for img in (info.metadata.get("extra_docker_images") or [])

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -645,7 +645,7 @@ def run_publish(
     # when the user supplied `--digest`) are left alone — re-resolving
     # would hit the registry and could overwrite an explicit user pin.
     resolved_extras = [
-        resolve_extra_image(img, registry, version, stage)
+        resolve_extra_image(img, registry, version, stage, revision)
         for img in (info.metadata.get("extra_docker_images") or [])
     ]
     extras_to_resolve = [

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -562,8 +562,8 @@ def _stage_and_pin_ref(
       1. *ref* itself (direct match).
       2. ``<name>:<clean_tag><stage_suffix>`` synthesis.
 
-    Returns *ref* unchanged when no candidate matches, the ref is
-    digest-pinned, or the ref has no ``/`` (can't split a name).
+    Returns *ref* unchanged when no candidate matches or the ref is
+    already digest-pinned.
 
     Stage suffixes: known built-ins (``-dev``/``-stage``) are stripped
     before reapplying so re-publishes round-trip cleanly. Custom-stage

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -81,20 +81,14 @@ class RegistryBuilder:
             version: Semver version string for this release. Substituted
                 into ``{version}`` placeholders in ``extra_docker_images``
                 entries.
-            stage: One of ``"prod"``, ``"stage"``, ``"dev"``, or any custom name.
-                Applied as a tag suffix to ``extra_docker_images`` entries
-                under *registry* that carried a ``{version}`` placeholder,
-                in the legacy synthesis path only. *revision* takes
-                precedence. Author-pinned literal tags pass through
-                untouched.
-            revision: Optional revision identifier (e.g. the CI-canonical
-                branch/release tag). When provided, included as a
-                top-level ``revision`` field on the entry (consumed by
-                ``CatalogDedupGuard`` to make CI re-publishes idempotent)
-                AND used as the tag for ``extra_docker_images`` entries
-                under *registry* with a ``{version}`` placeholder,
-                replacing the legacy ``<version><stage_suffix>``
-                synthesis.
+            stage: ``"prod"`` / ``"stage"`` / ``"dev"`` / custom name.
+                Tag suffix for ``{version}`` extras under *registry* in
+                the legacy (no-revision) synthesis path only.
+            revision: Optional revision identifier. When provided, set
+                as the entry's ``revision`` field (for
+                ``CatalogDedupGuard`` idempotency) AND used as the tag
+                for ``{version}`` extras under *registry*, overriding
+                the legacy ``<version><stage_suffix>`` synthesis.
             digest_map: Optional mapping of rewritten image ref
                 (``"<registry>/<ext>-<svc>:<tag>"``) to its OCI manifest
                 digest (``"sha256:..."``). When provided, matching service
@@ -593,16 +587,15 @@ def resolve_extra_image(
 ) -> str:
     """Apply ``{version}`` substitution and derive the tag for one ref.
 
-    For refs containing ``{version}`` under *registry*, the resulting tag
-    is *revision* when supplied (CI passes the canonical branch/release
-    tag — mirrors the primary ``docker_images`` path in
+    ``{version}`` is always substituted first. For refs under *registry*,
+    the resulting tag is *revision* when supplied (CI's canonical
+    branch/release tag — mirrors the primary ``docker_images`` path in
     ``commands/publish.py``), else the legacy ``<version><stage_suffix>``
     synthesis (for extensions not yet on the shared workflow).
 
-    Returns *image* unchanged when:
+    Tag derivation is skipped (substituted ref returned as-is) when:
 
-    - The ref carried no ``{version}`` placeholder (author-pinned tag —
-      independent release cadence, not ours to retag).
+    - The ref carried no ``{version}`` placeholder (author-pinned tag).
     - The ref is already digest-pinned (``@sha256:...``).
     - The ref is outside *registry* (external pass-through).
     """

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -111,7 +111,7 @@ class RegistryBuilder:
         # (same source of truth ``_apply_digests`` uses) so an env default
         # only gets restamped when this publish actually resolved that ref.
         transformed_compose = _apply_env_image_rewrites(
-            transformed_compose, stage, digest_map
+            transformed_compose, stage, digest_map, revision
         )
 
         # sort_keys=False preserves service key order from the source compose.
@@ -455,6 +455,7 @@ def _apply_env_image_rewrites(
     compose: Dict[str, Any],
     stage: str,
     digest_map: Optional[Dict[str, str]] = None,
+    revision: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Return a deep copy of *compose* with image refs in env values rewritten.
 
@@ -485,25 +486,26 @@ def _apply_env_image_rewrites(
         if isinstance(env, dict):
             for key, val in env.items():
                 if isinstance(val, str):
-                    env[key] = _rewrite_env_image_ref(val, stage, digest_map)
+                    env[key] = _rewrite_env_image_ref(val, stage, digest_map, revision)
         elif isinstance(env, list):
             for i, entry in enumerate(env):
                 if isinstance(entry, str) and "=" in entry:
                     k, v = entry.split("=", 1)
-                    new_v = _rewrite_env_image_ref(v, stage, digest_map)
+                    new_v = _rewrite_env_image_ref(v, stage, digest_map, revision)
                     if new_v != v:
                         env[i] = f"{k}={new_v}"
                 elif isinstance(entry, dict):
                     val = entry.get("value")
                     if isinstance(val, str):
                         entry["value"] = _rewrite_env_image_ref(
-                            val, stage, digest_map
+                            val, stage, digest_map, revision
                         )
     return result
 
 
 def _rewrite_env_image_ref(
     value: str, stage: str, digest_map: Dict[str, str],
+    revision: Optional[str] = None,
 ) -> str:
     """Apply stage suffix + digest pin to an image ref embedded in *value*.
 
@@ -517,28 +519,42 @@ def _rewrite_env_image_ref(
     Pass-through cases (none of which match *digest_map* membership):
     non-image-shaped strings, already ``@sha256:``-pinned refs, refs
     whose post-suffix candidate isn't in *digest_map*.
+
+    When *revision* is set, candidate construction follows
+    :func:`_stage_and_pin_ref`'s revision-aware path so env defaults
+    written against a concrete tag (e.g. ``agent:1.9.0``) still resolve
+    against a revision-keyed digest_map (e.g. ``agent:develop``).
     """
     match = _ENV_DEFAULT_SUB_RE.match(value)
     if match:
         prefix, default, brace = match.group(1), match.group(2), match.group(3)
-        new_ref = _stage_and_pin_ref(default, stage, digest_map)
+        new_ref = _stage_and_pin_ref(default, stage, digest_map, revision)
         if new_ref == default:
             return value
         return f"{prefix}{new_ref}{brace}"
-    return _stage_and_pin_ref(value, stage, digest_map)
+    return _stage_and_pin_ref(value, stage, digest_map, revision)
 
 
 def _stage_and_pin_ref(
     ref: str, stage: str, digest_map: Dict[str, str],
+    revision: Optional[str] = None,
 ) -> str:
-    """Return ``ref@digest`` when the staged candidate is in *digest_map*.
+    """Return ``ref@digest`` when a candidate ref is in *digest_map*.
 
-    Returns *ref* unchanged when:
+    Tries three candidates in order:
 
-    - The ref is already digest-pinned (``@sha256:...``).
-    - The post-suffix candidate isn't a key in *digest_map* — either the
-      ref points outside our published surface (external image, vendored
-      helper) or the publish didn't resolve it.
+    1. *ref* itself (direct match — catches literal-tag extras and
+       refs the author already wrote at the revision tag).
+    2. ``<name>:<revision>`` (only when *revision* is supplied) —
+       mirrors :func:`resolve_extra_image`'s revision branch so env
+       defaults written against a concrete tag (e.g. ``agent:1.9.0``)
+       still resolve under ``--revision`` (where digest_map is keyed by
+       e.g. ``agent:develop``).
+    3. ``<name>:<clean_tag><stage_suffix>`` — legacy synthesis for the
+       no-revision path.
+
+    Returns *ref* unchanged when none match, the ref is digest-pinned,
+    or the ref has no ``/`` (can't split a name).
 
     Stage suffixes: known built-ins (``-dev``/``-stage``) are stripped
     before reapplying so re-publishes round-trip cleanly. Custom-stage
@@ -548,16 +564,13 @@ def _stage_and_pin_ref(
     if "@" in ref:
         return ref
 
-    # Literal-tag refs in `extra_docker_images` (no `{version}` placeholder)
-    # round-trip through ``resolve_extra_image`` unchanged and land in
-    # ``digest_map`` keyed by the literal ref — no stage suffix applied.
-    # When the same ref shows up as an env default, pin against the literal
-    # key first so the env value matches what extras emit. Mirrors the
-    # "independent release cadence" semantics ``resolve_extra_image`` uses.
+    # Direct match catches literal-tag extras (no `{version}`) which
+    # ``resolve_extra_image`` leaves untouched and which land in
+    # ``digest_map`` keyed by the literal ref. Also catches the case
+    # where the env default was already written at the revision tag.
     if ref in digest_map:
         return f"{ref}@{digest_map[ref]}"
 
-    suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
     # Split on the last `:` after the final `/`; an earlier `:` is a
     # registry port (e.g. ``localhost:5000/org/agent:tag``).
     slash = ref.rfind("/")
@@ -568,10 +581,21 @@ def _stage_and_pin_ref(
         colon = last_segment.index(":")
         name = ref[: slash + 1 + colon]
         tag = last_segment[colon + 1:]
-        clean_tag = re.sub(r"-(dev|stage)$", "", tag)
     else:
-        name, clean_tag = ref, "latest"
+        name, tag = ref, "latest"
 
+    # Revision-tag candidate: under --revision, digest_map is keyed by
+    # `<name>:<revision>` (what ``resolve_extra_image`` emits). An env
+    # default with a concrete tag like `:1.9.0` needs this retag to
+    # agree with the extras entry in the same catalog row.
+    if revision is not None:
+        rev_candidate = f"{name}:{revision}"
+        if rev_candidate in digest_map:
+            return f"{rev_candidate}@{digest_map[rev_candidate]}"
+
+    # Legacy stage-suffix synthesis fallback.
+    clean_tag = re.sub(r"-(dev|stage)$", "", tag)
+    suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
     candidate = f"{name}:{clean_tag}{suffix}"
     if candidate in digest_map:
         return f"{candidate}@{digest_map[candidate]}"

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -111,7 +111,7 @@ class RegistryBuilder:
         # (same source of truth ``_apply_digests`` uses) so an env default
         # only gets restamped when this publish actually resolved that ref.
         transformed_compose = _apply_env_image_rewrites(
-            transformed_compose, stage, digest_map, revision
+            transformed_compose, stage, digest_map, revision, version
         )
 
         # sort_keys=False preserves service key order from the source compose.
@@ -456,6 +456,7 @@ def _apply_env_image_rewrites(
     stage: str,
     digest_map: Optional[Dict[str, str]] = None,
     revision: Optional[str] = None,
+    version: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Return a deep copy of *compose* with image refs in env values rewritten.
 
@@ -486,19 +487,23 @@ def _apply_env_image_rewrites(
         if isinstance(env, dict):
             for key, val in env.items():
                 if isinstance(val, str):
-                    env[key] = _rewrite_env_image_ref(val, stage, digest_map, revision)
+                    env[key] = _rewrite_env_image_ref(
+                        val, stage, digest_map, revision, version
+                    )
         elif isinstance(env, list):
             for i, entry in enumerate(env):
                 if isinstance(entry, str) and "=" in entry:
                     k, v = entry.split("=", 1)
-                    new_v = _rewrite_env_image_ref(v, stage, digest_map, revision)
+                    new_v = _rewrite_env_image_ref(
+                        v, stage, digest_map, revision, version
+                    )
                     if new_v != v:
                         env[i] = f"{k}={new_v}"
                 elif isinstance(entry, dict):
                     val = entry.get("value")
                     if isinstance(val, str):
                         entry["value"] = _rewrite_env_image_ref(
-                            val, stage, digest_map, revision
+                            val, stage, digest_map, revision, version
                         )
     return result
 
@@ -506,6 +511,7 @@ def _apply_env_image_rewrites(
 def _rewrite_env_image_ref(
     value: str, stage: str, digest_map: Dict[str, str],
     revision: Optional[str] = None,
+    version: Optional[str] = None,
 ) -> str:
     """Digest-pin an image ref embedded in *value*.
 
@@ -524,33 +530,40 @@ def _rewrite_env_image_ref(
     match = _ENV_DEFAULT_SUB_RE.match(value)
     if match:
         prefix, default, brace = match.group(1), match.group(2), match.group(3)
-        new_ref = _stage_and_pin_ref(default, stage, digest_map, revision)
+        new_ref = _stage_and_pin_ref(default, stage, digest_map, revision, version)
         if new_ref == default:
             return value
         return f"{prefix}{new_ref}{brace}"
-    return _stage_and_pin_ref(value, stage, digest_map, revision)
+    return _stage_and_pin_ref(value, stage, digest_map, revision, version)
 
 
 def _stage_and_pin_ref(
     ref: str, stage: str, digest_map: Dict[str, str],
     revision: Optional[str] = None,
+    version: Optional[str] = None,
 ) -> str:
     """Return ``ref@digest`` when a candidate ref is in *digest_map*.
 
-    Tries three candidates in order:
+    Candidate construction depends on whether *revision* is supplied:
 
-    1. *ref* itself (direct match — catches literal-tag extras and
-       refs the author already wrote at the revision tag).
-    2. ``<name>:<revision>`` (only when *revision* is supplied) —
-       mirrors :func:`resolve_extra_image`'s revision branch so env
-       defaults written against a concrete tag (e.g. ``agent:1.9.0``)
-       still resolve under ``--revision`` (where digest_map is keyed by
-       e.g. ``agent:develop``).
-    3. ``<name>:<clean_tag><stage_suffix>`` — legacy synthesis for the
-       no-revision path.
+    Under ``--revision``:
+      1. *ref* itself (direct match — author already wrote the
+         revision tag, or listed a literal-tag extra).
+      2. ``<name>:<revision>`` ONLY when ``ref``'s tag equals
+         *version* — same opt-in signal as ``{version}`` in
+         :func:`resolve_extra_image`. A literal pin to any other tag
+         signals independent release cadence and passes through.
+      No legacy stage-suffix fallback (would re-divergence env vs
+      extras; under --revision the catalog publish keys digest_map by
+      ``:<revision>``, so the stage candidate is unreachable in
+      practice and shouldn't be locked in tests).
 
-    Returns *ref* unchanged when none match, the ref is digest-pinned,
-    or the ref has no ``/`` (can't split a name).
+    Without ``--revision`` (legacy):
+      1. *ref* itself (direct match).
+      2. ``<name>:<clean_tag><stage_suffix>`` synthesis.
+
+    Returns *ref* unchanged when no candidate matches, the ref is
+    digest-pinned, or the ref has no ``/`` (can't split a name).
 
     Stage suffixes: known built-ins (``-dev``/``-stage``) are stripped
     before reapplying so re-publishes round-trip cleanly. Custom-stage
@@ -580,16 +593,22 @@ def _stage_and_pin_ref(
     else:
         name, tag = ref, "latest"
 
-    # Revision-tag candidate: under --revision, digest_map is keyed by
-    # `<name>:<revision>` (what ``resolve_extra_image`` emits). An env
-    # default with a concrete tag like `:1.9.0` needs this retag to
-    # agree with the extras entry in the same catalog row.
     if revision is not None:
-        rev_candidate = f"{name}:{revision}"
-        if rev_candidate in digest_map:
-            return f"{rev_candidate}@{digest_map[rev_candidate]}"
+        # Version-gate: only retag when the env default explicitly opts
+        # in by writing the current kamiwaza.json version as its tag.
+        # A literal pin to a different version (e.g. a helper at
+        # `:0.5.0` while the extension is at `:1.9.0`) passes through —
+        # mirrors ``resolve_extra_image``'s ``{version}``-opt-in
+        # semantics so the env-rewrite surface stays consistent with
+        # the extras surface. No legacy stage-suffix fallback under
+        # --revision.
+        if version is not None and tag == version:
+            rev_candidate = f"{name}:{revision}"
+            if rev_candidate in digest_map:
+                return f"{rev_candidate}@{digest_map[rev_candidate]}"
+        return ref
 
-    # Legacy stage-suffix synthesis fallback.
+    # Legacy stage-suffix synthesis (revision=None path only).
     clean_tag = re.sub(r"-(dev|stage)$", "", tag)
     suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
     candidate = f"{name}:{clean_tag}{suffix}"

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -459,13 +459,13 @@ def _apply_env_image_rewrites(
 ) -> Dict[str, Any]:
     """Return a deep copy of *compose* with image refs in env values rewritten.
 
-    Walks ``services[*].environment`` (dict and list shapes) and rewrites
-    image refs to the stage-suffixed-and-digest-pinned form ONLY when the
-    post-suffix candidate ref appears as a key in *digest_map*. Caller's
-    *compose* dict is not mutated.
+    Walks ``services[*].environment`` (dict and list shapes) and digest-
+    pins image refs when a candidate (direct / revision-tag / stage-
+    suffix — see :func:`_stage_and_pin_ref`) appears as a key in
+    *digest_map*. Caller's *compose* dict is not mutated.
 
     Sibling to :func:`_apply_digests` for the env-value surface. Kaizen's
-    ``${AGENT_SERVER_IMAGE:-<reg>/agent:1.8.13}`` default is the
+    ``${AGENT_SERVER_IMAGE:-<reg>/agent:1.9.0}`` default is the
     motivating case: the agent image is referenced by env var because
     the backend spawns sandbox pods dynamically, so the ref never appears
     as a service ``image:`` field that ``_apply_digests`` would catch.
@@ -474,8 +474,8 @@ def _apply_env_image_rewrites(
     actually resolved." Gating on its membership keeps env defaults from
     pointing at refs the publish never produced — e.g. a vendored
     ``shared-helper:0.5.0`` (independent release cadence) stays at
-    ``:0.5.0`` because ``:0.5.0-dev`` was never built or mirrored. Matches
-    the literal-tag-passthrough rule that :func:`resolve_extra_image`
+    ``:0.5.0`` because no published candidate matches it. Matches the
+    literal-tag-passthrough rule that :func:`resolve_extra_image`
     enforces on the extras surface.
     """
     if not digest_map:
@@ -507,7 +507,7 @@ def _rewrite_env_image_ref(
     value: str, stage: str, digest_map: Dict[str, str],
     revision: Optional[str] = None,
 ) -> str:
-    """Apply stage suffix + digest pin to an image ref embedded in *value*.
+    """Digest-pin an image ref embedded in *value*.
 
     Handles two shapes:
 
@@ -516,14 +516,10 @@ def _rewrite_env_image_ref(
       override still wins.
     - Bare ``<image>:<tag>`` — rewrites in place.
 
-    Pass-through cases (none of which match *digest_map* membership):
-    non-image-shaped strings, already ``@sha256:``-pinned refs, refs
-    whose post-suffix candidate isn't in *digest_map*.
-
-    When *revision* is set, candidate construction follows
-    :func:`_stage_and_pin_ref`'s revision-aware path so env defaults
-    written against a concrete tag (e.g. ``agent:1.9.0``) still resolve
-    against a revision-keyed digest_map (e.g. ``agent:develop``).
+    Candidate construction (direct / revision-tag / stage-suffix) and
+    pass-through rules are :func:`_stage_and_pin_ref`'s contract.
+    Non-image-shaped strings (no ``${VAR...}`` match, no recognizable
+    name) fall through unchanged.
     """
     match = _ENV_DEFAULT_SUB_RE.match(value)
     if match:

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -83,11 +83,18 @@ class RegistryBuilder:
                 entries.
             stage: One of ``"prod"``, ``"stage"``, ``"dev"``, or any custom name.
                 Applied as a tag suffix to ``extra_docker_images`` entries
-                under *registry* that carried a ``{version}`` placeholder.
-                Author-pinned literal tags pass through untouched.
-            revision: Optional revision identifier. When provided, included
-                as a top-level ``revision`` field on the entry; consumed by
-                ``CatalogDedupGuard`` to make CI re-publishes idempotent.
+                under *registry* that carried a ``{version}`` placeholder,
+                in the legacy synthesis path only. *revision* takes
+                precedence. Author-pinned literal tags pass through
+                untouched.
+            revision: Optional revision identifier (e.g. the CI-canonical
+                branch/release tag). When provided, included as a
+                top-level ``revision`` field on the entry (consumed by
+                ``CatalogDedupGuard`` to make CI re-publishes idempotent)
+                AND used as the tag for ``extra_docker_images`` entries
+                under *registry* with a ``{version}`` placeholder,
+                replacing the legacy ``<version><stage_suffix>``
+                synthesis.
             digest_map: Optional mapping of rewritten image ref
                 (``"<registry>/<ext>-<svc>:<tag>"``) to its OCI manifest
                 digest (``"sha256:..."``). When provided, matching service
@@ -126,7 +133,7 @@ class RegistryBuilder:
         # fields: compose-derived vs. author-declared. Downstream consumers
         # iterate each list separately; do not merge.
         extra_images = [
-            resolve_extra_image(img, registry, version, stage)
+            resolve_extra_image(img, registry, version, stage, revision)
             for img in (metadata.get("extra_docker_images") or [])
         ]
         if extra_images and digest_map:
@@ -578,15 +585,24 @@ def _stage_and_pin_ref(
 
 
 def resolve_extra_image(
-    image: str, registry: str, version: str, stage: str,
+    image: str,
+    registry: str,
+    version: str,
+    stage: str,
+    revision: Optional[str] = None,
 ) -> str:
-    """Apply ``{version}`` substitution and stage suffix to one ref.
+    """Apply ``{version}`` substitution and derive the tag for one ref.
 
-    Substitutes ``{version}`` literally, then applies the stage-derived
-    suffix only to substituted refs under *registry*. Returns *image*
-    unchanged when:
+    For refs containing ``{version}`` under *registry*, the resulting tag
+    is *revision* when supplied (CI passes the canonical branch/release
+    tag — mirrors the primary ``docker_images`` path in
+    ``commands/publish.py``), else the legacy ``<version><stage_suffix>``
+    synthesis (for extensions not yet on the shared workflow).
 
-    - The ref carried no ``{version}`` placeholder (author-pinned tag).
+    Returns *image* unchanged when:
+
+    - The ref carried no ``{version}`` placeholder (author-pinned tag —
+      independent release cadence, not ours to retag).
     - The ref is already digest-pinned (``@sha256:...``).
     - The ref is outside *registry* (external pass-through).
     """
@@ -601,20 +617,23 @@ def resolve_extra_image(
 
     # The tag, if any, lives after the last `/`. Splitting on the leftmost
     # `:` would catch a registry port (e.g. `localhost:5000/...`) instead.
-    suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
     slash = substituted.rfind("/")
     last_segment = substituted[slash + 1:]
     if ":" in last_segment:
         colon = last_segment.index(":")
         name = substituted[: slash + 1 + colon]
         tag = last_segment[colon + 1:]
-        # Strip an existing stage suffix so `agent:{version}-dev` published
-        # against a prod stage emits the unsuffixed tag rather than
-        # `agent:1.8.13-dev` reapplied.
-        clean_tag = re.sub(r"-(dev|stage)$", "", tag)
     else:
-        name, clean_tag = substituted, "latest"
+        name, tag = substituted, "latest"
 
+    if revision is not None:
+        return f"{name}:{revision}"
+
+    # Legacy synthesis. Strip an existing stage suffix so
+    # `agent:{version}-dev` published against a prod stage emits the
+    # unsuffixed tag rather than `agent:1.8.13-dev` reapplied.
+    clean_tag = re.sub(r"-(dev|stage)$", "", tag)
+    suffix = _STAGE_SUFFIXES.get(stage, f"-{stage}")
     return f"{name}:{clean_tag}{suffix}"
 
 

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -779,13 +779,15 @@ class TestPublishEnvImageRefsAgreeWithExtras:
         mock_publisher_cls,
         tmp_path,
     ):
-        # ENG-5599 H1 regression: the kaizen-shaped end-to-end under
-        # --revision. The compose env default is written at the literal
-        # version tag (the common author shape); the extras list uses
-        # {version}. After publish, both surfaces in the catalog entry
-        # must reference the same revision-tagged + digest-pinned ref.
-        # Pre-fix the env default would have been left at the unpinned
-        # `:1.9.0` while extras shipped `:develop@<digest>`.
+        # Kaizen-shaped end-to-end under --revision: the compose env
+        # default is written at the literal version tag (the common
+        # author shape); the extras list uses {version}. After
+        # publish, both surfaces in the catalog entry must reference
+        # the same revision-tagged + digest-pinned ref. Locks the
+        # env-default-matches-extras invariant under the revision
+        # path; sister test `test_env_default_matches_extras_entry_
+        # end_to_end` above exercises the same invariant without
+        # --revision.
         import yaml as _yaml
 
         metadata = {
@@ -861,15 +863,14 @@ class TestPublishEnvImageRefsAgreeWithExtras:
             "AGENT_SERVER_IMAGE"
         ]
 
-        # Acceptance: under --revision the canonical pinned ref appears
-        # in BOTH the extras list and the env default. This is the
-        # invariant pre-fix violated.
+        # Under --revision, the canonical pinned ref must appear in
+        # BOTH the extras list and the env default — the env-default-
+        # matches-extras invariant.
         expected_ref = f"ghcr.io/my-org/images/agent:develop@{agent_digest}"
         assert entry["extra_docker_images"] == [expected_ref]
         assert expected_ref in env_default, (
             f"under --revision develop, compose env default {env_default!r} "
-            f"must reference the same pinned ref as extras ({expected_ref!r}) "
-            f"— H1 regression check"
+            f"must reference the same pinned ref as extras ({expected_ref!r})"
         )
         assert env_default.startswith("${AGENT_SERVER_IMAGE:-")
         assert env_default.endswith("}")

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -761,6 +761,119 @@ class TestPublishEnvImageRefsAgreeWithExtras:
         assert env_default.startswith("${AGENT_SERVER_IMAGE:-")
         assert env_default.endswith("}")
 
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_env_default_matches_extras_entry_under_revision(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # ENG-5599 H1 regression: the kaizen-shaped end-to-end under
+        # --revision. The compose env default is written at the literal
+        # version tag (the common author shape); the extras list uses
+        # {version}. After publish, both surfaces in the catalog entry
+        # must reference the same revision-tagged + digest-pinned ref.
+        # Pre-fix the env default would have been left at the unpinned
+        # `:1.9.0` while extras shipped `:develop@<digest>`.
+        import yaml as _yaml
+
+        metadata = {
+            "name": "kaizenv3",
+            "version": "1.9.0",
+            "description": "Kaizen v3",
+            "extra_docker_images": ["ghcr.io/my-org/images/agent:{version}"],
+        }
+        compose_data = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "ghcr.io/my-org/kaizenv3-backend:1.9.0",
+                    "ports": ["8000"],
+                    "environment": {
+                        "AGENT_SERVER_IMAGE":
+                            "${AGENT_SERVER_IMAGE:-ghcr.io/my-org/images/agent:1.9.0}",
+                    },
+                },
+            },
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path,
+            name="kaizenv3",
+            version="1.9.0",
+            metadata=metadata,
+            compose_data=compose_data,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/kaizenv3-backend:develop",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        # Under --revision develop, _auto_resolve_digests queries the
+        # registry for the revision-tagged refs CI actually pushed.
+        agent_digest = "sha256:" + "d" * 64
+        digest_by_ref = {
+            "ghcr.io/my-org/kaizenv3-backend:develop": "sha256:" + "e" * 64,
+            "ghcr.io/my-org/images/agent:develop": agent_digest,
+        }
+        mock_pusher_cls.resolve_digest.side_effect = lambda ref: digest_by_ref[ref]
+
+        mock_publisher = MagicMock()
+        mock_publisher.publish.return_value = _make_publish_result(
+            extension_name="kaizenv3", version="1.9.0",
+        )
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", revision="develop")
+
+        publish_kwargs = mock_publisher.publish.call_args.kwargs
+        entry = publish_kwargs["entry"]
+        compose_out = _yaml.safe_load(entry["compose_yml"])
+        env_default = compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ]
+
+        # Acceptance: under --revision the canonical pinned ref appears
+        # in BOTH the extras list and the env default. This is the
+        # invariant pre-fix violated.
+        expected_ref = f"ghcr.io/my-org/images/agent:develop@{agent_digest}"
+        assert entry["extra_docker_images"] == [expected_ref]
+        assert expected_ref in env_default, (
+            f"under --revision develop, compose env default {env_default!r} "
+            f"must reference the same pinned ref as extras ({expected_ref!r}) "
+            f"— H1 regression check"
+        )
+        assert env_default.startswith("${AGENT_SERVER_IMAGE:-")
+        assert env_default.endswith("}")
+
 
 # ------------------------------------------------------------------
 # Dry-run mode

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -371,6 +371,94 @@ class TestBuildEntry:
         assert entry["extra_docker_images"] == [pinned_ref]
         assert pinned_ref not in entry["docker_images"]
 
+    def test_extra_docker_images_revision_overrides_synthesis(
+        self, builder, transformed_compose,
+    ):
+        # ENG-5599: under the new tag policy CI publishes images at the
+        # branch/release tag (e.g. `:develop`), not `:<version>-<stage>`.
+        # When --revision is supplied, the {version}-placeholder extras
+        # path must use it as the tag instead of synthesizing the legacy
+        # `<version><stage_suffix>` form. Mirrors the primary docker_images
+        # path in commands/publish.py.
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "2.0.1",
+            stage="dev", revision="develop",
+        )
+        assert entry["extra_docker_images"] == ["myreg/images/agent:develop"]
+        # The legacy synthesized ref must not also appear.
+        assert "myreg/images/agent:2.0.1-dev" not in entry["extra_docker_images"]
+
+    def test_extra_docker_images_no_revision_preserves_legacy_synthesis(
+        self, builder, transformed_compose,
+    ):
+        # Backwards-compat: extensions not yet on the shared workflow
+        # publish without --revision and rely on the `<version><stage_suffix>`
+        # synthesis. revision=None must not regress that behavior.
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13",
+            stage="dev",  # revision defaults to None
+        )
+        assert entry["extra_docker_images"] == ["myreg/images/agent:1.8.13-dev"]
+
+    def test_extra_docker_images_revision_does_not_retag_author_pinned(
+        self, builder, transformed_compose,
+    ):
+        # Asymmetric with primary docker_images by design: the {version}
+        # placeholder is the opt-in signal that an extra image's release
+        # cadence is coupled to the extension. Author-pinned literal tags
+        # signal independent cadence (vendored helper, frozen self-pin)
+        # and must pass through regardless of --revision.
+        meta = {
+            "name": "my-app",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/shared-helper:0.5.0"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13",
+            stage="dev", revision="develop",
+        )
+        assert entry["extra_docker_images"] == ["myreg/images/shared-helper:0.5.0"]
+
+    def test_extra_docker_images_revision_does_not_retag_external(
+        self, builder, transformed_compose,
+    ):
+        # External refs are never ours to retag, --revision or not.
+        meta = {
+            "name": "my-app",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": [
+                "ghcr.io/external/sidecar:2.0",
+                "quay.io/org/util:{version}",
+            ],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.8.13",
+            stage="dev", revision="develop",
+        )
+        # No-placeholder external: untouched.
+        assert "ghcr.io/external/sidecar:2.0" in entry["extra_docker_images"]
+        # Placeholder substituted, but external registry → no revision retag.
+        assert "quay.io/org/util:1.8.13" in entry["extra_docker_images"]
+        assert "quay.io/org/util:develop" not in entry["extra_docker_images"]
+
 
 # ------------------------------------------------------------------
 # Env-var image-ref rewriting (ENG-5260)

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -374,12 +374,12 @@ class TestBuildEntry:
     def test_extra_docker_images_revision_overrides_synthesis(
         self, builder, transformed_compose,
     ):
-        # ENG-5599: under the new tag policy CI publishes images at the
-        # branch/release tag (e.g. `:develop`), not `:<version>-<stage>`.
+        # CI publishes extension images at the branch/release tag
+        # (`:develop`, `:release-X.Y.Z`), not `:<version>-<stage>`.
         # When --revision is supplied, the {version}-placeholder extras
-        # path must use it as the tag instead of synthesizing the legacy
-        # `<version><stage_suffix>` form. Mirrors the primary docker_images
-        # path in commands/publish.py.
+        # path uses it as the tag instead of synthesizing the legacy
+        # `<version><stage_suffix>` form. Mirrors the primary
+        # docker_images path in commands/publish.py.
         meta = {
             "name": "kaizenv3",
             "description": "test",
@@ -440,9 +440,8 @@ class TestBuildEntry:
     ):
         # The full publish path: revision retags the extras ref, then
         # digest_map pins it. digest_map is keyed by the revision-tagged
-        # ref (matching what publish.py:_auto_resolve_digests resolves
-        # against the actual GHCR push). Locks the post-fix shape; pre-fix
-        # the key would be `agent:<version>-<stage>` and never match.
+        # ref — matches what publish.py:_auto_resolve_digests resolves
+        # against the actual GHCR push under the branch-name tag policy.
         digest = "sha256:" + "c" * 64
         digest_map = {"myreg/images/agent:develop": digest}
         meta = {
@@ -934,7 +933,7 @@ class TestBuildEntryEnvImageRewrites:
 
 
 # ------------------------------------------------------------------
-# Env-var image-ref rewriting under --revision (ENG-5599)
+# Env-var image-ref rewriting under --revision
 # ------------------------------------------------------------------
 
 
@@ -958,9 +957,10 @@ class TestBuildEntryEnvImageRewritesWithRevision:
         return base
 
     def test_concrete_tag_env_default_pinned_to_revision_tag(self, builder):
-        # The H1 regression: env default at literal `:1.9.0` + revision
-        # in digest_map → pinned to `:develop@<digest>`. Pre-fix the
-        # candidate was `:1.9.0-dev`, missed the map, env left unpinned.
+        # Env default at literal `:<version>` + revision in digest_map →
+        # pinned to `:<revision>@<digest>`. The tag-equals-version
+        # opt-in (mirroring resolve_extra_image's {version} semantics)
+        # is what triggers the retag.
         compose = _kaizen_shaped_compose(
             "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
         )
@@ -1057,14 +1057,13 @@ class TestBuildEntryEnvImageRewritesWithRevision:
             "AGENT_SERVER_IMAGE"
         ] == f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}"
 
-    def test_revision_miss_falls_back_to_legacy_stage_candidate(self, builder):
-        # When revision is supplied but the revision-tag candidate
-        # `agent:develop` isn't in digest_map, the legacy stage-suffix
-        # candidate `agent:1.9.0-dev` is tried next. If it hits, the env
-        # default is pinned to the legacy form. Locks the candidate
-        # ordering: direct → revision → legacy stage. Uses a non-empty
-        # digest_map so _apply_env_image_rewrites doesn't short-circuit
-        # at its outer empty-map guard.
+    def test_revision_miss_fail_closed_no_legacy_fallback(self, builder):
+        # Under --revision, the legacy stage-suffix candidate is NOT
+        # tried. The publish flow keys digest_map by `:<revision>` so
+        # the legacy candidate is unreachable in practice; locking the
+        # fallback would let a future caller building digest_map
+        # differently re-divergence the env vs extras surfaces.
+        # Invariant: revision miss → pass through unchanged.
         legacy_digest = "sha256:" + "9" * 64
         legacy_only_map = {"myreg/images/agent:1.9.0-dev": legacy_digest}
         compose = _kaizen_shaped_compose(
@@ -1075,12 +1074,44 @@ class TestBuildEntryEnvImageRewritesWithRevision:
             stage="dev", revision="develop", digest_map=legacy_only_map,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
+        # Env default is left verbatim — the legacy stage-suffix
+        # candidate is NOT tried under --revision.
         assert compose_out["services"]["backend"]["environment"][
             "AGENT_SERVER_IMAGE"
-        ] == (
-            "${AGENT_SERVER_IMAGE:-"
-            f"myreg/images/agent:1.9.0-dev@{legacy_digest}}}"
+        ] == "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
+
+    def test_literal_pinned_env_default_passes_through_under_revision(self, builder):
+        # An env default at a literal tag != kamiwaza.json version
+        # signals independent release cadence (e.g. a vendored helper
+        # pinned to :0.5.0 while the extension is at :1.9.0). The
+        # revision candidate must NOT retag it just because
+        # <name>:<revision> happens to be in digest_map — the env
+        # surface mirrors resolve_extra_image's {version}-opt-in
+        # semantics, with tag-equals-version as the opt-in signal
+        # (since compose env values can't carry the literal `{version}`
+        # placeholder the extras surface uses).
+        revision_digest = "sha256:" + "3" * 64
+        # digest_map carries the revision-tagged form (from the
+        # extension's own {version} extras), but NOT a key matching
+        # the literal env default tag.
+        map_with_revision = {"myreg/images/agent:develop": revision_digest}
+        compose = _kaizen_shaped_compose(
+            "${HELPER_IMAGE:-myreg/images/agent:0.5.0}"
         )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop", digest_map=map_with_revision,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        # Literal :0.5.0 is preserved — the version-gate skipped the
+        # revision candidate because tag (0.5.0) != version (1.9.0).
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${HELPER_IMAGE:-myreg/images/agent:0.5.0}"
+        # And the revision-tag candidate did NOT leak in.
+        assert "develop" not in compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ]
 
     def test_bare_ref_form_under_revision(self, builder):
         # Bare image ref (no ${...} wrapper) takes the same path through

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -934,6 +934,177 @@ class TestBuildEntryEnvImageRewrites:
 
 
 # ------------------------------------------------------------------
+# Env-var image-ref rewriting under --revision (ENG-5599)
+# ------------------------------------------------------------------
+
+
+class TestBuildEntryEnvImageRewritesWithRevision:
+    """Env-default rewriting under ``--revision``. Under the new CI tag
+    policy ``resolve_extra_image`` emits ``<name>:<revision>`` and
+    ``_auto_resolve_digests`` populates ``digest_map`` keyed by that
+    revision tag. Env defaults written against a concrete tag (the
+    common kaizen shape: ``${VAR:-<reg>/agent:1.9.0}``) must still
+    resolve to the same revision-tagged + digest-pinned ref so the
+    env default agrees with the extras entry in the same catalog row.
+    """
+
+    _DIGEST = "sha256:" + "f" * 64
+    _REV_MAP = {"myreg/images/agent:develop": _DIGEST}
+
+    def _meta(self, **overrides):
+        base = {"name": "kaizenv3", "description": "", "source_type": "kamiwaza",
+                "visibility": "public"}
+        base.update(overrides)
+        return base
+
+    def test_concrete_tag_env_default_pinned_to_revision_tag(self, builder):
+        # The H1 regression: env default at literal `:1.9.0` + revision
+        # in digest_map → pinned to `:develop@<digest>`. Pre-fix the
+        # candidate was `:1.9.0-dev`, missed the map, env left unpinned.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop", digest_map=self._REV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:develop@{self._DIGEST}}}"
+        )
+
+    def test_env_default_already_at_revision_tag_pinned_via_direct_match(self, builder):
+        # Defense in depth: if the author wrote the env default at the
+        # revision tag itself (e.g. `:develop`), the direct-match path
+        # at the top of _stage_and_pin_ref catches it before the
+        # revision-candidate branch is even consulted.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:develop}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop", digest_map=self._REV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:develop@{self._DIGEST}}}"
+        )
+
+    def test_external_ref_passes_through_under_revision(self, builder):
+        # External refs (outside our registry) are never in digest_map
+        # and so are never retagged — same invariant as without revision.
+        compose = _kaizen_shaped_compose(
+            "${SIDECAR:-ghcr.io/external/sidecar:2.0}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop", digest_map=self._REV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${SIDECAR:-ghcr.io/external/sidecar:2.0}"
+
+    def test_digest_pinned_env_default_unchanged_under_revision(self, builder):
+        # Already-`@sha256:`-pinned refs short-circuit at the top of
+        # _stage_and_pin_ref regardless of revision.
+        pinned_default = (
+            "myreg/images/agent:1.9.0@sha256:" + "a" * 64
+        )
+        compose = _kaizen_shaped_compose(f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}")
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop", digest_map=self._REV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}"
+
+    def test_revision_set_but_candidate_not_in_digest_map_falls_back(self, builder):
+        # When revision is supplied but the revision-tag candidate isn't
+        # in digest_map (e.g. publish didn't actually resolve that ref),
+        # the legacy stage-suffix candidate is tried next. If neither
+        # matches, the value is left verbatim — same gating contract
+        # as the no-revision path.
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop", digest_map={},
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
+
+    def test_bare_ref_form_under_revision(self, builder):
+        # Bare image ref (no ${...} wrapper) takes the same path through
+        # _stage_and_pin_ref. Locks parity between wrapped and bare forms.
+        compose = _kaizen_shaped_compose("myreg/images/agent:1.9.0")
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop", digest_map=self._REV_MAP,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == f"myreg/images/agent:develop@{self._DIGEST}"
+
+    def test_revision_none_preserves_legacy_stage_synthesis(self, builder):
+        # Backwards-compat: when revision=None, the env-rewrite path
+        # must behave exactly as before (stage-suffix synthesis only).
+        # Sister test to test_extra_docker_images_no_revision_preserves_legacy_synthesis.
+        legacy_digest = "sha256:" + "b" * 64
+        legacy_map = {"myreg/images/agent:1.9.0-dev": legacy_digest}
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.9.0",
+            stage="dev", digest_map=legacy_map,  # revision defaults to None
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:1.9.0-dev@{legacy_digest}}}"
+        )
+
+    def test_env_and_extras_agree_under_revision_end_to_end(self, builder):
+        # The acceptance criterion for H1: for kaizen-shaped input
+        # under --revision, the published compose env default and the
+        # extras list agree on tag + digest. Sister test to
+        # test_env_value_matches_extra_docker_images_entry at L908
+        # (which exercises the no-revision path).
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
+        )
+        meta = self._meta(
+            extra_docker_images=["myreg/images/agent:{version}"],
+        )
+        entry = builder.build_entry(
+            meta, compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop", digest_map=self._REV_MAP,
+        )
+        extras_ref = f"myreg/images/agent:develop@{self._DIGEST}"
+        assert entry["extra_docker_images"] == [extras_ref]
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        env_default = compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ]
+        assert extras_ref in env_default
+
+
+# ------------------------------------------------------------------
 # Publish-path ordering: end-to-end coverage
 # ------------------------------------------------------------------
 

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -977,22 +977,20 @@ class TestBuildEntryEnvImageRewritesWithRevision:
         )
 
     def test_direct_match_wins_over_revision_candidate(self, builder):
-        # Scenario: a literal-tag extra `agent:foo` AND a {version} extra
-        # for the same image are both declared, so digest_map ends up
-        # with BOTH `agent:foo` and `agent:develop`. With env default
-        # `agent:foo`, the direct-match path (candidate #1) must win
-        # over the revision-tag candidate (candidate #2). Locks the
-        # candidate ordering when direct and revision keys actually
-        # differ (the existing direct-match test uses `:develop` for
-        # both, so it doesn't disambiguate).
+        # Both candidates must be reachable for the ordering check to
+        # be meaningful. Env literal `agent:<version>` clears the
+        # version-gate so the revision candidate `agent:develop` WOULD
+        # be tried; both `agent:<version>` and `agent:develop` are in
+        # digest_map. Direct match must short-circuit before the
+        # revision candidate, returning the direct digest.
         direct_digest = "sha256:" + "1" * 64
         revision_digest = "sha256:" + "2" * 64
         both_map = {
-            "myreg/images/agent:foo": direct_digest,
+            "myreg/images/agent:1.9.0": direct_digest,
             "myreg/images/agent:develop": revision_digest,
         }
         compose = _kaizen_shaped_compose(
-            "${AGENT_SERVER_IMAGE:-myreg/images/agent:foo}"
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
         )
         entry = builder.build_entry(
             self._meta(), compose, "myreg/images", "1.9.0",
@@ -1003,7 +1001,7 @@ class TestBuildEntryEnvImageRewritesWithRevision:
             "AGENT_SERVER_IMAGE"
         ] == (
             "${AGENT_SERVER_IMAGE:-"
-            f"myreg/images/agent:foo@{direct_digest}}}"
+            f"myreg/images/agent:1.9.0@{direct_digest}}}"
         ), "direct-match must win over revision-tag candidate"
 
     def test_env_default_already_at_revision_tag_pinned_via_direct_match(self, builder):

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -435,6 +435,31 @@ class TestBuildEntry:
         )
         assert entry["extra_docker_images"] == ["myreg/images/shared-helper:0.5.0"]
 
+    def test_extra_docker_images_revision_and_digest_pin_together(
+        self, builder, transformed_compose,
+    ):
+        # The full publish path: revision retags the extras ref, then
+        # digest_map pins it. digest_map is keyed by the revision-tagged
+        # ref (matching what publish.py:_auto_resolve_digests resolves
+        # against the actual GHCR push). Locks the post-fix shape; pre-fix
+        # the key would be `agent:<version>-<stage>` and never match.
+        digest = "sha256:" + "c" * 64
+        digest_map = {"myreg/images/agent:develop": digest}
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": ["myreg/images/agent:{version}"],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "2.0.1",
+            stage="dev", revision="develop", digest_map=digest_map,
+        )
+        assert entry["extra_docker_images"] == [
+            f"myreg/images/agent:develop@{digest}"
+        ]
+
     def test_extra_docker_images_revision_does_not_retag_external(
         self, builder, transformed_compose,
     ):

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -348,6 +348,30 @@ class TestBuildEntry:
         )
         assert pinned in entry["extra_docker_images"]
 
+    def test_extra_docker_images_digest_pinned_ref_passthrough_under_revision(
+        self, builder, transformed_compose,
+    ):
+        # The `@sha256:` short-circuit in resolve_extra_image runs
+        # before the revision branch, so a digest-pinned ref is
+        # immutable regardless of --revision. Locks that guard under
+        # the revision-aware path.
+        pinned = (
+            "myreg/images/agent:1.9.0"
+            "@sha256:" + "a" * 64
+        )
+        meta = {
+            "name": "kaizenv3",
+            "description": "test",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "extra_docker_images": [pinned],
+        }
+        entry = builder.build_entry(
+            meta, transformed_compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop",
+        )
+        assert entry["extra_docker_images"] == [pinned]
+
     def test_extra_docker_images_digest_pinned_when_in_digest_map(
         self, builder, transformed_compose,
     ):

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -976,6 +976,36 @@ class TestBuildEntryEnvImageRewritesWithRevision:
             f"myreg/images/agent:develop@{self._DIGEST}}}"
         )
 
+    def test_direct_match_wins_over_revision_candidate(self, builder):
+        # Scenario: a literal-tag extra `agent:foo` AND a {version} extra
+        # for the same image are both declared, so digest_map ends up
+        # with BOTH `agent:foo` and `agent:develop`. With env default
+        # `agent:foo`, the direct-match path (candidate #1) must win
+        # over the revision-tag candidate (candidate #2). Locks the
+        # candidate ordering when direct and revision keys actually
+        # differ (the existing direct-match test uses `:develop` for
+        # both, so it doesn't disambiguate).
+        direct_digest = "sha256:" + "1" * 64
+        revision_digest = "sha256:" + "2" * 64
+        both_map = {
+            "myreg/images/agent:foo": direct_digest,
+            "myreg/images/agent:develop": revision_digest,
+        }
+        compose = _kaizen_shaped_compose(
+            "${AGENT_SERVER_IMAGE:-myreg/images/agent:foo}"
+        )
+        entry = builder.build_entry(
+            self._meta(), compose, "myreg/images", "1.9.0",
+            stage="dev", revision="develop", digest_map=both_map,
+        )
+        compose_out = yaml.safe_load(entry["compose_yml"])
+        assert compose_out["services"]["backend"]["environment"][
+            "AGENT_SERVER_IMAGE"
+        ] == (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:foo@{direct_digest}}}"
+        ), "direct-match must win over revision-tag candidate"
+
     def test_env_default_already_at_revision_tag_pinned_via_direct_match(self, builder):
         # Defense in depth: if the author wrote the env default at the
         # revision tag itself (e.g. `:develop`), the direct-match path
@@ -1027,23 +1057,30 @@ class TestBuildEntryEnvImageRewritesWithRevision:
             "AGENT_SERVER_IMAGE"
         ] == f"${{AGENT_SERVER_IMAGE:-{pinned_default}}}"
 
-    def test_revision_set_but_candidate_not_in_digest_map_falls_back(self, builder):
-        # When revision is supplied but the revision-tag candidate isn't
-        # in digest_map (e.g. publish didn't actually resolve that ref),
-        # the legacy stage-suffix candidate is tried next. If neither
-        # matches, the value is left verbatim — same gating contract
-        # as the no-revision path.
+    def test_revision_miss_falls_back_to_legacy_stage_candidate(self, builder):
+        # When revision is supplied but the revision-tag candidate
+        # `agent:develop` isn't in digest_map, the legacy stage-suffix
+        # candidate `agent:1.9.0-dev` is tried next. If it hits, the env
+        # default is pinned to the legacy form. Locks the candidate
+        # ordering: direct → revision → legacy stage. Uses a non-empty
+        # digest_map so _apply_env_image_rewrites doesn't short-circuit
+        # at its outer empty-map guard.
+        legacy_digest = "sha256:" + "9" * 64
+        legacy_only_map = {"myreg/images/agent:1.9.0-dev": legacy_digest}
         compose = _kaizen_shaped_compose(
             "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
         )
         entry = builder.build_entry(
             self._meta(), compose, "myreg/images", "1.9.0",
-            stage="dev", revision="develop", digest_map={},
+            stage="dev", revision="develop", digest_map=legacy_only_map,
         )
         compose_out = yaml.safe_load(entry["compose_yml"])
         assert compose_out["services"]["backend"]["environment"][
             "AGENT_SERVER_IMAGE"
-        ] == "${AGENT_SERVER_IMAGE:-myreg/images/agent:1.9.0}"
+        ] == (
+            "${AGENT_SERVER_IMAGE:-"
+            f"myreg/images/agent:1.9.0-dev@{legacy_digest}}}"
+        )
 
     def test_bare_ref_form_under_revision(self, builder):
         # Bare image ref (no ${...} wrapper) takes the same path through


### PR DESCRIPTION
## What this ships

`kz-ext publish` honors `--revision` for `{version}`-templated entries in `extra_docker_images`, mirroring the primary `docker_images` path. Unblocks Kaizen catalog publish under the new branch-name tag policy (first observed failure: kamiwaza-extensions-kaizen [run 26198660161](https://github.com/kamiwaza-internal/kamiwaza-extensions-kaizen/actions/runs/26198660161) for ENG-5573).

## Contract

For `extra_docker_images` entries under the extension's registry:

| Input | `--revision develop --stage dev` (CI) | no `--revision` (legacy) |
|---|---|---|
| `agent:{version}` | `agent:develop` | `agent:<version>-dev` |
| literal `helper:0.5.0` | unchanged | unchanged |
| external `postgres:15` | unchanged | unchanged |

Asymmetric with primary `docker_images` by design: `{version}` is the opt-in signal that an extra is release-coupled to the extension. Literal-tag extras signal independent cadence and aren't ours to retag.

Legacy `<version><stage_suffix>` synthesis preserved (revision=None) for extensions not yet on the shared CI workflow.

## Verification

- 5 new unit tests in `test_registry_builder.py`: revision overrides synthesis, revision + digest_map together, legacy synthesis preserved, literal-pin pass-through under revision, external pass-through under revision. 1319 pass in extensions suite.
- E2E trace of `build_entry` against Kaizen's real `kamiwaza.json` with the canonical CI registry produces:
  ```
  extra_docker_images: ghcr.io/.../images/agent:develop@sha256:...
  docker_images: postgres:v18.3, controller/backend/frontend:develop@sha256:...
  revision: develop
  ```
  Reproduces the catalog entry CI would emit for `--stage dev --revision develop`.