### PR TITLE
ENG-5643: kz-ext publish — support image_basename override in kamiwaza.json

### DIFF
--- a/kamiwaza_extensions/agent_guidance.md
+++ b/kamiwaza_extensions/agent_guidance.md
@@ -20,6 +20,9 @@ Every extension must end up with:
    `name`, `version`, `type` (or legacy `template_type`) ∈ `{"app", "tool", "service"}`,
    `source_type`, `visibility`, `description`, `risk_tier`,
    `kz_ext_version` (or legacy `kamiwaza_version`).
+   Optional `image_basename` overrides `name` as the prefix in the
+   ``{registry}/{basename}-{svc}:{tag}`` image-ref fallback — needed
+   when the bake target / pushed image basename diverges from `name`.
 2. **`docker-compose.yml`** at the extension root. Each service must
    declare `deploy.resources.limits` (cpus + memory) and a healthcheck
    on the primary HTTP service.

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -176,6 +176,7 @@ def _is_resumable(
     sdk_repo: Optional[str] = None,
     service: Optional[str] = None,
     registry: str = "",
+    image_basename: Optional[str] = None,
 ) -> bool:
     """Return True when the prior dev-state can resume the current run.
 
@@ -201,6 +202,10 @@ def _is_resumable(
       * **Registry** (``KAMIWAZA_REGISTRY`` / derived) — the prior push
         targeted a specific registry; a different registry means the
         image isn't there to skip-push to.
+      * **image_basename** — kamiwaza.json override that controls the
+        ``{registry}/{basename}-{svc}:{tag}`` legacy-fallback synthesis.
+        Build/push and deploy refs depend on it, so a flipped override
+        under the same ``--revision`` must invalidate resume.
     """
     if prior_state is None:
         return False
@@ -212,15 +217,17 @@ def _is_resumable(
         return False
     if prior_state.cluster != connection_url:
         return False
-    # Service filter, sdk_repo, and registry must all match. None vs ""
-    # are treated as equivalent for service/sdk_repo (older state files
-    # didn't record them — refuse resume on those by mismatching against
-    # current values when current is set).
+    # Service filter, sdk_repo, registry, and image_basename must all
+    # match. None vs "" are treated as equivalent for the Optional
+    # fields (older state files didn't record them — refuse resume on
+    # those by mismatching against current values when current is set).
     if (prior_state.last_service or None) != (service or None):
         return False
     if (prior_state.last_sdk_repo or None) != (sdk_repo or None):
         return False
     if prior_state.last_registry != registry:
+        return False
+    if (prior_state.last_image_basename or None) != (image_basename or None):
         return False
     return True
 
@@ -413,6 +420,7 @@ def run_dev_remote(
         sdk_repo=sdk_repo,
         service=service,
         registry=registry,
+        image_basename=info.image_basename,
     )
     if resumable and not no_build and prior_state.is_step_complete("build"):
         console.print(
@@ -605,11 +613,12 @@ def run_dev_remote(
                 extension_name=info.name,
                 deployer=deployer_email or "",
                 # Persist the resume-key inputs so the next invocation can
-                # detect when service-filter / sdk-repo / registry differ
-                # (review re-re-re-review PR #84 H1).
+                # detect when service-filter / sdk-repo / registry /
+                # image_basename differ (review re-re-re-review PR #84 H1).
                 service=service,
                 sdk_repo=sdk_repo,
                 registry=registry,
+                image_basename=info.image_basename,
             )
         except OSError as state_exc:
             console.print(

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -454,6 +454,7 @@ def run_dev_remote(
         extension_name=info.name,
         revision_tag=rev_tag,
         registry=registry,
+        image_basename=info.image_basename,
     )
     transformed = transformer.resolve_env_placeholders(transformed)
 
@@ -468,6 +469,7 @@ def run_dev_remote(
         registry=registry,
         extension_name=info.name,
         revision_tag=rev_tag,
+        image_basename=info.image_basename,
     )
 
     # 5b. Resolve SDK override for build
@@ -536,6 +538,7 @@ def run_dev_remote(
                 verbose=verbose,
                 build_overrides=build_overrides,
                 image_refs=canonical_refs,
+                image_basename=info.image_basename,
             )
         except ImageBuildError as exc:
             console.print(f"\n[red]Error:[/red] {exc}")

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -67,6 +67,7 @@ def _retag_appgarden_compose(
     extension_name: str,
     image_tag: str,
     registry: str,
+    image_basename: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Rewrite image tags on services that this publish actually owns.
 
@@ -121,6 +122,7 @@ def _retag_appgarden_compose(
                 fallback_registry=registry,
                 fallback_extension_name=extension_name,
                 revision_tag=image_tag,
+                fallback_image_basename=image_basename,
             )
     return out
 
@@ -161,12 +163,19 @@ def _collect_buildable_image_names(
     extension_name: str,
     version: str,
     registry: str,
+    image_basename: Optional[str] = None,
 ) -> List[str]:
-    """Return short image names (``name:tag``) for services with build contexts."""
+    """Return short image names (``basename:tag``) for services with build contexts.
+
+    Display-only (dry-run preview). ``image_basename`` (when set) overrides
+    ``extension_name`` so the preview matches what the live path would
+    actually push.
+    """
+    basename = image_basename or extension_name
     names: List[str] = []
     for svc_name, svc in (compose_data.get("services") or {}).items():
         if "build" in svc:
-            names.append(f"{extension_name}-{svc_name}:{version}")
+            names.append(f"{basename}-{svc_name}:{version}")
     return names
 
 
@@ -463,6 +472,7 @@ def run_publish(
             extension_name=info.name,
             image_tag=image_tag,
             registry=registry,
+            image_basename=info.image_basename,
         )
     else:
         transformer = ComposeTransformer()
@@ -471,6 +481,7 @@ def run_publish(
             extension_name=info.name,
             revision_tag=image_tag,
             registry=registry,
+            image_basename=info.image_basename,
         )
 
     # Canonical image refs for every build-context service. Single
@@ -490,12 +501,14 @@ def run_publish(
         extension_name=info.name,
         revision_tag=image_tag,
         appgarden_services=appgarden_services,
+        image_basename=info.image_basename,
     )
 
     # -- Dry-run path (still runs merge check to detect conflicts) --
     if dry_run:
         short_names = _collect_buildable_image_names(
-            info.compose_data, info.name, image_tag, registry
+            info.compose_data, info.name, image_tag, registry,
+            image_basename=info.image_basename,
         )
         console.print(
             f"  Would build images:    {', '.join(short_names) if short_names else '(none)'}"
@@ -563,6 +576,7 @@ def run_publish(
                 registry=registry,
                 verbose=verbose,
                 image_refs=canonical_refs,
+                image_basename=info.image_basename,
             )
         except ImageBuildError as exc:
             console.print("    [red]\u2717 build failed[/red]")

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -89,6 +89,7 @@ def compute_canonical_refs(
     extension_name: str,
     revision_tag: str,
     appgarden_services: Optional[Dict[str, Any]] = None,
+    image_basename: Optional[str] = None,
 ) -> Dict[str, str]:
     """Canonical image refs for every buildable service, keyed by service name.
 
@@ -106,6 +107,11 @@ def compute_canonical_refs(
     Filters out profile-gated services (matches ``buildable_services``
     in ``run_publish``) so profile-only helpers don't leak into the
     push list under ``--no-build``.
+
+    ``image_basename`` (when present and non-empty) overrides
+    ``extension_name`` for the legacy ``{registry}/{basename}-{svc}:{tag}``
+    synthesis — needed when the bake target / pushed image basename
+    diverges from the kamiwaza.json ``name``.
     """
     appgarden = appgarden_services or {}
     out: Dict[str, str] = {}
@@ -124,6 +130,7 @@ def compute_canonical_refs(
             fallback_registry=registry,
             fallback_extension_name=extension_name,
             revision_tag=revision_tag,
+            fallback_image_basename=image_basename,
         )
     return out
 
@@ -135,6 +142,7 @@ def _canonical_build_ref(
     fallback_registry: str,
     fallback_extension_name: str,
     revision_tag: str,
+    fallback_image_basename: Optional[str] = None,
 ) -> str:
     """Return the canonical registry image ref for a buildable service.
 
@@ -142,11 +150,18 @@ def _canonical_build_ref(
     explicit registry host (``ghcr.io/...``, ``localhost:5000/...``),
     the namespace is preserved and only the tag is rewritten to
     *revision_tag*. Unqualified refs (``api:latest``,
-    ``my-org/api:1.0``) and missing/empty declarations fall back to
-    the legacy
-    ``{fallback_registry}/{fallback_extension_name}-{svc_name}:{revision_tag}``
+    ``my-org/api:1.0``) and missing/empty declarations fall back to the
+    legacy ``{fallback_registry}/{basename}-{svc_name}:{revision_tag}``
     form — those would otherwise route ``docker push`` to Docker Hub
     while the cluster registry expects the rewritten path.
+
+    ``fallback_image_basename`` (when truthy) overrides
+    ``fallback_extension_name`` as the ``{basename}`` segment. This
+    lets a repo whose bake target / pushed image basename diverges
+    from its kamiwaza.json ``name`` (e.g. ``name=workroom-manager`` but
+    images pushed as ``outcome-d563-workroom-manager-<svc>``) declare
+    the override via ``image_basename`` in kamiwaza.json without
+    touching the manifest's primary identifier.
 
     Shared by ``ComposeTransformer.transform_service``,
     ``_retag_appgarden_compose``, ``ImageBuilder.build``, and
@@ -158,9 +173,8 @@ def _canonical_build_ref(
         stripped = declared.strip()
         if stripped and _looks_registry_qualified(stripped):
             return _replace_image_tag(stripped, revision_tag)
-    return (
-        f"{fallback_registry}/{fallback_extension_name}-{svc_name}:{revision_tag}"
-    )
+    basename = fallback_image_basename or fallback_extension_name
+    return f"{fallback_registry}/{basename}-{svc_name}:{revision_tag}"
 
 
 # Compose ``${VAR:-default}`` (use default if unset OR empty) and the
@@ -215,6 +229,7 @@ class ComposeTransformer:
         extension_name: str,
         revision_tag: str,
         registry: str,
+        image_basename: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Return a deployment-ready copy of *compose_data*.
 
@@ -225,6 +240,11 @@ class ComposeTransformer:
         4. Add / update ``image`` fields with *registry*/*revision_tag*
         5. Add resource limits if missing
         6. Remove ``extra_hosts``, ``container_name``, ``networks`` keys
+
+        ``image_basename`` (when present) overrides ``extension_name`` as
+        the prefix in the legacy ``{registry}/{basename}-{svc}:{tag}``
+        fallback synthesis; see ``_canonical_build_ref`` for the
+        precedence rules.
 
         Env-value ``${VAR}`` placeholders pass through unchanged. Callers
         shipping the result to a destination that does NOT perform its
@@ -246,6 +266,7 @@ class ComposeTransformer:
                 extension_name,
                 revision_tag,
                 registry,
+                image_basename=image_basename,
             )
 
         # Remove top-level networks (platform manages networking)
@@ -260,6 +281,7 @@ class ComposeTransformer:
         extension_name: str,
         revision_tag: str,
         registry: str,
+        image_basename: Optional[str] = None,
     ) -> Dict[str, Any]:
         svc = copy.deepcopy(service)
 
@@ -289,6 +311,7 @@ class ComposeTransformer:
                 fallback_registry=registry,
                 fallback_extension_name=extension_name,
                 revision_tag=revision_tag,
+                fallback_image_basename=image_basename,
             )
         # Services without a build context — both external (postgres, redis)
         # and prebuilt-internal (e.g. a helper image published from another

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -173,7 +173,13 @@ def _canonical_build_ref(
         stripped = declared.strip()
         if stripped and _looks_registry_qualified(stripped):
             return _replace_image_tag(stripped, revision_tag)
-    basename = fallback_image_basename or fallback_extension_name
+    # Strip whitespace so a malformed-but-truthy override (e.g. "   "
+    # — caller forgot to normalize) doesn't synthesize a broken
+    # `{registry}/   -svc:tag`. ExtensionDetector + MetadataValidator
+    # both normalize blank to None at their layers, but this function
+    # is also called directly from tests and downstream call sites
+    # that may bypass those normalizers.
+    basename = (fallback_image_basename or "").strip() or fallback_extension_name
     return f"{fallback_registry}/{basename}-{svc_name}:{revision_tag}"
 
 

--- a/kamiwaza_extensions/dev_state.py
+++ b/kamiwaza_extensions/dev_state.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 DEV_STATE_DIR = ".kz-ext"
 DEV_STATE_FILE = "dev-state.json"

--- a/kamiwaza_extensions/dev_state.py
+++ b/kamiwaza_extensions/dev_state.py
@@ -161,10 +161,13 @@ def mark_step(
     book-keeping fields, sets ``last_successful_step = step``, and writes
     the result atomically.
 
-    ``service``, ``sdk_repo``, ``registry`` are persisted so the next
-    ``kz-ext dev`` invocation can refuse resume when its inputs differ
-    (review re-re-re-review PR #84 H1) — e.g., a partial-service first
-    run must not let a later full run skip building the un-built service.
+    ``service``, ``sdk_repo``, ``registry``, ``image_basename`` are
+    persisted so the next ``kz-ext dev`` invocation can refuse resume
+    when its inputs differ (review re-re-re-review PR #84 H1) — e.g.,
+    a partial-service first run must not let a later full run skip
+    building the un-built service, and a flipped ``image_basename``
+    override under the same ``--revision`` must invalidate resume
+    (would otherwise deploy refs that were never pushed).
     """
     if step not in STEPS:
         raise ValueError(f"Unknown dev step '{step}'; expected one of {STEPS}")

--- a/kamiwaza_extensions/dev_state.py
+++ b/kamiwaza_extensions/dev_state.py
@@ -47,6 +47,11 @@ class DevState:
     last_service: Optional[str] = None  # `--service` filter, if any
     last_sdk_repo: Optional[str] = None  # `--sdk-repo` override path, if any
     last_registry: str = ""  # KAMIWAZA_REGISTRY / derived
+    # kamiwaza.json `image_basename` override at last run. Build/push and
+    # deploy refs depend on it, so a flipped override under the same
+    # `--revision` must invalidate resume — otherwise we'd skip
+    # build/push and deploy an image ref that was never built or pushed.
+    last_image_basename: Optional[str] = None
 
     def is_step_complete(self, step: str) -> bool:
         if not self.last_successful_step:
@@ -148,6 +153,7 @@ def mark_step(
     service: Optional[str] = None,
     sdk_repo: Optional[str] = None,
     registry: str = "",
+    image_basename: Optional[str] = None,
 ) -> DevState:
     """Update the dev-state to record completion of ``step``.
 
@@ -174,6 +180,7 @@ def mark_step(
     state.last_service = service
     state.last_sdk_repo = sdk_repo
     state.last_registry = registry
+    state.last_image_basename = image_basename
     write_state(extension_dir, state)
     return state
 

--- a/kamiwaza_extensions/extension_detector.py
+++ b/kamiwaza_extensions/extension_detector.py
@@ -23,6 +23,12 @@ class ExtensionInfo:
     metadata: Dict[str, Any]
     compose_path: Optional[Path] = None
     compose_data: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    # Optional override for the image-ref basename, populated from
+    # ``kamiwaza.json``'s ``image_basename`` field. When None, image
+    # refs fall back to ``name`` (today's behavior). Needed for repos
+    # whose bake target / pushed image basename diverges from ``name``;
+    # see ``_canonical_build_ref``.
+    image_basename: Optional[str] = None
 
 
 def infer_extension_type(metadata: Dict[str, Any]) -> str:
@@ -80,6 +86,12 @@ class ExtensionDetector:
         ext_dir = self._find_root(root)
         metadata = self._load_metadata(ext_dir)
         compose_path, compose_data = self._load_compose(ext_dir)
+        raw_basename = metadata.get("image_basename")
+        image_basename = (
+            raw_basename.strip()
+            if isinstance(raw_basename, str) and raw_basename.strip()
+            else None
+        )
         return ExtensionInfo(
             path=ext_dir,
             name=metadata.get("name", ext_dir.name),
@@ -87,6 +99,7 @@ class ExtensionDetector:
             metadata=metadata,
             compose_path=compose_path,
             compose_data=compose_data,
+            image_basename=image_basename,
         )
 
     def find_root(self, start_dir: Optional[Path] = None) -> Path:

--- a/kamiwaza_extensions/image_builder.py
+++ b/kamiwaza_extensions/image_builder.py
@@ -33,6 +33,7 @@ class ImageBuilder:
         verbose: bool = False,
         build_overrides: Optional[List[Any]] = None,
         image_refs: Optional[Dict[str, str]] = None,
+        image_basename: Optional[str] = None,
     ) -> List[str]:
         """Build images and return the list of image references.
 
@@ -49,9 +50,13 @@ class ImageBuilder:
             image_refs: Optional per-service canonical image refs keyed by
                 service name. When provided, services found in the map are
                 built at the supplied ref; services not in the map fall
-                back to the legacy ``{registry}/{ext}-{svc}:{tag}`` form.
-                Callers that own canonical-ref derivation (run_publish)
-                pass this so build/push and catalog-write stay in lockstep.
+                back to the legacy ``{registry}/{basename}-{svc}:{tag}``
+                form. Callers that own canonical-ref derivation
+                (run_publish) pass this so build/push and catalog-write
+                stay in lockstep.
+            image_basename: Optional override for the ``{basename}``
+                segment in the legacy fallback form. When None, falls
+                back to ``extension_name``.
 
         Returns:
             List of image references that were built.
@@ -64,6 +69,7 @@ class ImageBuilder:
 
         services = compose_data.get("services") or {}
         built: List[str] = []
+        basename = image_basename or extension_name
 
         for svc_name, svc in services.items():
             if service_filter and svc_name != service_filter:
@@ -74,7 +80,7 @@ class ImageBuilder:
             if image_refs is not None and svc_name in image_refs:
                 image_ref = image_refs[svc_name]
             else:
-                image_ref = f"{registry}/{extension_name}-{svc_name}:{revision_tag}"
+                image_ref = f"{registry}/{basename}-{svc_name}:{revision_tag}"
             dockerfile, context = self._resolve_build_config(svc["build"], extension_dir)
 
             override = override_map.get(svc_name)

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -154,6 +154,14 @@ class RegistryBuilder:
         entry.setdefault("description", "")
         entry.setdefault("source_type", "kamiwaza")
         entry.setdefault("visibility", "public")
+        # Mirror ExtensionDetector + MetadataValidator's blank-to-None
+        # normalization at the catalog boundary so a malformed
+        # `image_basename` (blank/whitespace-only that bypassed earlier
+        # layers — e.g. metadata re-fed from a stale catalog entry)
+        # doesn't ship a wrong-shaped field into the published catalog.
+        raw_basename = entry.get("image_basename")
+        if isinstance(raw_basename, str) and not raw_basename.strip():
+            entry.pop("image_basename", None)
         entry["compose_yml"] = compose_yml
         entry["docker_images"] = docker_images
         # Overwrite the deepcopy carryover with the resolved list (source

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -67,6 +67,10 @@ class KamiwazaMetadata(BaseModel):
     category: Optional[str] = None
     preferred_model_type: Optional[str] = None
     strip_path_prefix: Optional[bool] = None
+    # Override for the image-ref basename when the bake target / pushed
+    # image basename diverges from ``name``. Consumed by
+    # ``_canonical_build_ref``'s legacy-fallback synthesis.
+    image_basename: Optional[str] = Field(default=None, min_length=1)
     # ENG-3890 — stamped by scaffolder, consumed by `kz-ext update` to pick
     # the right TemplateManifest. Optional so existing scaffolds (created
     # before M2) load cleanly; ``update`` requires --bootstrap if missing.

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from kamiwaza_extensions import __version__
 from kamiwaza_extensions.validators.result import ValidationResult
@@ -69,8 +69,19 @@ class KamiwazaMetadata(BaseModel):
     strip_path_prefix: Optional[bool] = None
     # Override for the image-ref basename when the bake target / pushed
     # image basename diverges from ``name``. Consumed by
-    # ``_canonical_build_ref``'s legacy-fallback synthesis.
-    image_basename: Optional[str] = Field(default=None, min_length=1)
+    # ``_canonical_build_ref``'s legacy-fallback synthesis. Blank/
+    # whitespace-only values normalize to None so validation matches
+    # ``ExtensionDetector``'s lenient loader — a published manifest with
+    # ``"image_basename": ""`` must not hard-fail ``kz-ext validate``
+    # while ``kz-ext publish`` silently treats it as absent.
+    image_basename: Optional[str] = None
+
+    @field_validator("image_basename", mode="before")
+    @classmethod
+    def _blank_image_basename_is_none(cls, value: Any) -> Any:
+        if isinstance(value, str) and not value.strip():
+            return None
+        return value
     # ENG-3890 — stamped by scaffolder, consumed by `kz-ext update` to pick
     # the right TemplateManifest. Optional so existing scaffolds (created
     # before M2) load cleanly; ``update`` requires --bootstrap if missing.

--- a/kamiwaza_extensions/validators/metadata.py
+++ b/kamiwaza_extensions/validators/metadata.py
@@ -15,6 +15,14 @@ from kamiwaza_extensions import __version__
 from kamiwaza_extensions.validators.result import ValidationResult
 
 
+# OCI repo-component grammar for ``image_basename``: lowercase
+# alphanumerics, hyphens, underscores, dots, slashes. Must start and end
+# alphanumeric. Caps the length to keep the synthesized image ref well
+# under the OCI 255-char repository name limit (basename is one segment
+# of ``{registry}/{basename}-{svc}:{tag}``, so leaving headroom for
+# registry prefix, service suffix, and tag is intentional).
+_IMAGE_BASENAME_RE = re.compile(r"^[a-z0-9]([-a-z0-9._/]{0,126}[a-z0-9])?$")
+
 # Semver regex: X.Y.Z with optional pre-release
 _SEMVER_RE = re.compile(
     r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
@@ -81,6 +89,30 @@ class KamiwazaMetadata(BaseModel):
     def _blank_image_basename_is_none(cls, value: Any) -> Any:
         if isinstance(value, str) and not value.strip():
             return None
+        return value
+
+    @field_validator("image_basename", mode="after")
+    @classmethod
+    def _check_image_basename_grammar(cls, value: Optional[str]) -> Optional[str]:
+        # Hard-fail invalid charsets at validate time so a malformed
+        # override (uppercase, spaces, `:`, `..`, etc.) can't escape
+        # into the legacy `{registry}/{basename}-{svc}:{tag}` synthesis
+        # and break docker push silently. The grammar mirrors the OCI
+        # repo-component rules; see ``_IMAGE_BASENAME_RE`` for the
+        # length cap rationale.
+        if value is None:
+            return None
+        if not _IMAGE_BASENAME_RE.match(value):
+            raise ValueError(
+                f"image_basename '{value}' must match "
+                f"{_IMAGE_BASENAME_RE.pattern} (lowercase alphanumerics, "
+                "hyphens, underscores, dots, slashes; must start and end "
+                "alphanumeric; max 128 chars)"
+            )
+        if ".." in value:
+            raise ValueError(
+                f"image_basename '{value}' must not contain '..'"
+            )
         return value
     # ENG-3890 — stamped by scaffolder, consumed by `kz-ext update` to pick
     # the right TemplateManifest. Optional so existing scaffolds (created

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -966,3 +966,137 @@ class TestComputeCanonicalRefs:
         assert self._call(source) == {
             "backend": "registry.test/my-ext-backend:2.0.0-dev",
         }
+
+
+class TestCanonicalBuildRefImageBasename:
+    """``image_basename`` override on the legacy fallback path.
+
+    Repos whose docker-bake target / pushed image basename diverges from
+    kamiwaza.json ``name`` (e.g. workroom-manager → outcome-d563-
+    workroom-manager-<svc>) need to override the ``{basename}-`` prefix
+    without renaming the manifest. The override only affects the legacy
+    fallback synthesis — a registry-qualified declared ``image:`` still
+    wins.
+    """
+
+    @staticmethod
+    def _call(*, image=None, fallback_image_basename=None, has_build=True):
+        from kamiwaza_extensions.compose_transformer import _canonical_build_ref
+
+        svc: Dict[str, Any] = {}
+        if has_build:
+            svc["build"] = "."
+        if image is not None:
+            svc["image"] = image
+        return _canonical_build_ref(
+            svc, "api",
+            fallback_registry="registry.test",
+            fallback_extension_name="my-ext",
+            revision_tag="2.0.0-dev",
+            fallback_image_basename=fallback_image_basename,
+        )
+
+    def test_basename_absent_uses_extension_name(self):
+        # Today's behavior is preserved when the override is None — the
+        # fallback synthesis still uses fallback_extension_name.
+        assert self._call() == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_basename_present_overrides_extension_name(self):
+        # When supplied, the basename replaces fallback_extension_name in
+        # the legacy {basename}-{svc} prefix.
+        assert self._call(
+            fallback_image_basename="custom-basename",
+        ) == "registry.test/custom-basename-api:2.0.0-dev"
+
+    def test_basename_empty_string_falls_back_to_extension_name(self):
+        # Defensive: an empty override is treated as absent (don't ship
+        # `registry.test/-api:tag` if a misconfig leaks through).
+        assert self._call(
+            fallback_image_basename="",
+        ) == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_basename_ignored_when_image_registry_qualified(self):
+        # Override only affects the legacy fallback. A registry-qualified
+        # declared image still wins, exactly as without the override.
+        assert self._call(
+            image="ghcr.io/my-org/api:1.0",
+            fallback_image_basename="custom-basename",
+        ) == "ghcr.io/my-org/api:2.0.0-dev"
+
+
+class TestComposeTransformerImageBasenameRegression:
+    """Workroom-manager regression: synthetic kamiwaza.json with
+    ``name=workroom-manager`` + ``image_basename=outcome-d563-workroom-
+    manager`` + a docker-compose.yml that declares only ``build:`` blocks
+    (no ``image:``). The canonical refs MUST use the bake-target basename
+    so publish push and catalog refs match what GHCR actually serves.
+    """
+
+    def test_workroom_manager_basename_threaded_through_transform(self):
+        transformer = ComposeTransformer()
+        compose = {
+            "services": {
+                "backend": {"build": "./backend"},
+                "frontend": {"build": "./frontend"},
+            }
+        }
+        out = transformer.transform(
+            compose,
+            extension_name="workroom-manager",
+            revision_tag="0.13.0-dev",
+            registry="ghcr.io/kamiwaza-internal",
+            image_basename="outcome-d563-workroom-manager",
+        )
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/kamiwaza-internal/"
+            "outcome-d563-workroom-manager-backend:0.13.0-dev"
+        )
+        assert out["services"]["frontend"]["image"] == (
+            "ghcr.io/kamiwaza-internal/"
+            "outcome-d563-workroom-manager-frontend:0.13.0-dev"
+        )
+
+    def test_workroom_manager_basename_threaded_through_compute_canonical_refs(self):
+        from kamiwaza_extensions.compose_transformer import compute_canonical_refs
+
+        source = {
+            "backend": {"build": "./backend"},
+            "frontend": {"build": "./frontend"},
+        }
+        refs = compute_canonical_refs(
+            source,
+            registry="ghcr.io/kamiwaza-internal",
+            extension_name="workroom-manager",
+            revision_tag="0.13.0-dev",
+            image_basename="outcome-d563-workroom-manager",
+        )
+        assert refs == {
+            "backend": (
+                "ghcr.io/kamiwaza-internal/"
+                "outcome-d563-workroom-manager-backend:0.13.0-dev"
+            ),
+            "frontend": (
+                "ghcr.io/kamiwaza-internal/"
+                "outcome-d563-workroom-manager-frontend:0.13.0-dev"
+            ),
+        }
+
+    def test_basename_absent_preserves_legacy_workroom_manager_synthesis(self):
+        # The regression: before this PR, the absence of image_basename
+        # forced the synthesis to use `name`, producing the wrong GHCR
+        # path. Without the override, behavior is unchanged — same legacy
+        # synthesis as today.
+        from kamiwaza_extensions.compose_transformer import compute_canonical_refs
+
+        source = {"backend": {"build": "./backend"}}
+        refs = compute_canonical_refs(
+            source,
+            registry="ghcr.io/kamiwaza-internal",
+            extension_name="workroom-manager",
+            revision_tag="0.13.0-dev",
+        )
+        assert refs == {
+            "backend": (
+                "ghcr.io/kamiwaza-internal/workroom-manager-backend:0.13.0-dev"
+            ),
+        }

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -1015,6 +1015,16 @@ class TestCanonicalBuildRefImageBasename:
             fallback_image_basename="",
         ) == "registry.test/my-ext-api:2.0.0-dev"
 
+    def test_basename_whitespace_only_falls_back_to_extension_name(self):
+        # ExtensionDetector + MetadataValidator both normalize blank to
+        # None at their layers, but `_canonical_build_ref` is called
+        # directly from tests and downstream sites that may bypass
+        # those normalizers — strip here too so a "   " override
+        # doesn't escape as `registry.test/   -api:tag`.
+        assert self._call(
+            fallback_image_basename="   ",
+        ) == "registry.test/my-ext-api:2.0.0-dev"
+
     def test_basename_ignored_when_image_registry_qualified(self):
         # Override only affects the legacy fallback. A registry-qualified
         # declared image still wins, exactly as without the override.

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -483,6 +483,58 @@ class TestIsResumableServiceFilterAndRegistry:
             is False
         )
 
+    def test_image_basename_change_invalidates_resume(self):
+        # kamiwaza.json `image_basename` flipped between runs at the same
+        # --revision: build/push refs differ, but the prior push wrote
+        # the old basename. Skipping build+push would deploy refs that
+        # were never built or pushed.
+        from kamiwaza_extensions.commands.dev import _is_resumable
+
+        prior = self._state(last_image_basename="custom-a")
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry.test",
+                image_basename="custom-b",
+            )
+            is False
+        )
+
+    def test_image_basename_consistent_resumes(self):
+        # Same image_basename on both runs — resume is safe.
+        from kamiwaza_extensions.commands.dev import _is_resumable
+
+        prior = self._state(last_image_basename="custom-a")
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry.test",
+                image_basename="custom-a",
+            )
+            is True
+        )
+
+    def test_image_basename_added_invalidates_resume(self):
+        # Prior run had no override; new run sets one → build/push refs
+        # change, so build must run again.
+        from kamiwaza_extensions.commands.dev import _is_resumable
+
+        prior = self._state(last_image_basename=None)
+        assert (
+            _is_resumable(
+                prior,
+                rev_tag="1.0.0-dev-abc1234.1714999999",
+                connection_url="https://cluster.test/api",
+                registry="registry.test",
+                image_basename="custom-basename",
+            )
+            is False
+        )
+
     def test_legacy_state_without_resume_inputs_invalidates_when_current_set(self):
         # An older dev-state file (pre-H1) doesn't carry service /
         # sdk_repo / registry. Reading drops the unknown keys and

--- a/tests/unit/extensions/test_extension_detector.py
+++ b/tests/unit/extensions/test_extension_detector.py
@@ -7,7 +7,6 @@ import yaml
 
 from kamiwaza_extensions.extension_detector import (
     ExtensionDetector,
-    ExtensionInfo,
     ExtensionNotFoundError,
     MultipleExtensionsError,
 )

--- a/tests/unit/extensions/test_extension_detector.py
+++ b/tests/unit/extensions/test_extension_detector.py
@@ -76,6 +76,32 @@ class TestMetadataLoading:
         with pytest.raises(ExtensionNotFoundError, match="Cannot read"):
             detector.detect(tmp_path)
 
+    def test_image_basename_absent_is_none(self, detector, tmp_path):
+        (tmp_path / "kamiwaza.json").write_text(
+            json.dumps({"name": "x", "version": "1.0.0"})
+        )
+        info = detector.detect(tmp_path)
+        assert info.image_basename is None
+
+    def test_image_basename_present_is_loaded(self, detector, tmp_path):
+        (tmp_path / "kamiwaza.json").write_text(json.dumps({
+            "name": "workroom-manager",
+            "version": "0.13.0",
+            "image_basename": "outcome-d563-workroom-manager",
+        }))
+        info = detector.detect(tmp_path)
+        assert info.image_basename == "outcome-d563-workroom-manager"
+
+    def test_image_basename_empty_string_is_none(self, detector, tmp_path):
+        # An empty/whitespace override would synthesize bad refs like
+        # `registry/-svc:tag`; normalize to None so the legacy fallback
+        # (extension_name) is used.
+        (tmp_path / "kamiwaza.json").write_text(json.dumps({
+            "name": "x", "version": "1.0.0", "image_basename": "   ",
+        }))
+        info = detector.detect(tmp_path)
+        assert info.image_basename is None
+
 
 class TestComposeLoading:
     def test_compose_loaded(self, detector, ext_dir):

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -3251,3 +3251,207 @@ class TestPublishWithAppgarden:
         mock_resolve.assert_called_once_with(
             "ghcr.io/published/tool-foo/backend:1.0.0-dev"
         )
+
+
+# ------------------------------------------------------------------
+# ENG-5643 E2E: kamiwaza.json `image_basename` override end-to-end
+# ------------------------------------------------------------------
+
+
+class TestPublishDryRunImageBasename:
+    """End-to-end dry-run verification of the `image_basename` override.
+
+    Unit tests pin `_canonical_build_ref` math; these drive `run_publish`
+    with `dry_run=True` against a synthetic extension (kamiwaza.json +
+    docker-compose.yml mimicking workroom-manager's flat layout — two
+    services, build: only, no declared image:) and assert that the
+    canonical image refs reaching the catalog actually use the override.
+
+    Three runs:
+
+      A. ``name=workroom-manager-test`` + ``image_basename=outcome-d563-
+         workroom-manager-test`` → refs use the override.
+      B. Same name, ``image_basename`` field omitted → refs fall back
+         to ``name`` (today's behavior, backwards-compat guarantee).
+      C. Same name, ``image_basename=""`` (blank) → normalized to None,
+         same refs as run B.
+
+    ComposeTransformer runs for real so the full ref-synthesis path is
+    exercised; only the I/O-bound seams (detector, validators, profile,
+    catalog writer) are mocked.
+    """
+
+    _REGISTRY = (
+        "ghcr.io/kamiwaza-internal/"
+        "kamiwaza-extensions-workroom-manager/images"
+    )
+
+    @staticmethod
+    def _compose_data() -> Dict[str, Any]:
+        # Mimic workroom-manager's flat docker-compose.yml — both services
+        # have build: contexts and no image: field. This is the layout
+        # that triggers the legacy fallback synthesis where the bug bit.
+        return {
+            "services": {
+                "backend": {"build": "./backend"},
+                "frontend": {"build": "./frontend"},
+            },
+        }
+
+    @staticmethod
+    def _metadata(name: str, image_basename: Optional[str]) -> Dict[str, Any]:
+        meta: Dict[str, Any] = {
+            "name": name,
+            "version": "0.13.0",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "description": "ENG-5643 e2e",
+            "risk_tier": 0,
+            "verified": False,
+        }
+        if image_basename is not None:
+            meta["image_basename"] = image_basename
+        return meta
+
+    @classmethod
+    def _make_info(
+        cls,
+        tmp_path: Path,
+        *,
+        name: str,
+        image_basename: Optional[str],
+    ) -> Any:
+        from kamiwaza_extensions.extension_detector import ExtensionInfo
+
+        # Apply the same blank-to-None normalization ExtensionDetector
+        # does at read time, so the synthetic ExtensionInfo matches
+        # what the real loader would produce for these manifests.
+        if isinstance(image_basename, str) and not image_basename.strip():
+            effective = None
+        else:
+            effective = image_basename
+        return ExtensionInfo(
+            path=tmp_path,
+            name=name,
+            version="0.13.0",
+            metadata=cls._metadata(name, image_basename),
+            compose_path=tmp_path / "docker-compose.yml",
+            compose_data=cls._compose_data(),
+            image_basename=effective,
+        )
+
+    @classmethod
+    def _profile(cls):
+        from kamiwaza_extensions.profile_manager import PublishProfile
+
+        return PublishProfile(
+            name="dev",
+            registry=cls._REGISTRY,
+            catalog_endpoint="https://s3.example.com",
+            catalog_bucket="my-catalog",
+            catalog_credentials="env",
+        )
+
+    def _drive(self, info: Any) -> Dict[str, str]:
+        # Real ComposeTransformer runs — only I/O seams are mocked so the
+        # full ref-synthesis path is exercised end-to-end.
+        with patch(
+            "kamiwaza_extensions.catalog_publisher.CatalogPublisher"
+        ) as mock_publisher_cls, patch(
+            "kamiwaza_extensions.registry_builder.RegistryBuilder"
+        ) as mock_reg_builder_cls, patch(
+            "kamiwaza_extensions.profile_manager.ProfileManager"
+        ) as mock_profile_mgr_cls, patch(
+            "kamiwaza_extensions.validators.compose.ComposeValidator"
+        ) as mock_compose_validator_cls, patch(
+            "kamiwaza_extensions.validators.metadata.MetadataValidator"
+        ) as mock_meta_validator_cls, patch(
+            "kamiwaza_extensions.extension_detector.ExtensionDetector"
+        ) as mock_detector_cls:
+            mock_detector_cls.return_value.detect.return_value = info
+            mock_meta_validator_cls.return_value.validate.return_value = (
+                _make_validation_result()
+            )
+            mock_compose_validator_cls.return_value.validate.return_value = (
+                _make_validation_result()
+            )
+            mock_profile_mgr_cls.return_value.resolve_profile.return_value = (
+                self._profile()
+            )
+            mock_reg_builder_cls.return_value.build_entry.return_value = {
+                "name": info.name, "version": info.version,
+            }
+            mock_publisher_cls.return_value.publish.return_value = (
+                _make_publish_result(dry_run=True)
+            )
+
+            from kamiwaza_extensions.commands.publish import run_publish
+
+            run_publish(stage="dev", dry_run=True, revision="testrev")
+
+            # Capture the transformed-compose argument the catalog reg-builder
+            # receives. transformed["services"][svc]["image"] is the canonical
+            # ref the catalog (and therefore the operator) will see.
+            kwargs = (
+                mock_reg_builder_cls.return_value.build_entry.call_args.kwargs
+            )
+            transformed = kwargs["transformed_compose"]
+            return {
+                svc: transformed["services"][svc]["image"]
+                for svc in ("backend", "frontend")
+            }
+
+    def test_run_a_image_basename_override_used(self, tmp_path, capsys):
+        # Bug repro: name diverges from bake-target basename. With the
+        # override set, refs must use the basename — not `name`.
+        info = self._make_info(
+            tmp_path,
+            name="workroom-manager-test",
+            image_basename="outcome-d563-workroom-manager-test",
+        )
+        refs = self._drive(info)
+        prefix = self._REGISTRY
+        assert refs == {
+            "backend": f"{prefix}/outcome-d563-workroom-manager-test-backend:testrev",
+            "frontend": f"{prefix}/outcome-d563-workroom-manager-test-frontend:testrev",
+        }
+        # The "Would build images" preview also honors the override
+        # (display-only, but a useful regression signal). The override
+        # name has the manifest name as a SUBSTRING, so the negative
+        # check uses the full preview prefix to disambiguate.
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "outcome-d563-workroom-manager-test-backend:testrev" in combined
+        assert "outcome-d563-workroom-manager-test-frontend:testrev" in combined
+        assert "images:    workroom-manager-test-backend" not in combined
+
+    def test_run_b_no_override_falls_back_to_name(self, tmp_path):
+        # Backwards-compat: a manifest without the field must produce
+        # the same refs the codebase produced before this PR.
+        info = self._make_info(
+            tmp_path,
+            name="workroom-manager-test",
+            image_basename=None,
+        )
+        refs = self._drive(info)
+        prefix = self._REGISTRY
+        assert refs == {
+            "backend": f"{prefix}/workroom-manager-test-backend:testrev",
+            "frontend": f"{prefix}/workroom-manager-test-frontend:testrev",
+        }
+
+    def test_run_c_empty_string_normalizes_to_none(self, tmp_path):
+        # Blank override → normalized to None → identical to run B.
+        # Guards against an empty value silently producing
+        # `{registry}/-{svc}:tag` refs.
+        info = self._make_info(
+            tmp_path,
+            name="workroom-manager-test",
+            image_basename="",
+        )
+        refs = self._drive(info)
+        prefix = self._REGISTRY
+        assert refs == {
+            "backend": f"{prefix}/workroom-manager-test-backend:testrev",
+            "frontend": f"{prefix}/workroom-manager-test-frontend:testrev",
+        }

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -3401,7 +3401,7 @@ class TestPublishDryRunImageBasename:
                 for svc in ("backend", "frontend")
             }
 
-    def test_run_a_image_basename_override_used(self, tmp_path, capsys):
+    def test_run_a_image_basename_override_used(self, tmp_path):
         # Bug repro: name diverges from bake-target basename. With the
         # override set, refs must use the basename — not `name`.
         info = self._make_info(
@@ -3415,15 +3415,15 @@ class TestPublishDryRunImageBasename:
             "backend": f"{prefix}/outcome-d563-workroom-manager-test-backend:testrev",
             "frontend": f"{prefix}/outcome-d563-workroom-manager-test-frontend:testrev",
         }
-        # The "Would build images" preview also honors the override
-        # (display-only, but a useful regression signal). The override
-        # name has the manifest name as a SUBSTRING, so the negative
-        # check uses the full preview prefix to disambiguate.
-        captured = capsys.readouterr()
-        combined = captured.out + captured.err
-        assert "outcome-d563-workroom-manager-test-backend:testrev" in combined
-        assert "outcome-d563-workroom-manager-test-frontend:testrev" in combined
-        assert "images:    workroom-manager-test-backend" not in combined
+        # Override name has the manifest name as a SUBSTRING — anchor
+        # the negative invariant against the captured ref values
+        # themselves, not the formatted dry-run preview line. (Preview
+        # line spacing is presentation-layer churn that shouldn't
+        # break this test.)
+        for ref in refs.values():
+            assert (
+                f"{prefix}/workroom-manager-test-" not in ref
+            ), f"unexpected legacy fallback in ref: {ref!r}"
 
     def test_run_b_no_override_falls_back_to_name(self, tmp_path):
         # Backwards-compat: a manifest without the field must produce

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -2147,3 +2147,74 @@ class TestBuildEntryDigestPinning:
             f"kamiwazaai/my-app-backend:abc1234@{_DIGEST_A}"
             in entry["docker_images"]
         )
+
+
+class TestBuildEntryImageBasenameNormalization:
+    """Catalog-boundary normalization of `image_basename`. ENG-5643.
+
+    `ExtensionDetector` and `MetadataValidator` both normalize a blank/
+    whitespace-only override to None at their layers, but the catalog
+    builder is the boundary that *publishes* metadata downstream — a
+    stale catalog entry re-fed as `metadata` (or a programmatic caller
+    that bypasses the loaders) could otherwise ship a malformed field.
+    """
+
+    def test_blank_image_basename_dropped_from_catalog_entry(
+        self, builder, transformed_compose
+    ):
+        metadata = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "x",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "image_basename": "   ",
+        }
+        entry = builder.build_entry(
+            metadata, transformed_compose, "kamiwazaai", "1.0.0"
+        )
+        assert "image_basename" not in entry
+
+    def test_empty_string_image_basename_dropped_from_catalog_entry(
+        self, builder, transformed_compose
+    ):
+        metadata = {
+            "name": "my-app",
+            "version": "1.0.0",
+            "description": "x",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "image_basename": "",
+        }
+        entry = builder.build_entry(
+            metadata, transformed_compose, "kamiwazaai", "1.0.0"
+        )
+        assert "image_basename" not in entry
+
+    def test_valid_image_basename_passes_through(
+        self, builder, transformed_compose
+    ):
+        # Non-blank values survive — this is the happy path that the
+        # platform's downstream `_update_template_from_remote` consumes.
+        metadata = {
+            "name": "workroom-manager",
+            "version": "0.13.0",
+            "description": "x",
+            "source_type": "kamiwaza",
+            "visibility": "public",
+            "image_basename": "outcome-d563-workroom-manager",
+        }
+        entry = builder.build_entry(
+            metadata, transformed_compose, "kamiwazaai", "0.13.0"
+        )
+        assert entry["image_basename"] == "outcome-d563-workroom-manager"
+
+    def test_absent_image_basename_unchanged(
+        self, builder, metadata, transformed_compose
+    ):
+        # Manifests without the field don't gain it as a side effect.
+        assert "image_basename" not in metadata
+        entry = builder.build_entry(
+            metadata, transformed_compose, "kamiwazaai", "1.0.0"
+        )
+        assert "image_basename" not in entry

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -71,6 +71,37 @@ class TestMetadataValidator:
         result = validator.validate(f)
         assert not result.passed
 
+    def test_image_basename_present_validates(self, tmp_path, validator):
+        data = _valid_metadata()
+        data["image_basename"] = "outcome-d563-workroom-manager"
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed
+
+    def test_image_basename_blank_string_validates_as_absent(
+        self, tmp_path, validator
+    ):
+        # Blank/whitespace-only override must not hard-fail validation —
+        # `ExtensionDetector` treats it as absent, so the validator
+        # must agree (otherwise `kz-ext validate` and `kz-ext publish`
+        # disagree on a manifest the publish path silently accepts).
+        data = _valid_metadata()
+        data["image_basename"] = "   "
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed
+
+    def test_image_basename_absent_validates(self, tmp_path, validator):
+        # Today's behavior preserved when the optional field is omitted.
+        data = _valid_metadata()
+        assert "image_basename" not in data
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed
+
     def test_tool_naming_convention_warning(self, tmp_path, validator):
         data = _valid_metadata()
         data["name"] = "bad-name"

--- a/tests/unit/extensions/test_validators.py
+++ b/tests/unit/extensions/test_validators.py
@@ -102,6 +102,56 @@ class TestMetadataValidator:
         result = validator.validate(f)
         assert result.passed
 
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "BAD CASE",          # uppercase + space
+            "a b",               # internal whitespace
+            "foo:bar",           # tag-separator char leaks past push
+            "a/b/../c",          # path traversal
+            "-leading-hyphen",   # starts with punct
+            "trailing-hyphen-",  # ends with punct
+            "Ümlaut",            # non-ASCII
+            "a" * 129,           # exceeds 128-char cap
+        ],
+    )
+    def test_image_basename_invalid_charset_rejected(
+        self, tmp_path, validator, value
+    ):
+        # Hard-fail invalid charsets at validate time so a malformed
+        # override (uppercase, spaces, `:`, `..`, etc.) can't escape
+        # into the legacy `{registry}/{basename}-{svc}:{tag}` synthesis
+        # and break docker push silently.
+        data = _valid_metadata()
+        data["image_basename"] = value
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert not result.passed
+        assert any("image_basename" in e for e in result.errors)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "outcome-d563-workroom-manager",   # the bug repro
+            "workroom-manager",
+            "a",                                # min length
+            "kamiwaza-internal/foo/bar",        # path components allowed
+            "name_with_underscores",
+            "name.with.dots",
+            "a" * 128,                          # at length cap
+        ],
+    )
+    def test_image_basename_valid_values_pass(
+        self, tmp_path, validator, value
+    ):
+        data = _valid_metadata()
+        data["image_basename"] = value
+        f = tmp_path / "kamiwaza.json"
+        _write_json(f, data)
+        result = validator.validate(f)
+        assert result.passed, f"unexpected errors: {result.errors}"
+
     def test_tool_naming_convention_warning(self, tmp_path, validator):
         data = _valid_metadata()
         data["name"] = "bad-name"


### PR DESCRIPTION
## What this ships

Optional `image_basename` field in `kamiwaza.json`. When set, overrides
`name` as the prefix in the legacy
`{registry}/{basename}-{svc}:{tag}` image-ref synthesis. When absent,
behavior is unchanged.

Unblocks workroom-manager publishes (manifest name `workroom-manager`,
bake target `outcome-d563-workroom-manager-<svc>`) which currently
404 in GHCR at `_auto_resolve_digests`.

## Contract

| Field | Type | Required | Semantics |
|-------|------|----------|-----------|
| `image_basename` | `string` | no | Override for the `{basename}` segment of the legacy fallback synthesis. Blank/whitespace → treated as absent. |

Precedence: a registry-qualified declared `image:` still wins. The
override only affects the legacy fallback path.

## Load-bearing decisions

1. **`fallback_image_basename` as a new kwarg** on `_canonical_build_ref`
   (Option 1 in the brief). Single string threaded through callers — no
   metadata-struct refactor.
2. **Lenient blank normalization** in both `ExtensionDetector` and
   `MetadataValidator` (via `field_validator(mode="before")`). Publish
   path and validate path agree on `"image_basename": ""` → absent.
3. **Resume key includes `image_basename`.** `DevState.last_image_basename`
   added so a flipped override under the same `--revision` invalidates
   resume; otherwise build/push skip and deploy refs that were never
   pushed.

## Verification

- `make test` → 1977 passed, 9 skipped, 0 failures
- Codex pre-flight: 2 rounds; round 1 findings fixed (validator
  lenience + resume-key plumbing), round 2 findings are pre-existing
  drift on `develop` (extension_name not in resume key;
  `ImageBuilder.build` doesn't filter `profiles:`) — out of scope per
  brief, follow-up tickets proposed.

## Out of scope (deferring to follow-ups)

- `extension_name` rename → resume-key invalidation (pre-existing).
- `ImageBuilder.build` profile filtering (pre-existing).
- Workroom-manager repo edit (Loial owns the one-line follow-up PR
  after this lands + a develop revision is tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)