### PR TITLE
ENG-5648: kz-ext publish retags sibling services sharing a built image repo

### DIFF
--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -72,47 +72,32 @@ def _retag_appgarden_compose(
 ) -> Dict[str, Any]:
     """Rewrite image tags on services whose image repo this publish built.
 
-    A service is "owned" by this publish when its ``image:`` field points
-    at a registry repo that one of the source compose's buildable
-    services produces. That covers two shapes:
+    Ownership: a service is "owned" if either its name is in the source
+    compose's buildable set, or its ``image:`` points at a registry
+    repo one of those buildable services produces (the
+    multi-service-one-image idiom — e.g. an ``init`` container reusing
+    the main image to chown/migrate/seed). Owned services are retagged
+    via ``_canonical_build_ref`` so their declared namespace is
+    preserved and the tag becomes ``--stage`` / ``--revision``.
 
-    * The build service itself — its image lives at the canonical repo
-      ``ImageBuilder`` pushes to (matches the ``buildable_services``
-      filter ``run_publish`` uses to derive
-      ``published_refs``/``digest_map``).
-    * A sibling service whose ``image:`` repo matches a build service's
-      target repo — the multi-service-one-image idiom (e.g. a one-shot
-      ``init`` container reusing the main image to chown/migrate/seed).
-      Without this, the sibling would ship at its source-authored tag
-      (e.g. ``:2.3.0``) which is never pushed → catalog references an
-      unpullable image → ImagePullBackOff at deploy. See ENG-5648.
+    The repo-membership check is the safety boundary: refs we did not
+    build (third-party images, services in our namespace at a repo we
+    don't produce) pass through verbatim. Without sibling-image
+    retagging, the catalog would point at the source-authored tag
+    (never pushed) → ImagePullBackOff on deploy. See ENG-5648.
 
-    For owned services we set
-    ``image: {registry}/{ext}-{svc}:{image_tag}`` so the catalog points
-    at the image we just built with the resolved ``--stage`` /
-    ``--revision`` tag, and downstream ``_apply_digests`` finds a match
-    in ``digest_map`` to pin them all consistently. Refs we did not
-    build (``ghcr.io/.../neo4j``, helper images from other repos
-    declared in our own namespace, any service the extension's
-    ``sync-compose.py`` invented) are passed through verbatim — the
-    membership check against built repos is the safety boundary that
-    keeps external-passthrough semantics intact.
+    Profile-gated services are dropped, matching
+    ``ComposeTransformer.transform``'s policy — local-only services
+    must not reach the deployment-ready catalog entry.
 
-    Profile-gated build services are excluded so a ``build: + profiles:``
-    helper that leaks into the authored appgarden file is not retagged
-    into the catalog while being absent from
-    ``published_refs``/``digest_map`` — that would ship a local-only ref
-    with no corresponding push.
-
-    The appgarden file is otherwise considered deployment-ready by the
-    extension's authoring intent and passed through unchanged: host port
+    The appgarden file is otherwise considered deployment-ready by
+    ``sync-compose.py`` and passed through unchanged: host port
     bindings, bind mounts, ``extra_hosts``, ``container_name``,
-    top-level ``networks``, env-value placeholders, and the
+    top-level ``networks``, env placeholders, and the
     ``_ensure_resource_limits`` defaults that ``ComposeTransformer``
-    used to backfill are NOT applied here. ``sync-compose.py`` owns that
-    shape; if a service is missing ``deploy.resources.limits``,
-    ``ComposeValidator`` will surface the warning and the catalog ships
-    without the auto-fill.
+    backfills are NOT applied here. ``ComposeValidator`` surfaces
+    warnings on missing ``deploy.resources.limits``; the catalog
+    ships without auto-fill.
     """
     out = copy.deepcopy(appgarden_data)
     source_services = (
@@ -121,13 +106,6 @@ def _retag_appgarden_compose(
         else {}
     )
     appgarden_services = out.get("services") or {}
-    # Drop appgarden services with ``profiles:`` BEFORE retagging —
-    # mirrors ``ComposeTransformer.transform``'s same-shape deletion
-    # block (profiled services are local-only and must not appear in
-    # the deployment-ready catalog entry). Done up front so a profiled
-    # service can never reach either ownership gate or end up in the
-    # catalog at its source-authored tag (which was never pushed under
-    # the profile-aware push filter).
     profiled_in_appgarden = [
         name
         for name, svc in appgarden_services.items()
@@ -135,13 +113,8 @@ def _retag_appgarden_compose(
     ]
     for name in profiled_in_appgarden:
         del appgarden_services[name]
-    # Compute the canonical refs this publish will push for. Reuses the
-    # shared derivation so this gate, ``run_publish``'s
-    # ``published_refs``, and the dev pipeline can't drift on what
-    # counts as a buildable service or which namespace it lives at.
-    # Appgarden precedence: an appgarden-declared image namespace beats
-    # the source-compose ref, matching ``ImageBuilder``'s actual push
-    # target.
+    # Shared derivation: keeps this gate aligned with run_publish's
+    # published_refs and the dev pipeline.
     canonical_by_name = compute_canonical_refs(
         source_services,
         registry=registry,
@@ -150,21 +123,10 @@ def _retag_appgarden_compose(
         appgarden_services=appgarden_services,
         image_basename=image_basename,
     )
-    # Membership in ``built_repos`` is the sibling-image gate: any
-    # service whose ``image:`` resolves to a repo this publish builds
-    # consumes the freshly-pinned ref alongside the build service.
-    # ``built_repos`` is the safety boundary that keeps refs we did NOT
-    # build (third-party images, helper images from other repos that
-    # happen to live in our namespace) flowing through verbatim.
     built_repos = {_repo_part(ref) for ref in canonical_by_name.values()}
-    # Profile-gated source services are NEVER owned, even when their
-    # image repo collides with a non-profiled build service. Matches
-    # the generic ``ComposeTransformer.transform`` policy, which drops
-    # any service with a ``profiles:`` key as local-only. Covers both
-    # the ``build: + profiles:`` collision shape (a dev-only helper
-    # sharing a Dockerfile with the main service) and the no-build
-    # profiled shape (a helper reusing the built image just to run a
-    # different command under a dev profile).
+    # Block repo-match on source-side profiled services: their image
+    # repo can collide with a non-profiled build service's repo, and
+    # the appgarden-side delete above doesn't catch this case.
     profiled_source_names = {
         name
         for name, svc in source_services.items()
@@ -173,15 +135,6 @@ def _retag_appgarden_compose(
     for svc_name, svc in appgarden_services.items():
         if not isinstance(svc, dict):
             continue
-        # Two ways a service is "owned" by this publish:
-        # (1) it is a buildable service from the source compose — covers
-        #     the legacy-fallback path (no image declared anywhere) and
-        #     the divergent-namespace path (appgarden declares a
-        #     different image namespace from the source);
-        # (2) it carries no ``build:`` (or has ``build:`` without
-        #     ``profiles:``) AND its image repo matches one of the
-        #     repos we built — the multi-service-one-image idiom (init
-        #     container reusing the main image).
         img = svc.get("image")
         repo_owned = (
             isinstance(img, str)
@@ -190,11 +143,7 @@ def _retag_appgarden_compose(
             and svc_name not in profiled_source_names
         )
         if svc_name in canonical_by_name or repo_owned:
-            # The image field is the canonical declaration of where
-            # this build's image lives in the registry — set by the
-            # extension's sync-compose.py from its docker-compose.yml.
-            # We only own the *tag* (stage suffix or --revision SHA);
-            # the namespace stays what the extension authored.
+            # Preserve declared namespace; we only rewrite the tag.
             svc["image"] = _canonical_build_ref(
                 svc, svc_name,
                 fallback_registry=registry,

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -121,6 +121,20 @@ def _retag_appgarden_compose(
         else {}
     )
     appgarden_services = out.get("services") or {}
+    # Drop appgarden services with ``profiles:`` BEFORE retagging —
+    # mirrors ``ComposeTransformer.transform``'s same-shape deletion
+    # block (profiled services are local-only and must not appear in
+    # the deployment-ready catalog entry). Done up front so a profiled
+    # service can never reach either ownership gate or end up in the
+    # catalog at its source-authored tag (which was never pushed under
+    # the profile-aware push filter).
+    profiled_in_appgarden = [
+        name
+        for name, svc in appgarden_services.items()
+        if isinstance(svc, dict) and svc.get("profiles")
+    ]
+    for name in profiled_in_appgarden:
+        del appgarden_services[name]
     # Compute the canonical refs this publish will push for. Reuses the
     # shared derivation so this gate, ``run_publish``'s
     # ``published_refs``, and the dev pipeline can't drift on what
@@ -143,6 +157,19 @@ def _retag_appgarden_compose(
     # build (third-party images, helper images from other repos that
     # happen to live in our namespace) flowing through verbatim.
     built_repos = {_repo_part(ref) for ref in canonical_by_name.values()}
+    # Profile-gated source services are NEVER owned, even when their
+    # image repo collides with a non-profiled build service. Matches
+    # the generic ``ComposeTransformer.transform`` policy, which drops
+    # any service with a ``profiles:`` key as local-only. Covers both
+    # the ``build: + profiles:`` collision shape (a dev-only helper
+    # sharing a Dockerfile with the main service) and the no-build
+    # profiled shape (a helper reusing the built image just to run a
+    # different command under a dev profile).
+    profiled_source_names = {
+        name
+        for name, svc in source_services.items()
+        if isinstance(svc, dict) and svc.get("profiles")
+    }
     for svc_name, svc in appgarden_services.items():
         if not isinstance(svc, dict):
             continue
@@ -151,14 +178,16 @@ def _retag_appgarden_compose(
         #     the legacy-fallback path (no image declared anywhere) and
         #     the divergent-namespace path (appgarden declares a
         #     different image namespace from the source);
-        # (2) it carries no ``build:`` but its image repo matches one
-        #     of the repos we built — the multi-service-one-image idiom
-        #     (init container reusing the main image).
+        # (2) it carries no ``build:`` (or has ``build:`` without
+        #     ``profiles:``) AND its image repo matches one of the
+        #     repos we built — the multi-service-one-image idiom (init
+        #     container reusing the main image).
         img = svc.get("image")
         repo_owned = (
             isinstance(img, str)
             and bool(img)
             and _repo_part(img) in built_repos
+            and svc_name not in profiled_source_names
         )
         if svc_name in canonical_by_name or repo_owned:
             # The image field is the canonical declaration of where

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -134,6 +134,7 @@ def _retag_appgarden_compose(
         extension_name=extension_name,
         revision_tag=image_tag,
         appgarden_services=appgarden_services,
+        image_basename=image_basename,
     )
     # Membership in ``built_repos`` is the sibling-image gate: any
     # service whose ``image:`` resolves to a repo this publish builds

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from kamiwaza_extensions.catalog_publisher import DEFAULT_CATALOG_SCHEMA
 from kamiwaza_extensions.compose_transformer import (
     _canonical_build_ref,
+    _repo_part,
     compute_canonical_refs,
 )
 from kamiwaza_extensions.extension_detector import infer_extension_type
@@ -69,17 +70,39 @@ def _retag_appgarden_compose(
     registry: str,
     image_basename: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Rewrite image tags on services that this publish actually owns.
+    """Rewrite image tags on services whose image repo this publish built.
 
-    A service is "owned" by this publish if it has a ``build:`` block in
-    the source ``docker-compose.yml`` and is *not* gated by ``profiles:``
-    (i.e. ``ImageBuilder`` will build and push an image for it; this
-    mirrors the ``buildable_services`` filter ``run_publish`` uses to
-    derive ``published_refs``/``digest_map``). For those services we set
+    A service is "owned" by this publish when its ``image:`` field points
+    at a registry repo that one of the source compose's buildable
+    services produces. That covers two shapes:
+
+    * The build service itself — its image lives at the canonical repo
+      ``ImageBuilder`` pushes to (matches the ``buildable_services``
+      filter ``run_publish`` uses to derive
+      ``published_refs``/``digest_map``).
+    * A sibling service whose ``image:`` repo matches a build service's
+      target repo — the multi-service-one-image idiom (e.g. a one-shot
+      ``init`` container reusing the main image to chown/migrate/seed).
+      Without this, the sibling would ship at its source-authored tag
+      (e.g. ``:2.3.0``) which is never pushed → catalog references an
+      unpullable image → ImagePullBackOff at deploy. See ENG-5648.
+
+    For owned services we set
     ``image: {registry}/{ext}-{svc}:{image_tag}`` so the catalog points
-    at the image we just built with the resolved ``--stage`` / ``--revision``
-    tag. External refs (``ghcr.io/.../neo4j``) and any service the
-    extension's ``sync-compose.py`` invented are passed through verbatim.
+    at the image we just built with the resolved ``--stage`` /
+    ``--revision`` tag, and downstream ``_apply_digests`` finds a match
+    in ``digest_map`` to pin them all consistently. Refs we did not
+    build (``ghcr.io/.../neo4j``, helper images from other repos
+    declared in our own namespace, any service the extension's
+    ``sync-compose.py`` invented) are passed through verbatim — the
+    membership check against built repos is the safety boundary that
+    keeps external-passthrough semantics intact.
+
+    Profile-gated build services are excluded so a ``build: + profiles:``
+    helper that leaks into the authored appgarden file is not retagged
+    into the catalog while being absent from
+    ``published_refs``/``digest_map`` — that would ship a local-only ref
+    with no corresponding push.
 
     The appgarden file is otherwise considered deployment-ready by the
     extension's authoring intent and passed through unchanged: host port
@@ -97,26 +120,51 @@ def _retag_appgarden_compose(
         if isinstance(source_compose_data, dict)
         else {}
     )
-    # Mirror `buildable_services` (publish.py): exclude `profiles:`-gated
-    # services. Without this filter, a `build: + profiles:` service that
-    # leaks into the authored appgarden file would be retagged into the
-    # catalog while being absent from `published_refs`/`digest_map` — a
-    # local-only ref shipping with no corresponding push.
-    build_services = {
-        name
-        for name, svc in source_services.items()
-        if isinstance(svc, dict) and "build" in svc and not svc.get("profiles")
-    }
-    for svc_name, svc in (out.get("services") or {}).items():
+    appgarden_services = out.get("services") or {}
+    # Compute the canonical refs this publish will push for. Reuses the
+    # shared derivation so this gate, ``run_publish``'s
+    # ``published_refs``, and the dev pipeline can't drift on what
+    # counts as a buildable service or which namespace it lives at.
+    # Appgarden precedence: an appgarden-declared image namespace beats
+    # the source-compose ref, matching ``ImageBuilder``'s actual push
+    # target.
+    canonical_by_name = compute_canonical_refs(
+        source_services,
+        registry=registry,
+        extension_name=extension_name,
+        revision_tag=image_tag,
+        appgarden_services=appgarden_services,
+    )
+    # Membership in ``built_repos`` is the sibling-image gate: any
+    # service whose ``image:`` resolves to a repo this publish builds
+    # consumes the freshly-pinned ref alongside the build service.
+    # ``built_repos`` is the safety boundary that keeps refs we did NOT
+    # build (third-party images, helper images from other repos that
+    # happen to live in our namespace) flowing through verbatim.
+    built_repos = {_repo_part(ref) for ref in canonical_by_name.values()}
+    for svc_name, svc in appgarden_services.items():
         if not isinstance(svc, dict):
             continue
-        if svc_name in build_services:
-            # The appgarden compose's image field is the canonical
-            # declaration of where this build's image lives in the
-            # registry — set by the extension's sync-compose.py from
-            # its docker-compose.yml. We only own the *tag* (stage
-            # suffix or --revision SHA); the namespace stays what the
-            # extension authored.
+        # Two ways a service is "owned" by this publish:
+        # (1) it is a buildable service from the source compose — covers
+        #     the legacy-fallback path (no image declared anywhere) and
+        #     the divergent-namespace path (appgarden declares a
+        #     different image namespace from the source);
+        # (2) it carries no ``build:`` but its image repo matches one
+        #     of the repos we built — the multi-service-one-image idiom
+        #     (init container reusing the main image).
+        img = svc.get("image")
+        repo_owned = (
+            isinstance(img, str)
+            and bool(img)
+            and _repo_part(img) in built_repos
+        )
+        if svc_name in canonical_by_name or repo_owned:
+            # The image field is the canonical declaration of where
+            # this build's image lives in the registry — set by the
+            # extension's sync-compose.py from its docker-compose.yml.
+            # We only own the *tag* (stage suffix or --revision SHA);
+            # the namespace stays what the extension authored.
             svc["image"] = _canonical_build_ref(
                 svc, svc_name,
                 fallback_registry=registry,

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -82,6 +82,22 @@ def _split_image_ref(image_ref: str) -> Tuple[Optional[str], str, str]:
     return registry, repository, tag
 
 
+def _repo_part(image_ref: str) -> str:
+    """Return ``registry/repository`` from *image_ref*, stripping tag and digest.
+
+    Returns the bare ``repository`` for unqualified refs (no registry host).
+    Built on ``_split_image_ref`` so registry-host detection and tag-vs-port
+    disambiguation stay consistent with the rest of the ref-handling helpers.
+
+    Used by ``_retag_appgarden_compose`` to identify sibling services whose
+    ``image:`` field points at the same registry repo as a service this
+    publish actually built — those siblings consume the same retagged +
+    digest-pinned ref instead of their source-authored tag.
+    """
+    registry, repository, _ = _split_image_ref(image_ref)
+    return f"{registry}/{repository}" if registry else repository
+
+
 def compute_canonical_refs(
     source_services: Optional[Dict[str, Any]],
     *,

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -865,6 +865,58 @@ class TestSplitImageRef:
         )
 
 
+class TestRepoPart:
+    """`_repo_part` returns ``registry/repository`` from a ref, dropping
+    tag and digest. Used by ``_retag_appgarden_compose`` to identify
+    sibling services whose image points at a repo this publish built
+    (ENG-5648)."""
+
+    @staticmethod
+    def _repo(ref):
+        from kamiwaza_extensions.compose_transformer import _repo_part
+
+        return _repo_part(ref)
+
+    def test_registry_qualified_with_tag(self):
+        assert self._repo("ghcr.io/kamiwaza/foo:1.0") == "ghcr.io/kamiwaza/foo"
+
+    def test_strips_digest(self):
+        assert self._repo(
+            "ghcr.io/foo/bar:1.0@sha256:" + "a" * 64,
+        ) == "ghcr.io/foo/bar"
+
+    def test_registry_with_port(self):
+        assert self._repo("localhost:5000/my-app:dev") == "localhost:5000/my-app"
+
+    def test_no_tag(self):
+        assert self._repo("ghcr.io/kamiwaza/foo") == "ghcr.io/kamiwaza/foo"
+
+    def test_unqualified_short_form_has_no_registry(self):
+        # Bare repo names lack a registry host; return repository alone so
+        # the equality check in _retag_appgarden_compose still distinguishes
+        # `my-org/my-app` from `my-org/some-other-app`.
+        assert self._repo("my-org/my-app:1.0") == "my-org/my-app"
+
+    def test_bare_repo_name(self):
+        assert self._repo("redis:7") == "redis"
+
+    def test_multi_segment_repository(self):
+        assert self._repo(
+            "ghcr.io/kamiwaza-internal/"
+            "kamiwaza-extensions-milvus/images/service-milvus:2.3.0"
+        ) == (
+            "ghcr.io/kamiwaza-internal/"
+            "kamiwaza-extensions-milvus/images/service-milvus"
+        )
+
+    def test_two_refs_at_different_tags_share_repo(self):
+        # The membership check that drives sibling-image retagging
+        # depends on equal repos for refs at different tags.
+        assert self._repo("ghcr.io/org/app:1.0") == self._repo(
+            "ghcr.io/org/app:2.0"
+        )
+
+
 class TestComputeCanonicalRefs:
     """`compute_canonical_refs` is the shared canonical-refs derivation
     used by publish (live + dry-run) and dev. Same source of truth means

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -3045,6 +3045,184 @@ class TestRetagAppgardenCompose:
             "ghcr.io/my-org/my-app-dev-helper:local-only"
         )
 
+    def test_sibling_service_sharing_built_image_repo_is_retagged(self):
+        """Multi-service-one-image idiom: sibling with same image repo
+        as a build service must be retagged + digest-pinned alongside it
+        (ENG-5648).
+
+        Milvus-shape: a one-shot init container reuses the main image to
+        chown/migrate/seed. Pre-fix the sibling shipped at its
+        source-authored tag (e.g. ``:2.3.0``) which was never pushed →
+        catalog ref unpullable → ImagePullBackOff on deploy.
+        """
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        image = (
+            "ghcr.io/kamiwaza-internal/"
+            "kamiwaza-extensions-milvus/images/service-milvus:2.3.0"
+        )
+        appgarden = {
+            "services": {
+                "standalone-init": {"image": image, "user": "0:0"},
+                "standalone": {"image": image, "user": "65532:65532"},
+            },
+        }
+        source = {
+            "services": {
+                "standalone-init": {"image": image, "user": "0:0"},
+                "standalone": {
+                    "build": {"context": ".", "dockerfile": "Dockerfile"},
+                    "image": image,
+                },
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="service-milvus", image_tag="develop",
+            registry=(
+                "ghcr.io/kamiwaza-internal/"
+                "kamiwaza-extensions-milvus/images"
+            ),
+        )
+        expected = (
+            "ghcr.io/kamiwaza-internal/"
+            "kamiwaza-extensions-milvus/images/service-milvus:develop"
+        )
+        assert out["services"]["standalone"]["image"] == expected
+        # Sibling without `build:` retagged to match — both will resolve
+        # to the same digest in `digest_map` downstream.
+        assert out["services"]["standalone-init"]["image"] == expected
+
+    def test_sibling_in_same_namespace_but_different_repo_passes_through(self):
+        """Safety boundary: a sibling whose image repo is in our
+        namespace but was NOT built by this publish passes through
+        verbatim. Rewriting it would point the catalog at a ``:dev``
+        tag that was never pushed and break ``_auto_resolve_digests``
+        with a confusing 404.
+        """
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        appgarden = {
+            "services": {
+                "backend": {
+                    "image": "ghcr.io/my-org/my-app/images/backend:1.0"
+                },
+                "helper": {
+                    # Same namespace prefix (my-app), but `some-other-tool`
+                    # is a different repo nothing here builds.
+                    "image": (
+                        "ghcr.io/my-org/my-app/images/some-other-tool:1.0"
+                    ),
+                },
+            },
+        }
+        source = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "ghcr.io/my-org/my-app/images/backend:1.0",
+                },
+                # No build → not in built_repos.
+                "helper": {
+                    "image": (
+                        "ghcr.io/my-org/my-app/images/some-other-tool:1.0"
+                    ),
+                },
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="dev",
+            registry="ghcr.io/my-org/my-app/images",
+        )
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app/images/backend:dev"
+        )
+        # Unbuilt sibling-in-namespace: passed through, safety boundary
+        # preserves external-passthrough semantics for refs we didn't
+        # produce.
+        assert out["services"]["helper"]["image"] == (
+            "ghcr.io/my-org/my-app/images/some-other-tool:1.0"
+        )
+
+    def test_sibling_of_profiled_build_service_not_retagged(self):
+        """A sibling sharing the image repo of a profile-gated build
+        service must NOT be retagged. The profiled service's image is
+        never pushed (excluded from ``built_repos``), so the sibling
+        falls through as external.
+        """
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        helper_image = "ghcr.io/my-org/my-app-dev-helper:local-only"
+        appgarden = {
+            "services": {
+                "backend": {"image": "ghcr.io/my-org/my-app-backend:2.0.0"},
+                "dev-helper": {
+                    "build": {"context": "."},
+                    "image": helper_image,
+                },
+                # Hypothetical sibling reusing the profiled helper's
+                # image to seed test data; would only ever run alongside
+                # the dev-only helper.
+                "dev-helper-init": {"image": helper_image},
+            },
+        }
+        source = {
+            "services": {
+                "backend": {"build": {"context": "."}},
+                "dev-helper": {
+                    "build": {"context": "."},
+                    "image": helper_image,
+                    "profiles": ["dev-only"],
+                },
+                "dev-helper-init": {"image": helper_image},
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="2.0.0-dev",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:2.0.0-dev"
+        )
+        # Profiled service still passes through.
+        assert out["services"]["dev-helper"]["image"] == helper_image
+        # Its sibling does too — the profiled service did not contribute
+        # to built_repos.
+        assert out["services"]["dev-helper-init"]["image"] == helper_image
+
+    def test_sibling_retagged_when_build_service_uses_legacy_fallback(self):
+        """When a build service has no declared ``image:``,
+        ``_canonical_build_ref`` falls back to
+        ``{registry}/{ext}-{svc}:{tag}``. A sibling that explicitly
+        references that fallback repo (rare but legal) should still be
+        recognized as built and retagged.
+        """
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        fallback_repo = "ghcr.io/my-org/my-app-backend"
+        appgarden = {
+            "services": {
+                "backend": {},
+                "backend-init": {"image": f"{fallback_repo}:1.0"},
+            },
+        }
+        source = {
+            "services": {
+                # No image → legacy fallback applies.
+                "backend": {"build": {"context": "."}},
+                "backend-init": {"image": f"{fallback_repo}:1.0"},
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="dev",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["backend"]["image"] == f"{fallback_repo}:dev"
+        assert out["services"]["backend-init"]["image"] == f"{fallback_repo}:dev"
+
 
 class TestPublishWithAppgarden:
     """End-to-end: appgarden.yml on disk skips ComposeTransformer.transform."""

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -3223,6 +3223,45 @@ class TestRetagAppgardenCompose:
         assert out["services"]["backend"]["image"] == f"{fallback_repo}:dev"
         assert out["services"]["backend-init"]["image"] == f"{fallback_repo}:dev"
 
+    def test_sibling_matches_when_build_uses_image_basename_override(self):
+        """Sibling-image gate must honor ``image_basename`` so a build
+        service using the override and a sibling pointing at the same
+        override-derived repo both retag together (ENG-5648 × ENG-5643).
+
+        Without threading ``image_basename`` into ``compute_canonical_refs``
+        inside ``_retag_appgarden_compose``, ``built_repos`` would be
+        keyed on ``extension_name`` while the rewrite uses
+        ``image_basename`` — the sibling check would miss.
+        """
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        fallback_repo = "ghcr.io/my-org/outcome-d563-workroom-manager-backend"
+        appgarden = {
+            "services": {
+                # Build service: no image declared → uses image_basename
+                # fallback at deploy time.
+                "backend": {},
+                # Sibling pointing at the override-derived ref.
+                "backend-init": {"image": f"{fallback_repo}:1.0"},
+            },
+        }
+        source = {
+            "services": {
+                "backend": {"build": {"context": "."}},
+                "backend-init": {"image": f"{fallback_repo}:1.0"},
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="workroom-manager",
+            image_tag="dev",
+            registry="ghcr.io/my-org",
+            image_basename="outcome-d563-workroom-manager",
+        )
+        assert out["services"]["backend"]["image"] == f"{fallback_repo}:dev"
+        # Sibling caught only when built_repos honors image_basename.
+        assert out["services"]["backend-init"]["image"] == f"{fallback_repo}:dev"
+
 
 class TestPublishWithAppgarden:
     """End-to-end: appgarden.yml on disk skips ComposeTransformer.transform."""

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -3223,6 +3223,144 @@ class TestRetagAppgardenCompose:
         assert out["services"]["backend"]["image"] == f"{fallback_repo}:dev"
         assert out["services"]["backend-init"]["image"] == f"{fallback_repo}:dev"
 
+    def test_profiled_build_service_sharing_repo_not_retagged(self):
+        """A profile-gated build service whose image repo collides with
+        a non-profiled build service must still be excluded — repo
+        collision can't bypass the profile gate.
+
+        Realistic shape: a dev-only helper sharing the main service's
+        Dockerfile/image but running a different command. The profile
+        filter on ``ImageBuilder``/push would not produce that helper's
+        ref under normal publishes; retagging it into the catalog would
+        ship a ref to a tag that was never pushed.
+        """
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        shared_image = "ghcr.io/my-org/my-app-backend:1.0"
+        appgarden = {
+            "services": {
+                "backend": {"image": shared_image},
+                "backend-dev": {"image": shared_image},
+            },
+        }
+        source = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": shared_image,
+                },
+                "backend-dev": {
+                    "build": {"context": "."},
+                    "image": shared_image,
+                    "profiles": ["dev-only"],
+                },
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="dev",
+            registry="ghcr.io/my-org",
+        )
+        # Non-profiled build service: retagged.
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:dev"
+        )
+        # Profiled build service: NOT retagged, even though its image
+        # repo collides with the non-profiled service's built_repos
+        # entry.
+        assert out["services"]["backend-dev"]["image"] == shared_image
+
+    def test_profiled_no_build_service_sharing_repo_dropped(self):
+        """A profile-gated appgarden service that shares the built repo
+        is dropped entirely — matches the generic transformer's policy
+        of removing any profile-gated service as local-only.
+
+        Realistic shape: a helper reusing the main image to run a
+        different command under a dev profile (e.g. a smoke-test
+        runner). Keeping it in the catalog entry at its source-authored
+        tag would ship a ref to an image never pushed under the
+        profile-aware push filter.
+        """
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        shared_image = "ghcr.io/my-org/my-app-backend:1.0"
+        appgarden = {
+            "services": {
+                "backend": {"image": shared_image},
+                "backend-smoketest": {
+                    "image": shared_image,
+                    "profiles": ["dev-only"],
+                },
+            },
+        }
+        source = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": shared_image,
+                },
+                # No build, but profile-gated.
+                "backend-smoketest": {
+                    "image": shared_image,
+                    "profiles": ["dev-only"],
+                },
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="dev",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:dev"
+        )
+        # Profiled appgarden service: dropped from output entirely.
+        assert "backend-smoketest" not in out["services"]
+
+    def test_appgarden_only_profiled_service_dropped(self):
+        """A service profile-gated only in the appgarden compose (no
+        ``profiles:`` on the source side) is also dropped — keeps the
+        appgarden path in policy parity with
+        ``ComposeTransformer.transform`` (which removes any profiled
+        service).
+
+        Improbable shape today (``sync-compose.py`` doesn't emit
+        ``profiles:``), but defensive against future tooling that
+        might.
+        """
+        from kamiwaza_extensions.commands.publish import _retag_appgarden_compose
+
+        shared_image = "ghcr.io/my-org/my-app-backend:1.0"
+        appgarden = {
+            "services": {
+                "backend": {"image": shared_image},
+                # Appgarden-only profile: source doesn't gate it.
+                "appgarden-only-helper": {
+                    "image": shared_image,
+                    "profiles": ["dev-only"],
+                },
+            },
+        }
+        source = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": shared_image,
+                },
+                # Note: source does NOT carry the profile gate.
+            },
+        }
+        out = _retag_appgarden_compose(
+            appgarden, source,
+            extension_name="my-app", image_tag="dev",
+            registry="ghcr.io/my-org",
+        )
+        assert out["services"]["backend"]["image"] == (
+            "ghcr.io/my-org/my-app-backend:dev"
+        )
+        # Appgarden-only profiled service: dropped from output entirely.
+        assert "appgarden-only-helper" not in out["services"]
+
     def test_sibling_matches_when_build_uses_image_basename_override(self):
         """Sibling-image gate must honor ``image_basename`` so a build
         service using the override and a sibling pointing at the same


### PR DESCRIPTION
## What this ships

`_retag_appgarden_compose` now retags any appgarden service whose image repo matches one this publish actually builds — not just services whose name has `build:`. Closes the multi-service-one-image idiom (init container reusing the main image) that left milvus's `standalone-init` at an unpushed `:2.3.0` tag, producing ImagePullBackOff on deploy.

Profile-gated services match the generic `ComposeTransformer.transform` drop policy: deleted from the catalog output, never retagged.

## Contract

| Shape | Before | After |
|---|---|---|
| Build service with declared image | retag tag, preserve namespace | (unchanged) |
| Sibling service, no `build:`, same image repo as a build service | passthrough at source tag → unpullable | retag to canonical pushed ref |
| Sibling service, no `build:`, **different** repo in our namespace | passthrough | passthrough (safety boundary) |
| Profile-gated service in source | preserved, not retagged | preserved, not retagged |
| Profile-gated service in appgarden | preserved, not retagged | **dropped** (matches generic transformer) |
| External image | passthrough | passthrough |

Ownership gate is `name ∈ canonical_by_name ∨ image_repo ∈ built_repos`. `built_repos` derives from `compute_canonical_refs` so appgarden-namespace precedence and the `image_basename` override (ENG-5643) thread through consistently.

## Load-bearing decisions

1. **Gate on built repos, not service names.** The pre-fix gate was a name-set from `build:` membership. The new gate is a repo-set computed from `compute_canonical_refs`, which is the same source of truth `run_publish` uses for `published_refs` and `digest_map` — so the catalog refs and the digest pins can't drift.

2. **`built_repos` is the safety boundary.** A sibling whose image lives in our namespace but at a repo we didn't build still passes through — rewriting it would point the catalog at a tag never pushed and break `_auto_resolve_digests`.

3. **Appgarden-side profile = delete.** Matches `ComposeTransformer.transform`'s drop policy (compose_transformer.py:278). Source-side profile preservation is unchanged (pre-existing behavior, has tests asserting it).

## Verification

- 169 unit tests pass (4 existing `TestRetagAppgardenCompose` + 6 new sibling-image/profile cases + 8 new `TestRepoPart` cases for the helper)
- 5-round pre-flight Codex review; 4 findings applied (rounds 1-4), 2 dismissed as pre-existing drift outside PR scope (round 5)
- E2E dry-run against milvus / omniparse / vespa / dde / kaizen real appgarden composes:
  - milvus `standalone-init` now retags to `:develop` alongside `standalone` (the bug fix)
  - omniparse divergent namespace preserved
  - vespa / dde unchanged (single build service, no siblings)
  - kaizen `agent` (build+image+profiles) drops from output — matches what generic transformer does for kaizen today
  - External images untouched everywhere

## Out of scope (deferred follow-ups)

- `ImageBuilder.build` doesn't filter `profiles:` — pre-existing, shared with `kz-ext dev` where profiled services may intentionally need to build for local docker-compose. Documented in ENG-5643's commit message.
- `run_publish` derives `canonical_refs` from raw `appgarden_data` independently of the retag helper's profile deletion — pre-existing path that predates this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)