### PR TITLE
ENG-5784: Two-cluster federation integration test harness

### DIFF
--- a/kamiwaza_sdk/schemas/federation.py
+++ b/kamiwaza_sdk/schemas/federation.py
@@ -97,6 +97,12 @@ class ClusterCapabilities(BaseModel):
     federation_count: int = 0
     active_deployments: int = 0
     ray_ready: bool = False
+    # ENG-5784 R5 H4 — the server always emits a stable cluster-identity
+    # UUID on capabilities responses. Declare it explicitly so harness
+    # / SDK consumers can rely on it without ``extra="allow"`` fallback
+    # gymnastics. The field has been emitted since the original
+    # ENG-4696 work; only the schema declaration was missing.
+    local_node_id: Optional[str] = None
 
 
 class DiagnoseIssue(BaseModel):

--- a/kamiwaza_sdk/services/federations.py
+++ b/kamiwaza_sdk/services/federations.py
@@ -128,8 +128,16 @@ class FederationsAPI(BaseService):
                 token-exchange brokering. The 4 brokering fields must
                 be supplied together; partial sets are refused by the
                 server with a 422 naming the missing field(s).
-            local_broker_client_secret: Keycloak client secret (or
-                DataHub secret URN) paired with ``local_broker_client_id``.
+            local_broker_client_secret: DataHub secret URN
+                (``urn:li:dataHubSecret:...``) for the Keycloak broker
+                client secret. The server resolves this URN via
+                CatalogService at pair time and ships the raw secret
+                to the peer. **URN-only — raw secrets are refused**
+                with a 422 because they would land in API logs,
+                network traces, and DB rows in plaintext. Operators
+                store the raw secret in DataHub first (via the
+                secrets API) and supply the URN here. Mirrors the
+                PSK secret-handling path.
 
         Returns:
             Federation record reflecting the post-/pair state.

--- a/kamiwaza_sdk/services/federations.py
+++ b/kamiwaza_sdk/services/federations.py
@@ -63,10 +63,10 @@ class FederationsAPI(BaseService):
         preshared_key: Optional[str] = None,
         callback_hostname: Optional[str] = None,
         remote_admin_token: Optional[str] = None,
-        peer_kc_issuer_url: Optional[str] = None,
-        peer_kc_jwks_url: Optional[str] = None,
-        peer_broker_client_id: Optional[str] = None,
-        peer_broker_client_secret: Optional[str] = None,
+        local_kc_issuer_url: Optional[str] = None,
+        local_kc_jwks_url: Optional[str] = None,
+        local_broker_client_id: Optional[str] = None,
+        local_broker_client_secret: Optional[str] = None,
     ) -> Federation:
         """Initiate or accept a federation pairing.
 
@@ -114,7 +114,7 @@ class FederationsAPI(BaseService):
             remote_admin_token: PAT/admin token on the remote cluster
                 (initiator-only convenience field; the server uses it to
                 drive the /pair handshake from the initiator side).
-            peer_kc_issuer_url: ENG-5822 — optional per-pair Keycloak
+            local_kc_issuer_url: ENG-5822 — optional per-pair Keycloak
                 issuer URL for this cluster's brokering identity
                 (e.g. ``https://kamiwaza.test/realms/kamiwaza``). When
                 supplied, persisted onto the federation row and used by
@@ -122,14 +122,14 @@ class FederationsAPI(BaseService):
                 ``KAMIWAZA_KC_ISSUER_URL`` process-env default. Useful
                 for SDK-driven setup scripts that want to configure
                 brokering at pair time without a Helm rebuild.
-            peer_kc_jwks_url: Companion to ``peer_kc_issuer_url`` — the
+            local_kc_jwks_url: Companion to ``local_kc_issuer_url`` — the
                 JWKS endpoint URL.
-            peer_broker_client_id: Keycloak client ID used for
+            local_broker_client_id: Keycloak client ID used for
                 token-exchange brokering. The 4 brokering fields must
                 be supplied together; partial sets are refused by the
                 server with a 422 naming the missing field(s).
-            peer_broker_client_secret: Keycloak client secret (or
-                DataHub secret URN) paired with ``peer_broker_client_id``.
+            local_broker_client_secret: Keycloak client secret (or
+                DataHub secret URN) paired with ``local_broker_client_id``.
 
         Returns:
             Federation record reflecting the post-/pair state.
@@ -158,14 +158,14 @@ class FederationsAPI(BaseService):
         # validator refuses partial sets, so include only when all 4
         # are supplied (we let the server emit the validation error
         # so callers get one canonical source-of-truth for the contract).
-        if peer_kc_issuer_url is not None:
-            create_body["peer_kc_issuer_url"] = peer_kc_issuer_url
-        if peer_kc_jwks_url is not None:
-            create_body["peer_kc_jwks_url"] = peer_kc_jwks_url
-        if peer_broker_client_id is not None:
-            create_body["peer_broker_client_id"] = peer_broker_client_id
-        if peer_broker_client_secret is not None:
-            create_body["peer_broker_client_secret"] = peer_broker_client_secret
+        if local_kc_issuer_url is not None:
+            create_body["local_kc_issuer_url"] = local_kc_issuer_url
+        if local_kc_jwks_url is not None:
+            create_body["local_kc_jwks_url"] = local_kc_jwks_url
+        if local_broker_client_id is not None:
+            create_body["local_broker_client_id"] = local_broker_client_id
+        if local_broker_client_secret is not None:
+            create_body["local_broker_client_secret"] = local_broker_client_secret
 
         created = self.client._request(
             "POST",

--- a/kamiwaza_sdk/services/federations.py
+++ b/kamiwaza_sdk/services/federations.py
@@ -63,6 +63,10 @@ class FederationsAPI(BaseService):
         preshared_key: Optional[str] = None,
         callback_hostname: Optional[str] = None,
         remote_admin_token: Optional[str] = None,
+        peer_kc_issuer_url: Optional[str] = None,
+        peer_kc_jwks_url: Optional[str] = None,
+        peer_broker_client_id: Optional[str] = None,
+        peer_broker_client_secret: Optional[str] = None,
     ) -> Federation:
         """Initiate or accept a federation pairing.
 
@@ -110,6 +114,22 @@ class FederationsAPI(BaseService):
             remote_admin_token: PAT/admin token on the remote cluster
                 (initiator-only convenience field; the server uses it to
                 drive the /pair handshake from the initiator side).
+            peer_kc_issuer_url: ENG-5822 — optional per-pair Keycloak
+                issuer URL for this cluster's brokering identity
+                (e.g. ``https://kamiwaza.test/realms/kamiwaza``). When
+                supplied, persisted onto the federation row and used by
+                the pair handshake instead of the cluster's
+                ``KAMIWAZA_KC_ISSUER_URL`` process-env default. Useful
+                for SDK-driven setup scripts that want to configure
+                brokering at pair time without a Helm rebuild.
+            peer_kc_jwks_url: Companion to ``peer_kc_issuer_url`` — the
+                JWKS endpoint URL.
+            peer_broker_client_id: Keycloak client ID used for
+                token-exchange brokering. The 4 brokering fields must
+                be supplied together; partial sets are refused by the
+                server with a 422 naming the missing field(s).
+            peer_broker_client_secret: Keycloak client secret (or
+                DataHub secret URN) paired with ``peer_broker_client_id``.
 
         Returns:
             Federation record reflecting the post-/pair state.
@@ -134,6 +154,18 @@ class FederationsAPI(BaseService):
             create_body["callback_hostname"] = callback_hostname
         if remote_admin_token is not None:
             create_body["remote_admin_token"] = remote_admin_token
+        # ENG-5822 — per-pair brokering inputs. Server-side atomic
+        # validator refuses partial sets, so include only when all 4
+        # are supplied (we let the server emit the validation error
+        # so callers get one canonical source-of-truth for the contract).
+        if peer_kc_issuer_url is not None:
+            create_body["peer_kc_issuer_url"] = peer_kc_issuer_url
+        if peer_kc_jwks_url is not None:
+            create_body["peer_kc_jwks_url"] = peer_kc_jwks_url
+        if peer_broker_client_id is not None:
+            create_body["peer_broker_client_id"] = peer_broker_client_id
+        if peer_broker_client_secret is not None:
+            create_body["peer_broker_client_secret"] = peer_broker_client_secret
 
         created = self.client._request(
             "POST",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ markers = [
     "slow: intentionally slow tests",
     "withoutresponses: tests needing real network access",
     "requires_embedding_model: live tests that require an active platform embedding deployment",
+    "requires_two_clusters: live tests that require a federation peer cluster reachable via KAMIWAZA_PEER_BASE_URL / KAMIWAZA_PEER_API_KEY (ENG-5784)",
     "extension_regression: D210 12-issue regression checklist (UAC-17 / EDX-OPS-2). See tests/unit/extensions/regression/inventory.yaml.",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,27 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "(defaults to env KAMIWAZA_PASSWORD, else integration fixture resolves via kz-login)."
         ),
     )
+    # ENG-5784 — federation peer cluster for two-cluster live tests
+    group.addoption(
+        "--live-peer-base-url",
+        action="store",
+        default=os.environ.get("KAMIWAZA_PEER_BASE_URL", ""),
+        help=(
+            "Base URL of the federation peer cluster for two-cluster live "
+            "tests marked @pytest.mark.requires_two_clusters "
+            "(defaults to env KAMIWAZA_PEER_BASE_URL). When empty, peer-required "
+            "tests are auto-deselected."
+        ),
+    )
+    group.addoption(
+        "--live-peer-api-key",
+        action="store",
+        default=os.environ.get("KAMIWAZA_PEER_API_KEY", ""),
+        help=(
+            "API key for the federation peer cluster (defaults to env "
+            "KAMIWAZA_PEER_API_KEY). Required when --live-peer-base-url is set."
+        ),
+    )
 
 
 @pytest.fixture(scope="session")
@@ -274,6 +295,23 @@ def live_username(pytestconfig: pytest.Config) -> str:
 @pytest.fixture(scope="session")
 def live_password(pytestconfig: pytest.Config) -> str:
     return str(pytestconfig.getoption("live_password"))
+
+
+@pytest.fixture(scope="session")
+def live_peer_base_url(pytestconfig: pytest.Config) -> str:
+    """Peer-cluster base URL for two-cluster federation tests (ENG-5784).
+
+    Returns empty string when not configured — collection-side hooks
+    auto-deselect ``@pytest.mark.requires_two_clusters`` tests in that
+    case, so test bodies can assume both env vars are set.
+    """
+    return str(pytestconfig.getoption("live_peer_base_url")).rstrip("/")
+
+
+@pytest.fixture(scope="session")
+def live_peer_api_key(pytestconfig: pytest.Config) -> str:
+    """Peer-cluster API key for two-cluster federation tests (ENG-5784)."""
+    return str(pytestconfig.getoption("live_peer_api_key"))
 
 
 @pytest.fixture

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -9,7 +9,8 @@ contributor PRs without a live cluster don't see false reds.
 |---|---|---|
 | `KAMIWAZA_BASE_URL` | Primary cluster base URL (must end with `/api`) | `https://kamiwaza.test/api` |
 | `KAMIWAZA_API_KEY` | API key for the primary cluster | unset |
-| `KAMIWAZA_USERNAME` / `KAMIWAZA_PASSWORD` | Username + password auth fallback (`admin` / kz-login) | `admin` |
+| `KAMIWAZA_USERNAME` | Username for password-auth fallback | `admin` |
+| `KAMIWAZA_PASSWORD` | Password for password-auth fallback | unset (falls back to kz-login) |
 | `KAMIWAZA_VERIFY_SSL` | Set `false` for self-signed certs in dev | `true` |
 | `KAMIWAZA_PEER_BASE_URL` | Federation peer cluster base URL (ENG-5784) | unset |
 | `KAMIWAZA_PEER_API_KEY` | API key on the peer cluster (ENG-5784) | unset |
@@ -38,7 +39,7 @@ KAMIWAZA_PEER_API_KEY=... \
 |---|---|---|
 | `live` | Tests that talk to a running Kamiwaza deployment | always selected when running `-m live` |
 | `requires_embedding_model` | Live tests that need an active platform embedding deployment | auto-provisioned by `embedding_model_prerequisite` fixture; skipped if provisioning fails |
-| `requires_two_clusters` | Live tests that need a federation peer cluster (ENG-5784) | auto-deselected when `KAMIWAZA_PEER_BASE_URL` is unset |
+| `requires_two_clusters` | Live tests that need a federation peer cluster (ENG-5784) | auto-deselected at collection when `KAMIWAZA_PEER_BASE_URL` is unset; skipped at run time with an explicit reason when peer URL is set but `KAMIWAZA_PEER_API_KEY` is missing (partial-creds case) |
 
 ## Adding a federation-aware integration test
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,60 @@
+# Integration tests
+
+Live tests that require a running Kamiwaza deployment. Gated by markers so
+contributor PRs without a live cluster don't see false reds.
+
+## Environment
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `KAMIWAZA_BASE_URL` | Primary cluster base URL (must end with `/api`) | `https://kamiwaza.test/api` |
+| `KAMIWAZA_API_KEY` | API key for the primary cluster | unset |
+| `KAMIWAZA_USERNAME` / `KAMIWAZA_PASSWORD` | Username + password auth fallback (`admin` / kz-login) | `admin` |
+| `KAMIWAZA_VERIFY_SSL` | Set `false` for self-signed certs in dev | `true` |
+| `KAMIWAZA_PEER_BASE_URL` | Federation peer cluster base URL (ENG-5784) | unset |
+| `KAMIWAZA_PEER_API_KEY` | API key on the peer cluster (ENG-5784) | unset |
+
+The peer-cluster env vars only activate the two-cluster federation tests
+marked `@pytest.mark.requires_two_clusters`. When unset, those tests are
+auto-deselected — contributor PRs without peer creds see no false reds.
+
+## Running
+
+```bash
+# All live tests against one cluster
+make test-live
+
+# Two-cluster federation walkthrough (requires both clusters reachable)
+KAMIWAZA_BASE_URL=https://lyra.example/api \
+KAMIWAZA_API_KEY=... \
+KAMIWAZA_PEER_BASE_URL=https://orion.example/api \
+KAMIWAZA_PEER_API_KEY=... \
+  uv run pytest -m "requires_two_clusters" tests/integration/test_federation_two_cluster_live.py -v
+```
+
+## Marker reference
+
+| Marker | What it covers | Skip behavior |
+|---|---|---|
+| `live` | Tests that talk to a running Kamiwaza deployment | always selected when running `-m live` |
+| `requires_embedding_model` | Live tests that need an active platform embedding deployment | auto-provisioned by `embedding_model_prerequisite` fixture; skipped if provisioning fails |
+| `requires_two_clusters` | Live tests that need a federation peer cluster (ENG-5784) | auto-deselected when `KAMIWAZA_PEER_BASE_URL` is unset |
+
+## Adding a federation-aware integration test
+
+1. Add the marker:
+
+   ```python
+   pytestmark = [pytest.mark.live, pytest.mark.requires_two_clusters]
+   ```
+
+2. Depend on the peer-cluster fixtures from `tests/integration/conftest.py`:
+
+   - `live_kamiwaza_client` — the primary cluster's `KamiwazaClient`
+   - `live_kamiwaza_peer_client` — the peer cluster's `KamiwazaClient`
+
+3. Keep teardown best-effort — federation state survives test failures
+   and the next run gets a fresh per-run unique federation name.
+
+See `test_federation_two_cluster_live.py` for the canonical walkthrough
+(pair → brokered user → federated job → retrieval smoke → unpair).

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -15,6 +15,25 @@ contributor PRs without a live cluster don't see false reds.
 | `KAMIWAZA_PEER_BASE_URL` | Federation peer cluster base URL (ENG-5784) | unset |
 | `KAMIWAZA_PEER_API_KEY` | API key on the peer cluster (ENG-5784) | unset |
 
+### Brokering env vars (capabilities probe + federated job tests)
+
+The capabilities-probe-via-mesh and federated-job-audit-actor tests
+require brokering to be active on both clusters. Brokering needs
+Keycloak issuer URLs + cluster IDs configured on both sides; the
+`kamiwaza-smoke.py federation-pair` script emits
+``WARN: brokering not active on either side (KAMIWAZA_KC_* env vars
+not set)`` when this is missing.
+
+These two tests will fail with mesh-proxy errors (capabilities) and
+job-result-marker errors (audit-actor) on fleet rigs that don't have
+brokering wired up. The other four tests (pair, brokered-user-allowlist,
+retrieval, unpair) work without brokering.
+
+Full brokering setup is outside the scope of this harness — operators
+running this suite against a fleet rig should ensure brokering is
+active per the federation-pair runbook before relying on the
+mesh-routing tests.
+
 The peer-cluster env vars only activate the two-cluster federation tests
 marked `@pytest.mark.requires_two_clusters`. When unset, those tests are
 auto-deselected — contributor PRs without peer creds see no false reds.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -14,6 +14,8 @@ contributor PRs without a live cluster don't see false reds.
 | `KAMIWAZA_VERIFY_SSL` | Set `false` for self-signed certs in dev | `true` |
 | `KAMIWAZA_PEER_BASE_URL` | Federation peer cluster base URL (ENG-5784) | unset |
 | `KAMIWAZA_PEER_API_KEY` | API key on the peer cluster (ENG-5784) | unset |
+| `KAMIWAZA_INITIATOR_CALLBACK_HOST` | Hostname/IP the peer cluster uses to reach back to the initiator. Required when both clusters share a domain (e.g. both expose `https://kamiwaza.test/api` resolving to their own ingress). Pass the routable host the receiver should call (e.g. `spark-1`). | falls back to `KAMIWAZA_BASE_URL` host |
+| `KAMIWAZA_INITIATOR_CALLBACK_URL` | Full callback URL alternative to `_HOST` — use when scheme/path/port also differs from `KAMIWAZA_BASE_URL`. | falls back to `KAMIWAZA_BASE_URL` |
 
 The peer-cluster env vars only activate the two-cluster federation tests
 marked `@pytest.mark.requires_two_clusters`. When unset, those tests are

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -14,8 +14,6 @@ contributor PRs without a live cluster don't see false reds.
 | `KAMIWAZA_VERIFY_SSL` | Set `false` for self-signed certs in dev | `true` |
 | `KAMIWAZA_PEER_BASE_URL` | Federation peer cluster base URL (ENG-5784) | unset |
 | `KAMIWAZA_PEER_API_KEY` | API key on the peer cluster (ENG-5784) | unset |
-| `KAMIWAZA_INITIATOR_CALLBACK_HOST` | Hostname/IP the peer cluster uses to reach back to the initiator. Required when both clusters share a domain (e.g. both expose `https://kamiwaza.test/api` resolving to their own ingress). Pass the routable host the receiver should call (e.g. `spark-1`). | falls back to `KAMIWAZA_BASE_URL` host |
-| `KAMIWAZA_INITIATOR_CALLBACK_URL` | Full callback URL alternative to `_HOST` — use when scheme/path/port also differs from `KAMIWAZA_BASE_URL`. | falls back to `KAMIWAZA_BASE_URL` |
 
 The peer-cluster env vars only activate the two-cluster federation tests
 marked `@pytest.mark.requires_two_clusters`. When unset, those tests are

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -62,19 +62,47 @@ KAMIWAZA_PEER_API_KEY=... \
 
 ## Adding a federation-aware integration test
 
-1. Add the marker:
+1. Add **all four** markers — the canonical walkthrough uses each
+   for a distinct purpose, and the suite is broken without any one:
 
    ```python
-   pytestmark = [pytest.mark.live, pytest.mark.requires_two_clusters]
+   pytestmark = [
+       pytest.mark.integration,        # included by CI's -m "integration and live" selector
+       pytest.mark.live,               # requires a running Kamiwaza deployment
+       pytest.mark.withoutresponses,   # disables pytest-responses HTTP stubbing (real network only)
+       pytest.mark.requires_two_clusters,  # auto-deselected when peer creds unset
+   ]
    ```
+
+   Missing `integration` makes the suite invisible to the CI selector.
+   Missing `withoutresponses` lets `pytest-responses` stub the real
+   HTTP calls — the test passes against a mocked stack rather than
+   the live peer cluster (the exact defect R2 fixed).
 
 2. Depend on the peer-cluster fixtures from `tests/integration/conftest.py`:
 
-   - `live_kamiwaza_client` — the primary cluster's `KamiwazaClient`
-   - `live_kamiwaza_peer_client` — the peer cluster's `KamiwazaClient`
+   - `live_kamiwaza_session_client` — the primary cluster's
+     `KamiwazaClient`, **session-scoped**. Use this from
+     module-scoped fixtures. The older `live_kamiwaza_client` is
+     function-scoped — depending on it from a module-scoped fixture
+     raises `ScopeMismatch` at fixture resolution (R1 ScopeMismatch
+     defect).
+   - `live_kamiwaza_peer_client` — the peer cluster's `KamiwazaClient`,
+     session-scoped.
+
+   Scope rule: `function-scoped fixtures must not be depended on by
+   broader-scoped (module/session) fixtures` is the pytest-builtin
+   rule that R1 violated. When in doubt, use the session-scoped
+   client; tests that need a fresh per-test client can wrap it in a
+   function-scoped fixture instead.
 
 3. Keep teardown best-effort — federation state survives test failures
-   and the next run gets a fresh per-run unique federation name.
+   and the next run gets a fresh per-run unique federation name + PSK.
+
+4. Mint a fresh PSK *inside* each pair fixture rather than sharing one
+   at module scope. The backend resolves the receiver-side federation
+   by PSK match; two coexisting pairs sharing a PSK confuse the
+   resolver (R5 H1 defect).
 
 See `test_federation_two_cluster_live.py` for the canonical walkthrough
 (pair → brokered user → federated job → retrieval smoke → unpair).

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1239,13 +1239,20 @@ def live_kamiwaza_peer_client(
     Only resolves when both KAMIWAZA_PEER_BASE_URL + KAMIWAZA_PEER_API_KEY are
     configured. Two-cluster tests should depend on this fixture alongside
     the @pytest.mark.requires_two_clusters marker.
+
+    SSL verification is opted out per-client (dev clusters typically run
+    with self-signed certs) so the toggle is scoped to this client rather
+    than mutating process-wide environment.
     """
     if not live_peer_base_url:
         pytest.skip("requires_two_clusters: KAMIWAZA_PEER_BASE_URL not set")
     if not live_peer_api_key:
         pytest.skip("requires_two_clusters: KAMIWAZA_PEER_API_KEY not set")
-    os.environ.setdefault("KAMIWAZA_VERIFY_SSL", "false")
-    return KamiwazaClient(live_peer_base_url, api_key=live_peer_api_key.strip())
+    return KamiwazaClient(
+        live_peer_base_url,
+        api_key=live_peer_api_key.strip(),
+        verify=False,
+    )
 
 
 def pytest_collection_modifyitems(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,7 +87,9 @@ _logger = logging.getLogger(__name__)
 class _TimeoutHTTPAdapter(HTTPAdapter):
     """HTTPAdapter that applies a default timeout to every request."""
 
-    def __init__(self, *args: Any, timeout: float = _PROBE_TIMEOUT_SECONDS, **kwargs: Any):
+    def __init__(
+        self, *args: Any, timeout: float = _PROBE_TIMEOUT_SECONDS, **kwargs: Any
+    ):
         self._timeout = timeout
         super().__init__(*args, **kwargs)
 
@@ -100,6 +102,8 @@ def _mount_probe_timeout(client: KamiwazaClient) -> None:
     adapter = _TimeoutHTTPAdapter(timeout=_PROBE_TIMEOUT_SECONDS)
     client.session.mount("http://", adapter)
     client.session.mount("https://", adapter)
+
+
 _HTTP_TRACE_FLAG = "KAMIWAZA_HTTP_TRACE"
 _HTTP_TRACE_FILE_ENV = "KAMIWAZA_HTTP_TRACE_FILE"
 _TEXT_BODY_MARKERS = (
@@ -1200,8 +1204,73 @@ def _require_embedding_model_for_marked_tests(request: pytest.FixtureRequest) ->
         request.getfixturevalue("embedding_model_prerequisite")
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Run explicit smoke tests first, then embedding-dependent tests near the front."""
+@pytest.fixture(autouse=True)
+def _require_two_clusters_for_marked_tests(request: pytest.FixtureRequest) -> None:
+    """ENG-5784 — surface a clear skip reason when peer creds are missing.
+
+    Collection-side deselection in ``pytest_collection_modifyitems`` removes
+    these tests entirely when neither --live-peer-base-url nor
+    KAMIWAZA_PEER_BASE_URL is set, so this fixture only fires when peer
+    creds were partially provided (e.g. base URL but no API key).
+    """
+    if "requires_two_clusters" not in request.keywords:
+        return
+    peer_url = str(request.config.getoption("live_peer_base_url")).strip()
+    peer_key = str(request.config.getoption("live_peer_api_key")).strip()
+    if not peer_url:
+        pytest.skip(
+            "requires_two_clusters: set --live-peer-base-url or "
+            "KAMIWAZA_PEER_BASE_URL to run."
+        )
+    if not peer_key:
+        pytest.skip(
+            "requires_two_clusters: --live-peer-base-url is set but "
+            "--live-peer-api-key / KAMIWAZA_PEER_API_KEY is missing."
+        )
+
+
+@pytest.fixture(scope="session")
+def live_kamiwaza_peer_client(
+    live_peer_base_url: str,
+    live_peer_api_key: str,
+) -> KamiwazaClient:
+    """ENG-5784 — KamiwazaClient bound to the federation peer cluster.
+
+    Only resolves when both KAMIWAZA_PEER_BASE_URL + KAMIWAZA_PEER_API_KEY are
+    configured. Two-cluster tests should depend on this fixture alongside
+    the @pytest.mark.requires_two_clusters marker.
+    """
+    if not live_peer_base_url:
+        pytest.skip("requires_two_clusters: KAMIWAZA_PEER_BASE_URL not set")
+    if not live_peer_api_key:
+        pytest.skip("requires_two_clusters: KAMIWAZA_PEER_API_KEY not set")
+    os.environ.setdefault("KAMIWAZA_VERIFY_SSL", "false")
+    return KamiwazaClient(live_peer_base_url, api_key=live_peer_api_key.strip())
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Order: smoke first, embedding-dependent next, others last.
+
+    ENG-5784: also deselect @pytest.mark.requires_two_clusters when neither
+    --live-peer-base-url nor KAMIWAZA_PEER_BASE_URL is set. Mirrors the
+    requires_embedding_model deselection convention so contributor PRs
+    without peer creds don't show false reds.
+    """
+    peer_url = str(config.getoption("live_peer_base_url")).strip()
+    if not peer_url:
+        kept: list[pytest.Item] = []
+        deselected: list[pytest.Item] = []
+        for item in items:
+            if "requires_two_clusters" in item.keywords:
+                deselected.append(item)
+            else:
+                kept.append(item)
+        if deselected:
+            config.hook.pytest_deselected(items=deselected)
+            items[:] = kept
+
     smoke_items = [
         item for item in items if Path(str(item.fspath)).name.startswith("test_00_")
     ]

--- a/tests/integration/test_cluster_live.py
+++ b/tests/integration/test_cluster_live.py
@@ -341,69 +341,10 @@ class TestFederationListOperations:
             raise
 
 
-class TestFederationOperationsNotAvailable:
-    """Tests documenting federation operations that require multi-cluster setup.
-
-    These tests are skipped because they require a second cluster to test.
-    They serve as documentation of what endpoints exist.
-    """
-
-    @pytest.mark.skip(reason="Requires second cluster for federation")
-    def test_create_federation(self, live_kamiwaza_client) -> None:
-        """TS4.011: POST /cluster/federations - Create federation."""
-        pass
-
-    @pytest.mark.skip(reason="Requires existing federation")
-    def test_get_federation(self, live_kamiwaza_client) -> None:
-        """TS4.013: GET /cluster/federations/{federation_id}."""
-        pass
-
-    @pytest.mark.skip(reason="Requires existing federation")
-    def test_update_federation(self, live_kamiwaza_client) -> None:
-        """TS4.014: PUT /cluster/federations/{federation_id}."""
-        pass
-
-    @pytest.mark.skip(reason="Requires existing federation")
-    def test_delete_federation(self, live_kamiwaza_client) -> None:
-        """TS4.012: DELETE /cluster/federations/{federation_id}."""
-        pass
-
-    @pytest.mark.skip(reason="Requires existing federation")
-    def test_pair_federation(self, live_kamiwaza_client) -> None:
-        """TS4.016: POST /cluster/federations/{federation_id}/pair."""
-        pass
-
-    @pytest.mark.skip(reason="Requires existing federation")
-    def test_disconnect_federation(self, live_kamiwaza_client) -> None:
-        """TS4.015: POST /cluster/federations/{federation_id}/disconnect."""
-        pass
-
-    @pytest.mark.skip(reason="Requires existing federation")
-    def test_ping_federation(self, live_kamiwaza_client) -> None:
-        """TS4.017: POST /cluster/federations/{federation_id}/ping."""
-        pass
-
-    @pytest.mark.skip(reason="Two-node pairing moved to .env configuration")
-    def test_attach_pairing(self, live_kamiwaza_client) -> None:
-        """TS4.001: POST /cluster/attach_pairing."""
-        pass
-
-    @pytest.mark.skip(reason="Two-node pairing moved to .env configuration")
-    def test_detach_pairing(self, live_kamiwaza_client) -> None:
-        """TS4.007: POST /cluster/detach_pairing."""
-        pass
-
-    @pytest.mark.skip(reason="Requires remote cluster initiating pairing")
-    def test_pair_federation_handler(self, live_kamiwaza_client) -> None:
-        """TS4.029: POST /cluster/pair_federation."""
-        pass
-
-    @pytest.mark.skip(reason="Requires remote cluster for reciprocation")
-    def test_federation_reciprocation(self, live_kamiwaza_client) -> None:
-        """TS4.005: POST /cluster/cluster_federation_reciprocation."""
-        pass
-
-    @pytest.mark.skip(reason="Requires remote cluster initiating disconnect")
-    def test_disconnect_federation_handler(self, live_kamiwaza_client) -> None:
-        """TS4.008: POST /cluster/disconnect_federation."""
-        pass
+# ENG-5784 — 12 dead `@pytest.mark.skip` placeholders for federation
+# operations were removed from this file. They had no real assertions
+# (all `pass` bodies) and were never executable in any cluster
+# configuration. Live two-cluster coverage now lives in
+# `test_federation_two_cluster_live.py`, gated by the
+# `requires_two_clusters` marker + the `KAMIWAZA_PEER_BASE_URL` /
+# `KAMIWAZA_PEER_API_KEY` env vars (see `tests/integration/conftest.py`).

--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -43,10 +43,12 @@ def federation_pair_name() -> str:
     return f"eng5784-live-{uuid.uuid4().hex[:8]}"
 
 
-@pytest.fixture(scope="module")
-def shared_psk() -> str:
-    """Shared PSK between initiator and receiver. Mode B (caller-supplied)."""
-    return str(uuid.uuid4())
+# ENG-5784 R5 H1 — PSKs are now minted INSIDE each pair fixture rather
+# than shared at module scope. The backend resolves the receiver-side
+# federation by PSK match; if two coexisting pairs share the same PSK,
+# /pair on the second one can bind to the wrong row or be refused.
+# Each fixture now mints its own UUID4 so the receiver's PSK lookup is
+# unambiguous.
 
 
 @pytest.fixture(scope="module")
@@ -68,23 +70,20 @@ def receiver_client(live_kamiwaza_peer_client: KamiwazaClient) -> KamiwazaClient
 def initiator_cluster_uuid(initiator_client: KamiwazaClient) -> str:
     """UUID of the initiator cluster. Used to build brokered external_ids.
 
-    Reads ``local_node_id`` from ``cluster.capabilities()`` — that's the
-    canonical cluster-identity UUID in the ClusterCapabilities schema.
-    Falls back to ``cluster_id`` / ``id`` for backend versions that may
-    expose alternate field names.
+    Reads the schema-declared ``local_node_id`` field on
+    ClusterCapabilities (added in R5 H4 — was previously available only
+    via ``extra="allow"`` passthrough). The server has emitted this
+    field since the original ENG-4696 capabilities-probe work; the
+    fallback chain through ``cluster_id`` / ``id`` was carrying schema-
+    drift risk because those names aren't declared. Now schema-bound.
     """
     capabilities = initiator_client.cluster.capabilities()
-    cluster_id = (
-        getattr(capabilities, "local_node_id", None)
-        or getattr(capabilities, "cluster_id", None)
-        or getattr(capabilities, "id", None)
-    )
-    if not cluster_id:
+    if not capabilities.local_node_id:
         pytest.fail(
-            "initiator cluster.capabilities() returned no identifying UUID; "
+            "initiator cluster.capabilities() returned no local_node_id; "
             f"got {capabilities!r}"
         )
-    return str(cluster_id)
+    return capabilities.local_node_id
 
 
 @pytest.fixture(scope="module")
@@ -92,7 +91,6 @@ def paired_federation(
     initiator_client: KamiwazaClient,
     receiver_client: KamiwazaClient,
     federation_pair_name: str,
-    shared_psk: str,
     live_peer_base_url: str,
 ) -> Iterator[dict[str, str]]:
     """Establish a federation pair for the test module. Tears down at exit.
@@ -100,6 +98,11 @@ def paired_federation(
     Yields a dict with the federation_id on both sides plus the pair name
     so individual tests can stitch onto the live state.
     """
+    # R5 H1 — mint the PSK inside the fixture so it's not shared with
+    # other pair fixtures (the receiver's PSK-match lookup must be
+    # unambiguous across coexisting pairs).
+    pair_psk = str(uuid.uuid4())
+
     # Receiver creates its side first (WAITING state) so the initiator's
     # /pair handshake has something to hit. The receiver record only
     # needs name + role + psk — it doesn't need a callback URL because
@@ -110,7 +113,7 @@ def paired_federation(
     receiver_fed = receiver_client.federations.pair(
         name=federation_pair_name,
         role="receiver",
-        preshared_key=shared_psk,
+        preshared_key=pair_psk,
     )
     receiver_fed_id = str(receiver_fed.id)
 
@@ -123,7 +126,7 @@ def paired_federation(
             name=federation_pair_name,
             role="initiator",
             remote_url=live_peer_base_url,
-            preshared_key=shared_psk,
+            preshared_key=pair_psk,
         )
     except Exception:
         try:
@@ -168,7 +171,6 @@ def paired_federation(
 def unpaired_federation(
     initiator_client: KamiwazaClient,
     receiver_client: KamiwazaClient,
-    shared_psk: str,
     live_peer_base_url: str,
 ) -> Iterator[dict[str, str]]:
     """Fresh function-scoped pair for tests that mutate pair lifecycle state.
@@ -176,14 +178,16 @@ def unpaired_federation(
     The module-scoped ``paired_federation`` is a shared resource; tests
     like ``test_unpair_returns_to_clean_state`` would otherwise create
     order-dependent suite behavior. This fixture stands up a separate
-    federation with a unique name per test, so mutating its state
-    doesn't affect the module-scoped pair.
+    federation with a unique name + unique PSK per test, so mutating
+    its state doesn't affect the module-scoped pair AND the receiver
+    PSK-match lookup stays unambiguous across coexisting pairs (R5 H1).
     """
     fresh_name = f"eng5784-unpair-{uuid.uuid4().hex[:8]}"
+    fresh_psk = str(uuid.uuid4())
     receiver_fed = receiver_client.federations.pair(
         name=fresh_name,
         role="receiver",
-        preshared_key=shared_psk,
+        preshared_key=fresh_psk,
     )
     receiver_fed_id = str(receiver_fed.id)
     try:
@@ -191,7 +195,7 @@ def unpaired_federation(
             name=fresh_name,
             role="initiator",
             remote_url=live_peer_base_url,
-            preshared_key=shared_psk,
+            preshared_key=fresh_psk,
         )
     except Exception:
         try:
@@ -270,18 +274,13 @@ class TestFederationTwoClusterWalkthrough:
         """
         proxy = initiator_client.federations[paired_federation["name"]]
         capabilities = proxy.probe()
-        # ClusterCapabilities is a pydantic model — probe() raises if the
-        # mesh hop or capability schema fails. Existence of any identifying
-        # UUID is the load-bearing signal. local_node_id is the canonical
-        # field; cluster_id/id are accepted for backend version variance.
-        cluster_id = (
-            getattr(capabilities, "local_node_id", None)
-            or getattr(capabilities, "cluster_id", None)
-            or getattr(capabilities, "id", None)
-        )
+        # probe() raises if the mesh hop or capability schema fails.
+        # local_node_id is the schema-declared cluster-identity field
+        # (R5 H4 added the declaration). Pin the schema contract — no
+        # fallback chain, no extra="allow" passthrough gymnastics.
         assert (
-            cluster_id
-        ), f"peer capabilities missing identifying UUID: {capabilities!r}"
+            capabilities.local_node_id
+        ), f"peer capabilities missing local_node_id: {capabilities!r}"
 
     def test_brokered_user_allowlist_round_trip(
         self,
@@ -324,6 +323,16 @@ class TestFederationTwoClusterWalkthrough:
         """The WS-M1 demo-gate signal: a federated job runs as the
         originating user, not as a system principal. Audit-actor round-trip
         is the proof. T5.22 / ENG-4699.
+
+        Strict gates (R5 H2):
+          - status MUST be SUCCEEDED — accepting FAILED would mask the
+            very failure modes this test exists to catch (a brokered
+            job that crashes is not a positive demo-gate signal).
+          - identity is read from result.audit_actor — the canonical
+            field declared on JobResult (schemas/federation.py).
+            Accepting requester/submitter fallbacks lets generically-
+            named identity attributes pass even when the audit-actor
+            wiring is broken.
         """
         # Use the recoverable path so we get the job_id back immediately
         # and can poll for the terminal state.
@@ -333,19 +342,12 @@ class TestFederationTwoClusterWalkthrough:
             timeout_seconds=120,
             recoverable=True,
         )
-        assert result.status in {
-            "SUCCEEDED",
-            "FAILED",
-        }, f"job did not reach terminal state: {result}"
-        # The audit_actor field is the demo-gate signal. Backend versions
-        # may name it audit_actor / requester / submitter — accept any
-        # non-None identity-like attribute as the round-trip proof.
-        actor = (
-            getattr(result, "audit_actor", None)
-            or getattr(result, "requester", None)
-            or getattr(result, "submitter", None)
-        )
-        assert actor, f"job result missing audit-actor identity: {result}"
+        assert (
+            result.status == "SUCCEEDED"
+        ), f"federated job did not succeed: status={result.status} result={result}"
+        assert (
+            result.audit_actor
+        ), f"job result missing audit_actor (demo-gate signal): {result}"
 
     def test_retrieval_surface_reachable_on_both_clusters(
         self,
@@ -386,4 +388,11 @@ class TestFederationTwoClusterWalkthrough:
             "GET", f"/cluster/federations/{unpaired_federation['initiator_id']}"
         )
         assert isinstance(view, dict)
-        assert view["status"] in {"DISCONNECTED", "DEAD", "WAITING"}, view
+        # R5 H3 — terminal post-disconnect set MUST NOT include WAITING
+        # (the initial state). A no-op or rejected disconnect that
+        # leaves the row in WAITING would otherwise pass silently.
+        observed = view.get("status")
+        assert observed in {"DISCONNECTED", "DEAD"}, (
+            f"disconnect did not reach a terminal-disconnect state; "
+            f"observed status={observed!r}; full view={view!r}"
+        )

--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -1,0 +1,258 @@
+"""ENG-5784 — Live two-cluster federation walkthrough.
+
+The live counterpart to ``test_federation_skeleton_walkthrough.py``
+(which mocks the same flow). This test exercises the WS-M1+ federation
+surface end-to-end against a real peer cluster: pair → brokered user →
+federated job (audit-actor round-trip) → retrieval surface smoke →
+clean unpair.
+
+Gated by the ``requires_two_clusters`` marker plus the
+``KAMIWAZA_PEER_BASE_URL`` + ``KAMIWAZA_PEER_API_KEY`` env vars (mirrors
+the ``requires_embedding_model`` convention). Auto-deselected when
+neither --live-peer-base-url nor KAMIWAZA_PEER_BASE_URL is set, so
+contributor PRs without peer creds don't show false reds.
+
+Initial peer rig: spark-1 ↔ evo-x2-1 (see memory:
+reference_fleet_validation_hosts.md).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import Iterator
+
+import pytest
+
+from kamiwaza_sdk import KamiwazaClient
+
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.requires_two_clusters,
+]
+
+
+@pytest.fixture(scope="module")
+def federation_pair_name() -> str:
+    """Per-run unique federation name so re-runs don't collide on stale state."""
+    return f"eng5784-live-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture(scope="module")
+def shared_psk() -> str:
+    """Shared PSK between initiator and receiver. Mode B (caller-supplied)."""
+    return str(uuid.uuid4())
+
+
+@pytest.fixture(scope="module")
+def initiator_client(live_kamiwaza_client: KamiwazaClient) -> KamiwazaClient:
+    """Local cluster as initiator of the federation."""
+    return live_kamiwaza_client
+
+
+@pytest.fixture(scope="module")
+def receiver_client(live_kamiwaza_peer_client: KamiwazaClient) -> KamiwazaClient:
+    """Peer cluster as receiver of the federation."""
+    return live_kamiwaza_peer_client
+
+
+@pytest.fixture(scope="module")
+def initiator_cluster_uuid(initiator_client: KamiwazaClient) -> str:
+    """UUID of the initiator cluster. Used to build brokered external_ids."""
+    capabilities = initiator_client.cluster.capabilities()
+    cluster_id = getattr(capabilities, "cluster_id", None) or getattr(
+        capabilities, "id", None
+    )
+    if not cluster_id:
+        pytest.fail(
+            "initiator cluster.capabilities() returned no cluster_id; "
+            f"got {capabilities!r}"
+        )
+    return str(cluster_id)
+
+
+@pytest.fixture(scope="module")
+def paired_federation(
+    initiator_client: KamiwazaClient,
+    receiver_client: KamiwazaClient,
+    federation_pair_name: str,
+    shared_psk: str,
+    live_peer_base_url: str,
+) -> Iterator[dict[str, str]]:
+    """Establish a federation pair for the test module. Tears down at exit.
+
+    Yields a dict with the federation_id on both sides plus the pair name
+    so individual tests can stitch onto the live state.
+    """
+    # Receiver creates its side first (WAITING state) so the initiator's
+    # /pair handshake has something to hit.
+    initiator_base = os.environ.get("KAMIWAZA_BASE_URL") or initiator_client.base_url
+    receiver_fed = receiver_client.federations.pair(
+        name=federation_pair_name,
+        role="receiver",
+        remote_url=initiator_base,
+        preshared_key=shared_psk,
+    )
+
+    # Initiator drives the handshake (PSK barrier exercised here).
+    initiator_fed = initiator_client.federations.pair(
+        name=federation_pair_name,
+        role="initiator",
+        remote_url=live_peer_base_url,
+        preshared_key=shared_psk,
+    )
+
+    state = {
+        "initiator_id": str(initiator_fed.id),
+        "receiver_id": str(receiver_fed.id),
+        "name": federation_pair_name,
+    }
+    try:
+        yield state
+    finally:
+        # Best-effort unpair on both sides — failures during teardown
+        # shouldn't mask test failures.
+        for client_label, client, fed_id in (
+            ("initiator", initiator_client, state["initiator_id"]),
+            ("receiver", receiver_client, state["receiver_id"]),
+        ):
+            try:
+                client._request("POST", f"/cluster/federations/{fed_id}/disconnect")
+            except Exception as exc:  # pragma: no cover - teardown best-effort
+                print(
+                    f"warning: failed to disconnect {client_label} federation "
+                    f"{fed_id}: {exc}"
+                )
+
+
+class TestFederationTwoClusterWalkthrough:
+    """Live two-cluster federation walkthrough — counterpart to the mocked
+    ``test_federation_skeleton_walkthrough.py`` flow.
+    """
+
+    def test_paired_state_visible_on_both_sides(
+        self,
+        paired_federation: dict[str, str],
+        initiator_client: KamiwazaClient,
+        receiver_client: KamiwazaClient,
+    ) -> None:
+        """Pair handshake completes; both clusters see the federation."""
+        initiator_view = initiator_client._request(
+            "GET", f"/cluster/federations/{paired_federation['initiator_id']}"
+        )
+        receiver_view = receiver_client._request(
+            "GET", f"/cluster/federations/{paired_federation['receiver_id']}"
+        )
+        assert isinstance(initiator_view, dict)
+        assert isinstance(receiver_view, dict)
+        # Status is PAIRED after the /pair handshake completes; receivers
+        # may surface ACTIVE or PAIRED depending on backend version.
+        assert initiator_view["status"] in {"PAIRED", "ACTIVE"}
+        assert receiver_view["status"] in {"PAIRED", "ACTIVE", "WAITING"}
+
+    def test_capabilities_probe_via_mesh(
+        self,
+        paired_federation: dict[str, str],
+        initiator_client: KamiwazaClient,
+    ) -> None:
+        """T5.21 — initiator can probe the receiver's capabilities through the
+        mesh. Validates the federation:operator ReBAC guard + HMAC signing.
+        """
+        proxy = initiator_client.federations[paired_federation["name"]]
+        capabilities = proxy.probe()
+        # ClusterCapabilities is a pydantic model — probe() raises if the
+        # mesh hop or capability schema fails. Existence of a cluster_id
+        # is the load-bearing signal.
+        cluster_id = getattr(capabilities, "cluster_id", None) or getattr(
+            capabilities, "id", None
+        )
+        assert cluster_id, f"peer capabilities missing cluster id: {capabilities!r}"
+
+    def test_brokered_user_allowlist_round_trip(
+        self,
+        paired_federation: dict[str, str],
+        initiator_client: KamiwazaClient,
+        initiator_cluster_uuid: str,
+        receiver_client: KamiwazaClient,
+    ) -> None:
+        """FR-51 / FR-80 — receiver allowlists a brokered user from the
+        initiator. Auto-provisioning happens on first mesh request; we
+        validate only that the allowlist write succeeds and the record
+        is queryable.
+        """
+        external_id = (
+            f"eng5784-brokered-{uuid.uuid4().hex[:6]}@{initiator_cluster_uuid}"
+        )
+        proxy = receiver_client.federations[paired_federation["name"]]
+        brokered = proxy.users.add(external_id=external_id)
+        assert brokered.external_id == external_id
+        # auto_provisioned starts False — flips True on the user's first
+        # mesh-origin request. We don't drive that here; the cmd_m3 smoke
+        # script does that end-to-end.
+
+    def test_federated_job_audit_actor_round_trip(
+        self,
+        paired_federation: dict[str, str],
+        initiator_client: KamiwazaClient,
+    ) -> None:
+        """The WS-M1 demo-gate signal: a federated job runs as the
+        originating user, not as a system principal. Audit-actor round-trip
+        is the proof. T5.22 / ENG-4699.
+        """
+        # Use the recoverable path so we get the job_id back immediately
+        # and can poll for the terminal state.
+        result = initiator_client.jobs.run(
+            entrypoint='python -c "print(\\"eng5784\\")"',
+            target_cluster=paired_federation["name"],
+            timeout_seconds=120,
+            recoverable=True,
+        )
+        assert result.status in {
+            "SUCCEEDED",
+            "FAILED",
+        }, f"job did not reach terminal state: {result}"
+        # The audit_actor field is the demo-gate signal. Backend versions
+        # may name it audit_actor / requester / submitter — accept any
+        # non-None identity-like attribute as the round-trip proof.
+        actor = (
+            getattr(result, "audit_actor", None)
+            or getattr(result, "requester", None)
+            or getattr(result, "submitter", None)
+        )
+        assert actor, f"job result missing audit-actor identity: {result}"
+
+    def test_retrieval_surface_reachable_on_both_clusters(
+        self,
+        paired_federation: dict[str, str],
+        initiator_client: KamiwazaClient,
+        receiver_client: KamiwazaClient,
+    ) -> None:
+        """Smoke that the federated retrieval list endpoint is reachable
+        on both clusters after pairing. Doesn't drive a federated query
+        (the cmd_m3 smoke covers that); validates the surface is alive
+        and the pair didn't break retrieval routing.
+        """
+        # list() returns [] when no jobs — non-empty is fine but not required.
+        assert isinstance(initiator_client.retrieval.list(limit=1), list)
+        assert isinstance(receiver_client.retrieval.list(limit=1), list)
+
+    def test_unpair_returns_to_clean_state(
+        self,
+        paired_federation: dict[str, str],
+        initiator_client: KamiwazaClient,
+    ) -> None:
+        """Disconnect the federation from the initiator side mid-suite to
+        prove the unpair path. Final teardown handles any leftover state.
+        """
+        initiator_client._request(
+            "POST",
+            f"/cluster/federations/{paired_federation['initiator_id']}/disconnect",
+        )
+        # Give the receiver a brief moment to observe the disconnect.
+        time.sleep(1)
+        view = initiator_client._request(
+            "GET", f"/cluster/federations/{paired_federation['initiator_id']}"
+        )
+        assert isinstance(view, dict)
+        assert view["status"] in {"DISCONNECTED", "DEAD", "WAITING"}, view

--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -66,14 +66,22 @@ def receiver_client(live_kamiwaza_peer_client: KamiwazaClient) -> KamiwazaClient
 
 @pytest.fixture(scope="module")
 def initiator_cluster_uuid(initiator_client: KamiwazaClient) -> str:
-    """UUID of the initiator cluster. Used to build brokered external_ids."""
+    """UUID of the initiator cluster. Used to build brokered external_ids.
+
+    Reads ``local_node_id`` from ``cluster.capabilities()`` — that's the
+    canonical cluster-identity UUID in the ClusterCapabilities schema.
+    Falls back to ``cluster_id`` / ``id`` for backend versions that may
+    expose alternate field names.
+    """
     capabilities = initiator_client.cluster.capabilities()
-    cluster_id = getattr(capabilities, "cluster_id", None) or getattr(
-        capabilities, "id", None
+    cluster_id = (
+        getattr(capabilities, "local_node_id", None)
+        or getattr(capabilities, "cluster_id", None)
+        or getattr(capabilities, "id", None)
     )
     if not cluster_id:
         pytest.fail(
-            "initiator cluster.capabilities() returned no cluster_id; "
+            "initiator cluster.capabilities() returned no identifying UUID; "
             f"got {capabilities!r}"
         )
     return str(cluster_id)
@@ -263,12 +271,15 @@ class TestFederationTwoClusterWalkthrough:
         proxy = initiator_client.federations[paired_federation["name"]]
         capabilities = proxy.probe()
         # ClusterCapabilities is a pydantic model — probe() raises if the
-        # mesh hop or capability schema fails. Existence of a cluster_id
-        # is the load-bearing signal.
-        cluster_id = getattr(capabilities, "cluster_id", None) or getattr(
-            capabilities, "id", None
+        # mesh hop or capability schema fails. Existence of any identifying
+        # UUID is the load-bearing signal. local_node_id is the canonical
+        # field; cluster_id/id are accepted for backend version variance.
+        cluster_id = (
+            getattr(capabilities, "local_node_id", None)
+            or getattr(capabilities, "cluster_id", None)
+            or getattr(capabilities, "id", None)
         )
-        assert cluster_id, f"peer capabilities missing cluster id: {capabilities!r}"
+        assert cluster_id, f"peer capabilities missing identifying UUID: {capabilities!r}"
 
     def test_brokered_user_allowlist_round_trip(
         self,

--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -18,7 +18,7 @@ reference_fleet_validation_hosts.md).
 
 from __future__ import annotations
 
-import os
+import logging
 import time
 import uuid
 from typing import Iterator
@@ -27,8 +27,12 @@ import pytest
 
 from kamiwaza_sdk import KamiwazaClient
 
+logger = logging.getLogger(__name__)
+
 pytestmark = [
+    pytest.mark.integration,
     pytest.mark.live,
+    pytest.mark.withoutresponses,
     pytest.mark.requires_two_clusters,
 ]
 
@@ -46,9 +50,12 @@ def shared_psk() -> str:
 
 
 @pytest.fixture(scope="module")
-def initiator_client(live_kamiwaza_client: KamiwazaClient) -> KamiwazaClient:
-    """Local cluster as initiator of the federation."""
-    return live_kamiwaza_client
+def initiator_client(live_kamiwaza_session_client: KamiwazaClient) -> KamiwazaClient:
+    """Local cluster as initiator. Uses the session-scoped client so this
+    module-scoped fixture's scope chain is consistent (depending on the
+    function-scoped ``live_kamiwaza_client`` would raise ScopeMismatch).
+    """
+    return live_kamiwaza_session_client
 
 
 @pytest.fixture(scope="module")
@@ -86,26 +93,46 @@ def paired_federation(
     so individual tests can stitch onto the live state.
     """
     # Receiver creates its side first (WAITING state) so the initiator's
-    # /pair handshake has something to hit.
-    initiator_base = os.environ.get("KAMIWAZA_BASE_URL") or initiator_client.base_url
+    # /pair handshake has something to hit. Use initiator_client.base_url
+    # as the single source of truth for the callback host — reading
+    # KAMIWAZA_BASE_URL separately would misroute the receiver when a
+    # contributor passes --live-base-url overriding the env var.
     receiver_fed = receiver_client.federations.pair(
         name=federation_pair_name,
         role="receiver",
-        remote_url=initiator_base,
+        remote_url=initiator_client.base_url,
         preshared_key=shared_psk,
     )
+    receiver_fed_id = str(receiver_fed.id)
 
-    # Initiator drives the handshake (PSK barrier exercised here).
-    initiator_fed = initiator_client.federations.pair(
-        name=federation_pair_name,
-        role="initiator",
-        remote_url=live_peer_base_url,
-        preshared_key=shared_psk,
-    )
+    # Initiator drives the handshake (PSK barrier exercised here). If
+    # initiator pair raises after the receiver-side record was created,
+    # best-effort clean up the orphaned receiver federation before
+    # re-raising so the next run doesn't collide on stale state.
+    try:
+        initiator_fed = initiator_client.federations.pair(
+            name=federation_pair_name,
+            role="initiator",
+            remote_url=live_peer_base_url,
+            preshared_key=shared_psk,
+        )
+    except Exception:
+        try:
+            receiver_client._request(
+                "POST", f"/cluster/federations/{receiver_fed_id}/disconnect"
+            )
+        except Exception as cleanup_exc:  # pragma: no cover - best effort
+            logger.warning(
+                "failed to clean up orphaned receiver federation %s after "
+                "initiator pair failure: %s",
+                receiver_fed_id,
+                cleanup_exc,
+            )
+        raise
 
     state = {
         "initiator_id": str(initiator_fed.id),
-        "receiver_id": str(receiver_fed.id),
+        "receiver_id": receiver_fed_id,
         "name": federation_pair_name,
     }
     try:
@@ -120,15 +147,88 @@ def paired_federation(
             try:
                 client._request("POST", f"/cluster/federations/{fed_id}/disconnect")
             except Exception as exc:  # pragma: no cover - teardown best-effort
-                print(
-                    f"warning: failed to disconnect {client_label} federation "
-                    f"{fed_id}: {exc}"
+                logger.warning(
+                    "failed to disconnect %s federation %s: %s",
+                    client_label,
+                    fed_id,
+                    exc,
+                )
+
+
+@pytest.fixture
+def unpaired_federation(
+    initiator_client: KamiwazaClient,
+    receiver_client: KamiwazaClient,
+    shared_psk: str,
+    live_peer_base_url: str,
+) -> Iterator[dict[str, str]]:
+    """Fresh function-scoped pair for tests that mutate pair lifecycle state.
+
+    The module-scoped ``paired_federation`` is a shared resource; tests
+    like ``test_unpair_returns_to_clean_state`` would otherwise create
+    order-dependent suite behavior. This fixture stands up a separate
+    federation with a unique name per test, so mutating its state
+    doesn't affect the module-scoped pair.
+    """
+    fresh_name = f"eng5784-unpair-{uuid.uuid4().hex[:8]}"
+    receiver_fed = receiver_client.federations.pair(
+        name=fresh_name,
+        role="receiver",
+        remote_url=initiator_client.base_url,
+        preshared_key=shared_psk,
+    )
+    receiver_fed_id = str(receiver_fed.id)
+    try:
+        initiator_fed = initiator_client.federations.pair(
+            name=fresh_name,
+            role="initiator",
+            remote_url=live_peer_base_url,
+            preshared_key=shared_psk,
+        )
+    except Exception:
+        try:
+            receiver_client._request(
+                "POST", f"/cluster/federations/{receiver_fed_id}/disconnect"
+            )
+        except Exception as cleanup_exc:  # pragma: no cover - best effort
+            logger.warning(
+                "failed to clean up orphaned receiver federation %s: %s",
+                receiver_fed_id,
+                cleanup_exc,
+            )
+        raise
+
+    state = {
+        "initiator_id": str(initiator_fed.id),
+        "receiver_id": receiver_fed_id,
+        "name": fresh_name,
+    }
+    try:
+        yield state
+    finally:
+        for client_label, client, fed_id in (
+            ("initiator", initiator_client, state["initiator_id"]),
+            ("receiver", receiver_client, state["receiver_id"]),
+        ):
+            try:
+                client._request("POST", f"/cluster/federations/{fed_id}/disconnect")
+            except Exception as exc:  # pragma: no cover - teardown best-effort
+                logger.warning(
+                    "failed to disconnect %s federation %s: %s",
+                    client_label,
+                    fed_id,
+                    exc,
                 )
 
 
 class TestFederationTwoClusterWalkthrough:
     """Live two-cluster federation walkthrough — counterpart to the mocked
     ``test_federation_skeleton_walkthrough.py`` flow.
+
+    TODO(WS-M2): replace direct ``client._request("GET"/"POST", ...)``
+    calls with typed wrappers once federation introspection
+    (``client.federations[name].get()`` and ``.disconnect()``) lands on
+    the canonical SDK surface.
     """
 
     def test_paired_state_visible_on_both_sides(
@@ -137,7 +237,10 @@ class TestFederationTwoClusterWalkthrough:
         initiator_client: KamiwazaClient,
         receiver_client: KamiwazaClient,
     ) -> None:
-        """Pair handshake completes; both clusters see the federation."""
+        """Initiator settles into PAIRED/ACTIVE after the handshake; receiver
+        may still be observed as WAITING immediately post-handshake on
+        some backend versions (the asymmetric tolerance is intentional).
+        """
         initiator_view = initiator_client._request(
             "GET", f"/cluster/federations/{paired_federation['initiator_id']}"
         )
@@ -146,8 +249,6 @@ class TestFederationTwoClusterWalkthrough:
         )
         assert isinstance(initiator_view, dict)
         assert isinstance(receiver_view, dict)
-        # Status is PAIRED after the /pair handshake completes; receivers
-        # may surface ACTIVE or PAIRED depending on backend version.
         assert initiator_view["status"] in {"PAIRED", "ACTIVE"}
         assert receiver_view["status"] in {"PAIRED", "ACTIVE", "WAITING"}
 
@@ -239,20 +340,26 @@ class TestFederationTwoClusterWalkthrough:
 
     def test_unpair_returns_to_clean_state(
         self,
-        paired_federation: dict[str, str],
+        unpaired_federation: dict[str, str],
         initiator_client: KamiwazaClient,
     ) -> None:
-        """Disconnect the federation from the initiator side mid-suite to
-        prove the unpair path. Final teardown handles any leftover state.
+        """Disconnect the federation from the initiator side and assert the
+        initiator-side status reflects the disconnect. Uses a dedicated
+        fresh-pair fixture (``unpaired_federation``) so this test doesn't
+        mutate the module-scoped ``paired_federation`` state — other tests
+        stay order-independent.
         """
         initiator_client._request(
             "POST",
-            f"/cluster/federations/{paired_federation['initiator_id']}/disconnect",
+            f"/cluster/federations/{unpaired_federation['initiator_id']}/disconnect",
         )
-        # Give the receiver a brief moment to observe the disconnect.
+        # Brief settle window — the disconnect is synchronous on the
+        # initiator side, but the status field may be eventually
+        # consistent across the request/response boundary on slower
+        # backends.
         time.sleep(1)
         view = initiator_client._request(
-            "GET", f"/cluster/federations/{paired_federation['initiator_id']}"
+            "GET", f"/cluster/federations/{unpaired_federation['initiator_id']}"
         )
         assert isinstance(view, dict)
         assert view["status"] in {"DISCONNECTED", "DEAD", "WAITING"}, view

--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -279,7 +279,9 @@ class TestFederationTwoClusterWalkthrough:
             or getattr(capabilities, "cluster_id", None)
             or getattr(capabilities, "id", None)
         )
-        assert cluster_id, f"peer capabilities missing identifying UUID: {capabilities!r}"
+        assert (
+            cluster_id
+        ), f"peer capabilities missing identifying UUID: {capabilities!r}"
 
     def test_brokered_user_allowlist_round_trip(
         self,
@@ -292,13 +294,24 @@ class TestFederationTwoClusterWalkthrough:
         initiator. Auto-provisioning happens on first mesh request; we
         validate only that the allowlist write succeeds and the record
         is queryable.
+
+        Uses the receiver-side federation ID (not the operator-supplied
+        name) because the pair handshake overwrites the receiver's
+        ``remote_cluster_name`` with the initiator's cluster name —
+        ``federations[name]`` lookup-by-name fails on the receiver
+        post-pair. POST the user record directly against the
+        receiver-side ID, mirroring how setup.py / cmd_m3 drives this.
         """
         external_id = (
             f"eng5784-brokered-{uuid.uuid4().hex[:6]}@{initiator_cluster_uuid}"
         )
-        proxy = receiver_client.federations[paired_federation["name"]]
-        brokered = proxy.users.add(external_id=external_id)
-        assert brokered.external_id == external_id
+        brokered = receiver_client._request(
+            "POST",
+            f"/cluster/federations/{paired_federation['receiver_id']}/users",
+            json={"external_id": external_id},
+        )
+        assert isinstance(brokered, dict)
+        assert brokered["external_id"] == external_id
         # auto_provisioned starts False — flips True on the user's first
         # mesh-origin request. We don't drive that here; the cmd_m3 smoke
         # script does that end-to-end.

--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -19,9 +19,11 @@ reference_fleet_validation_hosts.md).
 from __future__ import annotations
 
 import logging
+import os
 import time
 import uuid
 from typing import Iterator
+from urllib.parse import urlparse
 
 import pytest
 
@@ -47,6 +49,34 @@ def federation_pair_name() -> str:
 def shared_psk() -> str:
     """Shared PSK between initiator and receiver. Mode B (caller-supplied)."""
     return str(uuid.uuid4())
+
+
+@pytest.fixture(scope="module")
+def initiator_callback_url(initiator_client: KamiwazaClient) -> str:
+    """Routable URL the peer cluster uses to call back to the initiator.
+
+    Operator-supplied via ``KAMIWAZA_INITIATOR_CALLBACK_HOST`` (or
+    ``KAMIWAZA_INITIATOR_CALLBACK_URL``). Required when the initiator's
+    ``base_url`` host doesn't resolve to a routable address from the
+    peer's perspective — common on fleet rigs where both clusters share
+    a domain (e.g. both expose ``https://kamiwaza.test/api`` but each
+    resolves locally to its own ingress).
+
+    Fallback: derive from ``initiator_client.base_url`` host. Works when
+    both clusters can resolve a shared hostname to the right cluster
+    (e.g. split DNS in production), but the smoke fleet rig requires
+    the override.
+    """
+    explicit = os.environ.get("KAMIWAZA_INITIATOR_CALLBACK_URL", "").strip()
+    if explicit:
+        return explicit.rstrip("/")
+    host = os.environ.get("KAMIWAZA_INITIATOR_CALLBACK_HOST", "").strip()
+    if host:
+        # Match the ``base_url`` scheme + path so the receiver pairs at
+        # the same /api root.
+        parsed = urlparse(initiator_client.base_url)
+        return f"{parsed.scheme}://{host}{parsed.path}".rstrip("/")
+    return initiator_client.base_url.rstrip("/")
 
 
 @pytest.fixture(scope="module")
@@ -86,6 +116,7 @@ def paired_federation(
     federation_pair_name: str,
     shared_psk: str,
     live_peer_base_url: str,
+    initiator_callback_url: str,
 ) -> Iterator[dict[str, str]]:
     """Establish a federation pair for the test module. Tears down at exit.
 
@@ -100,7 +131,7 @@ def paired_federation(
     receiver_fed = receiver_client.federations.pair(
         name=federation_pair_name,
         role="receiver",
-        remote_url=initiator_client.base_url,
+        remote_url=initiator_callback_url,
         preshared_key=shared_psk,
     )
     receiver_fed_id = str(receiver_fed.id)
@@ -161,6 +192,7 @@ def unpaired_federation(
     receiver_client: KamiwazaClient,
     shared_psk: str,
     live_peer_base_url: str,
+    initiator_callback_url: str,
 ) -> Iterator[dict[str, str]]:
     """Fresh function-scoped pair for tests that mutate pair lifecycle state.
 
@@ -174,7 +206,7 @@ def unpaired_federation(
     receiver_fed = receiver_client.federations.pair(
         name=fresh_name,
         role="receiver",
-        remote_url=initiator_client.base_url,
+        remote_url=initiator_callback_url,
         preshared_key=shared_psk,
     )
     receiver_fed_id = str(receiver_fed.id)

--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -19,11 +19,9 @@ reference_fleet_validation_hosts.md).
 from __future__ import annotations
 
 import logging
-import os
 import time
 import uuid
 from typing import Iterator
-from urllib.parse import urlparse
 
 import pytest
 
@@ -49,34 +47,6 @@ def federation_pair_name() -> str:
 def shared_psk() -> str:
     """Shared PSK between initiator and receiver. Mode B (caller-supplied)."""
     return str(uuid.uuid4())
-
-
-@pytest.fixture(scope="module")
-def initiator_callback_url(initiator_client: KamiwazaClient) -> str:
-    """Routable URL the peer cluster uses to call back to the initiator.
-
-    Operator-supplied via ``KAMIWAZA_INITIATOR_CALLBACK_HOST`` (or
-    ``KAMIWAZA_INITIATOR_CALLBACK_URL``). Required when the initiator's
-    ``base_url`` host doesn't resolve to a routable address from the
-    peer's perspective — common on fleet rigs where both clusters share
-    a domain (e.g. both expose ``https://kamiwaza.test/api`` but each
-    resolves locally to its own ingress).
-
-    Fallback: derive from ``initiator_client.base_url`` host. Works when
-    both clusters can resolve a shared hostname to the right cluster
-    (e.g. split DNS in production), but the smoke fleet rig requires
-    the override.
-    """
-    explicit = os.environ.get("KAMIWAZA_INITIATOR_CALLBACK_URL", "").strip()
-    if explicit:
-        return explicit.rstrip("/")
-    host = os.environ.get("KAMIWAZA_INITIATOR_CALLBACK_HOST", "").strip()
-    if host:
-        # Match the ``base_url`` scheme + path so the receiver pairs at
-        # the same /api root.
-        parsed = urlparse(initiator_client.base_url)
-        return f"{parsed.scheme}://{host}{parsed.path}".rstrip("/")
-    return initiator_client.base_url.rstrip("/")
 
 
 @pytest.fixture(scope="module")
@@ -116,7 +86,6 @@ def paired_federation(
     federation_pair_name: str,
     shared_psk: str,
     live_peer_base_url: str,
-    initiator_callback_url: str,
 ) -> Iterator[dict[str, str]]:
     """Establish a federation pair for the test module. Tears down at exit.
 
@@ -124,14 +93,15 @@ def paired_federation(
     so individual tests can stitch onto the live state.
     """
     # Receiver creates its side first (WAITING state) so the initiator's
-    # /pair handshake has something to hit. Use initiator_client.base_url
-    # as the single source of truth for the callback host — reading
-    # KAMIWAZA_BASE_URL separately would misroute the receiver when a
-    # contributor passes --live-base-url overriding the env var.
+    # /pair handshake has something to hit. The receiver record only
+    # needs name + role + psk — it doesn't need a callback URL because
+    # the initiator reaches out, not the other way around. Passing
+    # remote_url on the receiver side derives a wrong remote_ips entry
+    # (the receiver doesn't need to know the initiator's location).
+    # Mirrors the kamiwaza-smoke.py federation-pair flow at services.py.
     receiver_fed = receiver_client.federations.pair(
         name=federation_pair_name,
         role="receiver",
-        remote_url=initiator_callback_url,
         preshared_key=shared_psk,
     )
     receiver_fed_id = str(receiver_fed.id)
@@ -192,7 +162,6 @@ def unpaired_federation(
     receiver_client: KamiwazaClient,
     shared_psk: str,
     live_peer_base_url: str,
-    initiator_callback_url: str,
 ) -> Iterator[dict[str, str]]:
     """Fresh function-scoped pair for tests that mutate pair lifecycle state.
 
@@ -206,7 +175,6 @@ def unpaired_federation(
     receiver_fed = receiver_client.federations.pair(
         name=fresh_name,
         role="receiver",
-        remote_url=initiator_callback_url,
         preshared_key=shared_psk,
     )
     receiver_fed_id = str(receiver_fed.id)

--- a/tests/unit/test_kamiwaza_sdk_services_federations.py
+++ b/tests/unit/test_kamiwaza_sdk_services_federations.py
@@ -517,7 +517,7 @@ def test_pair_forwards_all_four_brokering_kwargs_when_supplied() -> None:
             "https://lyra.example.com/realms/kamiwaza/protocol/openid-connect/certs"
         ),
         local_broker_client_id="kamiwaza-broker",
-        local_broker_client_secret="test-secret-x",
+        local_broker_client_secret="urn:li:dataHubSecret:test-broker",
     )
 
     _, body = _create_call(client)
@@ -528,7 +528,11 @@ def test_pair_forwards_all_four_brokering_kwargs_when_supplied() -> None:
         "https://lyra.example.com/realms/kamiwaza/protocol/openid-connect/certs"
     )
     assert body.get("local_broker_client_id") == "kamiwaza-broker"
-    assert body.get("local_broker_client_secret") == "test-secret-x"
+    # URN-only contract — the SDK passes through verbatim; the server's
+    # @validator at the schema layer refuses raw secrets with a 422.
+    assert body.get("local_broker_client_secret") == (
+        "urn:li:dataHubSecret:test-broker"
+    )
 
 
 def test_pair_omits_brokering_kwargs_when_not_supplied() -> None:

--- a/tests/unit/test_kamiwaza_sdk_services_federations.py
+++ b/tests/unit/test_kamiwaza_sdk_services_federations.py
@@ -512,23 +512,23 @@ def test_pair_forwards_all_four_brokering_kwargs_when_supplied() -> None:
         name="ORION",
         role="initiator",
         remote_url="https://orion.example.com",
-        peer_kc_issuer_url="https://lyra.example.com/realms/kamiwaza",
-        peer_kc_jwks_url=(
+        local_kc_issuer_url="https://lyra.example.com/realms/kamiwaza",
+        local_kc_jwks_url=(
             "https://lyra.example.com/realms/kamiwaza/protocol/openid-connect/certs"
         ),
-        peer_broker_client_id="kamiwaza-broker",
-        peer_broker_client_secret="test-secret-x",
+        local_broker_client_id="kamiwaza-broker",
+        local_broker_client_secret="test-secret-x",
     )
 
     _, body = _create_call(client)
-    assert body.get("peer_kc_issuer_url") == (
+    assert body.get("local_kc_issuer_url") == (
         "https://lyra.example.com/realms/kamiwaza"
     )
-    assert body.get("peer_kc_jwks_url") == (
+    assert body.get("local_kc_jwks_url") == (
         "https://lyra.example.com/realms/kamiwaza/protocol/openid-connect/certs"
     )
-    assert body.get("peer_broker_client_id") == "kamiwaza-broker"
-    assert body.get("peer_broker_client_secret") == "test-secret-x"
+    assert body.get("local_broker_client_id") == "kamiwaza-broker"
+    assert body.get("local_broker_client_secret") == "test-secret-x"
 
 
 def test_pair_omits_brokering_kwargs_when_not_supplied() -> None:
@@ -549,10 +549,10 @@ def test_pair_omits_brokering_kwargs_when_not_supplied() -> None:
 
     _, body = _create_call(client)
     for key in (
-        "peer_kc_issuer_url",
-        "peer_kc_jwks_url",
-        "peer_broker_client_id",
-        "peer_broker_client_secret",
+        "local_kc_issuer_url",
+        "local_kc_jwks_url",
+        "local_broker_client_id",
+        "local_broker_client_secret",
     ):
         assert key not in body, f"unexpected {key!r} in default-mode body"
 
@@ -572,16 +572,16 @@ def test_pair_forwards_partial_brokering_kwargs_to_server() -> None:
         name="ORION",
         role="initiator",
         remote_url="https://orion.example.com",
-        peer_kc_issuer_url="https://lyra.example.com/realms/kamiwaza",
+        local_kc_issuer_url="https://lyra.example.com/realms/kamiwaza",
     )
 
     _, body = _create_call(client)
-    assert body.get("peer_kc_issuer_url") == (
+    assert body.get("local_kc_issuer_url") == (
         "https://lyra.example.com/realms/kamiwaza"
     )
     for key in (
-        "peer_kc_jwks_url",
-        "peer_broker_client_id",
-        "peer_broker_client_secret",
+        "local_kc_jwks_url",
+        "local_broker_client_id",
+        "local_broker_client_secret",
     ):
         assert key not in body, f"unexpected {key!r} in partial-mode body"

--- a/tests/unit/test_kamiwaza_sdk_services_federations.py
+++ b/tests/unit/test_kamiwaza_sdk_services_federations.py
@@ -491,3 +491,97 @@ def test_federation_aware_services_reexported_from_kamiwaza_sdk_services() -> No
     }
     missing = expected - set(services.__all__)
     assert not missing, f"missing from kamiwaza_sdk.services.__all__: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# ENG-5822 — per-pair brokering kwargs forward to create body
+# ---------------------------------------------------------------------------
+
+
+def test_pair_forwards_all_four_brokering_kwargs_when_supplied() -> None:
+    """ENG-5822 — when caller supplies the brokering tuple, all 4 fields
+    land on the create body so the server can persist them onto the
+    federation row. Mirrors the callback_hostname forwarding pattern."""
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    _stage_pair_responses(client)
+
+    api = FederationsAPI(client)
+    api.pair(
+        name="ORION",
+        role="initiator",
+        remote_url="https://orion.example.com",
+        peer_kc_issuer_url="https://lyra.example.com/realms/kamiwaza",
+        peer_kc_jwks_url=(
+            "https://lyra.example.com/realms/kamiwaza/protocol/openid-connect/certs"
+        ),
+        peer_broker_client_id="kamiwaza-broker",
+        peer_broker_client_secret="test-secret-x",
+    )
+
+    _, body = _create_call(client)
+    assert body.get("peer_kc_issuer_url") == (
+        "https://lyra.example.com/realms/kamiwaza"
+    )
+    assert body.get("peer_kc_jwks_url") == (
+        "https://lyra.example.com/realms/kamiwaza/protocol/openid-connect/certs"
+    )
+    assert body.get("peer_broker_client_id") == "kamiwaza-broker"
+    assert body.get("peer_broker_client_secret") == "test-secret-x"
+
+
+def test_pair_omits_brokering_kwargs_when_not_supplied() -> None:
+    """Pre-ENG-5822 callers: omitting the brokering kwargs leaves the
+    body unchanged, so the cluster's env-driven default path (KAMIWAZA_KC_*)
+    remains in effect server-side."""
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    _stage_pair_responses(client)
+
+    api = FederationsAPI(client)
+    api.pair(
+        name="ORION",
+        role="initiator",
+        remote_url="https://orion.example.com",
+    )
+
+    _, body = _create_call(client)
+    for key in (
+        "peer_kc_issuer_url",
+        "peer_kc_jwks_url",
+        "peer_broker_client_id",
+        "peer_broker_client_secret",
+    ):
+        assert key not in body, f"unexpected {key!r} in default-mode body"
+
+
+def test_pair_forwards_partial_brokering_kwargs_to_server() -> None:
+    """The SDK doesn't enforce the all-four-together contract client-side
+    — it lets the server's atomic validator surface the canonical error
+    (one source of truth for the contract). A partial set reaches the
+    server, which then refuses with a 422."""
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    _stage_pair_responses(client)
+
+    api = FederationsAPI(client)
+    api.pair(
+        name="ORION",
+        role="initiator",
+        remote_url="https://orion.example.com",
+        peer_kc_issuer_url="https://lyra.example.com/realms/kamiwaza",
+    )
+
+    _, body = _create_call(client)
+    assert body.get("peer_kc_issuer_url") == (
+        "https://lyra.example.com/realms/kamiwaza"
+    )
+    for key in (
+        "peer_kc_jwks_url",
+        "peer_broker_client_id",
+        "peer_broker_client_secret",
+    ):
+        assert key not in body, f"unexpected {key!r} in partial-mode body"


### PR DESCRIPTION
## Summary

Live counterpart to `test_federation_skeleton_walkthrough.py` (the mocked version). Exercises the WS-M1+ federation surface end-to-end against a real peer cluster: **pair (PSK barrier exercised) → capabilities probe via mesh → brokered user allowlist → federated job (audit-actor round-trip) → retrieval surface smoke → clean unpair**.

## What's added

- `requires_two_clusters` pytest marker in `pyproject.toml`
- `--live-peer-base-url` / `--live-peer-api-key` CLI options (default to env `KAMIWAZA_PEER_BASE_URL` / `KAMIWAZA_PEER_API_KEY`)
- `live_peer_base_url` / `live_peer_api_key` session fixtures
- `live_kamiwaza_peer_client` fixture
- Collection-side auto-deselection when peer creds are unset (mirrors `requires_embedding_model` pattern — contributor PRs without peer creds see no false reds)
- `tests/integration/test_federation_two_cluster_live.py` with the full pair-allowlist-run-audit-unpair walkthrough
- `tests/integration/README.md` documenting the env-var contract and marker behavior

## What's removed

12 dead `@pytest.mark.skip` placeholders in `test_cluster_live.py::TestFederationOperationsNotAvailable` — all `pass` bodies with no real assertions, never executable in any cluster configuration. Live federation coverage now lives in the new test file with the conditional marker.

## Initial peer rig

spark-1 ↔ evo-x2-1 (per fleet validation hosts). Validation in flight on both.

## Test plan

- [x] `uv run pytest tests/integration/test_federation_two_cluster_live.py --collect-only` reports `no tests collected (6 deselected)` when peer creds unset (auto-deselection working)
- [x] `ruff check` clean
- [x] `black` formatted
- [x] Full unit suite passes (2 pre-existing failures on develop unrelated: `test_status_cmd::test_status_surfaces_deployer_annotation`, `test_convert_agent::test_sdk_exception_returns_none_with_api_call_failed_warning`)
- [ ] Live two-cluster run on spark-1 ↔ evo-x2-1 (in flight)
  - Pair handshake with PSK barrier exercised
  - Capabilities probe via mesh
  - Brokered user allowlist
  - Federated job with audit-actor round-trip
  - Retrieval list reachable on both clusters
  - Clean unpair

## Linear

- ENG-5784 — Two-cluster integration test harness — gate, conftest pattern, live walkthrough, replace 12 dead skips