### PR TITLE
ENG-5954: parse compose-spec long-form ports end-to-end

### DIFF
--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -576,10 +576,24 @@ def _rewrite_url_hosts(
     return new_value if new_value != value else None
 
 
-def _strip_host_ports(ports: List[Any]) -> List[str]:
-    """``"3000:3000"`` -> ``"3000"``; ``"8080:3000/tcp"`` -> ``"3000/tcp"``."""
-    result = []
+def _strip_host_ports(ports: List[Any]) -> List[Any]:
+    """``"3000:3000"`` -> ``"3000"``; ``"8080:3000/tcp"`` -> ``"3000/tcp"``.
+
+    Long-form (compose-spec dict) entries are preserved verbatim except
+    for ``published`` / ``host_ip``, which would otherwise re-introduce a
+    host port binding through the back door. ENG-5954: long-form is the
+    only way to carry L7 protocol hints (``name`` + ``app_protocol``)
+    through to the K8s Service.
+    """
+    result: List[Any] = []
     for port in ports:
+        if isinstance(port, dict):
+            cleaned = {
+                k: v for k, v in port.items() if k not in ("published", "host_ip")
+            }
+            if cleaned.get("target") is not None:
+                result.append(cleaned)
+            continue
         s = str(port)
         if ":" in s:
             # Take the part after the last colon (container port + optional protocol)

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -409,8 +409,23 @@ class PayloadBuilder:
 
     @staticmethod
     def _parse_ports(ports: List[Any]) -> List[ExtensionPort]:
+        """Translate compose-spec ports into CR ExtensionPort entries.
+
+        Accepts both short-form (``"19530"``, ``"19530/udp"``) and long-form
+        compose-spec port entries (``{target, protocol, name, app_protocol}``).
+        For short-form the port name defaults to ``"http"`` — matches the
+        long-standing app/tool extension behavior. Long-form entries pass
+        ``name`` and ``app_protocol`` through to the K8s Service, which
+        istio reads for L7 protocol selection (ENG-5954).
+        """
         result = []
         for p in ports:
+            if isinstance(p, dict):
+                parsed = PayloadBuilder._parse_port_dict(p)
+                if parsed is not None:
+                    result.append(parsed)
+                continue
+
             s = str(p)
             # Strip protocol suffix if present
             proto = "TCP"
@@ -426,6 +441,48 @@ class PayloadBuilder:
             except (ValueError, TypeError):
                 continue
         return result
+
+    @staticmethod
+    def _parse_port_dict(port: Dict[str, Any]) -> Optional[ExtensionPort]:
+        """Translate one compose-spec long-form port entry."""
+        # Compose-spec long-form: ``target`` is the container port.
+        # ``published`` (host port) is stripped upstream by the transformer's
+        # ``_strip_host_ports`` and never reaches this function in the normal
+        # pipeline — we don't fall back to it because doing so would silently
+        # promote a host-port intent into a container port for any direct
+        # caller that bypasses the transformer.
+        target = port.get("target")
+        if target is None:
+            return None
+
+        proto_raw = str(port.get("protocol", "tcp")).upper()
+        proto = proto_raw if proto_raw in ("TCP", "UDP") else "TCP"
+
+        # Long-form ports without an explicit name still default to "http"
+        # so existing extensions that adopt long-form syntax for unrelated
+        # reasons (e.g. adding ``protocol: tcp``) don't silently lose the
+        # historical port name.
+        name = port.get("name") or "http"
+
+        # Prefer the compose-spec ``app_protocol`` key; fall back to the
+        # k8s-shaped ``appProtocol`` only when the spec key is absent.
+        # Explicit ``in`` rather than ``or`` so an explicitly-empty
+        # ``app_protocol: ""`` is treated as "set to empty" rather than
+        # silently falling through to ``appProtocol``.
+        if "app_protocol" in port:
+            app_protocol = port["app_protocol"]
+        else:
+            app_protocol = port.get("appProtocol")
+
+        try:
+            return ExtensionPort(
+                container_port=int(target),
+                protocol=proto,
+                name=name,
+                app_protocol=app_protocol,
+            )
+        except (ValueError, TypeError):
+            return None
 
     @staticmethod
     def _parse_env(env: Any) -> List[Dict[str, Any]]:
@@ -666,11 +723,20 @@ def _should_use_node_frontend_probe(svc_name: str, svc: Dict[str, Any]) -> bool:
 
     ports = svc.get("ports", [])
     for port in ports:
-        port_str = str(port).split("/", 1)[0]
-        try:
-            container_port = int(port_str.rsplit(":", 1)[-1])
-        except ValueError:
-            continue
+        if isinstance(port, dict):
+            target = port.get("target")
+            if target is None:
+                continue
+            try:
+                container_port = int(target)
+            except (ValueError, TypeError):
+                continue
+        else:
+            port_str = str(port).split("/", 1)[0]
+            try:
+                container_port = int(port_str.rsplit(":", 1)[-1])
+            except ValueError:
+                continue
         if container_port in {3000, 3001, 4173, 5173}:
             return True
 

--- a/kamiwaza_extensions/validators/compose.py
+++ b/kamiwaza_extensions/validators/compose.py
@@ -97,9 +97,19 @@ class ComposeValidator:
             if not isinstance(svc_config, dict):
                 continue
 
-            # Host port bindings
+            # Host port bindings. Short-form (``"8000:8080"``) trips on the
+            # colon; long-form (``{"target": 8000, "published": 8080, ...}``)
+            # exposes the host-port intent via the ``published`` key.
             ports = svc_config.get("ports", [])
             for port in ports:
+                if isinstance(port, dict):
+                    if port.get("published") is not None:
+                        warnings.append(
+                            f"Service '{svc_name}': host port binding "
+                            f"'{port.get('published')}:{port.get('target')}' "
+                            "— may conflict in deployment"
+                        )
+                    continue
                 port_str = str(port)
                 if ":" in port_str:
                     warnings.append(f"Service '{svc_name}': host port binding '{port_str}' — may conflict in deployment")

--- a/kamiwaza_sdk/schemas/extensions.py
+++ b/kamiwaza_sdk/schemas/extensions.py
@@ -11,7 +11,13 @@ from pydantic import BaseModel, ConfigDict, Field
 class ExtensionPort(BaseModel):
     """Port exposed by an extension service container."""
 
-    model_config = ConfigDict(extra="allow")
+    # serialize_by_alias keeps ``appProtocol`` camelCase in the JSON payload
+    # even when the parent (CreateExtension / patch payloads) is dumped with
+    # default model_dump(). Without it the K8s API server sees the unknown
+    # ``app_protocol`` key and drops the field.
+    model_config = ConfigDict(
+        extra="allow", populate_by_name=True, serialize_by_alias=True
+    )
 
     name: Optional[str] = None
     container_port: int = Field(
@@ -19,6 +25,14 @@ class ExtensionPort(BaseModel):
     )
     protocol: Literal["TCP", "UDP"] = Field(
         default="TCP", description="Port protocol (TCP or UDP)"
+    )
+    # L7 protocol hint. Mirrors corev1.ServicePort.appProtocol; istio reads
+    # this to pick the right L7 filter (grpc, http, http2) instead of falling
+    # back to name-prefix sniffing.
+    app_protocol: Optional[str] = Field(
+        default=None,
+        alias="appProtocol",
+        description="Application protocol hint (e.g., http, http2, grpc)",
     )
 
 

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -69,6 +69,55 @@ class TestStripHostPorts:
         result = transformer.transform(compose, "test", "v1", "reg")
         assert result["services"]["web"]["ports"] == ["8000"]
 
+    def test_long_form_port_preserved_with_l7_hints(self, transformer):
+        """ENG-5954: compose-spec long-form ports must survive transform so
+        downstream PayloadBuilder can stamp name + appProtocol on the CR."""
+        compose = {
+            "services": {
+                "web": {
+                    "ports": [
+                        {
+                            "target": 19530,
+                            "protocol": "tcp",
+                            "name": "grpc",
+                            "app_protocol": "grpc",
+                        }
+                    ]
+                }
+            }
+        }
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["web"]["ports"] == [
+            {
+                "target": 19530,
+                "protocol": "tcp",
+                "name": "grpc",
+                "app_protocol": "grpc",
+            }
+        ]
+
+    def test_long_form_port_strips_published_and_host_ip(self, transformer):
+        """``published`` / ``host_ip`` are the long-form equivalents of
+        ``HOST:CONTAINER`` short-form — same stripping treatment."""
+        compose = {
+            "services": {
+                "web": {
+                    "ports": [
+                        {
+                            "target": 8080,
+                            "published": 8080,
+                            "host_ip": "127.0.0.1",
+                            "name": "http",
+                        }
+                    ]
+                }
+            }
+        }
+        result = transformer.transform(compose, "test", "v1", "reg")
+        assert result["services"]["web"]["ports"] == [
+            {"target": 8080, "name": "http"}
+        ]
+
 
 class TestStripBindMounts:
     def test_strips_relative_bind_mount(self, transformer):

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -101,6 +101,150 @@ class TestBuild:
         assert payload.security.risk_tier == 1
 
 
+class TestParsePorts:
+    """ENG-5954 — compose-spec long-form port translation."""
+
+    def test_short_form_string_defaults_to_http(self):
+        ports = PayloadBuilder._parse_ports(["8000"])
+        assert len(ports) == 1
+        assert ports[0].container_port == 8000
+        assert ports[0].protocol == "TCP"
+        assert ports[0].name == "http"
+        assert ports[0].app_protocol is None
+
+    def test_short_form_udp_suffix(self):
+        ports = PayloadBuilder._parse_ports(["53/udp"])
+        assert len(ports) == 1
+        assert ports[0].container_port == 53
+        assert ports[0].protocol == "UDP"
+        assert ports[0].name == "http"
+
+    def test_long_form_name_and_app_protocol_propagate(self):
+        ports = PayloadBuilder._parse_ports(
+            [{"target": 19530, "protocol": "tcp", "name": "grpc", "app_protocol": "grpc"}]
+        )
+        assert len(ports) == 1
+        assert ports[0].container_port == 19530
+        assert ports[0].protocol == "TCP"
+        assert ports[0].name == "grpc"
+        assert ports[0].app_protocol == "grpc"
+
+    def test_long_form_name_only(self):
+        ports = PayloadBuilder._parse_ports([{"target": 9000, "name": "metrics"}])
+        assert len(ports) == 1
+        assert ports[0].container_port == 9000
+        assert ports[0].name == "metrics"
+        assert ports[0].app_protocol is None
+
+    def test_long_form_without_name_falls_back_to_http(self):
+        ports = PayloadBuilder._parse_ports([{"target": 8080, "protocol": "tcp"}])
+        assert len(ports) == 1
+        assert ports[0].name == "http"
+
+    def test_long_form_udp_protocol(self):
+        ports = PayloadBuilder._parse_ports(
+            [{"target": 53, "protocol": "udp", "name": "dns"}]
+        )
+        assert len(ports) == 1
+        assert ports[0].protocol == "UDP"
+        assert ports[0].name == "dns"
+
+    def test_long_form_camel_case_app_protocol_alias(self):
+        # accept both `app_protocol` (compose-spec) and `appProtocol` (k8s)
+        ports = PayloadBuilder._parse_ports(
+            [{"target": 19530, "name": "grpc", "appProtocol": "grpc"}]
+        )
+        assert len(ports) == 1
+        assert ports[0].app_protocol == "grpc"
+
+    def test_long_form_explicit_app_protocol_wins_over_appprotocol(self):
+        """When both keys are present, the compose-spec ``app_protocol`` wins
+        even if it's an empty string — explicit None check rather than a
+        falsy ``or`` fallback."""
+        ports = PayloadBuilder._parse_ports(
+            [
+                {
+                    "target": 19530,
+                    "name": "grpc",
+                    "app_protocol": "",
+                    "appProtocol": "http2",
+                }
+            ]
+        )
+        assert len(ports) == 1
+        assert ports[0].app_protocol == ""
+
+    def test_mixed_short_and_long_form(self):
+        ports = PayloadBuilder._parse_ports(
+            [
+                "8000",
+                {"target": 19530, "name": "grpc", "app_protocol": "grpc"},
+            ]
+        )
+        assert len(ports) == 2
+        assert ports[0].name == "http"
+        assert ports[0].container_port == 8000
+        assert ports[1].name == "grpc"
+        assert ports[1].app_protocol == "grpc"
+
+    def test_long_form_serializes_appprotocol_camel_case(self):
+        """CR must use camelCase appProtocol for K8s compatibility."""
+        ports = PayloadBuilder._parse_ports(
+            [{"target": 19530, "name": "grpc", "app_protocol": "grpc"}]
+        )
+        dumped = ports[0].model_dump(by_alias=True, exclude_none=True)
+        assert dumped["appProtocol"] == "grpc"
+        assert "app_protocol" not in dumped
+
+    def test_default_dump_emits_appprotocol_for_nested_payload(self):
+        """Regression: ExtensionService.create_extension / patch_extension
+        call .model_dump() without by_alias=True. Without
+        serialize_by_alias=True on ExtensionPort, the resulting JSON
+        carries the unknown ``app_protocol`` key and the K8s API server
+        silently drops the field. This test pins the parent-level shape
+        the real create path produces."""
+        from kamiwaza_sdk.schemas.extensions import (
+            CreateExtension,
+            ExtensionPort,
+            ExtensionServiceSpec,
+        )
+
+        req = CreateExtension(
+            name="service-milvus-x",
+            type="service",
+            version="2.4.0",
+            services=[
+                ExtensionServiceSpec(
+                    name="standalone",
+                    image="milvus/milvus:2.5.27",
+                    primary=True,
+                    ports=[
+                        ExtensionPort(
+                            container_port=19530,
+                            protocol="TCP",
+                            name="grpc",
+                            app_protocol="grpc",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        # NO by_alias=True — mirrors ExtensionService.create_extension.
+        dumped = req.model_dump()
+        port_dict = dumped["services"][0]["ports"][0]
+        assert port_dict.get("appProtocol") == "grpc"
+        assert "app_protocol" not in port_dict
+
+    def test_long_form_missing_target_skipped(self):
+        ports = PayloadBuilder._parse_ports([{"name": "grpc"}])
+        assert ports == []
+
+    def test_long_form_invalid_target_skipped(self):
+        ports = PayloadBuilder._parse_ports([{"target": "not-a-number"}])
+        assert ports == []
+
+
 class TestAnnotations:
     """ENG-3887 / §4.2.9 — DeployedImageAnnotation on the CRD payload."""
 
@@ -793,6 +937,30 @@ class TestHealthChecks:
                 "frontend": {
                     "image": "registry.test/my-app-frontend:1.0.0-dev",
                     "ports": ["3000"],
+                },
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "test")
+        frontend = payload.services[0]
+
+        health_check = frontend.model_dump()["healthCheck"]
+        assert frontend.primary is True
+        assert health_check["exec"]["command"][0] == "node"
+
+    def test_frontend_long_form_port_3000_uses_node_probe(
+        self, builder, metadata, connection
+    ):
+        """ENG-5954: the Node-probe heuristic must recognize long-form
+        port targets too. Before the fix, ``str({"target": 3000, ...})``
+        was parsed as a single string and the int() conversion failed
+        silently, causing frontend services authored with long-form to
+        fall through to the HTTP probe."""
+        transformed = {
+            "services": {
+                "frontend": {
+                    "image": "registry.test/my-app-frontend:1.0.0-dev",
+                    "ports": [{"target": 3000, "name": "http"}],
                 },
             },
         }

--- a/tests/unit/extensions/test_validate_cmd.py
+++ b/tests/unit/extensions/test_validate_cmd.py
@@ -169,6 +169,61 @@ class TestRunValidate:
         assert output["passed"] is False
         assert any("container port 80 is privileged" in err for err in output["errors"])
 
+    def test_long_form_port_target_only_does_not_warn(self, tmp_path, capsys):
+        """ENG-5954: compose-spec long-form ports without ``published`` are
+        the standard kamiwaza pattern (no host port). They must not trip the
+        host-port-binding warning, which used to fire because ``str({...})``
+        contains a colon."""
+        from kamiwaza_extensions.commands.validate import run_validate
+
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginxinc/nginx-unprivileged:stable-alpine",
+                    "ports": [
+                        {
+                            "target": 19530,
+                            "protocol": "tcp",
+                            "name": "grpc",
+                            "app_protocol": "grpc",
+                        }
+                    ],
+                    "deploy": {"resources": {"limits": {"cpus": "1.0", "memory": "1G"}}},
+                },
+            },
+        }
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(_valid_metadata()))
+        (tmp_path / "docker-compose.yml").write_text(yaml.dump(compose))
+
+        run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["passed"] is True
+        joined_warnings = " ".join(output.get("warnings", []))
+        assert "host port binding" not in joined_warnings
+
+    def test_long_form_port_with_published_warns(self, tmp_path, capsys):
+        """Long-form ports with ``published`` still surface as host bindings."""
+        from kamiwaza_extensions.commands.validate import run_validate
+
+        compose = {
+            "services": {
+                "web": {
+                    "image": "nginxinc/nginx-unprivileged:stable-alpine",
+                    "ports": [{"target": 8080, "published": 8080}],
+                    "deploy": {"resources": {"limits": {"cpus": "1.0", "memory": "1G"}}},
+                },
+            },
+        }
+        (tmp_path / "kamiwaza.json").write_text(json.dumps(_valid_metadata()))
+        (tmp_path / "docker-compose.yml").write_text(yaml.dump(compose))
+
+        run_validate(path=str(tmp_path), json_output=True)
+
+        output = json.loads(capsys.readouterr().out)
+        joined_warnings = " ".join(output.get("warnings", []))
+        assert "host port binding" in joined_warnings
+
     def test_validate_passes_for_unprivileged_static_runtime(self, tmp_path, capsys):
         from kamiwaza_extensions.commands.validate import run_validate
 


### PR DESCRIPTION
## What this ships

Teaches the kz-ext publish pipeline to handle compose-spec long-form port dicts and propagate `name` + `appProtocol` end-to-end to the K8s Service. Short-form behavior unchanged.

## Contract

Compose long-form is now valid in `docker-compose.yml`:

```yaml
ports:
  - target: 19530
    protocol: tcp
    name: grpc
    app_protocol: grpc
```

Translates to K8s Service:

```yaml
ports:
- name: grpc
  appProtocol: grpc
  port: 19530
  protocol: TCP
```

## Load-bearing decisions

- `serialize_by_alias=True` on `ExtensionPort` so default `model_dump()` emits camelCase. Without it, the K8s API server silently drops the field on `ExtensionService.create_extension` / `patch_extension`.
- `published`/`host_ip` are stripped in long-form by `_strip_host_ports` (closes a back-door host-port-binding vector that the validator alone couldn't catch).

## Verification

- 1405 extension tests pass (was 1402; +3 regression pins)
- Codex round 1 caught the `serialize_by_alias` gap; round 2 (after fixes) clean
- 3-agent local-review caught 3 more `str(port)`-on-dict sibling sites in `payload_builder.py` — all fixed in-PR
- End-to-end Python introspection through `ComposeTransformer → RegistryBuilder.build_entry → PayloadBuilder.build` confirmed the milvus example produces `name=grpc`/`appProtocol=grpc` on the wire

Part of ENG-5954 — companion PRs in `kamiwaza-internal/operators` and `kamiwaza-internal/kamiwaza-extensions-milvus`.