### PR TITLE
fix(dev-local): load docker-compose.override.yml in kz-ext dev local (ENG-6281)

### DIFF
--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -183,6 +183,7 @@ class DevLocalRunner:
         sdk_build_dockerfiles: List[str] = []
         extra_hosts_file: Optional[str] = None
         auth_env_file: Optional[str] = None
+        local_override_file: Optional[str] = None
         # Initialised here (not in 10a) so the ``finally`` cleanup always
         # has them in scope — even if an exception bubbles out of the
         # try body before the polling thread would have been spawned.
@@ -211,6 +212,26 @@ class DevLocalRunner:
                 compose_file_arg = patched_compose_file
             else:
                 compose_file_arg = str(info.compose_path)
+
+            # 6a. Load the developer's local-only compose override if present.
+            # kz-ext builds an explicit ``-f`` list, which disables Compose's
+            # automatic ``docker-compose.override.yml`` loading. Re-add it so
+            # the documented local-only override path works (e.g. mounting the
+            # Docker socket for SANDBOX_BACKEND=docker). Placed after the base
+            # file but before kz-ext's generated overlays so functional
+            # overlays (auth / extra-hosts) still win on conflict. See ENG-6281.
+            compose_dir = Path(info.compose_path).parent
+            for _override_name in (
+                "docker-compose.override.yml",
+                "docker-compose.override.yaml",
+            ):
+                _candidate = compose_dir / _override_name
+                if _candidate.is_file():
+                    local_override_file = str(_candidate)
+                    console.print(
+                        f"[dim]Loading local override: {_override_name}[/dim]"
+                    )
+                    break
 
             # 7. Generate SDK override compose file
             if override_spec and info.compose_data:
@@ -346,6 +367,10 @@ class DevLocalRunner:
             # parent directory or with override files (review re-review
             # PR #84 M1).
             compose_prefix = compose_cmd + ["-f", compose_file_arg]
+            # User's local-only override loads after the base file but before
+            # kz-ext's generated overlays (ENG-6281).
+            if local_override_file:
+                compose_prefix += ["-f", local_override_file]
             if sdk_override_file:
                 compose_prefix += ["-f", sdk_override_file]
             # The build patch must apply to the same services the runtime
@@ -360,6 +385,7 @@ class DevLocalRunner:
                 compose_prefix += ["-f", auth_env_file]
             if (
                 patched_compose_file
+                or local_override_file
                 or sdk_override_file
                 or sdk_build_patch_file
                 or extra_hosts_file

--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -215,22 +215,37 @@ class DevLocalRunner:
 
             # 6a. Load the developer's local-only compose override if present.
             # kz-ext builds an explicit ``-f`` list, which disables Compose's
-            # automatic ``docker-compose.override.yml`` loading. Re-add it so
+            # automatic ``<base-stem>.override.<ext>`` loading. Re-add it so
             # the documented local-only override path works (e.g. mounting the
             # Docker socket for SANDBOX_BACKEND=docker). Placed after the base
             # file but before kz-ext's generated overlays so functional
             # overlays (auth / extra-hosts) still win on conflict. See ENG-6281.
-            compose_dir = Path(info.compose_path).parent
-            for _override_name in (
-                "docker-compose.override.yml",
-                "docker-compose.override.yaml",
-            ):
-                _candidate = compose_dir / _override_name
-                if _candidate.is_file():
-                    local_override_file = str(_candidate)
-                    console.print(
-                        f"[dim]Loading local override: {_override_name}[/dim]"
-                    )
+            #
+            # Compose mirrors the override name to the *detected base file's*
+            # stem: a ``compose.yml`` base pairs with ``compose.override.yml``,
+            # a ``docker-compose.yaml`` base with
+            # ``docker-compose.override.yaml`` — see ``COMPOSE_FILENAMES`` for
+            # the four supported base names. Derive the candidate from the
+            # detected base (not a hardcoded ``docker-compose.override.*``) so
+            # the supported ``compose.{yml,yaml}`` bases don't silently lose
+            # their override — the very bug this fixes (PR #131 review High #1).
+            base_compose_path = Path(info.compose_path)
+            compose_dir = base_compose_path.parent
+            override_stem = base_compose_path.stem
+            base_ext = base_compose_path.suffix.lstrip(".") or "yml"
+            # Prefer the suffix matching the base file, then the alternate, so
+            # a ``compose.yml`` base finds ``compose.override.yml`` first but
+            # still picks up ``compose.override.yaml`` if that's what the
+            # developer wrote.
+            override_exts = [base_ext] + [
+                ext for ext in ("yml", "yaml") if ext != base_ext
+            ]
+            for ext in override_exts:
+                override_name = f"{override_stem}.override.{ext}"
+                candidate = compose_dir / override_name
+                if candidate.is_file():
+                    local_override_file = str(candidate)
+                    console.print(f"[dim]Loading local override: {override_name}[/dim]")
                     break
 
             # 7. Generate SDK override compose file

--- a/tests/unit/extensions/test_dev_local.py
+++ b/tests/unit/extensions/test_dev_local.py
@@ -604,6 +604,131 @@ class TestRunnerEnvPassthroughOverlay:
 
 
 @pytest.mark.unit
+class TestRunnerLocalComposeOverride:
+    """ENG-6281 / PR #131 — kz-ext builds an explicit ``-f`` list, which
+    disables Compose's automatic ``<stem>.override.<ext>`` loading. The
+    runner must re-add the developer's local-only override so the
+    documented Docker-socket-mount path works, placed *after* the base
+    file but *before* kz-ext's generated overlays, and must NOT delete
+    the user's own file in cleanup."""
+
+    def _make_runner(self, monkeypatch, info):
+        """Wire a DevLocalRunner that captures the compose argv without
+        touching the real environment. Returns ``(runner, captured)``."""
+        from kamiwaza_extensions import dev_local as dev_local_mod
+        from kamiwaza_extensions import sdk_override as sdk_override_mod
+        from kamiwaza_extensions.dev_local import DevLocalRunner
+
+        runner = DevLocalRunner()
+        runner._detector = MagicMock()
+        runner._detector.detect.return_value = info
+        runner._conn_mgr = MagicMock()
+        runner._conn_mgr.get_active_connection.return_value = ConnectionInfo(
+            name="dev",
+            url="https://kamiwaza.test/api",
+            active=True,
+            created_at=0.0,
+        )
+
+        monkeypatch.setattr(
+            dev_local_mod, "detect_compose_command", lambda: ["docker", "compose"]
+        )
+        monkeypatch.setattr(
+            sdk_override_mod, "resolve_sdk_override", lambda *a, **kw: None
+        )
+        monkeypatch.setattr(
+            dev_local_mod, "resolve_port_conflicts", lambda *a, **kw: {}
+        )
+
+        captured: dict = {}
+
+        def capture_subprocess(cmd, *, env, cwd):
+            captured["cmd"] = list(cmd)
+            return 0
+
+        runner._run_subprocess = capture_subprocess
+        runner._print_urls = MagicMock()
+        return runner, captured
+
+    def _make_info(self, tmp_path, compose_name="docker-compose.yml"):
+        import yaml as _yaml
+
+        compose_data = {
+            "services": {
+                "frontend": {"build": "./frontend", "ports": ["3000"]},
+                "backend": {"build": "./backend", "ports": ["8000"]},
+            }
+        }
+        compose_path = tmp_path / compose_name
+        compose_path.write_text(_yaml.dump(compose_data))
+
+        info = MagicMock()
+        info.name = "my-app"
+        info.path = tmp_path
+        info.compose_path = compose_path
+        info.compose_data = compose_data
+        info.metadata = {"type": "app"}
+        return info
+
+    def test_runner_loads_docker_compose_override_when_present(
+        self, tmp_path, monkeypatch
+    ):
+        info = self._make_info(tmp_path, "docker-compose.yml")
+        override_path = tmp_path / "docker-compose.override.yml"
+        override_path.write_text("services:\n  backend:\n    volumes: []\n")
+
+        runner, captured = self._make_runner(monkeypatch, info)
+        assert runner.run(detach=False, auth=False) == 0
+
+        cmd = captured["cmd"]
+        # The override must be wired in via `-f` (without the flag compose
+        # ignores it) ...
+        idx = cmd.index(str(override_path))
+        assert cmd[idx - 1] == "-f", f"override not preceded by `-f`. cmd={cmd!r}"
+        # ... after the base compose file ...
+        base_idx = cmd.index(str(info.compose_path))
+        assert base_idx < idx, (
+            f"override must load after the base file so it patches it, "
+            f"not before. cmd={cmd!r}"
+        )
+        # ... and the user's own file must survive cleanup — deleting a
+        # developer's file would be a nasty surprise.
+        assert override_path.is_file(), "user's override file was deleted in cleanup"
+
+    def test_runner_does_not_add_override_when_absent(self, tmp_path, monkeypatch):
+        info = self._make_info(tmp_path, "docker-compose.yml")
+        # No override file written.
+        runner, captured = self._make_runner(monkeypatch, info)
+        assert runner.run(detach=False, auth=False) == 0
+
+        cmd = captured["cmd"]
+        # Exactly one `-f` (the base compose file) — no phantom override.
+        assert cmd.count("-f") == 1, f"expected only the base `-f`. cmd={cmd!r}"
+        assert str(info.compose_path) in cmd
+
+    def test_runner_loads_override_for_compose_yml_base(self, tmp_path, monkeypatch):
+        """PR #131 review High #1 — the override name must mirror the
+        detected base stem. A ``compose.yml`` base pairs with
+        ``compose.override.yml``; hardcoding ``docker-compose.override.*``
+        would silently ignore it, reproducing the exact bug this fixes."""
+        info = self._make_info(tmp_path, "compose.yml")
+        override_path = tmp_path / "compose.override.yml"
+        override_path.write_text("services:\n  backend:\n    volumes: []\n")
+
+        runner, captured = self._make_runner(monkeypatch, info)
+        assert runner.run(detach=False, auth=False) == 0
+
+        cmd = captured["cmd"]
+        assert str(override_path) in cmd, (
+            f"compose.override.yml not loaded for compose.yml base — "
+            f"override discovery is not stem-derived. cmd={cmd!r}"
+        )
+        idx = cmd.index(str(override_path))
+        assert cmd[idx - 1] == "-f"
+        assert override_path.is_file()
+
+
+@pytest.mark.unit
 class TestRunnerAuthExtensionTypeGate:
     """PR #87 round-5 review High #2 — `--auth` is only meaningful for
     `app`-type extensions (the bridge mechanism is the Next.js


### PR DESCRIPTION
## Summary

`kz-ext dev local` builds an explicit `-f` compose-file list (base compose + its own generated `kz-extra-hosts-*` / `kz-auth-env-*` overlays). Passing explicit `-f` files **disables Docker Compose's automatic `docker-compose.override.yml` loading**, so the developer's local-only override is silently ignored.

This breaks the **documented** mechanism extensions rely on for local Docker sandbox-backend development. Per kaizen's own docs, the Docker socket mount (and other local-only bits) must live in a local override, never the canonical compose:

- `CONVERT_NOTES.md`: "The canonical compose does not mount the Docker socket. Any direct local Docker sandbox workflow should use an explicit local-only override."
- `AGENTS.md`: "Avoid adding local Docker socket mounts to the canonical compose unless they are isolated to a local-only override."

With the override ignored, `SANDBOX_BACKEND=docker` local dev can't mount the socket, so the sandbox-controller can't spawn agents.

## Change

In `dev_local.py`, discover a sibling `docker-compose.override.yml` (or `.yaml`) next to the base compose file and append it to the `-f` list — **after** the base file but **before** kz-ext's generated overlays, so the user's override applies while functional overlays (auth bridge, extra_hosts) still win on conflict. The file is the user's own, so it is intentionally **not** added to the temp-file cleanup list.

## Scope / safety

Scoped to `dev local` only. The build/push/deploy path is untouched (images build via `docker-bake.hcl`; the deploy CR payload is built from the canonical `docker-compose.yml` via `COMPOSE_FILENAMES`, which doesn't include the override). So local-only override config **cannot leak** into published images or deployed extensions. Because kz-ext passes explicit `-f` flags, there is also no double-load with Compose's auto-load.

## Context

Gap 1 of **ENG-6281** ("`kz-ext dev local --auth` doesn't fully provision the local Docker sandbox backend"). The remaining gaps (socket auto-provisioning, `extra_docker_images` build, agent→backend routing, and two cert/auth open questions) are tracked there; this PR is the one clean, value-free code fix.

## Test

Validated end-to-end on a macOS install-dev box: with this change, `kz-ext dev local --auth` loads `docker-compose.override.yml` (confirmed via the new `Loading local override:` log line and the compose `project.config_files` label), the controller gets the Docker socket, and the full kaizen agent flow (create agent → chat → sandbox spawn → response) works.