### PR TITLE
[codex] Expose SDK CLI console script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project.scripts]
+kamiwaza = "kamiwaza_sdk.cli:main"
 kz-ext = "kamiwaza_extensions.cli:app"
 
 # `kamiwaza-extensions-lib` is published as its own PyPI distribution

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -10,6 +11,11 @@ import pytest
 from kamiwaza_sdk import cli
 from kamiwaza_sdk.exceptions import AuthenticationError
 from kamiwaza_sdk.token_store import StoredToken, TokenStore
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
 
 pytestmark = pytest.mark.unit
 
@@ -26,6 +32,12 @@ class MemoryStore(TokenStore):
 
     def clear(self):
         self.value = None
+
+
+def test_sdk_cli_console_script_declared():
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+
+    assert pyproject["project"]["scripts"]["kamiwaza"] == "kamiwaza_sdk.cli:main"
 
 
 def test_login_command_uses_authenticator(monkeypatch):


### PR DESCRIPTION
## Summary
Expose the SDK CLI as the installed `kamiwaza` console script so `pip install kamiwaza-sdk` lands the shipped CLI in `bin`.

## Type
- [ ] Feature - New functionality
- [x] Bug Fix - Corrects existing behavior
- [ ] Refactor - Code improvement without behavior change
- [ ] Documentation - Docs only
- [x] Test - Test coverage improvement
- [ ] Chore - Dependencies, config, CI/CD

## Change Flags
- [ ] API change - Endpoints added, modified, or removed
- [ ] Configuration change - New or modified config parameters
- [ ] Requirements change - Dependencies added, updated, or removed
- [ ] Schema change - Database or Pydantic model changes

## Breaking Changes
- [x] None - Fully backward compatible
- [ ] API contract - Existing clients may need updates
- [ ] Database schema - Migration required before/after deploy
- [ ] Configuration format - Existing config files need updating
- [ ] Internal interface - Other services/modules need coordinated updates

## Motivation
`kamiwaza_sdk/cli.py` could run via `python -m kamiwaza_sdk.cli`, but the package metadata only declared `kz-ext`, so installs did not expose the SDK CLI as a shell command.

## Source
- [ ] Issue/Ticket: N/A
- [ ] Spec/Design Doc: N/A
- [x] Conversation/Discussion: User reported that the shipped CLI did not land in `bin` after install.
- [ ] Self-identified: N/A

## Alternatives Considered
- Keep the CLI module-only: rejected because the CLI text already instructs users to run `kamiwaza login`, and the install contract should expose that executable.
- Add another alias: rejected to keep the package surface minimal and match the existing CLI wording.

## Changes Made
- Added `kamiwaza = "kamiwaza_sdk.cli:main"` under `[project.scripts]`.
- Added a unit regression test asserting the SDK console script remains declared in `pyproject.toml`.

## Technical Notes
`kz-ext` remains unchanged as the extension developer tooling CLI. This PR only exposes the existing SDK CLI entry point.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No tests needed - explain below

## Verification
| Environment | Steps Performed | Result |
|-------------|-----------------|--------|
| Local | `uv run pytest tests/unit/test_cli.py tests/unit/extensions/test_cli.py` | Passed: 23 tests |
| Local | `uv run ruff check tests/unit/test_cli.py` | Passed |
| Local package smoke | Built a wheel into `/tmp`, installed it into a throwaway venv with `pip install --no-deps`, and inspected wheel entry points plus `venv/bin` | Passed: both `kamiwaza` and `kz-ext` existed |
| Local | `uv run kamiwaza --help` | Passed |

## Test Coverage
Covers the packaging metadata contract that controls installed console scripts. Existing CLI behavior tests continue to cover command implementation.

## Review Focus
Confirm `kamiwaza` is the intended installed SDK CLI command name and that no additional aliases are needed.

## Deployment Notes
N/A. Standard package release will include the new console script metadata.

## Checklist
- [x] Self-reviewed the code
- [x] Tests pass locally
- [ ] Verified on live system (see Verification above) - N/A, packaging-only change verified with local wheel install
- [x] Documentation updated (if applicable) - N/A, no docs change needed for the metadata fix

## Vibe Check
N/A
