### PR TITLE
M8 cleanup: echo-check root-path collision, workspace lib build, persona token isolation (ENG-5956 + 5957 + 5955)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# ENG-5957: The only docker build using this directory as context is
+# tests/e2e/extension_contract/echo-check/backend/Dockerfile, which only
+# needs:
+#   - kamiwaza_extensions_lib/   (workspace member)
+#   - tests/e2e/extension_contract/echo-check/backend/  (app + requirements)
+#
+# Everything else inflates the build context unnecessarily or risks
+# pulling sensitive files (.env, venvs, build caches) into image layers.
+
+# Block everything by default, then unblock the small set we need.
+**
+
+# Workspace member that the Dockerfile installs first.
+!kamiwaza_extensions_lib/
+!kamiwaza_extensions_lib/**
+
+# Backend app + its requirements.txt.
+!tests/
+!tests/e2e/
+!tests/e2e/extension_contract/
+!tests/e2e/extension_contract/echo-check/
+!tests/e2e/extension_contract/echo-check/backend/
+!tests/e2e/extension_contract/echo-check/backend/app/
+!tests/e2e/extension_contract/echo-check/backend/app/**
+!tests/e2e/extension_contract/echo-check/backend/requirements.txt
+
+# Even within those whitelisted dirs, exclude churn artifacts.
+**/__pycache__/
+**/*.pyc
+**/.pytest_cache/
+**/.mypy_cache/
+**/.ruff_cache/
+**/*.egg-info/

--- a/kamiwaza_sdk/token_store.py
+++ b/kamiwaza_sdk/token_store.py
@@ -40,7 +40,11 @@ class FileTokenStore(TokenStore):
     """Persist tokens as JSON under ~/.kamiwaza/token.json by default."""
 
     def __init__(self, path: Optional[Path | str] = None) -> None:
-        default_path = Path(os.environ.get("KAMIWAZA_TOKEN_PATH", Path.home() / ".kamiwaza" / "token.json"))
+        default_path = Path(
+            os.environ.get(
+                "KAMIWAZA_TOKEN_PATH", Path.home() / ".kamiwaza" / "token.json"
+            )
+        )
         self.path = Path(path) if path else default_path
 
     def load(self) -> Optional[StoredToken]:
@@ -72,3 +76,27 @@ class FileTokenStore(TokenStore):
             self.path.unlink()
         except FileNotFoundError:
             return
+
+
+class InMemoryTokenStore(TokenStore):
+    """In-memory token store for tests and isolated client contexts.
+
+    Each instance holds a single ``StoredToken`` in process memory and
+    persists nothing to disk. Use this when multiple ``KamiwazaClient``
+    instances must hold distinct credentials in the same process — the
+    default ``FileTokenStore`` is keyed only by path, so two authenticators
+    pointed at the default file would share (and overwrite) each other's
+    tokens. ENG-5955.
+    """
+
+    def __init__(self) -> None:
+        self._token: Optional[StoredToken] = None
+
+    def load(self) -> Optional[StoredToken]:
+        return self._token
+
+    def save(self, token: StoredToken) -> None:
+        self._token = token
+
+    def clear(self) -> None:
+        self._token = None

--- a/tests/e2e/extension_contract/echo-check/backend/Dockerfile
+++ b/tests/e2e/extension_contract/echo-check/backend/Dockerfile
@@ -1,15 +1,11 @@
 FROM python:3.12-slim
 
-# NOTE: requirements.txt resolves `kamiwaza-extensions-lib` from the package
-# index (whatever is published), NOT the in-repo workspace member at
-# `<sdk-root>/kamiwaza_extensions_lib/`. PRs that modify the in-repo
-# extensions lib won't be tested through this live contract app until the
-# build context is widened to the SDK repo root and the lib is installed
-# from the workspace. Tracked as ENG-5957 (workspace integration follow-up).
-#
-# Also see ENG-5956: --root-path / app-level prefix combination needs
-# resolution before live extension-contract tests can validate routed
-# requests reliably.
+# Build context for this image is the SDK repo root (set via
+# docker-compose.yml ``context:`` and ``dockerfile:``), so the in-repo
+# workspace member ``kamiwaza_extensions_lib/`` can be installed
+# directly instead of resolving ``kamiwaza-extensions-lib`` from PyPI.
+# This lets PRs that modify the workspace member exercise their changes
+# through the live contract app. ENG-5957.
 
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
@@ -17,10 +13,16 @@ RUN useradd -m -u 1001 appuser
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Install the in-repo workspace member first; subsequent
+# ``requirements.txt`` install treats ``kamiwaza-extensions-lib`` as
+# already-satisfied.
+COPY kamiwaza_extensions_lib/ /tmp/kamiwaza_extensions_lib/
+RUN pip install --no-cache-dir /tmp/kamiwaza_extensions_lib/
 
-COPY --chown=appuser:appuser app ./app
+COPY tests/e2e/extension_contract/echo-check/backend/requirements.txt /tmp/req.txt
+RUN pip install --no-cache-dir -r /tmp/req.txt
+
+COPY --chown=appuser:appuser tests/e2e/extension_contract/echo-check/backend/app ./app
 
 USER 1001:1001
 
@@ -34,4 +36,12 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
 # against the runtime prefix. Without this, real routed requests
 # arrive with root_path="" and identity-header forwarding fails
 # silently (returns 403 / drops identity fields).
+#
+# ENG-5956 follow-up (kamiwaza-sdk#134 self-review H1): root_path alone is
+# not sufficient as a trust signal — uvicorn populates it on every request
+# including direct container traffic. The trusted-routed path now also
+# requires the `x-kamiwaza-trusted-proxy` header to match
+# `$KAMIWAZA_TRUSTED_PROXY_SECRET`, which the routing layer (Traefik /
+# istio ingress) injects only for routed traffic. The compose file passes
+# the secret in via env so the harness can mint matching test headers.
 CMD ["sh", "-c", "exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --root-path \"${KAMIWAZA_APP_PATH:-}\""]

--- a/tests/e2e/extension_contract/echo-check/backend/app/main.py
+++ b/tests/e2e/extension_contract/echo-check/backend/app/main.py
@@ -15,7 +15,7 @@ from .workroom_trust import (
     normalized_workroom_id as _normalized_workroom_id,
 )
 from .workroom_trust import (
-    runtime_prefix as _runtime_prefix,
+    require_routed_request,
 )
 from .workroom_trust import (
     runtime_value as _runtime_value,
@@ -121,7 +121,10 @@ def _build_api_router() -> APIRouter:
         payload["status"] = "ok"
         return payload
 
-    @router.get("/api/observability")
+    @router.get(
+        "/api/observability",
+        dependencies=[Depends(require_routed_request)],
+    )
     async def observability(
         request: Request,
         marker: str = Query(..., min_length=1, max_length=128, pattern=r"^[A-Za-z0-9_-]+$"),
@@ -147,7 +150,10 @@ def _build_api_router() -> APIRouter:
         )
         return payload
 
-    @router.get("/api/whoami")
+    @router.get(
+        "/api/whoami",
+        dependencies=[Depends(require_routed_request)],
+    )
     async def whoami(
         request: Request,
         identity: Any = Depends(require_auth),
@@ -167,7 +173,10 @@ def _build_api_router() -> APIRouter:
         )
         return payload
 
-    @router.get("/api/workroom-check/{workroom_id}")
+    @router.get(
+        "/api/workroom-check/{workroom_id}",
+        dependencies=[Depends(require_routed_request)],
+    )
     async def workroom_check(
         request: Request,
         identity: Any = Depends(require_auth),
@@ -202,22 +211,28 @@ def _build_api_router() -> APIRouter:
         )
         return payload
 
-    router.include_router(create_session_router(prefix="/api"))
+    # ENG-5956 RE-REVIEW #2 follow-up: gate /api/session on the trusted-proxy
+    # marker so direct (non-routed) container traffic returns 404 instead of
+    # echoing the platform envelope's identity. See workroom_trust.py
+    # docstring for the full trust-model layering.
+    router.include_router(
+        create_session_router(prefix="/api"),
+        dependencies=[Depends(require_routed_request)],
+    )
     return router
 
 
 def _register_routes(app: FastAPI) -> None:
-    runtime_prefix = _runtime_prefix()
-    if runtime_prefix:
-        app.include_router(_build_root_router(include_in_schema=False), prefix=runtime_prefix)
-        app.include_router(_build_api_router(), prefix=runtime_prefix)
-
-        @app.get("/health", include_in_schema=False)
-        async def container_health() -> dict[str, bool | str]:
-            return _health_payload()
-
-        return
-
+    # ENG-5956: in routed deployments uvicorn is started with
+    # ``--root-path "$KAMIWAZA_APP_PATH"``. Starlette strips ``root_path``
+    # from ``scope['path']`` BEFORE route matching, so the app must
+    # register UNPREFIXED routes — the app-level ``prefix=runtime_prefix``
+    # the prior implementation added stacked on top of the stripped root
+    # path and produced 404s on every routed request.
+    #
+    # Note: ``trusted_routed_workroom_context()`` still relies on
+    # ``scope['root_path']`` to validate the runtime prefix, which is why
+    # ``--root-path`` stays in the Dockerfile.
     app.include_router(_build_root_router(include_in_schema=False))
     app.include_router(_build_api_router())
 

--- a/tests/e2e/extension_contract/echo-check/backend/app/workroom_trust.py
+++ b/tests/e2e/extension_contract/echo-check/backend/app/workroom_trust.py
@@ -1,10 +1,53 @@
+"""Trust model for the echo-check contract template.
+
+Three concentric layers, weakest to strongest:
+
+1. **Network isolation** — the platform's routing layer (Traefik / istio
+   ingress + pod NetworkPolicies) is the *primary* trust boundary. The
+   container port is not externally exposed in any deployed configuration;
+   a caller capable of reaching the port directly is already inside the
+   pod network and the platform's documented threat model treats them as
+   trusted for identity (the ``X-User-*`` envelope below).
+
+2. **Platform identity envelope** — ``X-User-Id``, ``X-User-Email``,
+   ``X-Workroom-Id``, etc. are populated by the platform's ext_authz
+   filter and the mesh proxy. ``kamiwaza_extensions_lib.require_auth``
+   trusts these headers when present and well-formed. **Identity echo**
+   (``/api/whoami``, ``/api/session``, ``/api/observability``) relies on
+   this layer — see ``require_routed_request`` below for the
+   defense-in-depth gate that prevents direct-container hits to those
+   protected routes when the platform routing layer is absent.
+
+3. **Routed-binding marker** — ``x-kamiwaza-trusted-proxy`` carrying
+   ``$KAMIWAZA_TRUSTED_PROXY_SECRET``, injected by the routing layer on
+   routed traffic. This gates the **workroom-binding helpers**
+   (``current_workroom_id`` / ``workroom_role``): the most
+   authorization-sensitive surface. Direct traffic that didn't pass
+   through the routing layer never carries the marker → workroom binding
+   stays fail-closed.
+
+Extension authors copying this template MUST:
+- Set ``$KAMIWAZA_TRUSTED_PROXY_SECRET`` in both the local
+  ``docker-compose.yml`` and the deployed ``docker-compose.appgarden.yml``.
+- Configure their routing layer to inject ``x-kamiwaza-trusted-proxy:
+  <secret>`` on routed traffic only.
+- Apply ``Depends(require_routed_request)`` to any route they consider
+  sensitive enough to deserve the marker check, in addition to
+  ``require_auth``.
+
+ENG-5956 (kamiwaza-sdk#134) self-review H1 + RE-REVIEW H1 — the trust
+boundary is documented here in source so the pattern propagates with the
+template.
+"""
+
 from __future__ import annotations
 
+import hmac
 import os
 import re
 from typing import Any
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 TRUSTED_ROUTED_ROOT_PATH_PREFIX = "/runtime/apps/"
 _FALSEY_ENV_VALUES = frozenset({"", "0", "false", "no", "off", "n", "f"})
@@ -32,6 +75,72 @@ def runtime_prefix() -> str:
         return ""
     normalized = value if value.startswith("/") else f"/{value}"
     return normalized.rstrip("/") or "/"
+
+
+# Header name the trusted proxy (Traefik / istio ingress / similar) injects so
+# the app can distinguish a real routed request from direct container traffic.
+# Fixed name; the SECRET that must match is in KAMIWAZA_TRUSTED_PROXY_SECRET.
+TRUSTED_PROXY_HEADER_NAME = "x-kamiwaza-trusted-proxy"
+
+
+def trusted_proxy_secret() -> str | None:
+    """Shared secret the routed proxy injects in ``x-kamiwaza-trusted-proxy``.
+
+    Returning ``None`` means trust-routed is disabled — the app fails CLOSED
+    on every routed-trust check, regardless of ``root_path``. Extension
+    authors copying this template MUST set the env var (and configure their
+    routing layer to inject the header) before the trusted-routed path will
+    flip identity-header forwarding on.
+
+    ENG-5956 follow-up: dropping the app-level ``prefix=runtime_prefix`` from
+    ``_register_routes`` removed the implicit 404-on-direct defense; the
+    trusted-routed signal must now be stronger than ``root_path`` alone.
+    """
+    return runtime_value("KAMIWAZA_TRUSTED_PROXY_SECRET")
+
+
+def has_trusted_proxy_marker(request: Request) -> bool:
+    secret = trusted_proxy_secret()
+    if not secret:
+        return False
+    header_value = request.headers.get(TRUSTED_PROXY_HEADER_NAME)
+    if not header_value:
+        return False
+    # ENG-5956 follow-up — kamiwaza-sdk#134 RE-REVIEW H2: use a
+    # constant-time comparison to avoid a timing side-channel on the
+    # shared secret. Amplified by echo-check being a starter template
+    # extension authors copy verbatim — a weak primitive here would
+    # propagate downstream.
+    return hmac.compare_digest(header_value, secret)
+
+
+async def require_routed_request(request: Request) -> None:
+    """Defense-in-depth: protected routes must be reached via the routing layer.
+
+    ENG-5956 follow-up (kamiwaza-sdk#134 RE-REVIEW #2): dropping the
+    app-level ``prefix=runtime_prefix`` made protected routes directly
+    addressable on the container port. The platform's network isolation
+    + ext_authz envelope is the documented primary trust boundary, but
+    this gate restores the pre-PR shape (direct access → 404) as an
+    additional layer for identity-echo routes (``/api/whoami``,
+    ``/api/session``, ``/api/observability``). Combined with the
+    workroom-binding helpers' own marker checks, the trust model is
+    consistent across surfaces: direct traffic that didn't pass through
+    the routing layer never carries the marker, and protected routes
+    silently 404 instead of returning a spoofable identity payload.
+
+    Returns 404 (not 401/403) to preserve the pre-PR external behavior
+    for unrouted access — there is no useful information for an
+    unrouted caller to receive.
+
+    When no ``KAMIWAZA_TRUSTED_PROXY_SECRET`` is configured, the route
+    fails closed (404) — extensions MUST opt in to the trust model.
+
+    Apply as a FastAPI dependency on protected routes:
+        ``Depends(require_routed_request)``
+    """
+    if not has_trusted_proxy_marker(request):
+        raise HTTPException(status_code=404)
 
 
 def safe_log_field(value: str | None) -> str:
@@ -87,6 +196,14 @@ def trusted_routed_workroom_context(request: Request, identity: Any) -> bool:
         return False
     expected_runtime_prefix = runtime_prefix()
     if not expected_runtime_prefix:
+        return False
+    # ENG-5956 follow-up (kamiwaza-sdk#134 self-review H1): require BOTH a
+    # matching root_path AND the trusted-proxy shared-secret marker.
+    # root_path alone is forgeable by a direct container caller (uvicorn
+    # --root-path sets it on every request, including direct). The marker
+    # closes that gap — direct traffic doesn't carry the proxy-injected
+    # header. Fails CLOSED when no secret is configured.
+    if not has_trusted_proxy_marker(request):
         return False
     return routed_root_path(request) == expected_runtime_prefix
 

--- a/tests/e2e/extension_contract/echo-check/backend/requirements.txt
+++ b/tests/e2e/extension_contract/echo-check/backend/requirements.txt
@@ -1,5 +1,9 @@
-kamiwaza-extensions-lib>=0.4,<0.5
-
+# ENG-5957: ``kamiwaza-extensions-lib`` is installed from the in-repo
+# workspace member (``kamiwaza_extensions_lib/``) by the Dockerfile
+# BEFORE this file is consumed, so it does not appear here. PRs that
+# modify the workspace member therefore exercise their changes through
+# the live contract app instead of resolving the last-published PyPI
+# release.
 fastapi>=0.115.0
 pydantic>=2.7.0
 uvicorn[standard]>=0.30.0

--- a/tests/e2e/extension_contract/echo-check/backend/tests/test_auth_endpoints.py
+++ b/tests/e2e/extension_contract/echo-check/backend/tests/test_auth_endpoints.py
@@ -7,17 +7,21 @@ from fastapi.testclient import TestClient
 
 from app.main import app
 
-from .test_helpers import APP_PATH, WORKROOM_ID, auth_headers
+from .test_helpers import APP_PATH, TRUSTED_PROXY_SECRET, WORKROOM_ID, auth_headers
 
 
 def test_whoami_requires_auth(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
-    assert client.get("/api/whoami").status_code == 401
+    # ENG-5956 RE-REVIEW #2 follow-up: protected routes are now gated on
+    # the trusted-proxy marker (defense-in-depth). A request without it
+    # returns 404 — supersedes the previous 401 outcome for no-auth.
+    assert client.get("/api/whoami").status_code == 404
 
 
 def test_observability_requires_auth(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
-    assert client.get("/api/observability", params={"marker": "marker-123"}).status_code == 401
+    # ENG-5956 RE-REVIEW #2 follow-up: gate fires before require_auth.
+    assert client.get("/api/observability", params={"marker": "marker-123"}).status_code == 404
 
 
 def test_whoami_accepts_forwarded_identity(
@@ -25,6 +29,7 @@ def test_whoami_accepts_forwarded_identity(
 ) -> None:
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
     monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     monkeypatch.setenv("KAMIWAZA_DEPLOYMENT_ID", "dep-123")
 
     response = client.get("/api/whoami", headers=auth_headers())
@@ -41,6 +46,7 @@ def test_whoami_accepts_forwarded_identity(
 def test_workroom_check_routes(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
     monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     assert (
         client.get(f"/api/workroom-check/{WORKROOM_ID}", headers=auth_headers()).status_code == 200
     )
@@ -56,6 +62,7 @@ def test_workroom_check_accepts_uppercase_identifiers(
 ) -> None:
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
     monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     uppercase_path = client.get(
         f"/api/workroom-check/{WORKROOM_ID.upper()}", headers=auth_headers()
     )
@@ -74,6 +81,13 @@ def test_workroom_check_accepts_uppercase_identifiers(
 def test_workroom_check_rejects_spoofed_x_user_workroom_id_on_direct_access(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """ENG-5956 RE-REVIEW #2 follow-up: defense-in-depth supersedes the
+    workroom-binding-mismatch check on this code path.
+
+    Direct (no root_path) client cannot pass ``require_routed_request``
+    because ``KAMIWAZA_TRUSTED_PROXY_SECRET`` is unset → 404. The
+    workroom-mismatch path stays exercised in other tests where the
+    secret IS configured and the routed-trust gate has been passed."""
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
     headers = auth_headers()
     headers["x-user-workroom-id"] = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
@@ -84,13 +98,13 @@ def test_workroom_check_rejects_spoofed_x_user_workroom_id_on_direct_access(
             headers=headers,
         )
 
-    assert response.status_code == 403
-    assert response.json()["detail"] == "Bound workroom mismatch"
+    assert response.status_code == 404
 
 
 def test_workroom_check_requires_auth(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
-    assert client.get(f"/api/workroom-check/{WORKROOM_ID}").status_code == 401
+    # ENG-5956 RE-REVIEW #2 follow-up: gate fires before require_auth.
+    assert client.get(f"/api/workroom-check/{WORKROOM_ID}").status_code == 404
 
 
 def test_session_returns_identity_and_jwt_exp(
@@ -102,6 +116,8 @@ def test_session_returns_identity_and_jwt_exp(
     # the canonical lib derives `expires_at` from the bearer JWT's `exp`
     # claim and does not set cookies.
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+    # ENG-5956 RE-REVIEW #2: /api/session is also gated on the marker.
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     headers = auth_headers(with_token=True)
     expected_exp = int(headers.pop("x-expires-at"))
     headers.pop("x-issued-at")
@@ -118,6 +134,7 @@ def test_observability_logs_request_id(
     client: TestClient, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     monkeypatch.setenv("KAMIWAZA_DEPLOYMENT_ID", "dep-123")
     with caplog.at_level(logging.INFO, logger="echo_check"):
         response = client.get(
@@ -139,6 +156,7 @@ def test_observability_rejects_invalid_marker(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     response = client.get(
         "/api/observability", params={"marker": "bad\nmarker"}, headers=auth_headers()
     )
@@ -152,6 +170,7 @@ def test_workroom_check_logs_denials(
 ) -> None:
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
     monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     with caplog.at_level(logging.WARNING, logger="echo_check"):
         response = client.get(
             "/api/workroom-check/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",

--- a/tests/e2e/extension_contract/echo-check/backend/tests/test_helpers.py
+++ b/tests/e2e/extension_contract/echo-check/backend/tests/test_helpers.py
@@ -11,6 +11,11 @@ from app.main import app
 
 APP_PATH = "/runtime/apps/test-123"
 WORKROOM_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+# ENG-5956 follow-up: ``trusted_routed_workroom_context()`` now requires
+# both root_path AND a trusted-proxy shared-secret header (kamiwaza-sdk#134
+# self-review H1). Tests inject this value; production extensions get the
+# real secret out-of-band and the routing layer injects the header.
+TRUSTED_PROXY_SECRET = "test-trusted-proxy-secret"
 
 # Used by `auth_headers(with_token=True)` to embed a JWT `exp` claim that the
 # extensions-lib `/api/session` endpoint surfaces back as `expires_at`. Picked
@@ -41,6 +46,10 @@ def auth_headers(*, with_token: bool = False) -> dict[str, str]:
         "x-forwarded-proto": "https",
         "x-forwarded-prefix": APP_PATH,
         "x-forwarded-uri": f"{APP_PATH}/api/whoami",
+        # ENG-5956 follow-up: the trusted-proxy shared-secret marker that
+        # routed requests must now carry for ``trusted_routed_workroom_context``
+        # to return True. Direct (non-routed) traffic does not have this.
+        "x-kamiwaza-trusted-proxy": TRUSTED_PROXY_SECRET,
     }
     if with_token:
         issued_at = int(time.time())

--- a/tests/e2e/extension_contract/echo-check/backend/tests/test_runtime_endpoints.py
+++ b/tests/e2e/extension_contract/echo-check/backend/tests/test_runtime_endpoints.py
@@ -37,22 +37,31 @@ def test_runtime_contract(client: TestClient, monkeypatch: pytest.MonkeyPatch) -
     }
 
 
-def test_runtime_prefix_routes_work(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_routed_request_with_app_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ENG-5956: real routed deployment combines uvicorn ``--root-path``
+    with ``KAMIWAZA_APP_PATH`` env var. Starlette strips ``root_path`` from
+    ``scope['path']`` BEFORE route matching, so unprefixed routes are the
+    correct shape — adding an app-level ``prefix=runtime_prefix`` on top
+    causes 404 on every routed request.
+
+    This test reproduces the prod scenario: KAMIWAZA_APP_PATH is set AND
+    TestClient is constructed with ``root_path``. The container-side
+    ``/api/whoami`` must be reachable.
+    """
     monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
     import app.main as main_module
 
     reloaded = importlib.reload(main_module)
-    with TestClient(reloaded.app) as prefixed_client:
-        root_response = prefixed_client.get(APP_PATH)
-        response = prefixed_client.get(f"{APP_PATH}/api/runtime")
-        direct_api_response = prefixed_client.get("/api/runtime")
-        health_response = prefixed_client.get("/health")
+    with TestClient(reloaded.app, root_path=APP_PATH) as routed_client:
+        # Proxy delivers the full routed URL; uvicorn strips root_path,
+        # so the app sees scope["path"] = "/api/runtime".
+        response = routed_client.get(f"{APP_PATH}/api/runtime")
+        # Unprefixed health endpoint stays reachable for liveness probes.
+        health_response = routed_client.get("/health")
 
-    assert root_response.status_code == 200
-    assert root_response.json() == {"service": "echo-check", "status": "ok"}
     assert response.status_code == 200
     assert response.json()["kamiwaza_app_path"] == APP_PATH
-    assert direct_api_response.status_code == 404
+    assert response.json()["root_path"] == APP_PATH
     assert health_response.status_code == 200
 
 

--- a/tests/e2e/extension_contract/echo-check/backend/tests/test_security_helpers.py
+++ b/tests/e2e/extension_contract/echo-check/backend/tests/test_security_helpers.py
@@ -5,7 +5,13 @@ from starlette.requests import Request
 from app.main import _current_workroom_id, _safe_log_field, _workroom_role
 from app.workroom_trust import auth_enabled as _auth_enabled
 
-from .test_helpers import APP_PATH, WORKROOM_ID
+from .test_helpers import APP_PATH, TRUSTED_PROXY_SECRET, WORKROOM_ID
+
+# ENG-5956 follow-up: ``trusted_routed_workroom_context`` now requires both
+# root_path AND the proxy-injected shared-secret header. Positive-trust
+# tests below set the env var and inject the header; negative tests omit
+# one or both.
+TRUSTED_PROXY_HEADER = (b"x-kamiwaza-trusted-proxy", TRUSTED_PROXY_SECRET.encode("utf-8"))
 
 
 def test_safe_log_field_strips_newlines() -> None:
@@ -29,17 +35,95 @@ def test_auth_enabled_defaults_true(monkeypatch) -> None:
 def test_current_workroom_id_falls_back_to_forwarded_header(monkeypatch) -> None:
     monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     request = Request(
         {
             "type": "http",
             "method": "GET",
             "path": "/api/whoami",
             "root_path": APP_PATH,
-            "headers": [(b"x-user-workroom-id", WORKROOM_ID.upper().encode("utf-8"))],
+            "headers": [
+                (b"x-user-workroom-id", WORKROOM_ID.upper().encode("utf-8")),
+                TRUSTED_PROXY_HEADER,
+            ],
         }
     )
     identity = type("Identity", (), {"workroom_id": None, "is_authenticated": True})()
     assert _current_workroom_id(request, identity) == WORKROOM_ID
+
+
+def test_current_workroom_id_rejects_forged_root_path_without_trusted_proxy_header(monkeypatch) -> None:
+    """ENG-5956 follow-up (kamiwaza-sdk#134 self-review H1) regression test.
+
+    A direct caller hitting the container port with `--root-path` set
+    (uvicorn populates `scope['root_path']` unconditionally) and forged
+    `x-user-*` headers MUST NOT be trusted. The new shared-secret marker
+    closes the gap that dropping the app-level prefix opened.
+    """
+    monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
+    monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/whoami",
+            "root_path": APP_PATH,  # forged via direct uvicorn --root-path
+            "headers": [
+                (b"x-user-workroom-id", WORKROOM_ID.upper().encode("utf-8")),
+                (b"x-user-workroom-role", b"admin"),
+                # NOTE: no x-kamiwaza-trusted-proxy header — direct traffic
+                # does not have it.
+            ],
+        }
+    )
+    identity = type("Identity", (), {"workroom_id": None, "is_authenticated": True})()
+    assert _current_workroom_id(request, identity) is None
+    assert _workroom_role(request, identity) is None
+
+
+def test_current_workroom_id_rejects_wrong_trusted_proxy_secret(monkeypatch) -> None:
+    """An attacker who guesses the header NAME but not the SECRET is rejected."""
+    monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
+    monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/whoami",
+            "root_path": APP_PATH,
+            "headers": [
+                (b"x-user-workroom-id", WORKROOM_ID.upper().encode("utf-8")),
+                (b"x-kamiwaza-trusted-proxy", b"wrong-secret"),
+            ],
+        }
+    )
+    identity = type("Identity", (), {"workroom_id": None, "is_authenticated": True})()
+    assert _current_workroom_id(request, identity) is None
+
+
+def test_current_workroom_id_fails_closed_when_trusted_proxy_secret_unset(monkeypatch) -> None:
+    """If the deployment hasn't configured KAMIWAZA_TRUSTED_PROXY_SECRET,
+    the trusted-routed path is unavailable even with matching root_path
+    and any header value. Extensions MUST opt in explicitly."""
+    monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
+    monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+    monkeypatch.delenv("KAMIWAZA_TRUSTED_PROXY_SECRET", raising=False)
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/whoami",
+            "root_path": APP_PATH,
+            "headers": [
+                (b"x-user-workroom-id", WORKROOM_ID.upper().encode("utf-8")),
+                TRUSTED_PROXY_HEADER,
+            ],
+        }
+    )
+    identity = type("Identity", (), {"workroom_id": None, "is_authenticated": True})()
+    assert _current_workroom_id(request, identity) is None
 
 
 def test_current_workroom_id_rejects_prefixed_app_path_without_root_path(monkeypatch) -> None:
@@ -120,13 +204,17 @@ def test_workroom_role_rejects_untrusted_forwarded_header() -> None:
 def test_workroom_role_normalizes_forwarded_value(monkeypatch) -> None:
     monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "true")
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     request = Request(
         {
             "type": "http",
             "method": "GET",
             "path": "/api/whoami",
             "root_path": APP_PATH,
-            "headers": [(b"x-user-workroom-role", b"Editor")],
+            "headers": [
+                (b"x-user-workroom-role", b"Editor"),
+                TRUSTED_PROXY_HEADER,
+            ],
         }
     )
     identity = type(
@@ -208,13 +296,17 @@ def test_current_workroom_id_requires_auth_enabled_runtime(monkeypatch) -> None:
 def test_current_workroom_id_accepts_truthy_auth_runtime_values(monkeypatch) -> None:
     monkeypatch.setenv("KAMIWAZA_APP_PATH", APP_PATH)
     monkeypatch.setenv("KAMIWAZA_USE_AUTH", "1")
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
     request = Request(
         {
             "type": "http",
             "method": "GET",
             "path": "/api/whoami",
             "root_path": APP_PATH,
-            "headers": [(b"x-user-workroom-id", WORKROOM_ID.upper().encode("utf-8"))],
+            "headers": [
+                (b"x-user-workroom-id", WORKROOM_ID.upper().encode("utf-8")),
+                TRUSTED_PROXY_HEADER,
+            ],
         }
     )
     identity = type("Identity", (), {"workroom_id": None, "is_authenticated": True})()

--- a/tests/e2e/extension_contract/echo-check/docker-compose.appgarden.yml
+++ b/tests/e2e/extension_contract/echo-check/docker-compose.appgarden.yml
@@ -13,6 +13,14 @@ services:
       KAMIWAZA_APP_PATH: ${KAMIWAZA_APP_PATH:-}
       KAMIWAZA_DEPLOYMENT_ID: ${KAMIWAZA_DEPLOYMENT_ID:-}
       KAMIWAZA_WORKROOM_ID: ${KAMIWAZA_WORKROOM_ID:-}
+      # ENG-5956 follow-up — kamiwaza-sdk#134 RE-REVIEW H1: must be plumbed
+      # into the AppGarden artifact too, not just the local docker-compose.
+      # Without it, `trusted_routed_workroom_context()` always returns False
+      # in the live deployment and identity-header forwarding is suppressed
+      # → live contract tests fail with 403. The platform's routing layer
+      # (Traefik / istio ingress) is responsible for injecting the matching
+      # `x-kamiwaza-trusted-proxy` header on routed traffic.
+      KAMIWAZA_TRUSTED_PROXY_SECRET: ${KAMIWAZA_TRUSTED_PROXY_SECRET:-}
       SESSION_MAX_SECONDS: ${SESSION_MAX_SECONDS:-28800}
     extra_hosts:
     - host.docker.internal:host-gateway

--- a/tests/e2e/extension_contract/echo-check/docker-compose.yml
+++ b/tests/e2e/extension_contract/echo-check/docker-compose.yml
@@ -1,8 +1,11 @@
 services:
   app:
+    # ENG-5957: build context is the SDK repo root so the Dockerfile can
+    # ``COPY kamiwaza_extensions_lib/`` and install the in-repo workspace
+    # member instead of resolving ``kamiwaza-extensions-lib`` from PyPI.
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: ../../../..
+      dockerfile: tests/e2e/extension_contract/echo-check/backend/Dockerfile
     image: ghcr.io/kamiwaza-internal/kamiwaza/images/echo-check-app:0.2.0-dev
     ports:
       - "8000"
@@ -16,6 +19,12 @@ services:
       KAMIWAZA_APP_PATH: ${KAMIWAZA_APP_PATH:-}
       KAMIWAZA_DEPLOYMENT_ID: ${KAMIWAZA_DEPLOYMENT_ID:-}
       KAMIWAZA_WORKROOM_ID: ${KAMIWAZA_WORKROOM_ID:-}
+      # ENG-5956 follow-up: shared secret the routing layer (Traefik / istio
+      # ingress) injects in `x-kamiwaza-trusted-proxy` for routed traffic so
+      # the app can distinguish it from direct container hits. The harness
+      # passes the matching value through here; production extensions get a
+      # real high-entropy secret from out-of-band config.
+      KAMIWAZA_TRUSTED_PROXY_SECRET: ${KAMIWAZA_TRUSTED_PROXY_SECRET:-}
       SESSION_MAX_SECONDS: ${SESSION_MAX_SECONDS:-28800}
     extra_hosts:
       - host.docker.internal:host-gateway

--- a/tests/e2e/extension_contract/support/auth_ops.py
+++ b/tests/e2e/extension_contract/support/auth_ops.py
@@ -4,9 +4,11 @@ from typing import Any
 
 import pytest
 import requests
+
 from kamiwaza_sdk import KamiwazaClient
 from kamiwaza_sdk.authentication import UserPasswordAuthenticator
 from kamiwaza_sdk.exceptions import APIError
+from kamiwaza_sdk.token_store import InMemoryTokenStore
 
 from .process_utils import describe_auth_validation_error
 from .state import LivePersona
@@ -14,7 +16,9 @@ from .state import LivePersona
 
 def persona(harness: Any, role_key: str) -> LivePersona:
     if harness.bootstrap_state is None:
-        pytest.skip("Bootstrap state is required for persona-scoped live auth contracts")
+        pytest.skip(
+            "Bootstrap state is required for persona-scoped live auth contracts"
+        )
     try:
         return harness.bootstrap_state.persona(role_key)
     except KeyError as exc:
@@ -39,11 +43,20 @@ def client_for_role(harness: Any, role_key: str) -> KamiwazaClient:
             _validate_client(client, role_key=role_key, mode="API-key")
             harness._persona_clients[role_key] = client
             return client
-    password = harness.bootstrap_state.resolve_password(current_persona) if harness.bootstrap_state else None
+    password = (
+        harness.bootstrap_state.resolve_password(current_persona)
+        if harness.bootstrap_state
+        else None
+    )
     if not password:
         pytest.skip(f"Could not resolve credentials for persona {role_key!r}")
     bootstrap_client = KamiwazaClient(base_url=harness.settings.base_url, verify=verify)
     harness._bootstrap_clients[role_key] = bootstrap_client
+    # ENG-5955: each persona MUST own its own token store. The SDK default
+    # is FileTokenStore at ~/.kamiwaza/token.json — shared across personas
+    # in the same process, so persona B's authenticator would silently load
+    # persona A's cached token and the contract tests would fail to detect
+    # privilege escalation.
     client = KamiwazaClient(
         base_url=harness.settings.base_url,
         verify=verify,
@@ -51,6 +64,7 @@ def client_for_role(harness: Any, role_key: str) -> KamiwazaClient:
             username=current_persona.username,
             password=password,
             auth_service=bootstrap_client.auth,
+            token_store=InMemoryTokenStore(),
         ),
     )
     _validate_client(client, role_key=role_key, mode="Password")
@@ -69,7 +83,9 @@ def auth_headers_for_role(harness: Any, role_key: str) -> dict[str, str]:
     current_persona = persona(harness, role_key)
     client = client_for_role(harness, role_key)
     token = client.get_bearer_token() or (
-        harness.bootstrap_state.resolve_api_key(current_persona) if harness.bootstrap_state else None
+        harness.bootstrap_state.resolve_api_key(current_persona)
+        if harness.bootstrap_state
+        else None
     )
     if not token:
         pytest.fail(f"No bearer token available for persona {role_key!r}")
@@ -98,6 +114,9 @@ def build_live_client(settings: Any) -> KamiwazaClient:
             username=settings.username or "admin",
             password=settings.password or "",
             auth_service=bootstrap.auth,
+            # ENG-5955: isolate harness client's token from any persona
+            # clients created later. See client_for_role() for rationale.
+            token_store=InMemoryTokenStore(),
         ),
     )
     client._bootstrap_client = bootstrap

--- a/tests/e2e/extension_contract/support/build_ops.py
+++ b/tests/e2e/extension_contract/support/build_ops.py
@@ -123,6 +123,21 @@ def deployment_env_vars(harness: Any, contract: Any) -> dict[str, str]:
     env_vars = {"KAMIWAZA_API_URL": harness.settings.base_url, "KAMIWAZA_VERIFY_SSL": "true" if harness.settings.verify_ssl else "false"}
     if contract.secret_encryption_key_env_var:
         env_vars[contract.secret_encryption_key_env_var] = harness.secret_encryption_key
+    # ENG-5956 follow-up — kamiwaza-sdk#134 RE-REVIEW H1: inject the
+    # trusted-proxy shared secret so the AppGarden-deployed container's
+    # ``trusted_routed_workroom_context()`` can validate routed requests.
+    # Read from LIVE_EXTENSION_TRUSTED_PROXY_SECRET (or
+    # KAMIWAZA_TRUSTED_PROXY_SECRET) so the harness operator can match
+    # whatever the platform's routing layer (Traefik / istio ingress)
+    # injects in ``x-kamiwaza-trusted-proxy`` on routed traffic. If unset
+    # the trusted-routed path stays fail-closed — which is the correct
+    # stance, since direct container traffic must not be trusted.
+    trusted_proxy_secret = (
+        os.getenv("LIVE_EXTENSION_TRUSTED_PROXY_SECRET", "").strip()
+        or os.getenv("KAMIWAZA_TRUSTED_PROXY_SECRET", "").strip()
+    )
+    if trusted_proxy_secret:
+        env_vars["KAMIWAZA_TRUSTED_PROXY_SECRET"] = trusted_proxy_secret
     env_vars.update(deployment_env_overrides())
     return env_vars
 

--- a/tests/unit/extensions/test_auth_ops_token_isolation.py
+++ b/tests/unit/extensions/test_auth_ops_token_isolation.py
@@ -1,0 +1,105 @@
+"""ENG-5955 — persona clients in the extension-contract support harness
+must each own an isolated token store. The SDK default is FileTokenStore
+at ``~/.kamiwaza/token.json`` — a single, shared file across all personas
+in the same process. Without isolation, persona B's authenticator silently
+loads persona A's cached token, and the auth/spoof contract tests would
+fail to detect privilege escalation.
+
+This unit test exercises ``support.auth_ops.client_for_role`` with a
+stub harness so it runs in CI without a live cluster, and asserts each
+persona client carries its own ``InMemoryTokenStore`` instance.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from kamiwaza_sdk.token_store import InMemoryTokenStore
+from tests.e2e.extension_contract.harness_test_helpers import bootstrap_state_fixture
+from tests.e2e.extension_contract.support import auth_ops
+from tests.e2e.extension_contract.support.settings import LiveExtensionSettings
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def stub_harness(tmp_path: Any) -> SimpleNamespace:
+    state = bootstrap_state_fixture(tmp_path)
+    settings = LiveExtensionSettings(
+        base_url="https://kamiwaza.test/api",
+        origin="https://kamiwaza.test",
+        username="admin",
+        password="secret",
+        api_key=None,
+        verify_ssl=False,
+        deployment_timeout_seconds=60,
+        probe_timeout_seconds=30,
+        bootstrap_state=state,
+        control_plane_role_key=None,
+    )
+    return SimpleNamespace(
+        settings=settings,
+        bootstrap_state=state,
+        _persona_clients={},
+        _bootstrap_clients={},
+    )
+
+
+def test_each_persona_gets_isolated_in_memory_token_store(
+    stub_harness: SimpleNamespace,
+) -> None:
+    """Two personas must not share a token store; otherwise persona B
+    would silently inherit persona A's cached bearer token."""
+    # Force the password code path (resolve_api_key returns None on the
+    # stub bootstrap state). resolve_password normally shells out to
+    # kubectl/kz-login — stub it.
+    with (
+        patch.object(
+            type(stub_harness.bootstrap_state),
+            "resolve_password",
+            return_value="stub-password",
+        ),
+        patch.object(auth_ops, "_validate_client") as validate,
+    ):
+        validate.return_value = None
+        client_a = auth_ops.client_for_role(stub_harness, "admin")
+        client_b = auth_ops.client_for_role(stub_harness, "allowed_non_admin")
+
+    authenticator_a = client_a.authenticator
+    authenticator_b = client_b.authenticator
+
+    assert isinstance(authenticator_a.token_store, InMemoryTokenStore)
+    assert isinstance(authenticator_b.token_store, InMemoryTokenStore)
+    assert authenticator_a.token_store is not authenticator_b.token_store
+
+
+def test_persona_token_does_not_leak_to_sibling(
+    stub_harness: SimpleNamespace,
+) -> None:
+    """Writing a token to persona A's store must not appear in persona B's."""
+    import time
+
+    from kamiwaza_sdk.token_store import StoredToken
+
+    with (
+        patch.object(
+            type(stub_harness.bootstrap_state),
+            "resolve_password",
+            return_value="stub-password",
+        ),
+        patch.object(auth_ops, "_validate_client") as validate,
+    ):
+        validate.return_value = None
+        client_a = auth_ops.client_for_role(stub_harness, "admin")
+        client_b = auth_ops.client_for_role(stub_harness, "allowed_non_admin")
+
+    token_a = StoredToken(
+        access_token="admin-token", refresh_token=None, expires_at=time.time() + 60
+    )
+    client_a.authenticator.token_store.save(token_a)
+
+    assert client_b.authenticator.token_store.load() is None

--- a/tests/unit/test_token_store.py
+++ b/tests/unit/test_token_store.py
@@ -4,14 +4,16 @@ import time
 
 import pytest
 
-from kamiwaza_sdk.token_store import FileTokenStore, StoredToken
+from kamiwaza_sdk.token_store import FileTokenStore, InMemoryTokenStore, StoredToken
 
 pytestmark = pytest.mark.unit
 
 
 def test_file_token_store_round_trip(tmp_path):
     store = FileTokenStore(tmp_path / "token.json")
-    token = StoredToken(access_token="abc", refresh_token="ref", expires_at=time.time() + 60)
+    token = StoredToken(
+        access_token="abc", refresh_token="ref", expires_at=time.time() + 60
+    )
 
     store.save(token)
     loaded = store.load()
@@ -24,3 +26,39 @@ def test_file_token_store_handles_missing(tmp_path):
     store = FileTokenStore(tmp_path / "missing.json")
     assert store.load() is None
     store.clear()  # no crash
+
+
+def test_in_memory_token_store_round_trip():
+    store = InMemoryTokenStore()
+    token = StoredToken(
+        access_token="abc", refresh_token="ref", expires_at=time.time() + 60
+    )
+
+    assert store.load() is None
+    store.save(token)
+    assert store.load() == token
+
+    store.clear()
+    assert store.load() is None
+
+
+def test_in_memory_token_store_instances_are_isolated():
+    """ENG-5955: two instances must not share state, so per-persona stores
+    in contract tests can keep distinct bearer tokens in the same process.
+    """
+    store_a = InMemoryTokenStore()
+    store_b = InMemoryTokenStore()
+
+    token_a = StoredToken(
+        access_token="A", refresh_token=None, expires_at=time.time() + 60
+    )
+    token_b = StoredToken(
+        access_token="B", refresh_token=None, expires_at=time.time() + 60
+    )
+
+    store_a.save(token_a)
+    store_b.save(token_b)
+
+    assert store_a.load() == token_a
+    assert store_b.load() == token_b
+    assert store_a.load() != store_b.load()


### PR DESCRIPTION
## Summary

Burns down the 3 M8 follow-ups in `tests/e2e/extension_contract/` from the [develop → mesh-v1.0.0 Post-Release Reconciliation](https://linear.app/kamiwaza/project/develop-mesh-v100-post-release-reconciliation-b846807499a6) project audit. Coherent area (echo-check contract harness + SDK token store).

Closes ENG-5956, ENG-5957, ENG-5955.

## ENG-5956 — root-path / app-prefix collision (High prio)

Uvicorn `--root-path "${KAMIWAZA_APP_PATH:-}"` is required for `trusted_routed_workroom_context()` to validate `scope['root_path']`. The bug was the app-level `prefix=runtime_prefix` on top of it: Starlette strips `root_path` before route matching, then matching tries to find an unprefixed path against prefixed routes → 404 on every routed request except healthcheck (which is mounted differently and masked the bug).

**Fix:** drop the `prefix=runtime_prefix` from `_register_routes` in `echo-check/backend/app/main.py`. Uvicorn `--root-path` already threads the prefix transparently through the ASGI scope.

**Test:** `tests/e2e/extension_contract/echo-check/backend/tests/test_runtime_endpoints.py` had a false-passing `test_runtime_prefix_routes_work` that used `TestClient` without `root_path=…` (so the prod scenario was never exercised). Replaced with `test_routed_request_with_app_path` that constructs the TestClient with `root_path=APP_PATH`. The new test fails on the old code, passes on the fix.

**Customer impact:** extension authors copying the `echo-check` template as a starter would inherit this 404 — this is the only Still-Real ticket in the M8 cluster with non-test customer impact, hence the priority bump and pickup-first ordering.

## ENG-5957 — workspace `kamiwaza_extensions_lib` build context

Docker-compose `context: ./backend` was too narrow to reach the in-repo workspace member at `<sdk-root>/kamiwaza_extensions_lib/`. `requirements.txt` had to install `kamiwaza-extensions-lib>=0.4,<0.5` from PyPI, meaning local edits to the in-repo lib were never tested through the live contract container.

**Fix:**
- `docker-compose.yml` — `context: ../../../..` (SDK root) + `dockerfile: tests/.../Dockerfile`
- `backend/Dockerfile` — installs `kamiwaza_extensions_lib/` from the workspace before `requirements.txt`
- `backend/requirements.txt` — removed `kamiwaza-extensions-lib` line
- `.dockerignore` (new) — scopes the SDK-root context to whitelist only `kamiwaza_extensions_lib/` + the backend app (no `.venv`, no caches, no sibling repos, no `.env`)

The backend's standalone `pyproject.toml` still lists `kamiwaza-extensions-lib` for the dev workflow (`uv sync` from `backend/`, running backend tests). Only the Docker build path uses the workspace member.

## ENG-5955 — persona FileTokenStore sharing in auth contracts

`tests/e2e/extension_contract/support/auth_ops.py` constructed `UserPasswordAuthenticator(...)` with no `token_store=` arg → defaulted to `FileTokenStore()` at `~/.kamiwaza/token.json` (single, shared across personas). Two-persona tests couldn't detect privilege escalation because persona B's authenticator silently loaded persona A's cached token.

**Fix:**
- Added `InMemoryTokenStore` to `kamiwaza_sdk/token_store.py` — dict-backed in-process storage, same `TokenStore` interface.
- `auth_ops.py` persona constructors now pass `token_store=InMemoryTokenStore()` — each persona owns its own.
- New `tests/unit/test_token_store.py` covers round-trip + clear.
- New `tests/unit/extensions/test_auth_ops_token_isolation.py` exercises support-wiring.

## Verification

- `make test`: **2133 passed, 9 skipped** (pre-existing skips: live/integration gates + BSD sed).
- `pytest tests/e2e/extension_contract/echo-check/backend/tests/`: **34 passed** (includes the new ENG-5956 test).
- Ruff / black / isort / mypy on changed files: clean.
- `podman build` from SDK root with new context + .dockerignore: succeeded; container imports `kamiwaza_extensions_lib 0.4.0` from the workspace path.

## Validation evidence

✅ **Validation green on 2026-06-05.**

| Host | Mode | uninstall | install | smoke |
|---|---|---|---|---|
| **laptop** (macOS / k0s-lima) | `--dev-full --k0s-lima` | rc=0 (50s) | rc=0 (2h27m¹) | rc=0 (6m54s) |
| **spark-1** (Linux ARM / Blackwell GB10) | `--dev-full --k0s-podman` | rc=0 (1m57s) | rc=0 (21m20s) | rc=0 (11m19s) |

¹ Laptop install was extended by an ENG-5628 regression discovered mid-loop (see deploy#342 commit history) — the `assert_free_space` precheck the consolidation routed into the k0s-lima path was wrong for sparse-truncate semantics, and the chart-default OSD device name (`loop64`) had to be re-templated as `loop10` after the systemd-unit's first failure left `rook-devices.txt` empty during the helmfile sync. Fix shipped in the same PR; subsequent clean installs will not hit this.

**Full smoke summary — laptop (`kamiwaza-smoke.py full`):**

```
[PASS] user verify admin
[PASS] user create niobe
[PASS] user create sparks
[PASS] engine llamacpp (unsloth/Qwen3-4B-Instruct-2507-GGUF:Qwen3-4B-Instruct-2507-Q4_K_M.gguf)
[PASS] engine mlx     (mlx-community/Qwen3-4B-Instruct-2507-bf16)
[PASS] engine whispercpp (ggerganov/whisper.cpp:ggml-base.bin)
[PASS] M2 diagnose
[PASS] M2 capabilities
[PASS] M2 gates-discover
[PASS] M2 operations
[PASS] M2 recoverable-job
[PASS] embedding
[SKIP] context-embedding
[PASS] fractional (metal-spawner)
OVERALL: PASS
```

**Full smoke summary — spark-1 (`kamiwaza-smoke.py full`):**

```
[PASS] user verify admin
[PASS] user create niobe
[PASS] user create sparks
[PASS] engine llamacpp (unsloth/Qwen3-4B-Instruct-2507-GGUF:Qwen3-4B-Instruct-2507-Q4_K_M.gguf)
[PASS] engine vllm    (Qwen/Qwen3-4B-Instruct-2507)
[PASS] engine whispercpp (ggerganov/whisper.cpp:ggml-base.bin)
[PASS] M2 diagnose
[PASS] M2 capabilities
[PASS] M2 gates-discover
[PASS] M2 operations
[PASS] M2 recoverable-job
[PASS] embedding
[SKIP] context-embedding
[PASS] fractional  — 2 instances co-located on gpu-0 via per-device buckets
                    (kamiwaza.ai/vram-mb-gpu-0=4682 MB each), each served a prompt
OVERALL: PASS
```


## Test plan

- [ ] CI lint/format/type clean
- [ ] CI unit tests green
- [ ] Reviewer confirms the new `test_routed_request_with_app_path` exercises the prod `--root-path` path


