### PR TITLE
Compare echo-check proxy marker as bytes so non-ASCII headers fail closed (ENG-6495)

### DIFF
--- a/tests/e2e/extension_contract/echo-check/backend/app/workroom_trust.py
+++ b/tests/e2e/extension_contract/echo-check/backend/app/workroom_trust.py
@@ -111,7 +111,27 @@ def has_trusted_proxy_marker(request: Request) -> bool:
     # shared secret. Amplified by echo-check being a starter template
     # extension authors copy verbatim — a weak primitive here would
     # propagate downstream.
-    return hmac.compare_digest(header_value, secret)
+    #
+    # ENG-6495: compare bytes, not strings. Starlette decodes inbound
+    # header values as latin-1, so any byte >= 0x80 yields a non-ASCII
+    # `str`. `hmac.compare_digest(str, str)` raises TypeError on such
+    # inputs ("comparing strings with non-ASCII characters is not
+    # supported"), and FastAPI surfaces that as an unhandled 500 — which
+    # distinguishes a gated protected route (500) from a truly absent
+    # route (404), partially defeating the defense-in-depth gate's
+    # route-hiding intent. Encoding both sides to UTF-8 bytes (or
+    # ASCII-safe ignoring is fine since the secret is configured by
+    # the operator with a known charset; UTF-8 is the safe superset
+    # here) sidesteps that. The try/except wrapper is belt-and-suspenders
+    # against any future input that still trips compare_digest — treat
+    # any error as "no marker" so the gate stays fail-closed.
+    try:
+        return hmac.compare_digest(
+            header_value.encode("utf-8"),
+            secret.encode("utf-8"),
+        )
+    except (UnicodeEncodeError, TypeError, ValueError):
+        return False
 
 
 async def require_routed_request(request: Request) -> None:

--- a/tests/e2e/extension_contract/echo-check/backend/tests/test_security_helpers.py
+++ b/tests/e2e/extension_contract/echo-check/backend/tests/test_security_helpers.py
@@ -103,6 +103,61 @@ def test_current_workroom_id_rejects_wrong_trusted_proxy_secret(monkeypatch) -> 
     assert _current_workroom_id(request, identity) is None
 
 
+def test_has_trusted_proxy_marker_fails_closed_on_non_ascii_header(monkeypatch) -> None:
+    """ENG-6495: Starlette decodes inbound header values as latin-1, so any
+    byte >= 0x80 yields a non-ASCII `str`. The original implementation called
+    ``hmac.compare_digest(str, str)``, which raises ``TypeError`` on such
+    inputs ("comparing strings with non-ASCII characters is not supported")
+    and surfaces as an unhandled 500 — distinguishing a gated protected
+    route from a truly absent route. The fix encodes both sides as UTF-8
+    bytes and wraps in a defensive try/except so any other exotic input
+    also returns ``False`` (fail-closed) rather than raising.
+    """
+    from app.workroom_trust import has_trusted_proxy_marker
+
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
+
+    # latin-1 byte 0xff decodes to "ÿ" (U+00FF) — a single non-ASCII char.
+    # We pass it through the headers exactly as Starlette would deliver it.
+    raw_marker = bytes([0xFF])
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/whoami",
+            "root_path": APP_PATH,
+            "headers": [(b"x-kamiwaza-trusted-proxy", raw_marker)],
+        }
+    )
+
+    # Must return False, NOT raise. The old implementation would raise
+    # TypeError inside compare_digest, which FastAPI would translate to
+    # an unhandled 500.
+    assert has_trusted_proxy_marker(request) is False
+
+
+def test_has_trusted_proxy_marker_matches_correct_secret(monkeypatch) -> None:
+    """Positive control: the bytes-encoded compare still accepts the
+    matching ASCII secret. Guards against an over-aggressive try/except
+    that silently rejects all inputs.
+    """
+    from app.workroom_trust import has_trusted_proxy_marker
+
+    monkeypatch.setenv("KAMIWAZA_TRUSTED_PROXY_SECRET", TRUSTED_PROXY_SECRET)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/api/whoami",
+            "root_path": APP_PATH,
+            "headers": [TRUSTED_PROXY_HEADER],
+        }
+    )
+
+    assert has_trusted_proxy_marker(request) is True
+
+
 def test_current_workroom_id_fails_closed_when_trusted_proxy_secret_unset(monkeypatch) -> None:
     """If the deployment hasn't configured KAMIWAZA_TRUSTED_PROXY_SECRET,
     the trusted-routed path is unavailable even with matching root_path


### PR DESCRIPTION
## Summary

ENG-5956 introduced ``has_trusted_proxy_marker`` as the routed-binding gate (kamiwaza-sdk#134). It compared the inbound ``x-kamiwaza-trusted-proxy`` header against the shared secret with ``hmac.compare_digest(str, str)``.

Starlette decodes inbound headers as latin-1, so any byte ≥ 0x80 produces a non-ASCII ``str``, and ``hmac.compare_digest`` raises ``TypeError`` on such inputs. FastAPI returns 500 — distinguishing a gated route from a truly absent one (which is 404), partially defeating the route-hiding intent of the RE-REVIEW #2 defense-in-depth gate. Fail-closed still holds (a 500 still denies access), but the existence signal leaks and the weak primitive propagates downstream because echo-check is a starter template.

Fix: encode both sides as UTF-8 bytes (``hmac.compare_digest`` handles bytes without raising on non-ASCII content); wrap in a defensive try/except over ``UnicodeEncodeError``, ``TypeError``, ``ValueError`` so any future exotic input also returns ``False`` rather than raising.

Discovered by the kamiwaza-sdk#134 RE-REVIEW round 2 (High Priority finding #1). PR merged via admin override at 660e2e5e with this explicitly flagged as a recommended follow-up rather than a blocker.

## Test plan

- [x] ``pytest tests/e2e/extension_contract/echo-check/backend/tests/`` — 35/35 pass
  - New ``test_has_trusted_proxy_marker_fails_closed_on_non_ascii_header`` (regression for the original 500 path)
  - New ``test_has_trusted_proxy_marker_matches_correct_secret`` (positive control)

## Context

- Linear ticket: [ENG-6495](https://linear.app/kamiwaza/issue/ENG-6495)
- Project: develop → mesh-v1.0.0 Post-Release Reconciliation (M8)
- Originating finding: kamiwaza-sdk#134 RE-REVIEW round 2 ([comment](https://github.com/kamiwaza-ai/kamiwaza-sdk/pull/134#issuecomment-4637316889))