### PR TITLE
Fail loudly when live Kamiwaza server is unreachable (ENG-6504)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ python_version = "3.10"
 
 [dependency-groups]
 dev = [
-    "pytest>=7.0",
+    "pytest>=8.1",  # __wrapped__ on FixtureFunctionDefinition required by tests/unit/test_live_server_available_fixture.py (ENG-6504)
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.0",
     "pytest-responses>=0.5",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -987,21 +987,28 @@ def live_server_available(live_base_url: str) -> str:
             last_exc = exc
             if attempt < attempts - 1:
                 time.sleep(backoff_seconds)
+    # pytest's exit code 2 normally means EXIT_INTERRUPTED. We reuse it here
+    # because "infrastructure unreachable" is operationally the same shape
+    # from a pipeline perspective: the run did not complete normally, and any
+    # caller that already treats non-zero pytest exits as failure (e.g. the
+    # kajiya smoke runner) handles it without special-casing. The collision is
+    # intentional and documented.
+    _INFRA_UNAVAILABLE_RETURNCODE = 2
     if response is None:
         pytest.exit(
             f"Kamiwaza server unavailable at {live_base_url} after {attempts} attempts: {last_exc}",
-            returncode=2,
+            returncode=_INFRA_UNAVAILABLE_RETURNCODE,
         )
     if response.status_code >= 500:
         pytest.exit(
             f"Kamiwaza server unhealthy at {health_url}: {response.status_code}",
-            returncode=2,
+            returncode=_INFRA_UNAVAILABLE_RETURNCODE,
         )
     if response.status_code >= 400 and response.status_code not in (401, 403):
         pytest.exit(
             f"Kamiwaza server at {health_url} returned unexpected status {response.status_code}; "
             "check base URL or ping route configuration.",
-            returncode=2,
+            returncode=_INFRA_UNAVAILABLE_RETURNCODE,
         )
     return live_base_url
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -952,9 +952,17 @@ def _resolve_live_password_once(
 def live_server_available(live_base_url: str) -> str:
     """Ensure a running Kamiwaza server is reachable before running live tests.
 
-    Retries a few times before skipping: a ``pytest.skip`` raised from a
-    session-scoped fixture is cached for every dependent test, so a single
-    slow request against a cold platform can cascade into a whole-suite skip.
+    Retries a few times, then ``pytest.exit`` if the server is unreachable or
+    unhealthy. Earlier versions raised ``pytest.skip`` here, which pytest caches
+    on a session-scoped fixture and replays as a skip on every dependent test —
+    producing a green report with 165+ silent skips when the platform was
+    actually down (see ENG-6504). Exiting fails the run loudly with the actual
+    cause; tests that intentionally don't need a live server should not depend
+    on this fixture.
+
+    Auth-related skips in sibling fixtures (``live_kamiwaza_client``,
+    ``resolved_live_password``) stay as ``pytest.skip`` — missing credentials
+    is a legitimate opt-out, distinct from "infrastructure is broken."
     """
 
     health_url = f"{live_base_url}/ping"
@@ -980,17 +988,20 @@ def live_server_available(live_base_url: str) -> str:
             if attempt < attempts - 1:
                 time.sleep(backoff_seconds)
     if response is None:
-        pytest.skip(
-            f"Kamiwaza server unavailable at {live_base_url} after {attempts} attempts: {last_exc}"
+        pytest.exit(
+            f"Kamiwaza server unavailable at {live_base_url} after {attempts} attempts: {last_exc}",
+            returncode=2,
         )
     if response.status_code >= 500:
-        pytest.skip(
-            f"Kamiwaza server unhealthy at {health_url}: {response.status_code}"
+        pytest.exit(
+            f"Kamiwaza server unhealthy at {health_url}: {response.status_code}",
+            returncode=2,
         )
     if response.status_code >= 400 and response.status_code not in (401, 403):
-        pytest.skip(
+        pytest.exit(
             f"Kamiwaza server at {health_url} returned unexpected status {response.status_code}; "
-            "check base URL or ping route configuration."
+            "check base URL or ping route configuration.",
+            returncode=2,
         )
     return live_base_url
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -983,7 +983,7 @@ def live_server_available(live_base_url: str) -> str:
                 verify=_verify_ssl_enabled(),
             )
             break
-        except requests.RequestException as exc:  # pragma: no cover - network guard
+        except requests.RequestException as exc:
             last_exc = exc
             if attempt < attempts - 1:
                 time.sleep(backoff_seconds)

--- a/tests/integration/test_operator_compatible_tags.py
+++ b/tests/integration/test_operator_compatible_tags.py
@@ -20,6 +20,11 @@ from kamiwaza_extensions.platform_compat import (
     OPERATOR_IMAGE,
 )
 
+# The module docstring already says "Marked ``integration`` so it does not run
+# in the default ``make test`` path" — but the marker had drifted away. This
+# restores it so the GHCR resolve sanity-check stays out of the unit lane.
+pytestmark = pytest.mark.integration
+
 # OPERATOR_IMAGE is "ghcr.io/<owner>/<repo>" — split into the registry path
 # expected by GHCR's OCI distribution API.
 _GHCR_HOST = "ghcr.io"

--- a/tests/integration/test_write_scope_access.py
+++ b/tests/integration/test_write_scope_access.py
@@ -15,6 +15,14 @@ import pytest
 from kamiwaza_sdk import KamiwazaClient
 from kamiwaza_sdk.exceptions import APIError  # noqa: F401 – used in pytest.raises
 
+# These tests depend on ``live_write_client`` → ``live_session_write_key`` →
+# ``live_server_available`` and run against a live cluster. Without the marker
+# they get selected by ``make test`` (which runs ``-m "not integration and not
+# live and not e2e"``), and the session-scoped ``live_server_available`` fixture
+# would then ``pytest.exit`` the unit job on any runner without a reachable
+# Kamiwaza server. See ENG-6504.
+pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
+
 
 # ---------------------------------------------------------------------------
 # Health / status endpoints — should always work for authenticated users

--- a/tests/unit/test_live_server_available_fixture.py
+++ b/tests/unit/test_live_server_available_fixture.py
@@ -1,0 +1,148 @@
+"""ENG-6504 regression guard: ``live_server_available`` must fail the session
+loudly when the platform is unreachable, not silently skip every dependent
+test.
+
+The integration conftest's ``live_server_available`` previously called
+``pytest.skip(...)`` on the three "infrastructure broken" paths (no response,
+5xx, unexpected 4xx). Because pytest caches skips raised from session-scoped
+fixtures and replays them on every dependent test, a single unreachable ``/ping``
+turned into 165 silent skips and a green smoke report (see ENG-6504).
+
+These tests pin the new contract: each of those three paths must raise
+``SystemExit`` via ``pytest.exit``, so the session terminates with a non-zero
+return code instead of cascading skips.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+from _pytest.outcomes import Exit
+
+CONFTEST_PATH = (
+    Path(__file__).resolve().parents[1] / "integration" / "conftest.py"
+)
+
+
+@pytest.fixture(scope="module")
+def integration_conftest():
+    spec = importlib.util.spec_from_file_location(
+        "_integration_conftest_under_test", CONFTEST_PATH
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def live_server_fn(integration_conftest):
+    """Underlying function of the ``live_server_available`` fixture."""
+    fn = getattr(integration_conftest.live_server_available, "__wrapped__", None)
+    assert fn is not None, "pytest fixture must expose __wrapped__ for testing"
+    return fn
+
+
+def _make_response(status_code: int) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    return response
+
+
+def test_live_server_available_exits_when_unreachable(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """No response after retries -> pytest.exit, not pytest.skip cascade."""
+    monkeypatch.setattr(integration_conftest.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(side_effect=requests.ConnectionError("connection refused")),
+    )
+
+    with pytest.raises(Exit) as excinfo:
+        live_server_fn("https://example.invalid/api")
+
+    assert excinfo.value.returncode == 2
+    # System.exit re-raises pytest.Exit which preserves the message; we don't
+    # assert on the text here to avoid coupling to pytest's internals.
+
+
+def test_live_server_available_exits_on_5xx(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """5xx response -> pytest.exit, not pytest.skip cascade."""
+    monkeypatch.setattr(integration_conftest.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(503)),
+    )
+
+    with pytest.raises(Exit) as excinfo:
+        live_server_fn("https://example.invalid/api")
+
+    assert excinfo.value.returncode == 2
+
+
+def test_live_server_available_exits_on_unexpected_4xx(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """4xx other than 401/403 -> pytest.exit (config / base URL is wrong)."""
+    monkeypatch.setattr(integration_conftest.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(418)),
+    )
+
+    with pytest.raises(Exit) as excinfo:
+        live_server_fn("https://example.invalid/api")
+
+    assert excinfo.value.returncode == 2
+
+
+def test_live_server_available_passes_on_200(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """Healthy server -> returns base URL, no skip, no exit."""
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(200)),
+    )
+
+    result = live_server_fn("https://example.invalid/api")
+    assert result == "https://example.invalid/api"
+
+
+def test_live_server_available_passes_on_401(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """401 is a legitimate auth-required response, not infra failure."""
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(401)),
+    )
+
+    result = live_server_fn("https://example.invalid/api")
+    assert result == "https://example.invalid/api"
+
+
+def test_live_server_available_passes_on_403(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """403 is a legitimate forbidden response, not infra failure."""
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(403)),
+    )
+
+    result = live_server_fn("https://example.invalid/api")
+    assert result == "https://example.invalid/api"

--- a/tests/unit/test_live_server_available_fixture.py
+++ b/tests/unit/test_live_server_available_fixture.py
@@ -56,20 +56,23 @@ def _make_response(status_code: int) -> requests.Response:
 def test_live_server_available_exits_when_unreachable(
     integration_conftest, live_server_fn, monkeypatch
 ) -> None:
-    """No response after retries -> pytest.exit, not pytest.skip cascade."""
+    """No response after retries -> pytest.exit, not pytest.skip cascade.
+
+    Also pins the retry contract: requests.get is invoked exactly 3 times before
+    the fixture gives up. A regression that short-circuits the loop or drops a
+    retry would still satisfy "raises Exit" but should still fail this test.
+    """
     monkeypatch.setattr(integration_conftest.time, "sleep", lambda _: None)
-    monkeypatch.setattr(
-        integration_conftest.requests,
-        "get",
-        Mock(side_effect=requests.ConnectionError("connection refused")),
-    )
+    mock_get = Mock(side_effect=requests.ConnectionError("connection refused"))
+    monkeypatch.setattr(integration_conftest.requests, "get", mock_get)
 
     with pytest.raises(Exit) as excinfo:
         live_server_fn("https://example.invalid/api")
 
     assert excinfo.value.returncode == 2
-    # System.exit re-raises pytest.Exit which preserves the message; we don't
-    # assert on the text here to avoid coupling to pytest's internals.
+    assert mock_get.call_count == 3, (
+        f"expected 3 retry attempts before exit, got {mock_get.call_count}"
+    )
 
 
 def test_live_server_available_exits_on_5xx(

--- a/tests/unit/test_live_server_available_fixture.py
+++ b/tests/unit/test_live_server_available_fixture.py
@@ -8,9 +8,10 @@ The integration conftest's ``live_server_available`` previously called
 fixtures and replays them on every dependent test, a single unreachable ``/ping``
 turned into 165 silent skips and a green smoke report (see ENG-6504).
 
-These tests pin the new contract: each of those three paths must raise
-``SystemExit`` via ``pytest.exit``, so the session terminates with a non-zero
-return code instead of cascading skips.
+These tests pin the new contract: each of those three paths must call
+``pytest.exit``, which raises ``_pytest.outcomes.Exit`` (a distinct exception
+from ``SystemExit``) so the session terminates with a non-zero return code
+instead of cascading skips.
 """
 
 from __future__ import annotations
@@ -22,6 +23,12 @@ from unittest.mock import Mock
 import pytest
 import requests
 from _pytest.outcomes import Exit
+
+# Mark the whole module so the regression guard runs in the ``make test-unit``
+# lane. Without this, ``pytest -m unit`` deselects all six tests and the guard
+# silently never executes — ironic for a PR whose thesis is "don't silently
+# skip" (PR #136 re-review Medium #1).
+pytestmark = pytest.mark.unit
 
 CONFTEST_PATH = (
     Path(__file__).resolve().parents[1] / "integration" / "conftest.py"

--- a/uv.lock
+++ b/uv.lock
@@ -980,7 +980,7 @@ dev = [
     { name = "pdoc", specifier = ">=14.0" },
     { name = "pyarrow", specifier = ">=17.0" },
     { name = "pyjwt", specifier = ">=2.8" },
-    { name = "pytest", specifier = ">=7.0" },
+    { name = "pytest", specifier = ">=8.1" },
     { name = "pytest-asyncio", specifier = ">=0.23" },
     { name = "pytest-cov", specifier = ">=4.0" },
     { name = "pytest-httpx", specifier = ">=0.30" },


### PR DESCRIPTION
## Summary

L1 piece of [ENG-6504](https://linear.app/kamiwaza/issue/ENG-6504): convert the three `pytest.skip` calls in `live_server_available` to `pytest.exit(returncode=2)`. Eliminates the cached-skip cascade that turned one unreachable `/ping` into 165 silent skips and a green smoke report.

Companion to kajiya [#154](https://github.com/kamiwaza-internal/kajiya/pull/154) (L4 — TCP-probe in resource gate). L4 stops the bug at gate time; L1 stops it the moment the SDK suite touches the broken fixture.

## Why

`live_server_available` is session-scoped. When a session-scoped fixture raises `pytest.skip`, pytest caches the skip and replays it on every dependent test — that's by design for skip semantics. The result: one ping failure becomes N silent skips, the suite exits 0, and downstream pipelines (e.g. the kajiya smoke) report green.

This is exactly the failure mode ENG-6504 documents. The kamiwaza-sdk-side fix is to never raise a skip in this fixture for infrastructure failure modes — those should fail the run loudly with a single clear cause.

## Scope

Three call sites in `tests/integration/conftest.py:983-994` (no response after retries, 5xx response, unexpected 4xx response). All three pass an instructive message describing the failure, now routed through `pytest.exit` with `returncode=2`.

**Out of scope:** auth-related skips in `live_kamiwaza_client`, `live_kamiwaza_session_client`, and `resolved_live_password`. Those skip on missing credentials — a legitimate opt-out, not infrastructure failure. The new docstring explicitly calls this out.

## Changes

| File | Change |
|---|---|
| `tests/integration/conftest.py` | Three `pytest.skip(...)` → `pytest.exit(..., returncode=2)`; new docstring explains the contract and links the auth-fixture distinction |
| `tests/unit/test_live_server_available_fixture.py` | NEW: 6 unit tests covering exits-on-unreachable / 5xx / unexpected 4xx and passes-on-200 / 401 / 403 |

## Test plan

- [x] `uv run pytest tests/unit/test_live_server_available_fixture.py -v` → 6 passed
- [ ] Full SDK suite against a healthy cluster (no behavior change expected for the happy path)
- [ ] Next kajiya `/kajiya smoke` against a broken install: pipeline reports red with the actual cause, no 165-skip cascade

## Implementation notes

The unit tests use `importlib.util.spec_from_file_location` to load `tests/integration/conftest.py` as a module without depending on package import paths (`tests/` is not a package; `tests/integration/` is). The fixture's underlying function is accessed via `__wrapped__` (pytest uses `functools.wraps`). `pytest.exit` raises `_pytest.outcomes.Exit`, which is what `pytest.raises(Exit)` catches.

## Related

- ENG-6504 — full L1–L4 layered root cause
- kajiya #154 — L4 resource-gate TCP probe (companion fix in different repo)