### PR TITLE
Fail loudly when live Kamiwaza server is unreachable (ENG-6504)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -948,9 +948,17 @@ def _resolve_live_password_once(
 def live_server_available(live_base_url: str) -> str:
     """Ensure a running Kamiwaza server is reachable before running live tests.
 
-    Retries a few times before skipping: a ``pytest.skip`` raised from a
-    session-scoped fixture is cached for every dependent test, so a single
-    slow request against a cold platform can cascade into a whole-suite skip.
+    Retries a few times, then ``pytest.exit`` if the server is unreachable or
+    unhealthy. Earlier versions raised ``pytest.skip`` here, which pytest caches
+    on a session-scoped fixture and replays as a skip on every dependent test —
+    producing a green report with 165+ silent skips when the platform was
+    actually down (see ENG-6504). Exiting fails the run loudly with the actual
+    cause; tests that intentionally don't need a live server should not depend
+    on this fixture.
+
+    Auth-related skips in sibling fixtures (``live_kamiwaza_client``,
+    ``resolved_live_password``) stay as ``pytest.skip`` — missing credentials
+    is a legitimate opt-out, distinct from "infrastructure is broken."
     """
 
     health_url = f"{live_base_url}/ping"
@@ -971,22 +979,32 @@ def live_server_available(live_base_url: str) -> str:
                 verify=_verify_ssl_enabled(),
             )
             break
-        except requests.RequestException as exc:  # pragma: no cover - network guard
+        except requests.RequestException as exc:
             last_exc = exc
             if attempt < attempts - 1:
                 time.sleep(backoff_seconds)
+    # pytest's exit code 2 normally means EXIT_INTERRUPTED. We reuse it here
+    # because "infrastructure unreachable" is operationally the same shape
+    # from a pipeline perspective: the run did not complete normally, and any
+    # caller that already treats non-zero pytest exits as failure (e.g. the
+    # kajiya smoke runner) handles it without special-casing. The collision is
+    # intentional and documented.
+    _INFRA_UNAVAILABLE_RETURNCODE = 2
     if response is None:
-        pytest.skip(
-            f"Kamiwaza server unavailable at {live_base_url} after {attempts} attempts: {last_exc}"
+        pytest.exit(
+            f"Kamiwaza server unavailable at {live_base_url} after {attempts} attempts: {last_exc}",
+            returncode=_INFRA_UNAVAILABLE_RETURNCODE,
         )
     if response.status_code >= 500:
-        pytest.skip(
-            f"Kamiwaza server unhealthy at {health_url}: {response.status_code}"
+        pytest.exit(
+            f"Kamiwaza server unhealthy at {health_url}: {response.status_code}",
+            returncode=_INFRA_UNAVAILABLE_RETURNCODE,
         )
     if response.status_code >= 400 and response.status_code not in (401, 403):
-        pytest.skip(
+        pytest.exit(
             f"Kamiwaza server at {health_url} returned unexpected status {response.status_code}; "
-            "check base URL or ping route configuration."
+            "check base URL or ping route configuration.",
+            returncode=_INFRA_UNAVAILABLE_RETURNCODE,
         )
     return live_base_url
 

--- a/tests/integration/test_write_scope_access.py
+++ b/tests/integration/test_write_scope_access.py
@@ -15,6 +15,14 @@ import pytest
 from kamiwaza_sdk import KamiwazaClient
 from kamiwaza_sdk.exceptions import APIError  # noqa: F401 – used in pytest.raises
 
+# These tests depend on ``live_write_client`` → ``live_session_write_key`` →
+# ``live_server_available`` and run against a live cluster. Without the marker
+# they get selected by ``make test`` (which runs ``-m "not integration and not
+# live and not e2e"``), and the session-scoped ``live_server_available`` fixture
+# would then ``pytest.exit`` the unit job on any runner without a reachable
+# Kamiwaza server. See ENG-6504.
+pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
+
 
 # ---------------------------------------------------------------------------
 # Health / status endpoints — should always work for authenticated users

--- a/tests/unit/test_live_server_available_fixture.py
+++ b/tests/unit/test_live_server_available_fixture.py
@@ -1,0 +1,158 @@
+"""ENG-6504 regression guard: ``live_server_available`` must fail the session
+loudly when the platform is unreachable, not silently skip every dependent
+test.
+
+The integration conftest's ``live_server_available`` previously called
+``pytest.skip(...)`` on the three "infrastructure broken" paths (no response,
+5xx, unexpected 4xx). Because pytest caches skips raised from session-scoped
+fixtures and replays them on every dependent test, a single unreachable ``/ping``
+turned into 165 silent skips and a green smoke report (see ENG-6504).
+
+These tests pin the new contract: each of those three paths must call
+``pytest.exit``, which raises ``_pytest.outcomes.Exit`` (a distinct exception
+from ``SystemExit``) so the session terminates with a non-zero return code
+instead of cascading skips.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+from _pytest.outcomes import Exit
+
+# Mark the whole module so the regression guard runs in the ``make test-unit``
+# lane. Without this, ``pytest -m unit`` deselects all six tests and the guard
+# silently never executes — ironic for a PR whose thesis is "don't silently
+# skip" (PR #136 re-review Medium #1).
+pytestmark = pytest.mark.unit
+
+CONFTEST_PATH = (
+    Path(__file__).resolve().parents[1] / "integration" / "conftest.py"
+)
+
+
+@pytest.fixture(scope="module")
+def integration_conftest():
+    spec = importlib.util.spec_from_file_location(
+        "_integration_conftest_under_test", CONFTEST_PATH
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def live_server_fn(integration_conftest):
+    """Underlying function of the ``live_server_available`` fixture."""
+    fn = getattr(integration_conftest.live_server_available, "__wrapped__", None)
+    assert fn is not None, "pytest fixture must expose __wrapped__ for testing"
+    return fn
+
+
+def _make_response(status_code: int) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    return response
+
+
+def test_live_server_available_exits_when_unreachable(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """No response after retries -> pytest.exit, not pytest.skip cascade.
+
+    Also pins the retry contract: requests.get is invoked exactly 3 times before
+    the fixture gives up. A regression that short-circuits the loop or drops a
+    retry would still satisfy "raises Exit" but should still fail this test.
+    """
+    monkeypatch.setattr(integration_conftest.time, "sleep", lambda _: None)
+    mock_get = Mock(side_effect=requests.ConnectionError("connection refused"))
+    monkeypatch.setattr(integration_conftest.requests, "get", mock_get)
+
+    with pytest.raises(Exit) as excinfo:
+        live_server_fn("https://example.invalid/api")
+
+    assert excinfo.value.returncode == 2
+    assert mock_get.call_count == 3, (
+        f"expected 3 retry attempts before exit, got {mock_get.call_count}"
+    )
+
+
+def test_live_server_available_exits_on_5xx(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """5xx response -> pytest.exit, not pytest.skip cascade."""
+    monkeypatch.setattr(integration_conftest.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(503)),
+    )
+
+    with pytest.raises(Exit) as excinfo:
+        live_server_fn("https://example.invalid/api")
+
+    assert excinfo.value.returncode == 2
+
+
+def test_live_server_available_exits_on_unexpected_4xx(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """4xx other than 401/403 -> pytest.exit (config / base URL is wrong)."""
+    monkeypatch.setattr(integration_conftest.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(418)),
+    )
+
+    with pytest.raises(Exit) as excinfo:
+        live_server_fn("https://example.invalid/api")
+
+    assert excinfo.value.returncode == 2
+
+
+def test_live_server_available_passes_on_200(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """Healthy server -> returns base URL, no skip, no exit."""
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(200)),
+    )
+
+    result = live_server_fn("https://example.invalid/api")
+    assert result == "https://example.invalid/api"
+
+
+def test_live_server_available_passes_on_401(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """401 is a legitimate auth-required response, not infra failure."""
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(401)),
+    )
+
+    result = live_server_fn("https://example.invalid/api")
+    assert result == "https://example.invalid/api"
+
+
+def test_live_server_available_passes_on_403(
+    integration_conftest, live_server_fn, monkeypatch
+) -> None:
+    """403 is a legitimate forbidden response, not infra failure."""
+    monkeypatch.setattr(
+        integration_conftest.requests,
+        "get",
+        Mock(return_value=_make_response(403)),
+    )
+
+    result = live_server_fn("https://example.invalid/api")
+    assert result == "https://example.invalid/api"


### PR DESCRIPTION
## Summary

Port the ENG-6504 L1 "fail loud" guard from `develop` (#136) to **`main`**: convert the three `pytest.skip` calls in the session-scoped `live_server_available` fixture to `pytest.exit(returncode=2)`.

## Why this is needed on main specifically

`live_server_available` is session-scoped. A `pytest.skip` raised from a session-scoped fixture is cached and replayed on every dependent test, so a single unreachable `/ping` cascades into a whole-suite skip and the run still exits 0 — a **green report that silently exercised almost nothing**.

This is exactly what the kajiya Azure smoke hit: run 27101925299 reported green with `tests=197 ... skipped=196`, every skip reading `Kamiwaza server unavailable ... Connection refused`. The kajiya smoke runs **`sdk_ref=main`**, but #136 only landed on `develop` — so today main still silently false-greens on an unreachable server. This PR closes that gap.

Companion to kajiya **#162** (resolves the smoke's `/etc/hosts → 127.0.0.1` connectivity bug that triggered the unreachable condition). #162 makes the suite reachable; this guard makes a *future* outage fail loudly instead of false-greening.

## Scope

- Three call sites in `live_server_available` (no response after retries, 5xx, unexpected 4xx) now `pytest.exit(returncode=2)` with the same instructive messages.
- **Out of scope (unchanged):** auth-related skips in `live_kamiwaza_client` / `resolved_live_password` stay `pytest.skip` — missing credentials is a legitimate opt-out, distinct from "infrastructure is broken." The new docstring documents this distinction.

## Changes

| File | Change |
|---|---|
| `tests/integration/conftest.py` | three `pytest.skip` → `pytest.exit(..., returncode=2)`; docstring documents the contract + auth-fixture distinction |
| `tests/unit/test_live_server_available_fixture.py` | NEW — 6 unit tests: exits on unreachable/5xx/unexpected-4xx, passes on 200/401/403 |

## Test plan

- [x] `uv run pytest tests/unit/test_live_server_available_fixture.py -v` → **6 passed**

This is a faithful, minimal port of #136's conftest guard; the ENG-5784-coupled test-file tweaks in #136 are intentionally omitted (that harness isn't on main).

ENG-6504
