### PR TITLE
Add 'oci' to StorageType enum for model files (ENG-6537)

### DIFF
--- a/kamiwaza_sdk/schemas/models/model_file.py
+++ b/kamiwaza_sdk/schemas/models/model_file.py
@@ -9,6 +9,7 @@ class StorageType(str, Enum):
     FILE = 'file'
     S3 = 's3'
     SCRATCH = 'scratch'
+    OCI = 'oci'  # OCI-registry / ImageVolume-backed model files (ENG-6537)
 
     def __str__(self):
         return self.value
@@ -17,7 +18,7 @@ class CreateModelFile(BaseModel):
     """Object with fields required to create a ModelFile"""
     name: str = Field(..., description="The name of the model file")
     size: Optional[int] = Field(None, description="The size of the model file in bytes")
-    storage_type: Optional[StorageType] = Field(None, description="The type of storage where the file is located (file or s3)")
+    storage_type: Optional[StorageType] = Field(None, description="The type of storage where the file is located (file, s3, scratch, or oci)")
     storage_host: str = Field(default="localhost", description="Host where the file is stored")
     storage_location: Optional[str] = Field(None, description="The location path or key where the file is stored")
 

--- a/tests/unit/test_model_file_storage_type.py
+++ b/tests/unit/test_model_file_storage_type.py
@@ -1,0 +1,36 @@
+"""Regression tests for ModelFile storage_type (ENG-6537).
+
+The platform returns ``storage_type='oci'`` for OCI / ImageVolume-backed model
+files. Before ENG-6537 the SDK ``StorageType`` enum only allowed
+``file``/``s3``/``scratch``, so any ``Model`` whose ``m_files`` used OCI storage
+failed pydantic validation — which silently skip-cascaded ~36 live SDK tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kamiwaza_sdk.schemas.models.model_file import (
+    CreateModelFile,
+    ModelFile,
+    StorageType,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_storage_type_accepts_oci():
+    assert StorageType("oci") is StorageType.OCI
+    assert str(StorageType.OCI) == "oci"
+
+
+@pytest.mark.parametrize("value", ["file", "s3", "scratch", "oci"])
+def test_model_file_deserializes_all_storage_types(value):
+    # Mirrors the failing path: Model.m_files[].storage_type coming back from the API.
+    mf = ModelFile.model_validate({"name": "weights.gguf", "storage_type": value})
+    assert mf.storage_type == StorageType(value)
+
+
+def test_create_model_file_accepts_oci():
+    cmf = CreateModelFile.model_validate({"name": "weights.gguf", "storage_type": "oci"})
+    assert cmf.storage_type is StorageType.OCI


### PR DESCRIPTION
## Problem

In the kajiya Azure SDK e2e smoke (run 27139729807, sdk `main`), **~36 of 53 failures/errors** were a single schema mismatch:
```
pydantic ValidationError: Model.m_files[0].storage_type
  Input should be 'file', 's3' or 'scratch'  [input_value='oci']
```
The platform returns `storage_type='oci'` for OCI / `ImageVolume`-backed model files, but `StorageType` only allowed `file`/`s3`/`scratch`. The strict enum rejected `oci`, so any `Model` with an OCI-backed file failed to deserialize (28 direct + 8 fixture-setup failures).

## Fix
Add `OCI = 'oci'` to `StorageType` (`kamiwaza_sdk/schemas/models/model_file.py`) and update the field description. Adds `tests/unit/test_model_file_storage_type.py` (6 tests, all storage types via `model_validate`).

## Test plan
- [x] `uv run pytest tests/unit/test_model_file_storage_type.py` -> 6 passed
- Expected effect on the live smoke: clears the ~36 `storage_type` failures (107 -> ~143 passing).

ENG-6537
