### PR TITLE
Skip context LLM tests when undeployable — develop (ENG-6533)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1163,7 +1163,15 @@ def context_llm_prerequisite(
     live_kamiwaza_session_client: KamiwazaClient,
     ensure_repo_ready,
 ) -> Iterator[str]:
-    """Ensure a usable LLM deployment exists for context ontology operations."""
+    """Ensure a usable LLM deployment exists for context ontology operations, or skip once.
+
+    Mirrors ``embedding_model_prerequisite``: if no LLM is already deployed the
+    fixture attempts to provision one, but it **skips** (does not error) when the
+    platform cannot bring one up — e.g. a CPU-only smoke host with no inference
+    capacity, or an MLX-only test model on a non-Apple-Silicon runner. This keeps
+    the context ontology/vectordb tests as conditional skips on incapable hosts
+    instead of a cascade of fixture-setup ERRORs.
+    """
     client = live_kamiwaza_session_client
 
     existing = _preferred_active_model_deployment(
@@ -1175,30 +1183,40 @@ def context_llm_prerequisite(
         yield existing["deployment_id"]
         return
 
-    model = ensure_repo_ready(client, CONTEXT_TEST_LLM_REPO)
-    configs = client.models.get_model_configs(model.id)
-    if not configs:
-        pytest.fail(
-            f"No model configs available for context LLM repo '{CONTEXT_TEST_LLM_REPO}'"
+    try:
+        model = ensure_repo_ready(client, CONTEXT_TEST_LLM_REPO)
+        configs = client.models.get_model_configs(model.id)
+        if not configs:
+            pytest.skip(
+                f"No model configs available for context LLM repo '{CONTEXT_TEST_LLM_REPO}'"
+            )
+        default_config = next(
+            (config for config in configs if config.default), configs[0]
         )
-    default_config = next((config for config in configs if config.default), configs[0])
 
-    deployment_id = client.serving.deploy_model(
-        model_id=str(model.id),
-        m_config_id=default_config.id,
-        lb_port=0,
-        autoscaling=False,
-        min_copies=1,
-        starting_copies=1,
-    )
-    deployment = client.serving.wait_for_deployment(
-        deployment_id,
-        poll_interval=5,
-        timeout=CONTEXT_TEST_LLM_DEPLOY_TIMEOUT_SECONDS,
-    )
+        deployment_id = client.serving.deploy_model(
+            model_id=str(model.id),
+            m_config_id=default_config.id,
+            lb_port=0,
+            autoscaling=False,
+            min_copies=1,
+            starting_copies=1,
+        )
+        deployment = client.serving.wait_for_deployment(
+            deployment_id,
+            poll_interval=5,
+            timeout=CONTEXT_TEST_LLM_DEPLOY_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001 — any provisioning failure → skip, not error
+        pytest.skip(
+            "No active LLM deployment for context ontology tests and one could not "
+            f"be provisioned (repo={CONTEXT_TEST_LLM_REPO}): "
+            f"{type(exc).__name__}: {exc}"
+        )
+
     if not _platform_deployment_ready(deployment):
-        pytest.fail(
-            "Context ontology prerequisite deployment is not ready: "
+        pytest.skip(
+            "Context ontology prerequisite LLM deployment did not become ready: "
             f"deployment_id={deployment.id}, status={deployment.status}, "
             f"instance_statuses={[instance.status for instance in deployment.instances]}"
         )


### PR DESCRIPTION
## What
Ports kamiwaza-sdk **#141** (merged to `main`) to **develop**: `context_llm_prerequisite` now **skips** instead of erroring when an LLM cannot be provisioned for context ontology/vectordb tests.

## Why develop too
The routine **develop-merge** Azure smoke (kajiya nightly + comment-canary) runs `sdk_ref=develop`, not main. The fix on main alone does **not** reach the nightly — develop's fixture still used `pytest.fail`, so the nightly keeps cascading **15 `test_context_live.py` fixture-setup ERRORs** on inference-incapable hosts (CPU-only smoke; `CONTEXT_TEST_LLM_REPO` is an Apple-Silicon-only MLX model). This port closes that gap.

## Change
Identical to #141 — mirror `embedding_model_prerequisite`'s attempt-then-`pytest.skip` pattern; broad `except Exception` → skip with `type(exc).__name__: {exc}` in the reason. Behavior on a capable host (existing/deployable LLM) unchanged.

Note: develop already carries `StorageType.OCI` (#139's main-parity change isn't needed here). Validated by an upcoming `sdk=develop` Azure smoke.

Refs ENG-6533.