### PR TITLE
Skip serving/CLI deploy tests on incapable hosts — main (ENG-6533)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ markers = [
     "slow: intentionally slow tests",
     "withoutresponses: tests needing real network access",
     "requires_embedding_model: live tests that require an active platform embedding deployment",
+    "requires_deployable_model: live tests that require the host to deploy the integration test model; skips on hosts without compatible inference capacity (e.g. x86 CPU smoke vs an MLX model)",
     "extension_regression: D210 12-issue regression checklist (UAC-17 / EDX-OPS-2). See tests/unit/extensions/regression/inventory.yaml.",
 ]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -120,6 +120,13 @@ CONTEXT_TEST_LLM_REPO = os.environ.get(
 CONTEXT_TEST_LLM_DEPLOY_TIMEOUT_SECONDS = float(
     os.environ.get("KAMIWAZA_CONTEXT_LLM_DEPLOY_TIMEOUT_SECONDS", "600")
 )
+DEPLOYABLE_TEST_MODEL_REPO = os.environ.get(
+    "KAMIWAZA_DEPLOYABLE_TEST_MODEL_REPO",
+    "mlx-community/Qwen3-4B-4bit",
+)
+DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS = float(
+    os.environ.get("KAMIWAZA_DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS", "600")
+)
 EMBEDDING_TEST_MODEL_REPO = os.environ.get(
     "KAMIWAZA_TEST_EMBEDDING_MODEL_REPO",
     "sentence-transformers/all-MiniLM-L6-v2",
@@ -492,6 +499,18 @@ def _platform_deployment_ready(deployment: object) -> bool:
         str(getattr(instance, "status", "")).upper() == "DEPLOYED"
         for instance in instances
     )
+
+
+def _stop_deployment_quietly(
+    client: KamiwazaClient, deployment_id: str | None
+) -> None:
+    """Best-effort stop of a deployment (used for capability probes / cleanup)."""
+    if not deployment_id:
+        return
+    try:
+        client.serving.stop_deployment(deployment_id=deployment_id, force=True)
+    except Exception:  # noqa: BLE001 — teardown is best-effort
+        pass
 
 
 def _active_model_deployments(
@@ -1247,10 +1266,88 @@ def context_llm_prerequisite(
         _stop_provisioned(provisioned_deployment_id)
 
 
+@pytest.fixture(scope="session")
+def deployable_model_prerequisite(
+    live_kamiwaza_session_client: KamiwazaClient,
+    ensure_repo_ready,
+) -> None:
+    """Skip once if this host cannot deploy the integration test model.
+
+    Serving/CLI tests that deploy ``DEPLOYABLE_TEST_MODEL_REPO`` (an MLX model)
+    fail with a 5xx on hosts without compatible inference capacity — e.g. the
+    x86 CPU Azure smoke. Probe deployability once per session and skip the
+    marked tests instead of failing them. Mirrors ``embedding_model_prerequisite``
+    / ``context_llm_prerequisite``; the probe tears down its own deployment so
+    dependent tests perform their own deploys.
+    """
+    client = live_kamiwaza_session_client
+    if (
+        _preferred_active_model_deployment(
+            client,
+            desired_type="llm",
+            preferred_repo_id=DEPLOYABLE_TEST_MODEL_REPO,
+        )
+        is not None
+    ):
+        return  # a model is already deployed → host is capable
+
+    probe_deployment_id: str | None = None
+    try:
+        model = ensure_repo_ready(client, DEPLOYABLE_TEST_MODEL_REPO)
+        configs = client.models.get_model_configs(model.id)
+        if not configs:
+            pytest.skip(
+                "No model configs available for deployable test model "
+                f"'{DEPLOYABLE_TEST_MODEL_REPO}'"
+            )
+        default_config = next(
+            (config for config in configs if config.default), configs[0]
+        )
+        raw_deployment_id = client.serving.deploy_model(
+            model_id=str(model.id),
+            m_config_id=default_config.id,
+            lb_port=0,
+            autoscaling=False,
+            min_copies=1,
+            starting_copies=1,
+        )
+        if not raw_deployment_id:
+            pytest.skip(
+                f"deploy_model returned no id for '{DEPLOYABLE_TEST_MODEL_REPO}' "
+                "(deploy refused on this host)."
+            )
+        probe_deployment_id = str(raw_deployment_id)
+        deployment = client.serving.wait_for_deployment(
+            probe_deployment_id,
+            poll_interval=5,
+            timeout=DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS,
+        )
+    except Exception as exc:  # noqa: BLE001 — any provisioning failure → skip, not error
+        _stop_deployment_quietly(client, probe_deployment_id)
+        pytest.skip(
+            "Host cannot deploy integration test model "
+            f"'{DEPLOYABLE_TEST_MODEL_REPO}': {type(exc).__name__}: {exc}"
+        )
+
+    ready = _platform_deployment_ready(deployment)
+    _stop_deployment_quietly(client, probe_deployment_id)
+    if not ready:
+        pytest.skip(
+            f"Integration test model '{DEPLOYABLE_TEST_MODEL_REPO}' did not become "
+            "ready on this host."
+        )
+
+
 @pytest.fixture(autouse=True)
 def _require_embedding_model_for_marked_tests(request: pytest.FixtureRequest) -> None:
     if "requires_embedding_model" in request.keywords:
         request.getfixturevalue("embedding_model_prerequisite")
+
+
+@pytest.fixture(autouse=True)
+def _require_deployable_model_for_marked_tests(request: pytest.FixtureRequest) -> None:
+    if "requires_deployable_model" in request.keywords:
+        request.getfixturevalue("deployable_model_prerequisite")
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -120,10 +120,13 @@ CONTEXT_TEST_LLM_REPO = os.environ.get(
 CONTEXT_TEST_LLM_DEPLOY_TIMEOUT_SECONDS = float(
     os.environ.get("KAMIWAZA_CONTEXT_LLM_DEPLOY_TIMEOUT_SECONDS", "600")
 )
-DEPLOYABLE_TEST_MODEL_REPO = os.environ.get(
-    "KAMIWAZA_DEPLOYABLE_TEST_MODEL_REPO",
-    "mlx-community/Qwen3-4B-4bit",
-)
+# Must stay in sync with TEST_REPO_ID in test_serving_workflow.py and
+# test_cli_live.py: the capability probe deploys the SAME model the gated tests
+# deploy, so the gate's skip/run verdict matches what the tests will actually do.
+# Intentionally not env-overridable — an override here that the test modules
+# don't honor would let the probe pass while the tests deploy a different model
+# and fail instead of skip.
+DEPLOYABLE_TEST_MODEL_REPO = "mlx-community/Qwen3-4B-4bit"
 DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS = float(
     os.environ.get("KAMIWAZA_DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS", "600")
 )
@@ -1281,15 +1284,16 @@ def deployable_model_prerequisite(
     dependent tests perform their own deploys.
     """
     client = live_kamiwaza_session_client
-    if (
-        _preferred_active_model_deployment(
-            client,
-            desired_type="llm",
-            preferred_repo_id=DEPLOYABLE_TEST_MODEL_REPO,
-        )
-        is not None
-    ):
-        return  # a model is already deployed → host is capable
+    # Short-circuit ONLY when the exact test model is already deployed — a
+    # different active LLM does not prove this host can deploy DEPLOYABLE_TEST_MODEL_REPO
+    # (e.g. MLX on x86), so in that case we must still probe.
+    existing = _preferred_active_model_deployment(
+        client,
+        desired_type="llm",
+        preferred_repo_id=DEPLOYABLE_TEST_MODEL_REPO,
+    )
+    if existing is not None and existing.get("repo_model_id") == DEPLOYABLE_TEST_MODEL_REPO:
+        return  # the test model itself is already deployed → host is capable
 
     probe_deployment_id: str | None = None
     try:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1326,10 +1326,14 @@ def deployable_model_prerequisite(
             poll_interval=5,
             timeout=DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS,
         )
-    except Exception as exc:  # noqa: BLE001 — any provisioning failure → skip, not error
+    except (KamiwazaError, TimeoutError) as exc:
+        # Capability/infra failure → skip: a deploy refused with a 5xx on an
+        # incapable host (APIError), or a download/registration timeout. Any
+        # other (non-SDK) exception is an unexpected regression and propagates
+        # as an error rather than being masked as a skip.
         _stop_deployment_quietly(client, probe_deployment_id)
         pytest.skip(
-            "Host cannot deploy integration test model "
+            "Host cannot provision integration test model (download/deploy) "
             f"'{DEPLOYABLE_TEST_MODEL_REPO}': {type(exc).__name__}: {exc}"
         )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1326,11 +1326,13 @@ def deployable_model_prerequisite(
             poll_interval=5,
             timeout=DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS,
         )
-    except (KamiwazaError, TimeoutError) as exc:
-        # Capability/infra failure → skip: a deploy refused with a 5xx on an
-        # incapable host (APIError), or a download/registration timeout. Any
-        # other (non-SDK) exception is an unexpected regression and propagates
-        # as an error rather than being masked as a skip.
+    except (KamiwazaError, TimeoutError, RuntimeError) as exc:
+        # Capability/infra failure → skip + tear down: deploy refused with a 5xx
+        # on an incapable host (APIError), a download/registration timeout
+        # (TimeoutError), or the deployment entering FAILED/ERROR status because
+        # the instance can't load the model (RuntimeError from wait_for_deployment,
+        # kamiwaza_sdk/services/serving.py). Any other (non-SDK) exception is an
+        # unexpected regression and propagates as an error rather than a skip.
         _stop_deployment_quietly(client, probe_deployment_id)
         pytest.skip(
             "Host cannot provision integration test model (download/deploy) "

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1326,17 +1326,28 @@ def deployable_model_prerequisite(
             poll_interval=5,
             timeout=DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS,
         )
-    except (KamiwazaError, TimeoutError, RuntimeError) as exc:
-        # Capability/infra failure → skip + tear down: deploy refused with a 5xx
-        # on an incapable host (APIError), a download/registration timeout
-        # (TimeoutError), or the deployment entering FAILED/ERROR status because
-        # the instance can't load the model (RuntimeError from wait_for_deployment,
-        # kamiwaza_sdk/services/serving.py). Any other (non-SDK) exception is an
-        # unexpected regression and propagates as an error rather than a skip.
+    except (TimeoutError, RuntimeError) as exc:
+        # Download/registration timeout, or the deployment entering FAILED/ERROR
+        # status because the instance can't load the model on this host
+        # (RuntimeError from wait_for_deployment, kamiwaza_sdk/services/serving.py)
+        # — capability/infra failure → skip + tear down.
         _stop_deployment_quietly(client, probe_deployment_id)
         pytest.skip(
             "Host cannot provision integration test model (download/deploy) "
             f"'{DEPLOYABLE_TEST_MODEL_REPO}': {type(exc).__name__}: {exc}"
+        )
+    except APIError as exc:
+        # Only a 5xx (server cannot bring the model up on this host) is a
+        # capability failure → skip. A 4xx (auth / scope / validation /
+        # request-shape) is a real regression and MUST fail, not be masked as a
+        # skip, so it is re-raised.
+        status_code = getattr(exc, "status_code", None)
+        _stop_deployment_quietly(client, probe_deployment_id)
+        if status_code is None or status_code < 500:
+            raise
+        pytest.skip(
+            "Host cannot provision integration test model (download/deploy) "
+            f"'{DEPLOYABLE_TEST_MODEL_REPO}': APIError {status_code}: {exc}"
         )
 
     ready = _platform_deployment_ready(deployment)

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -87,10 +87,10 @@ def test_cli_login_and_pat_flow(
     env = os.environ.copy()
     env.setdefault("PYTHONWARNINGS", "ignore")
 
-    pat_token = _cli_login_and_create_pat(
+    # _cli_login_and_create_pat asserts the session token, PAT, and cache match.
+    _cli_login_and_create_pat(
         base_args, env, live_username, live_password, token_path, pat_prefix="cli-m1"
     )
-    assert pat_token
 
 
 @pytest.mark.requires_deployable_model

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -25,28 +25,30 @@ def run_cli(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess
     )
 
 
-def test_cli_login_and_pat_flow(
-    live_server_available: str,
+def _cli_login_and_create_pat(
+    base_args: list[str],
+    env: dict[str, str],
     live_username: str,
     live_password: str,
-    client_factory,
-    ensure_repo_ready,
-    tmp_path: Path,
-) -> None:
-    token_path = tmp_path / "token.json"
-    base_args = ["--base-url", live_server_available, "--token-path", str(token_path)]
+    token_path: Path,
+    *,
+    pat_prefix: str,
+) -> str:
+    """Login + create a cached PAT via the CLI; return the PAT token.
 
-    env = os.environ.copy()
-    env.setdefault("PYTHONWARNINGS", "ignore")
-
-    # Login and persist session token
-    run_cli([*base_args, "login", "--username", live_username, "--password", live_password], env)
+    Asserts the session token and PAT cache are persisted along the way, so this
+    doubles as the shared CLI-auth coverage for both the auth-only and the
+    deploy tests below.
+    """
+    run_cli(
+        [*base_args, "login", "--username", live_username, "--password", live_password],
+        env,
+    )
     assert token_path.exists()
     session_token = json.loads(token_path.read_text())
     assert "access_token" in session_token
 
-    # Create PAT via CLI and cache it
-    pat_name = f"cli-m1-{int(time.time())}"
+    pat_name = f"{pat_prefix}-{int(time.time())}"
     result = run_cli(
         [
             *base_args,
@@ -69,7 +71,52 @@ def test_cli_login_and_pat_flow(
 
     cached = json.loads(token_path.read_text())
     assert cached["access_token"] == pat_token
+    return pat_token
 
+
+def test_cli_login_and_pat_flow(
+    live_server_available: str,
+    live_username: str,
+    live_password: str,
+    tmp_path: Path,
+) -> None:
+    """CLI login + PAT creation/caching (no model deployment required)."""
+    token_path = tmp_path / "token.json"
+    base_args = ["--base-url", live_server_available, "--token-path", str(token_path)]
+
+    env = os.environ.copy()
+    env.setdefault("PYTHONWARNINGS", "ignore")
+
+    pat_token = _cli_login_and_create_pat(
+        base_args, env, live_username, live_password, token_path, pat_prefix="cli-m1"
+    )
+    assert pat_token
+
+
+@pytest.mark.requires_deployable_model
+def test_cli_serve_deploy(
+    live_server_available: str,
+    live_username: str,
+    live_password: str,
+    client_factory,
+    ensure_repo_ready,
+    tmp_path: Path,
+) -> None:
+    """CLI ``serve deploy`` round-trip.
+
+    Requires a host that can actually deploy the test model; gated by
+    ``requires_deployable_model`` so it skips (rather than fails) on hosts
+    without compatible inference capacity (e.g. the x86 CPU smoke vs an MLX model).
+    """
+    token_path = tmp_path / "token.json"
+    base_args = ["--base-url", live_server_available, "--token-path", str(token_path)]
+
+    env = os.environ.copy()
+    env.setdefault("PYTHONWARNINGS", "ignore")
+
+    pat_token = _cli_login_and_create_pat(
+        base_args, env, live_username, live_password, token_path, pat_prefix="cli-deploy"
+    )
     pat_client = client_factory(base_url=live_server_available, api_key=pat_token)
     ensure_repo_ready(pat_client, TEST_REPO_ID)
 

--- a/tests/integration/test_serving_workflow.py
+++ b/tests/integration/test_serving_workflow.py
@@ -41,6 +41,7 @@ def _ensure_model_cached(client, model):
         pytest.skip(f"Model download API unavailable: {exc}")
 
 
+@pytest.mark.requires_deployable_model
 def test_deploy_qwen_and_infer_with_strip_thinking(live_kamiwaza_client, ensure_repo_ready):
     client = live_kamiwaza_client
     model = ensure_repo_ready(client, TEST_REPO_ID)


### PR DESCRIPTION
## What
Main sibling of the develop PR. Adds a registered `requires_deployable_model` marker + autouse `deployable_model_prerequisite` that probes deployability of the MLX test model and **skips** marked tests on hosts that can't deploy it. Applied to `test_deploy_qwen_and_infer`; `test_cli_login_and_pat_flow` **split** so login+PAT coverage keeps running and only `test_cli_serve_deploy` is gated.

## Why
Keeps main's integration suite consistent with develop (the routine smoke runs `sdk=develop`, but main shouldn't diverge on test infra). On x86 CPU hosts the MLX deploy 500s — a host-capability gap that should skip, not fail. Mirrors `requires_embedding_model` / `context_llm_prerequisite`.

Context/workroom failures are **not** touched (left failing pending the ENG-6538 global-workroom decision).

Refs ENG-6533.