### PR TITLE
feat(dev-local): build extra_docker_images from source (ENG-6281)

### DIFF
--- a/kamiwaza_extensions/dev_local.py
+++ b/kamiwaza_extensions/dev_local.py
@@ -408,6 +408,50 @@ class DevLocalRunner:
             ):
                 compose_prefix += ["--project-directory", str(info.path)]
 
+            # Build extra_docker_images from source before `up` (ENG-6281).
+            # `up --build` only builds default-profile services, so
+            # profile-gated extra images (e.g. the agent runtime under
+            # `profiles: [image-only]`) are never rebuilt and go stale
+            # against their pinned tag. Mirror the cache-backed
+            # `up --build` pattern — always build, letting Docker's layer
+            # cache no-op when nothing changed. (Hash-based short-circuit is
+            # future work; tracked as an ENG-6281 follow-up.) Reuses
+            # compose_prefix so the same -f overlays apply — notably the
+            # sdk_build_patch_file that fixes pinned-version build merges.
+            extra_services, extra_profiles = _resolve_extra_image_build_targets(
+                info.metadata, info.compose_data, info.version
+            )
+            if extra_services:
+                sandbox_backend = _resolve_env_value("SANDBOX_BACKEND", info.path)
+                # Gate on the docker sandbox backend: skip only when
+                # SANDBOX_BACKEND is explicitly set to a non-docker value, so
+                # extensions that never set it still get their extra images.
+                if sandbox_backend is not None and sandbox_backend != "docker":
+                    console.print(
+                        f"[dim]Skipping extra image build "
+                        f"({', '.join(extra_services)}): "
+                        f"SANDBOX_BACKEND={sandbox_backend} (not 'docker').[/dim]"
+                    )
+                else:
+                    build_cmd = list(compose_prefix)
+                    for profile in extra_profiles:
+                        build_cmd += ["--profile", profile]
+                    build_cmd += ["build", *extra_services]
+                    console.print(
+                        f"[dim]Building extra images "
+                        f"({', '.join(extra_services)}):[/dim] "
+                        f"{' '.join(build_cmd)}"
+                    )
+                    build_rc = self._run_subprocess(
+                        build_cmd, env=env, cwd=str(info.path)
+                    )
+                    if build_rc != 0:
+                        console.print(
+                            "[red]Extra image build failed; "
+                            "aborting before `up`.[/red]"
+                        )
+                        return build_rc
+
             cmd = list(compose_prefix) + ["up", "--build"]
             if detach:
                 cmd.append("-d")
@@ -790,6 +834,78 @@ def build_env_overlay(
         env["KZ_EXT_DEV_LOCAL_AUTH"] = "1"
         env["KAMIWAZA_BEARER_TOKEN"] = bridge.bearer_token
     return env
+
+
+def _resolve_env_value(key: str, ext_path: Path) -> Optional[str]:
+    """Resolve an env var the way Docker Compose does, for gating decisions.
+
+    Precedence mirrors Compose: a value exported in the shell wins over the
+    extension's ``.env`` file. Returns ``None`` when set in neither.
+
+    Intentionally a minimal ``KEY=value`` scan (strips surrounding quotes) —
+    enough to read a gating flag like ``SANDBOX_BACKEND``. Full Compose
+    ``.env`` interpolation is deliberately not reproduced.
+    """
+    shell_value = os.environ.get(key)
+    if shell_value is not None:
+        return shell_value
+    env_file = ext_path / ".env"
+    if not env_file.exists():
+        return None
+    for raw_line in env_file.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, _, value = line.partition("=")
+        if name.strip() == key:
+            return value.strip().strip('"').strip("'")
+    return None
+
+
+def _resolve_extra_image_build_targets(
+    metadata: Dict[str, Any],
+    compose_data: Optional[Dict[str, Any]],
+    version: str,
+) -> Tuple[List[str], List[str]]:
+    """Map manifest ``extra_docker_images`` to buildable compose services.
+
+    ``kz-ext dev local`` runs ``compose up --build``, which only builds
+    services in the active (default) profile. Images declared in
+    ``kamiwaza.json``'s ``extra_docker_images`` are typically profile-gated
+    (e.g. an agent runtime under ``profiles: [image-only]``), so they are
+    never rebuilt locally and silently go stale against their pinned tag
+    (ENG-6281). This locates the compose services that *produce* those
+    images so the caller can build them explicitly.
+
+    A service qualifies when its (``{version}``-substituted) ``image`` ref
+    matches an ``extra_docker_images`` entry AND it declares a ``build``
+    block. Registry-only refs (no matching buildable service) are ignored —
+    they are pulled at ``up`` time as before.
+
+    Returns ``(service_names, profiles)`` where ``profiles`` is the
+    de-duplicated union of profiles the matched services declare, so the
+    caller can enable them for the build.
+    """
+    raw_refs = metadata.get("extra_docker_images") or []
+    if not raw_refs or not compose_data:
+        return [], []
+    wanted = {str(ref).replace("{version}", version) for ref in raw_refs}
+    services = compose_data.get("services", {}) or {}
+    matched: List[str] = []
+    profiles: List[str] = []
+    for svc_name, svc in services.items():
+        if not isinstance(svc, dict):
+            continue
+        image = svc.get("image")
+        if not image or "build" not in svc:
+            continue
+        if str(image).replace("{version}", version) not in wanted:
+            continue
+        matched.append(svc_name)
+        for profile in svc.get("profiles", []) or []:
+            if profile not in profiles:
+                profiles.append(profile)
+    return matched, profiles
 
 
 def _write_compose_overlay(

--- a/tests/unit/extensions/test_dev_local.py
+++ b/tests/unit/extensions/test_dev_local.py
@@ -10,6 +10,8 @@ import pytest
 
 from kamiwaza_extensions.connections import ConnectionInfo
 from kamiwaza_extensions.dev_local import (
+    _resolve_env_value,
+    _resolve_extra_image_build_targets,
     apply_port_remaps,
     build_compose_extra_hosts,
     build_env_overlay,
@@ -1229,6 +1231,7 @@ class TestPollAndPrintUrls:
         get TWO URLs printed, not one — and the loop must terminate as
         soon as both are resolved, not spin to the 60s deadline."""
         import threading
+
         from kamiwaza_extensions import dev_local
 
         runner = self._runner()
@@ -1270,6 +1273,7 @@ class TestPollAndPrintUrls:
         the moment the single URL is resolved (PR #91 round-3 / Claude
         review)."""
         import threading
+
         from kamiwaza_extensions import dev_local
 
         runner = self._runner()
@@ -1510,3 +1514,129 @@ class TestDockerComposePortV1Compat:
             "3000",
         ]
         assert captured["cwd"] == "/Users/dev/my-app"
+
+
+# kaizen-shaped manifest + compose: an agent extra-image built from source
+# under a profile, alongside an ordinary buildable service that is NOT an
+# extra image, to verify selectivity.
+_META_WITH_EXTRA = {"extra_docker_images": ["ghcr.io/org/images/agent:{version}"]}
+_COMPOSE_WITH_EXTRA = {
+    "services": {
+        "backend": {
+            "image": "ghcr.io/org/images/backend:2.0.1",
+            "build": {"context": "."},
+        },
+        "agent": {
+            "image": "ghcr.io/org/images/agent:2.0.1",
+            "build": {"context": ".", "dockerfile": "backend/Dockerfile.agent"},
+            "profiles": ["image-only"],
+        },
+    }
+}
+
+
+@pytest.mark.unit
+class TestResolveExtraImageBuildTargets:
+    def test_matches_buildable_profile_gated_extra_image(self):
+        services, profiles = _resolve_extra_image_build_targets(
+            _META_WITH_EXTRA, _COMPOSE_WITH_EXTRA, "2.0.1"
+        )
+        # Only the agent: backend is buildable but is NOT an extra image.
+        assert services == ["agent"]
+        assert profiles == ["image-only"]
+
+    def test_substitutes_version_placeholder(self):
+        # Manifest ref carries {version}; compose pins the literal tag.
+        services, _ = _resolve_extra_image_build_targets(
+            {"extra_docker_images": ["ghcr.io/org/images/agent:{version}"]},
+            {
+                "services": {
+                    "agent": {
+                        "image": "ghcr.io/org/images/agent:3.1.4",
+                        "build": {"context": "."},
+                    }
+                }
+            },
+            "3.1.4",
+        )
+        assert services == ["agent"]
+
+    def test_skips_extra_ref_without_buildable_service(self):
+        # Declared as an extra image but the matching service has no build
+        # block → registry-only; pulled at `up`, not built here.
+        services, profiles = _resolve_extra_image_build_targets(
+            {"extra_docker_images": ["ghcr.io/org/images/agent:{version}"]},
+            {
+                "services": {
+                    "agent": {"image": "ghcr.io/org/images/agent:2.0.1"},
+                }
+            },
+            "2.0.1",
+        )
+        assert services == []
+        assert profiles == []
+
+    def test_empty_when_no_extra_docker_images(self):
+        assert _resolve_extra_image_build_targets({}, _COMPOSE_WITH_EXTRA, "2.0.1") == (
+            [],
+            [],
+        )
+
+    def test_empty_when_no_compose_data(self):
+        assert _resolve_extra_image_build_targets(_META_WITH_EXTRA, None, "2.0.1") == (
+            [],
+            [],
+        )
+
+    def test_dedupes_profiles_across_multiple_extra_images(self):
+        meta = {
+            "extra_docker_images": [
+                "ghcr.io/org/images/agent:{version}",
+                "ghcr.io/org/images/worker:{version}",
+            ]
+        }
+        compose = {
+            "services": {
+                "agent": {
+                    "image": "ghcr.io/org/images/agent:2.0.1",
+                    "build": {"context": "."},
+                    "profiles": ["image-only"],
+                },
+                "worker": {
+                    "image": "ghcr.io/org/images/worker:2.0.1",
+                    "build": {"context": "."},
+                    "profiles": ["image-only", "extras"],
+                },
+            }
+        }
+        services, profiles = _resolve_extra_image_build_targets(meta, compose, "2.0.1")
+        assert sorted(services) == ["agent", "worker"]
+        # Union, de-duplicated, order-preserving.
+        assert profiles == ["image-only", "extras"]
+
+
+@pytest.mark.unit
+class TestResolveEnvValue:
+    def test_shell_env_wins_over_dotenv(self, tmp_path, monkeypatch):
+        (tmp_path / ".env").write_text("SANDBOX_BACKEND=local\n")
+        monkeypatch.setenv("SANDBOX_BACKEND", "docker")
+        assert _resolve_env_value("SANDBOX_BACKEND", tmp_path) == "docker"
+
+    def test_reads_from_dotenv_when_not_in_shell(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SANDBOX_BACKEND", raising=False)
+        (tmp_path / ".env").write_text("# comment\n\nSANDBOX_BACKEND=docker\nOTHER=x\n")
+        assert _resolve_env_value("SANDBOX_BACKEND", tmp_path) == "docker"
+
+    def test_strips_surrounding_quotes(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SANDBOX_BACKEND", raising=False)
+        (tmp_path / ".env").write_text('SANDBOX_BACKEND="docker"\n')
+        assert _resolve_env_value("SANDBOX_BACKEND", tmp_path) == "docker"
+
+    def test_none_when_absent_everywhere(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SANDBOX_BACKEND", raising=False)
+        (tmp_path / ".env").write_text("OTHER=x\n")
+        assert _resolve_env_value("SANDBOX_BACKEND", tmp_path) is None
+
+    def test_none_when_no_dotenv_and_no_shell(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("SANDBOX_BACKEND", raising=False)
+        assert _resolve_env_value("SANDBOX_BACKEND", tmp_path) is None


### PR DESCRIPTION
## Problem

`kz-ext dev local` runs `compose up --build`, which only builds services in the active (default) profile. Images declared in `kamiwaza.json`'s `extra_docker_images` are typically **profile-gated** (e.g. the kaizen agent runtime under `profiles: [image-only]`), so they were **never rebuilt locally**. Because the ref is pinned to a fixed tag (`agent:2.0.1`), the stale-but-present image was silently reused after a `develop` sync.

This surfaced in practice as a runtime failure: the freshly-built backend injected a tool (`GoogleDriveToolSet`) that the 6-day-old agent image didn't register, so the agent crashed in `init_state` with `ToolDefinition 'GoogleDriveToolSet' is not registered`, presented in the UI as *"agent workspace is temporarily unavailable: Internal Server Error."*

This is one of the documented ENG-6281 gaps (`kz-ext dev local` doesn't build `extra_docker_images`).

## Change

Before `up`, build the buildable extra images from source:

- Match `extra_docker_images` refs (after `{version}` substitution) against compose services that declare a `build:` block. Registry-only refs (no buildable service) are skipped — pulled at `up` as before.
- Build via `docker-compose <same -f overlays> --profile <profiles> build <services>`, reusing the existing prefix so the build-patch overlay still applies, and enabling the services' profiles (e.g. `image-only`).
- **No hash check** — mirrors the existing cache-backed `up --build` pattern (always build; Docker's layer cache no-ops when nothing changed). A hash-based short-circuit was considered and intentionally deferred (current build time is acceptable).
- **Gated on the docker sandbox backend**: skip only when `SANDBOX_BACKEND` is explicitly set to a non-`docker` value (build when `docker` or unset), so extensions that never set it still get their extra images. The skip is logged.

New helpers `_resolve_extra_image_build_targets` and `_resolve_env_value` (compose-style precedence: shell env > `.env`).

## Testing

- 11 new unit tests (version substitution, selectivity, registry-only skip, profile de-dup, env precedence); full `tests/unit/extensions` suite green (1435 passed).
- ruff / black / isort clean; no new mypy errors.
- Verified end-to-end against kaizen via an editable install: `kz-ext dev local` now builds `agent:2.0.1` automatically before `up`, and agent chat works without any manual `docker-compose build agent`.