### PR TITLE
Add client-side wait to deploy_model

### DIFF
--- a/docs/services/serving/README.md
+++ b/docs/services/serving/README.md
@@ -29,7 +29,7 @@ ray_status = client.serving.get_status()
 
 ### Available Methods
 - `estimate_model_vram(model_id: UUID) -> int`: Estimate model VRAM requirements
-- `deploy_model(model_id=..., repo_id=..., wait=True, timeout_seconds=3600, **kwargs) -> Union[UUID, bool]`: Deploy a model. The server accepts the request asynchronously and returns the deployment id immediately; with `wait=True` (default) the SDK polls client-side until the deployment is ready, with `wait=False` it returns the id right away
+- `deploy_model(model_id=..., repo_id=..., wait=True, timeout_seconds=3600, poll_interval_seconds=5.0, **kwargs) -> Union[UUID, bool]`: Deploy a model. The server accepts the request asynchronously and returns the deployment id immediately; with `wait=True` (default) the SDK polls client-side until the deployment is ready, with `wait=False` it returns the id right away
 - `wait_deployment_ready(deployment_id, timeout_seconds=3600, poll_interval_seconds=5.0) -> UIModelDeployment`: Poll an existing deployment until it reaches `DEPLOYED`; raises `DeploymentFailedError` on a FAILED/ERROR/MUST_REDOWNLOAD terminal status and `TimeoutError` past the deadline
 - `list_deployments() -> List[ModelDeployment]`: List all deployments
 - `list_active_deployments() -> List[UIModelDeployment]`: List only active deployments with running instances

--- a/docs/services/serving/README.md
+++ b/docs/services/serving/README.md
@@ -30,7 +30,7 @@ ray_status = client.serving.get_status()
 ### Available Methods
 - `estimate_model_vram(model_id: UUID) -> int`: Estimate model VRAM requirements
 - `deploy_model(model_id=..., repo_id=..., wait=True, timeout_seconds=3600, **kwargs) -> Union[UUID, bool]`: Deploy a model. The server accepts the request asynchronously and returns the deployment id immediately; with `wait=True` (default) the SDK polls client-side until the deployment is ready, with `wait=False` it returns the id right away
-- `wait_deployment_ready(deployment_id, timeout_seconds=3600, poll_interval_seconds=5.0) -> UIModelDeployment`: Poll an existing deployment until it reaches `DEPLOYED`; raises `DeploymentFailedError` on FAILED/ERROR and `TimeoutError` past the deadline
+- `wait_deployment_ready(deployment_id, timeout_seconds=3600, poll_interval_seconds=5.0) -> UIModelDeployment`: Poll an existing deployment until it reaches `DEPLOYED`; raises `DeploymentFailedError` on a FAILED/ERROR/MUST_REDOWNLOAD terminal status and `TimeoutError` past the deadline
 - `list_deployments() -> List[ModelDeployment]`: List all deployments
 - `list_active_deployments() -> List[UIModelDeployment]`: List only active deployments with running instances
 - `get_deployment(deployment_id: UUID) -> ModelDeployment`: Get deployment details
@@ -101,7 +101,8 @@ from kamiwaza_sdk.exceptions import APIError, DeploymentFailedError
 try:
     deployment_id = client.serving.deploy_model(repo_id="org/model-repo")
 except DeploymentFailedError as e:
-    # Terminal FAILED/ERROR status observed while waiting for readiness.
+    # Terminal FAILED/ERROR/MUST_REDOWNLOAD status observed while waiting
+    # for readiness (MUST_REDOWNLOAD = corrupted/incomplete model files).
     print(f"Deployment failed ({e.status}, {e.last_error_code}): {e.last_error_message}")
 except TimeoutError:
     print("Deployment did not become ready in time")

--- a/docs/services/serving/README.md
+++ b/docs/services/serving/README.md
@@ -29,7 +29,8 @@ ray_status = client.serving.get_status()
 
 ### Available Methods
 - `estimate_model_vram(model_id: UUID) -> int`: Estimate model VRAM requirements
-- `deploy_model(deployment: CreateModelDeployment) -> ModelDeployment`: Deploy a model
+- `deploy_model(model_id=..., repo_id=..., wait=True, timeout_seconds=3600, **kwargs) -> Union[UUID, bool]`: Deploy a model. The server accepts the request asynchronously and returns the deployment id immediately; with `wait=True` (default) the SDK polls client-side until the deployment is ready, with `wait=False` it returns the id right away
+- `wait_deployment_ready(deployment_id, timeout_seconds=3600, poll_interval_seconds=5.0) -> UIModelDeployment`: Poll an existing deployment until it reaches `DEPLOYED`; raises `DeploymentFailedError` on FAILED/ERROR and `TimeoutError` past the deadline
 - `list_deployments() -> List[ModelDeployment]`: List all deployments
 - `list_active_deployments() -> List[UIModelDeployment]`: List only active deployments with running instances
 - `get_deployment(deployment_id: UUID) -> ModelDeployment`: Get deployment details
@@ -40,13 +41,12 @@ ray_status = client.serving.get_status()
 # Estimate VRAM requirements
 vram_needed = client.serving.estimate_model_vram(model_id)
 
-# Deploy a model
-deployment = client.serving.deploy_model(CreateModelDeployment(
-    model_id=model_id,
-    name="my-deployment",
-    replicas=1,
-    max_concurrent_requests=4
-))
+# Deploy a model (blocks until ready via client-side polling)
+deployment_id = client.serving.deploy_model(repo_id="org/model-repo")
+
+# Fire-and-forget deploy: get the id immediately, observe readiness later
+deployment_id = client.serving.deploy_model(repo_id="org/model-repo", wait=False)
+deployment = client.serving.wait_deployment_ready(deployment_id)
 
 # List all deployments
 deployments = client.serving.list_deployments()
@@ -96,12 +96,15 @@ client.serving.load_model(deployment_id)
 ## Error Handling
 The service includes built-in error handling for common scenarios:
 ```python
+from kamiwaza_sdk.exceptions import APIError, DeploymentFailedError
+
 try:
-    deployment = client.serving.deploy_model(deployment_config)
-except DeploymentError as e:
-    print(f"Deployment failed: {e}")
-except ResourceError as e:
-    print(f"Resource allocation failed: {e}")
+    deployment_id = client.serving.deploy_model(repo_id="org/model-repo")
+except DeploymentFailedError as e:
+    # Terminal FAILED/ERROR status observed while waiting for readiness.
+    print(f"Deployment failed ({e.status}, {e.last_error_code}): {e.last_error_message}")
+except TimeoutError:
+    print("Deployment did not become ready in time")
 except APIError as e:
     print(f"Operation failed: {e}")
 ```

--- a/docs/services/serving/README.md
+++ b/docs/services/serving/README.md
@@ -103,8 +103,10 @@ try:
 except DeploymentFailedError as e:
     # Terminal FAILED/ERROR/MUST_REDOWNLOAD status observed while waiting
     # for readiness (MUST_REDOWNLOAD = corrupted/incomplete model files).
+    # e.deployment_id identifies the in-flight deployment for cleanup.
     print(f"Deployment failed ({e.status}, {e.last_error_code}): {e.last_error_message}")
-except TimeoutError:
+except TimeoutError as e:
+    # Also carries e.deployment_id so the stuck deployment can be stopped.
     print("Deployment did not become ready in time")
 except APIError as e:
     print(f"Operation failed: {e}")

--- a/kamiwaza_sdk/cli.py
+++ b/kamiwaza_sdk/cli.py
@@ -165,6 +165,9 @@ def serve_deploy_command(
         duration=args.duration,
         autoscaling=args.autoscaling,
         force_cpu=args.force_cpu,
+        # The CLI owns the wait: the args.wait-gated wait_for_deployment below
+        # is the single authoritative wait so --timeout/--poll-interval hold.
+        wait=False,
     )
 
     summary: dict[str, str] = {"deployment_id": str(deployment_id)}

--- a/kamiwaza_sdk/exceptions.py
+++ b/kamiwaza_sdk/exceptions.py
@@ -152,6 +152,9 @@ class DeploymentFailedError(KamiwazaError, RuntimeError):
             the deployment carries one.
         last_error_code: Short server-side error code (e.g. ``"OOM"``,
             ``"MODEL_LOADING_FAILURE"``), when available.
+        deployment_id: Id of the deployment that failed, as a string, so
+            callers can stop/inspect the in-flight deployment even when
+            ``deploy_model(wait=True)`` raises before returning the id.
     """
 
     def __init__(
@@ -161,11 +164,13 @@ class DeploymentFailedError(KamiwazaError, RuntimeError):
         status: Optional[str] = None,
         last_error_message: Optional[str] = None,
         last_error_code: Optional[str] = None,
+        deployment_id: Optional[str] = None,
     ) -> None:
         super().__init__(message)
         self.status = status
         self.last_error_message = last_error_message
         self.last_error_code = last_error_code
+        self.deployment_id = deployment_id
 
 
 class VectorDBUnavailableError(APIError):

--- a/kamiwaza_sdk/exceptions.py
+++ b/kamiwaza_sdk/exceptions.py
@@ -26,6 +26,7 @@ Hierarchy:
         TimeoutError
         NonAPIResponseError
         TransportNotSupportedError
+        DeploymentFailedError              (also RuntimeError; terminal deploy failure)
         FederationPairTimeoutError      (503 + psk_propagation_timeout)
         MeshJobTimeoutError             (mesh job exceeded wall-clock)
         MeshJobFailedError              (mesh job terminal FAILED state)
@@ -131,6 +132,38 @@ class NonAPIResponseError(KamiwazaError):
 
 class TransportNotSupportedError(KamiwazaError):
     """Raised when a retrieval transport cannot satisfy the request."""
+
+
+class DeploymentFailedError(KamiwazaError, RuntimeError):
+    """A model deployment reached a terminal failure status (ENG-6530).
+
+    Raised by client-side deployment polling (``ServingService.
+    wait_deployment_ready`` / ``deploy_model(wait=True)``) when the
+    deployment enters a FAILED/ERROR terminal state. Also subclasses
+    ``RuntimeError`` because ``wait_for_deployment`` historically raised
+    ``RuntimeError`` on failure statuses — existing ``except
+    RuntimeError`` callers keep working.
+
+    Attributes:
+        status: Terminal deployment status observed (e.g. ``"FAILED"``).
+        last_error_message: Server-reported failure explanation, when
+            the deployment carries one.
+        last_error_code: Short server-side error code (e.g. ``"OOM"``,
+            ``"MODEL_LOADING_FAILURE"``), when available.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: Optional[str] = None,
+        last_error_message: Optional[str] = None,
+        last_error_code: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.last_error_message = last_error_message
+        self.last_error_code = last_error_code
 
 
 class VectorDBUnavailableError(APIError):

--- a/kamiwaza_sdk/exceptions.py
+++ b/kamiwaza_sdk/exceptions.py
@@ -139,7 +139,9 @@ class DeploymentFailedError(KamiwazaError, RuntimeError):
 
     Raised by client-side deployment polling (``ServingService.
     wait_deployment_ready`` / ``deploy_model(wait=True)``) when the
-    deployment enters a FAILED/ERROR terminal state. Also subclasses
+    deployment enters a FAILED/ERROR/MUST_REDOWNLOAD terminal state
+    (MUST_REDOWNLOAD: the server detected corrupted or incomplete model
+    files; the deploy will not recover without a redownload). Also subclasses
     ``RuntimeError`` because ``wait_for_deployment`` historically raised
     ``RuntimeError`` on failure statuses — existing ``except
     RuntimeError`` callers keep working.

--- a/kamiwaza_sdk/schemas/serving/serving.py
+++ b/kamiwaza_sdk/schemas/serving/serving.py
@@ -77,6 +77,13 @@ class ModelDeployment(CreateModelDeployment):
     )
     single_node_mode: Optional[bool] = Field(default=False, description="Whether the deployment is in single node mode")
     status: str = Field(description="Status of the deployment")
+    last_error_code: Optional[str] = Field(
+        default=None,
+        description="Short error code for the last failure (e.g., OOM, CUDA_ERROR, MODEL_LOADING_FAILURE, CONTAINER_EXITED)",
+    )
+    last_error_message: Optional[str] = Field(
+        default=None, description="Last error message/explanation"
+    )
     instances: List[ModelInstance] = Field(default_factory=list, description="List of instances associated with the deployment")
 
     def __str__(self):

--- a/kamiwaza_sdk/services/models/downloads.py
+++ b/kamiwaza_sdk/services/models/downloads.py
@@ -548,6 +548,13 @@ class ModelDownloadMixin:
                     # deploy_model blocking on readiness each retry costs up
                     # to the full wait timeout. Propagate the typed error.
                     raise
+                except TimeoutError:
+                    # The deploy wait timed out on a hung, non-terminal
+                    # deployment. Retrying stacks new deployments on top of
+                    # the still-in-flight one (worst case ~3x the wait plus
+                    # orphaned deployments) and would wrap away the
+                    # deployment_id attribute callers need for cleanup.
+                    raise
                 except Exception as e:
                     deploy_retry_count += 1
                     

--- a/kamiwaza_sdk/services/models/downloads.py
+++ b/kamiwaza_sdk/services/models/downloads.py
@@ -6,6 +6,7 @@ import sys
 from ...schemas.models.model import Model
 from ...schemas.models.model_file import ModelFile
 from ...schemas.models.model_search import HubModelFileSearch
+from ...exceptions import DeploymentFailedError
 from ...schemas.models.downloads import ModelDownloadRequest, ModelDownloadStatus
 from ...utils.download_tracker import DownloadTracker
 from ...utils.progress_formatter import ProgressFormatter
@@ -541,6 +542,12 @@ class ModelDownloadMixin:
                     
                     deployment_id = self.client.serving.deploy_model(repo_id=repo_id)
                     break  # Deployment successful, exit the retry loop
+                except DeploymentFailedError:
+                    # Terminal FAILED/ERROR/MUST_REDOWNLOAD status: an
+                    # immediate redeploy will not succeed, and with
+                    # deploy_model blocking on readiness each retry costs up
+                    # to the full wait timeout. Propagate the typed error.
+                    raise
                 except Exception as e:
                     deploy_retry_count += 1
                     

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -17,18 +17,13 @@ from ..schemas.serving.serving import (
     UIModelDeployment,
 )
 from ..schemas.serving.inference import (
-    GenerateRequest,
-    GenerateResponse,
     LoadModelRequest,
     LoadModelResponse,
     UnloadModelRequest,
     UnloadModelResponse,
 )
-from ..schemas.models.model_search import HubModelFileSearch
 from ..exceptions import DeploymentFailedError
 from .base_service import BaseService
-from urllib.parse import urlparse
-import os
 
 
 class ServingService(BaseService):

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -25,6 +25,7 @@ from ..schemas.serving.inference import (
     UnloadModelResponse,
 )
 from ..schemas.models.model_search import HubModelFileSearch
+from ..exceptions import DeploymentFailedError
 from .base_service import BaseService
 from urllib.parse import urlparse
 import os
@@ -196,7 +197,40 @@ class ServingService(BaseService):
             failure_status=failure_status,
         )
 
-    def stop_deployment(self, 
+    def wait_deployment_ready(
+        self,
+        deployment_id: Union[str, UUID],
+        timeout_seconds: int = 3600,
+        poll_interval_seconds: float = 5.0,
+    ) -> UIModelDeployment:
+        """Block until a deployment reaches the DEPLOYED terminal state.
+
+        The server accepts deploy requests asynchronously (ENG-6530) and
+        returns the deployment id immediately; readiness is observed by
+        polling ``get_deployment`` client-side.
+
+        Args:
+            deployment_id: The id returned by ``deploy_model``.
+            timeout_seconds: Max seconds to wait before giving up.
+            poll_interval_seconds: Seconds between status polls.
+
+        Returns:
+            The deployment once its status is ``DEPLOYED``.
+
+        Raises:
+            DeploymentFailedError: The deployment entered a FAILED/ERROR
+                terminal status. Carries ``status``,
+                ``last_error_message`` and ``last_error_code``.
+            TimeoutError: The deployment did not become ready within
+                ``timeout_seconds``.
+        """
+        return self.wait_for_deployment(
+            deployment_id,
+            poll_interval=poll_interval_seconds,
+            timeout=timeout_seconds,
+        )
+
+    def stop_deployment(self,
                     deployment_id: Optional[UUID] = None, 
                     repo_id: Optional[str] = None,
                     force: Optional[bool] = False) -> bool:
@@ -350,8 +384,18 @@ class DeploymentStatusPoller:
             if current in desired:
                 return deployment
             if failures and current in failures:
-                raise RuntimeError(
+                last_error_message = getattr(deployment, "last_error_message", None)
+                last_error_code = getattr(deployment, "last_error_code", None)
+                message = (
                     f"Deployment {deployment_uuid} entered failure status {deployment.status}"
+                )
+                if last_error_message:
+                    message = f"{message}: {last_error_message}"
+                raise DeploymentFailedError(
+                    message,
+                    status=deployment.status,
+                    last_error_message=last_error_message,
+                    last_error_code=last_error_code,
                 )
             if self._timeout is not None and (self._time() - start) > self._timeout:
                 raise TimeoutError(

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -45,14 +45,26 @@ class ServingService(BaseService):
         """Estimate the VRAM required for a model deployment."""
         return self.client.post("/serving/estimate_model_vram", json=deployment_request.model_dump())
     
-    def deploy_model(self, 
+    def deploy_model(self,
                 model_id: Optional[Union[str, UUID]] = None,
                 repo_id: Optional[str] = None,
                 m_config_id: Optional[Union[str, UUID]] = None,
                 m_file_id: Optional[Union[str, UUID]] = None,
+                *,
+                wait: bool = True,
+                timeout_seconds: int = 3600,
                 **kwargs) -> Union[UUID, bool]:
         """
         Deploy a model based on the provided model ID or repo ID and optional parameters.
+
+        The server accepts the deploy request asynchronously (ENG-6530)
+        and returns the deployment id immediately — it no longer blocks
+        until the deployment is ready. With ``wait=True`` (the default)
+        this method preserves the blocking behaviour by polling
+        ``wait_deployment_ready`` client-side, without the HTTP-timeout
+        cliff of the old long-blocking request. With ``wait=False`` the
+        deployment id is returned as soon as the server acknowledges the
+        request; use ``wait_deployment_ready`` to observe readiness.
 
         Args:
             model_id (Optional[Union[str, UUID]]): The ID of the model to deploy.
@@ -61,10 +73,20 @@ class ServingService(BaseService):
                                     Required if model_id is not provided.
             m_config_id (Optional[Union[str, UUID]]): The ID of the model configuration to use.
             m_file_id (Optional[Union[str, UUID]]): The ID of the specific model file to use.
+            wait (bool): Block until the deployment reaches DEPLOYED.
+                        Defaults to True. Skipped when the server refuses
+                        the deploy (returns False instead of an id).
+            timeout_seconds (int): Max seconds to wait when ``wait=True``.
             **kwargs: Additional deployment parameters (engine_name, min_copies, etc.)
 
         Returns:
             Union[UUID, bool]: The deployment ID if successful, or False if deployment failed.
+
+        Raises:
+            DeploymentFailedError: ``wait=True`` and the deployment
+                entered a FAILED/ERROR terminal status.
+            TimeoutError: ``wait=True`` and the deployment did not become
+                ready within ``timeout_seconds``.
         """
         # Ensure at least one identifier is provided
         if model_id is None and repo_id is None:
@@ -107,7 +129,12 @@ class ServingService(BaseService):
         request_dict['m_config_id'] = str(request_dict['m_config_id'])
     
         response = self.client.post("/serving/deploy_model", json=request_dict)
-        return UUID(response) if isinstance(response, str) else response
+        deployment_id = UUID(response) if isinstance(response, str) else response
+
+        if wait and isinstance(deployment_id, UUID):
+            self.wait_deployment_ready(deployment_id, timeout_seconds=timeout_seconds)
+
+        return deployment_id
     
 
 

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -84,7 +84,7 @@ class ServingService(BaseService):
 
         Raises:
             DeploymentFailedError: ``wait=True`` and the deployment
-                entered a FAILED/ERROR terminal status.
+                entered a FAILED/ERROR/MUST_REDOWNLOAD terminal status.
             TimeoutError: ``wait=True`` and the deployment did not become
                 ready within ``timeout_seconds``.
         """
@@ -202,7 +202,7 @@ class ServingService(BaseService):
         deployment_id: Union[str, UUID],
         *,
         desired_status: Iterable[str] = ("DEPLOYED",),
-        failure_status: Iterable[str] = ("FAILED", "ERROR"),
+        failure_status: Iterable[str] = ("FAILED", "ERROR", "MUST_REDOWNLOAD"),
         poll_interval: float = 5.0,
         timeout: Optional[float] = 600.0,
     ) -> ModelDeployment:
@@ -240,8 +240,8 @@ class ServingService(BaseService):
             The deployment once its status is ``DEPLOYED``.
 
         Raises:
-            DeploymentFailedError: The deployment entered a FAILED/ERROR
-                terminal status. Carries ``status``,
+            DeploymentFailedError: The deployment entered a FAILED/ERROR/
+                MUST_REDOWNLOAD terminal status. Carries ``status``,
                 ``last_error_message`` and ``last_error_code``.
             TimeoutError: The deployment did not become ready within
                 ``timeout_seconds``.

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -22,7 +22,7 @@ from ..schemas.serving.inference import (
     UnloadModelRequest,
     UnloadModelResponse,
 )
-from ..exceptions import DeploymentFailedError
+from ..exceptions import APIError, DeploymentFailedError
 from .base_service import BaseService
 
 
@@ -85,8 +85,11 @@ class ServingService(BaseService):
         Raises:
             DeploymentFailedError: ``wait=True`` and the deployment
                 entered a FAILED/ERROR/MUST_REDOWNLOAD terminal status.
+                Carries ``deployment_id`` so the in-flight deployment can
+                be stopped/inspected.
             TimeoutError: ``wait=True`` and the deployment did not become
-                ready within ``timeout_seconds``.
+                ready within ``timeout_seconds``. Also carries a
+                ``deployment_id`` attribute.
         """
         # Ensure at least one identifier is provided
         if model_id is None and repo_id is None:
@@ -239,12 +242,17 @@ class ServingService(BaseService):
         Returns:
             The deployment once its status is ``DEPLOYED``.
 
+        Transient poll failures (connection blips, HTTP 5xx) are retried
+        up to ``DeploymentStatusPoller.MAX_TRANSIENT_POLL_ERRORS``
+        consecutive times before propagating.
+
         Raises:
             DeploymentFailedError: The deployment entered a FAILED/ERROR/
                 MUST_REDOWNLOAD terminal status. Carries ``status``,
-                ``last_error_message`` and ``last_error_code``.
+                ``last_error_message``, ``last_error_code`` and
+                ``deployment_id``.
             TimeoutError: The deployment did not become ready within
-                ``timeout_seconds``.
+                ``timeout_seconds``. Carries a ``deployment_id`` attribute.
         """
         return self.wait_for_deployment(
             deployment_id,
@@ -371,8 +379,25 @@ class ServingService(BaseService):
         return LoadModelResponse.model_validate(response)
 
 
+def _is_transient_poll_error(exc: APIError) -> bool:
+    """Connection-level failures (no status code) and server-side 5xx are
+    transient; 4xx client errors are not — retrying cannot fix the request."""
+    status_code = getattr(exc, "status_code", None)
+    return status_code is None or status_code >= 500
+
+
 class DeploymentStatusPoller:
-    """Utility helper that polls deployment status until completion."""
+    """Utility helper that polls deployment status until completion.
+
+    Tolerates up to ``MAX_TRANSIENT_POLL_ERRORS`` consecutive transient
+    poll failures (connection blips, HTTP 5xx) before propagating, so a
+    single blip cannot abort a default up-to-1-hour deploy wait. Errors
+    raised from the wait carry a ``deployment_id`` attribute so callers
+    can stop/inspect the in-flight deployment.
+    """
+
+    #: Consecutive transient poll failures tolerated before propagating.
+    MAX_TRANSIENT_POLL_ERRORS = 3
 
     def __init__(
         self,
@@ -400,31 +425,51 @@ class DeploymentStatusPoller:
         desired = {status.upper() for status in desired_status}
         failures = {status.upper() for status in failure_status}
         start = self._time()
+        transient_errors = 0
         while True:
-            deployment = self._service.get_deployment(deployment_uuid)
-            current = (deployment.status or "").upper()
-            if current in desired:
-                return deployment
-            if failures and current in failures:
-                last_error_message = getattr(deployment, "last_error_message", None)
-                last_error_code = getattr(deployment, "last_error_code", None)
-                message = (
-                    f"Deployment {deployment_uuid} entered failure status {deployment.status}"
-                )
-                if last_error_message:
-                    message = f"{message}: {last_error_message}"
-                raise DeploymentFailedError(
-                    message,
-                    status=deployment.status,
-                    last_error_message=last_error_message,
-                    last_error_code=last_error_code,
-                )
+            try:
+                deployment = self._service.get_deployment(deployment_uuid)
+            except APIError as exc:
+                transient_errors += 1
+                if (
+                    not _is_transient_poll_error(exc)
+                    or transient_errors >= self.MAX_TRANSIENT_POLL_ERRORS
+                ):
+                    raise
+            else:
+                transient_errors = 0
+                current = (deployment.status or "").upper()
+                if current in desired:
+                    return deployment
+                if failures and current in failures:
+                    self._raise_failure(deployment, deployment_uuid)
             if self._timeout is not None and (self._time() - start) > self._timeout:
-                raise TimeoutError(
+                timeout_error = TimeoutError(
                     f"Timed out waiting for deployment {deployment_uuid} to reach {desired}"
                 )
+                # Builtin TimeoutError for caller compatibility; carry the id
+                # programmatically rather than only inside the message string.
+                timeout_error.deployment_id = str(deployment_uuid)
+                raise timeout_error
             if self._poll_interval > 0:
                 self._sleep(self._poll_interval)
+
+    @staticmethod
+    def _raise_failure(deployment: ModelDeployment, deployment_uuid: UUID) -> None:
+        last_error_message = getattr(deployment, "last_error_message", None)
+        last_error_code = getattr(deployment, "last_error_code", None)
+        message = (
+            f"Deployment {deployment_uuid} entered failure status {deployment.status}"
+        )
+        if last_error_message:
+            message = f"{message}: {last_error_message}"
+        raise DeploymentFailedError(
+            message,
+            status=deployment.status,
+            last_error_message=last_error_message,
+            last_error_code=last_error_code,
+            deployment_id=str(deployment_uuid),
+        )
 
 
 class DeploymentLogStreamer:

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -53,6 +53,7 @@ class ServingService(BaseService):
                 *,
                 wait: bool = True,
                 timeout_seconds: int = 3600,
+                poll_interval_seconds: float = 5.0,
                 **kwargs) -> Union[UUID, bool]:
         """
         Deploy a model based on the provided model ID or repo ID and optional parameters.
@@ -77,6 +78,8 @@ class ServingService(BaseService):
                         Defaults to True. Skipped when the server refuses
                         the deploy (returns False instead of an id).
             timeout_seconds (int): Max seconds to wait when ``wait=True``.
+            poll_interval_seconds (float): Seconds between status polls
+                when ``wait=True``.
             **kwargs: Additional deployment parameters (engine_name, min_copies, etc.)
 
         Returns:
@@ -135,7 +138,11 @@ class ServingService(BaseService):
         deployment_id = UUID(response) if isinstance(response, str) else response
 
         if wait and isinstance(deployment_id, UUID):
-            self.wait_deployment_ready(deployment_id, timeout_seconds=timeout_seconds)
+            self.wait_deployment_ready(
+                deployment_id,
+                timeout_seconds=timeout_seconds,
+                poll_interval_seconds=poll_interval_seconds,
+            )
 
         return deployment_id
     

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1239,6 +1239,9 @@ def context_llm_prerequisite(
             autoscaling=False,
             min_copies=1,
             starting_copies=1,
+            # The fixture's wait_for_deployment below owns the timeout; the
+            # SDK-internal wait would block up to its own 3600s default first.
+            wait=False,
         )
         if not raw_deployment_id:
             pytest.skip(
@@ -1318,6 +1321,9 @@ def deployable_model_prerequisite(
             autoscaling=False,
             min_copies=1,
             starting_copies=1,
+            # The probe's wait_for_deployment below owns the timeout
+            # (DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS), not the SDK default.
+            wait=False,
         )
         if not raw_deployment_id:
             pytest.skip(

--- a/tests/integration/test_serving_workflow.py
+++ b/tests/integration/test_serving_workflow.py
@@ -67,6 +67,8 @@ def test_deploy_qwen_and_infer_with_strip_thinking(live_kamiwaza_client, ensure_
 
     deployments = []
     try:
+        # wait=False: both deploys are launched back-to-back and the explicit
+        # wait_for_deployment calls below own the WAIT_TIMEOUT budget.
         default_deployment = client.serving.deploy_model(
             model_id=str(model.id),
             m_config_id=default_config.id,
@@ -74,6 +76,7 @@ def test_deploy_qwen_and_infer_with_strip_thinking(live_kamiwaza_client, ensure_
             autoscaling=False,
             min_copies=1,
             starting_copies=1,
+            wait=False,
         )
         deployments.append(default_deployment)
 
@@ -84,6 +87,7 @@ def test_deploy_qwen_and_infer_with_strip_thinking(live_kamiwaza_client, ensure_
             autoscaling=False,
             min_copies=1,
             starting_copies=1,
+            wait=False,
         )
         deployments.append(strip_deployment)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -179,4 +179,7 @@ def test_serve_deploy_command_invokes_service(monkeypatch):
     assert summary["deployment_id"] == str(deployment_id)
     assert summary["status"] == "DEPLOYED"
     assert fake_serving.deploy_calls, "Expected deploy_model to be invoked"
+    # The CLI owns the wait via --wait/--timeout/--poll-interval; the SDK's
+    # internal deploy_model wait must stay off or those flags are void.
+    assert fake_serving.deploy_calls[0]["wait"] is False
     assert fake_serving.wait_kwargs == {"poll_interval": 0.5, "timeout": 2.5}

--- a/tests/unit/test_kamiwaza_sdk_exceptions.py
+++ b/tests/unit/test_kamiwaza_sdk_exceptions.py
@@ -300,11 +300,22 @@ def test_deployment_failed_error_is_a_runtime_error() -> None:
 
 
 def test_deployment_failed_error_context_defaults_none() -> None:
-    """status / last_error_message / last_error_code default to None for
-    failure paths where the deployment carries no error metadata."""
+    """status / last_error_message / last_error_code / deployment_id default
+    to None for failure paths where the deployment carries no metadata."""
     from kamiwaza_sdk.exceptions import DeploymentFailedError
 
     err = DeploymentFailedError("deployment failed")
     assert err.status is None
     assert err.last_error_message is None
     assert err.last_error_code is None
+    assert err.deployment_id is None
+
+
+def test_deployment_failed_error_carries_deployment_id() -> None:
+    """Wait-phase failures must hand the caller the deployment id so the
+    in-flight deployment can be stopped or inspected — otherwise the id is
+    lost when deploy_model(wait=True) raises before returning it."""
+    from kamiwaza_sdk.exceptions import DeploymentFailedError
+
+    err = DeploymentFailedError("deployment failed", deployment_id="dep-123")
+    assert err.deployment_id == "dep-123"

--- a/tests/unit/test_kamiwaza_sdk_exceptions.py
+++ b/tests/unit/test_kamiwaza_sdk_exceptions.py
@@ -264,3 +264,47 @@ def test_kamiwaza_sdk_error_aliases_kamiwaza_error() -> None:
     from kamiwaza_sdk.exceptions import KamiwazaError, KamiwazaSDKError
 
     assert KamiwazaSDKError is KamiwazaError
+
+
+# ---------------------------------------------------------------------------
+# DeploymentFailedError — ENG-6530 async deploy_model client-side polling
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_failed_error_carries_failure_context() -> None:
+    """ENG-6530: when client-side polling observes a terminal failure
+    status, the typed error carries the status plus the deployment's
+    last_error_message / last_error_code so callers can react without
+    re-fetching the deployment."""
+    from kamiwaza_sdk.exceptions import DeploymentFailedError, KamiwazaError
+
+    err = DeploymentFailedError(
+        "deployment failed",
+        status="FAILED",
+        last_error_message="CUDA out of memory while loading weights",
+        last_error_code="OOM",
+    )
+    assert isinstance(err, KamiwazaError)
+    assert err.status == "FAILED"
+    assert err.last_error_message == "CUDA out of memory while loading weights"
+    assert err.last_error_code == "OOM"
+
+
+def test_deployment_failed_error_is_a_runtime_error() -> None:
+    """wait_for_deployment historically raised RuntimeError on failure
+    statuses; existing ``except RuntimeError`` callers (e.g. the
+    integration fixtures) must keep catching the typed replacement."""
+    from kamiwaza_sdk.exceptions import DeploymentFailedError
+
+    assert issubclass(DeploymentFailedError, RuntimeError)
+
+
+def test_deployment_failed_error_context_defaults_none() -> None:
+    """status / last_error_message / last_error_code default to None for
+    failure paths where the deployment carries no error metadata."""
+    from kamiwaza_sdk.exceptions import DeploymentFailedError
+
+    err = DeploymentFailedError("deployment failed")
+    assert err.status is None
+    assert err.last_error_message is None
+    assert err.last_error_code is None

--- a/tests/unit/test_model_service.py
+++ b/tests/unit/test_model_service.py
@@ -85,6 +85,78 @@ def test_download_and_deploy_does_not_retry_terminal_deploy_failure(monkeypatch)
     assert len(deploy_calls) == 1
 
 
+def test_download_and_deploy_does_not_retry_deploy_wait_timeout(monkeypatch):
+    """A hung-but-not-terminal deployment surfaces as a builtin
+    TimeoutError from deploy_model(wait=True). Retrying redeploys on top
+    of the still-in-flight deployment — worst case ~3x the 3600s wait and
+    up to 3 orphaned deployments — and the blanket retry wrapped away the
+    deployment id needed for cleanup. The timeout must propagate
+    immediately with the deployment id intact."""
+    import time as time_module
+    from types import SimpleNamespace
+
+    deploy_calls: list[dict] = []
+    deployment_id = str(uuid.uuid4())
+
+    def hung_deploy(**kwargs):
+        deploy_calls.append(kwargs)
+        timeout_error = TimeoutError(
+            f"Timed out waiting for deployment {deployment_id} to reach DEPLOYED"
+        )
+        timeout_error.deployment_id = deployment_id
+        raise timeout_error
+
+    client = DummyClient({})
+    client.serving = SimpleNamespace(deploy_model=hung_deploy)
+    service = ModelService(client)
+    monkeypatch.setattr(service, "initiate_model_download", lambda *a, **k: None)
+    monkeypatch.setattr(
+        service,
+        "get_model_by_repo_id",
+        lambda repo_id: SimpleNamespace(id=uuid.uuid4(), m_files=[]),
+    )
+    monkeypatch.setattr(time_module, "sleep", lambda _seconds: None)
+
+    with pytest.raises(TimeoutError) as exc_info:
+        service.download_and_deploy_model("org/model", wait_for_download=False)
+
+    assert len(deploy_calls) == 1
+    assert exc_info.value.deployment_id == deployment_id
+
+
+def test_download_and_deploy_retries_transient_deploy_error(monkeypatch):
+    """Generic transient deploy errors (connection blips, 5xx) keep the
+    existing backoff retries; only typed terminal/timeout errors are
+    excluded from the retry loop."""
+    import time as time_module
+    from types import SimpleNamespace
+
+    deploy_calls: list[dict] = []
+    deployment_id = uuid.uuid4()
+
+    def flaky_deploy(**kwargs):
+        deploy_calls.append(kwargs)
+        if len(deploy_calls) < 3:
+            raise RuntimeError("connection reset")
+        return deployment_id
+
+    client = DummyClient({})
+    client.serving = SimpleNamespace(deploy_model=flaky_deploy)
+    service = ModelService(client)
+    monkeypatch.setattr(service, "initiate_model_download", lambda *a, **k: None)
+    monkeypatch.setattr(
+        service,
+        "get_model_by_repo_id",
+        lambda repo_id: SimpleNamespace(id=uuid.uuid4(), m_files=[]),
+    )
+    monkeypatch.setattr(time_module, "sleep", lambda _seconds: None)
+
+    result = service.download_and_deploy_model("org/model", wait_for_download=False)
+
+    assert len(deploy_calls) == 3
+    assert result["deployment_id"] == deployment_id
+
+
 def test_create_and_delete_model():
     model_id = str(uuid.uuid4())
     responses = {

--- a/tests/unit/test_model_service.py
+++ b/tests/unit/test_model_service.py
@@ -50,6 +50,41 @@ def test_get_model_fetches_by_uuid():
     assert client.calls[0][1] == f"/models/{model_id}"
 
 
+def test_download_and_deploy_does_not_retry_terminal_deploy_failure(monkeypatch):
+    """A deployment that reached a terminal FAILED/ERROR/MUST_REDOWNLOAD
+    status will not succeed on an immediate redeploy; with deploy_model
+    now blocking on readiness by default, retrying three times costs up
+    to 3x the wait timeout. The typed error must propagate immediately."""
+    import time as time_module
+    from types import SimpleNamespace
+
+    from kamiwaza_sdk.exceptions import DeploymentFailedError
+
+    deploy_calls: list[dict] = []
+
+    def failing_deploy(**kwargs):
+        deploy_calls.append(kwargs)
+        raise DeploymentFailedError(
+            "Deployment entered failure status FAILED", status="FAILED"
+        )
+
+    client = DummyClient({})
+    client.serving = SimpleNamespace(deploy_model=failing_deploy)
+    service = ModelService(client)
+    monkeypatch.setattr(service, "initiate_model_download", lambda *a, **k: None)
+    monkeypatch.setattr(
+        service,
+        "get_model_by_repo_id",
+        lambda repo_id: SimpleNamespace(id=uuid.uuid4(), m_files=[]),
+    )
+    monkeypatch.setattr(time_module, "sleep", lambda _seconds: None)
+
+    with pytest.raises(DeploymentFailedError):
+        service.download_and_deploy_model("org/model", wait_for_download=False)
+
+    assert len(deploy_calls) == 1
+
+
 def test_create_and_delete_model():
     model_id = str(uuid.uuid4())
     responses = {

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -314,7 +314,9 @@ def test_log_streamer_respects_custom_stop_condition():
     service = _LogService(responses)
     streamer = DeploymentLogStreamer(service, poll_interval=0, sleep_fn=lambda _: None)
 
-    stop_after_two = lambda resp: resp.total_lines_seen >= 2
+    def stop_after_two(resp):
+        return resp.total_lines_seen >= 2
+
     lines = list(
         streamer.stream(
             deployment_id,

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -52,20 +52,62 @@ def test_deploy_model_builds_payload_with_repo_lookup(dummy_client):
 
 
 def test_deploy_model_waits_until_ready_by_default(mock_client):
+    """wait is omitted (default True) — the deploy polls through to
+    DEPLOYED. poll_interval_seconds/timeout_seconds are forwarded to the
+    wait so a status-match regression fails the suite in milliseconds
+    instead of spinning through the 3600s/5s production defaults."""
     deployment_id = uuid4()
     mock_client.expect("POST", "/serving/deploy_model", str(deployment_id))
-    mock_client.expect(
+    mock_client.expect_sequence(
         "GET",
         f"/serving/deployment/{deployment_id}",
-        _deployment_payload(deployment_id, "DEPLOYED"),
+        [
+            _deployment_payload(deployment_id, "DEPLOYING"),
+            _deployment_payload(deployment_id, "DEPLOYED"),
+        ],
     )
     service = ServingService(mock_client)
 
-    result = service.deploy_model(model_id=uuid4(), m_config_id=uuid4())
+    result = service.deploy_model(
+        model_id=uuid4(),
+        m_config_id=uuid4(),
+        poll_interval_seconds=0,
+        timeout_seconds=5,
+    )
 
     assert result == deployment_id
     get_calls = [call for call in mock_client.calls if call[0] == "GET"]
-    assert len(get_calls) == 1
+    assert len(get_calls) == 2
+    # SDK-side wait knob: must drive the poll, not leak into the request
+    # body via **kwargs (where it would otherwise land in the payload).
+    post_payload = mock_client.calls[0][2]["json"]
+    assert "poll_interval_seconds" not in post_payload
+
+
+def test_deploy_model_forwards_wait_knobs(mock_client, monkeypatch):
+    """poll_interval_seconds/timeout_seconds are SDK-side wait knobs and
+    must reach wait_deployment_ready — not be silently dropped by the
+    **kwargs -> CreateModelDeployment path (extras are discarded there,
+    so a typo'd knob would otherwise revert to the 5s/3600s defaults)."""
+    deployment_id = uuid4()
+    mock_client.expect("POST", "/serving/deploy_model", str(deployment_id))
+    service = ServingService(mock_client)
+    recorded = {}
+
+    def fake_wait(dep_id, timeout_seconds, poll_interval_seconds):
+        recorded["args"] = (dep_id, timeout_seconds, poll_interval_seconds)
+        return SimpleNamespace(status="DEPLOYED")
+
+    monkeypatch.setattr(service, "wait_deployment_ready", fake_wait)
+
+    service.deploy_model(
+        model_id=uuid4(),
+        m_config_id=uuid4(),
+        poll_interval_seconds=0.25,
+        timeout_seconds=42,
+    )
+
+    assert recorded["args"] == (deployment_id, 42, 0.25)
 
 
 def test_deploy_model_wait_false_returns_id_immediately(mock_client):

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -40,13 +40,57 @@ def test_deploy_model_builds_payload_with_repo_lookup(dummy_client):
     client.models = DummyModels()
     service = ServingService(client)
 
-    result = service.deploy_model(repo_id="mlx-community/Qwen3-4B-4bit", lb_port=0, autoscaling=False)
+    result = service.deploy_model(
+        repo_id="mlx-community/Qwen3-4B-4bit", lb_port=0, autoscaling=False, wait=False
+    )
 
     assert result == deployment_id
     method, path, payload = client.calls[0]
     assert (method, path) == ("post", "/serving/deploy_model")
     assert payload["json"]["m_id"] == str(model_id)
     assert payload["json"]["m_config_id"] == str(config_id)
+
+
+def test_deploy_model_waits_until_ready_by_default(mock_client):
+    deployment_id = uuid4()
+    mock_client.expect("POST", "/serving/deploy_model", str(deployment_id))
+    mock_client.expect(
+        "GET",
+        f"/serving/deployment/{deployment_id}",
+        _deployment_payload(deployment_id, "DEPLOYED"),
+    )
+    service = ServingService(mock_client)
+
+    result = service.deploy_model(model_id=uuid4(), m_config_id=uuid4())
+
+    assert result == deployment_id
+    get_calls = [call for call in mock_client.calls if call[0] == "GET"]
+    assert len(get_calls) == 1
+
+
+def test_deploy_model_wait_false_returns_id_immediately(mock_client):
+    deployment_id = uuid4()
+    mock_client.expect("POST", "/serving/deploy_model", str(deployment_id))
+    service = ServingService(mock_client)
+
+    result = service.deploy_model(model_id=uuid4(), m_config_id=uuid4(), wait=False)
+
+    assert result == deployment_id
+    assert [call[0] for call in mock_client.calls] == ["POST"]
+    # wait/timeout knobs are SDK-side only and must not leak into the request.
+    post_payload = mock_client.calls[0][2]["json"]
+    assert "wait" not in post_payload
+    assert "timeout_seconds" not in post_payload
+
+
+def test_deploy_model_returns_false_without_polling_when_deploy_refused(mock_client):
+    mock_client.expect("POST", "/serving/deploy_model", False)
+    service = ServingService(mock_client)
+
+    result = service.deploy_model(model_id=uuid4(), m_config_id=uuid4())
+
+    assert result is False
+    assert [call[0] for call in mock_client.calls] == ["POST"]
 
 
 def _deployment_payload(deployment_id: UUID, status: str, **extra) -> dict:

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from kamiwaza_sdk.exceptions import DeploymentFailedError
+from kamiwaza_sdk.exceptions import APIError, DeploymentFailedError
 from kamiwaza_sdk.schemas.serving.serving import (
     ContainerLogResponse,
     UIModelDeployment,
@@ -174,6 +174,7 @@ def test_wait_deployment_ready_raises_deployment_failed_error(mock_client):
     assert err.status == "FAILED"
     assert err.last_error_message == "CUDA out of memory while loading weights"
     assert err.last_error_code == "OOM"
+    assert err.deployment_id == str(deployment_id)
     assert "CUDA out of memory while loading weights" in str(err)
 
 
@@ -212,10 +213,14 @@ def test_wait_deployment_ready_times_out(mock_client):
     )
     service = ServingService(mock_client)
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(TimeoutError) as exc_info:
         service.wait_deployment_ready(
             deployment_id, timeout_seconds=0, poll_interval_seconds=0
         )
+
+    # Callers need the id to stop/inspect the in-flight deployment; the
+    # message string is not a programmatic surface.
+    assert exc_info.value.deployment_id == str(deployment_id)
 
 
 class _StatusService:
@@ -272,6 +277,102 @@ def test_status_poller_raises_on_failure_status():
 
     with pytest.raises(RuntimeError):
         poller.wait_for(deployment_id, desired_status=["DEPLOYED"], failure_status=["FAILED"])
+
+
+class _FlakyStatusService:
+    """get_deployment stub: Exception outcomes raise, str outcomes are
+    returned as the deployment status. The last outcome repeats."""
+
+    def __init__(self, outcomes: list):
+        self.outcomes = outcomes
+        self.calls = 0
+
+    def get_deployment(self, deployment_id: UUID):
+        idx = min(self.calls, len(self.outcomes) - 1)
+        self.calls += 1
+        outcome = self.outcomes[idx]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return SimpleNamespace(status=outcome, id=deployment_id)
+
+
+def _fast_poller(service) -> DeploymentStatusPoller:
+    return DeploymentStatusPoller(
+        service,
+        poll_interval=0,
+        timeout=10.0,
+        sleep_fn=lambda _: None,
+        time_fn=_TimeStub(step=0.01),
+    )
+
+
+def test_status_poller_retries_transient_api_errors():
+    """A single 5xx/connection blip over a default up-to-1-hour wait must
+    not abort the deploy wait; transient errors are retried."""
+    deployment_id = uuid4()
+    service = _FlakyStatusService(
+        [
+            APIError("bad gateway", status_code=502),
+            APIError("connection reset"),  # no status_code: connection-level
+            "DEPLOYED",
+        ]
+    )
+
+    deployment = _fast_poller(service).wait_for(
+        deployment_id, desired_status=["DEPLOYED"], failure_status=["FAILED"]
+    )
+
+    assert deployment.status == "DEPLOYED"
+    assert service.calls == 3
+
+
+def test_status_poller_resets_transient_count_on_successful_poll():
+    deployment_id = uuid4()
+    service = _FlakyStatusService(
+        [
+            APIError("blip", status_code=503),
+            APIError("blip", status_code=503),
+            "DEPLOYING",
+            APIError("blip", status_code=503),
+            APIError("blip", status_code=503),
+            "DEPLOYED",
+        ]
+    )
+
+    deployment = _fast_poller(service).wait_for(
+        deployment_id, desired_status=["DEPLOYED"], failure_status=["FAILED"]
+    )
+
+    assert deployment.status == "DEPLOYED"
+    assert service.calls == 6
+
+
+def test_status_poller_propagates_after_consecutive_transient_errors():
+    deployment_id = uuid4()
+    service = _FlakyStatusService([APIError("bad gateway", status_code=502)])
+
+    with pytest.raises(APIError):
+        _fast_poller(service).wait_for(
+            deployment_id, desired_status=["DEPLOYED"], failure_status=["FAILED"]
+        )
+
+    assert service.calls == DeploymentStatusPoller.MAX_TRANSIENT_POLL_ERRORS
+
+
+def test_status_poller_propagates_client_errors_immediately():
+    """4xx means the request itself is wrong (gone deployment, bad auth);
+    retrying cannot help and must not delay the failure."""
+    deployment_id = uuid4()
+    service = _FlakyStatusService(
+        [APIError("not found", status_code=404), "DEPLOYED"]
+    )
+
+    with pytest.raises(APIError):
+        _fast_poller(service).wait_for(
+            deployment_id, desired_status=["DEPLOYED"], failure_status=["FAILED"]
+        )
+
+    assert service.calls == 1
 
 
 def test_status_poller_times_out_when_threshold_exceeded():

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from kamiwaza_sdk.exceptions import DeploymentFailedError
 from kamiwaza_sdk.schemas.serving.serving import (
     ContainerLogResponse,
     UIModelDeployment,
@@ -82,6 +83,69 @@ def test_deployment_schema_defaults_last_error_fields_to_none():
 
     assert deployment.last_error_message is None
     assert deployment.last_error_code is None
+
+
+def test_wait_deployment_ready_polls_until_deployed(mock_client):
+    deployment_id = uuid4()
+    mock_client.expect_sequence(
+        "GET",
+        f"/serving/deployment/{deployment_id}",
+        [
+            _deployment_payload(deployment_id, "DEPLOYING"),
+            _deployment_payload(deployment_id, "DEPLOYED"),
+        ],
+    )
+    service = ServingService(mock_client)
+
+    deployment = service.wait_deployment_ready(
+        deployment_id, poll_interval_seconds=0
+    )
+
+    assert deployment.status == "DEPLOYED"
+    get_calls = [call for call in mock_client.calls if call[0] == "GET"]
+    assert len(get_calls) == 2
+
+
+def test_wait_deployment_ready_raises_deployment_failed_error(mock_client):
+    deployment_id = uuid4()
+    mock_client.expect_sequence(
+        "GET",
+        f"/serving/deployment/{deployment_id}",
+        [
+            _deployment_payload(deployment_id, "DEPLOYING"),
+            _deployment_payload(
+                deployment_id,
+                "FAILED",
+                last_error_message="CUDA out of memory while loading weights",
+                last_error_code="OOM",
+            ),
+        ],
+    )
+    service = ServingService(mock_client)
+
+    with pytest.raises(DeploymentFailedError) as exc_info:
+        service.wait_deployment_ready(deployment_id, poll_interval_seconds=0)
+
+    err = exc_info.value
+    assert err.status == "FAILED"
+    assert err.last_error_message == "CUDA out of memory while loading weights"
+    assert err.last_error_code == "OOM"
+    assert "CUDA out of memory while loading weights" in str(err)
+
+
+def test_wait_deployment_ready_times_out(mock_client):
+    deployment_id = uuid4()
+    mock_client.expect(
+        "GET",
+        f"/serving/deployment/{deployment_id}",
+        _deployment_payload(deployment_id, "DEPLOYING"),
+    )
+    service = ServingService(mock_client)
+
+    with pytest.raises(TimeoutError):
+        service.wait_deployment_ready(
+            deployment_id, timeout_seconds=0, poll_interval_seconds=0
+        )
 
 
 class _StatusService:

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -177,6 +177,32 @@ def test_wait_deployment_ready_raises_deployment_failed_error(mock_client):
     assert "CUDA out of memory while loading weights" in str(err)
 
 
+def test_wait_deployment_ready_raises_on_must_redownload(mock_client):
+    """The server background-launch path (ENG-6530) has a third resting
+    terminal failure state, MUST_REDOWNLOAD (corrupted/incomplete model
+    files). The poll must short-circuit with the typed error instead of
+    burning the full timeout. The row may carry no last_error_* metadata,
+    so the message must be meaningful from the status alone."""
+    deployment_id = uuid4()
+    mock_client.expect_sequence(
+        "GET",
+        f"/serving/deployment/{deployment_id}",
+        [
+            _deployment_payload(deployment_id, "DEPLOYING"),
+            _deployment_payload(deployment_id, "MUST_REDOWNLOAD"),
+        ],
+    )
+    service = ServingService(mock_client)
+
+    with pytest.raises(DeploymentFailedError) as exc_info:
+        service.wait_deployment_ready(deployment_id, poll_interval_seconds=0)
+
+    err = exc_info.value
+    assert err.status == "MUST_REDOWNLOAD"
+    assert err.last_error_message is None
+    assert "MUST_REDOWNLOAD" in str(err)
+
+
 def test_wait_deployment_ready_times_out(mock_client):
     deployment_id = uuid4()
     mock_client.expect(

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -5,7 +5,10 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from kamiwaza_sdk.schemas.serving.serving import ContainerLogResponse
+from kamiwaza_sdk.schemas.serving.serving import (
+    ContainerLogResponse,
+    UIModelDeployment,
+)
 from kamiwaza_sdk.services.serving import (
     DeploymentLogStreamer,
     DeploymentStatusPoller,
@@ -43,6 +46,42 @@ def test_deploy_model_builds_payload_with_repo_lookup(dummy_client):
     assert (method, path) == ("post", "/serving/deploy_model")
     assert payload["json"]["m_id"] == str(model_id)
     assert payload["json"]["m_config_id"] == str(config_id)
+
+
+def _deployment_payload(deployment_id: UUID, status: str, **extra) -> dict:
+    return {
+        "id": str(deployment_id),
+        "m_id": str(uuid4()),
+        "m_config_id": str(uuid4()),
+        "requested_at": "2026-06-09T00:00:00Z",
+        "status": status,
+        "instances": [],
+        **extra,
+    }
+
+
+def test_deployment_schema_preserves_last_error_fields():
+    deployment_id = uuid4()
+    payload = _deployment_payload(
+        deployment_id,
+        "FAILED",
+        last_error_message="CUDA out of memory while loading weights",
+        last_error_code="OOM",
+    )
+
+    deployment = UIModelDeployment.model_validate(payload)
+
+    assert deployment.last_error_message == "CUDA out of memory while loading weights"
+    assert deployment.last_error_code == "OOM"
+
+
+def test_deployment_schema_defaults_last_error_fields_to_none():
+    deployment = UIModelDeployment.model_validate(
+        _deployment_payload(uuid4(), "DEPLOYED")
+    )
+
+    assert deployment.last_error_message is None
+    assert deployment.last_error_code is None
 
 
 class _StatusService:


### PR DESCRIPTION
## Summary

SDK half of ENG-6530(c): the server now returns 202 immediately, so `deploy_model` keeps its blocking UX **client-side** — `wait: bool = True` (default preserves today's semantics with no HTTP-timeout cliff), `timeout_seconds`, and `wait_deployment_ready()` as a thin delegate to the existing `DeploymentStatusPoller` (no duplicate poll loop — the SDK already had the right machinery).

## Key decisions (reality-first)

- `DeploymentFailedError` subclasses **both** `KamiwazaError` and `RuntimeError` — the existing poller raised RuntimeError and live integration fixtures catch it; a pure KamiwazaError would have broken them. Carries status + last_error_message/code.
- Timeout keeps raising the **builtin** `TimeoutError` (existing poller contract), now annotated with the deployment id.
- **`MUST_REDOWNLOAD` added to the terminal-failure set** (review catch — the server's third resting failure status; without it, polling would spin until timeout).
- Poll hardened against transient GET blips; CLI threads through with `--no-wait`/poll flags; internal helpers that own their own wait now pass `wait=False`.

## Tests

Full `make test`: 2277 passed. 14 new/updated unit tests across deploy-wait, exceptions, and CLI; TDD red-first per change.

Refs ENG-6530.