### PR TITLE
ENG-6293 add kz-ext publish --all

### DIFF
--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -378,6 +378,11 @@ def publish(
             "(K8s/v3 extensions). Pass 2 to publish to the legacy v2 catalog."
         ),
     ),
+    publish_all: bool = typer.Option(
+        False,
+        "--all",
+        help="Publish every extension discovered under the current repository.",
+    ),
 ) -> None:
     """Publish extension to catalog."""
     from kamiwaza_extensions.commands.publish import run_publish
@@ -391,6 +396,7 @@ def publish(
         revision=revision,
         digest=digest,
         catalog_schema=catalog_schema,
+        publish_all=publish_all,
     )
 
 

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -16,7 +16,7 @@ from kamiwaza_extensions.compose_transformer import (
     _repo_part,
     compute_canonical_refs,
 )
-from kamiwaza_extensions.extension_detector import infer_extension_type
+from kamiwaza_extensions.extension_detector import ExtensionInfo, infer_extension_type
 
 console = Console(stderr=True)
 
@@ -277,7 +277,8 @@ def _auto_resolve_digests(
     return digest_map
 
 
-def run_publish(
+def _publish_one(
+    info: ExtensionInfo,
     *,
     stage: str,
     dry_run: bool = False,
@@ -289,21 +290,18 @@ def run_publish(
     digest: Optional[str] = None,
     catalog_schema: int = DEFAULT_CATALOG_SCHEMA,
 ) -> None:
-    """Build, push, and publish extension to catalog."""
+    """Build, push, and publish one detected extension to catalog."""
     from kamiwaza_extensions.catalog_publisher import (
         CatalogDedupError,
-        CatalogDedupGuard,
         CatalogPublishError,
         CatalogPublisher,
     )
     from kamiwaza_extensions.compose_transformer import ComposeTransformer
     from kamiwaza_extensions.exit_codes import ExitCode
-    from kamiwaza_extensions.extension_detector import ExtensionDetector
     from kamiwaza_extensions.image_builder import ImageBuilder, ImageBuildError
     from kamiwaza_extensions.image_pusher import (
         ImagePushError,
         ImagePusher,
-        validate_digest,
     )
     from kamiwaza_extensions.profile_manager import ProfileManager
     from kamiwaza_extensions.registry_builder import (
@@ -312,36 +310,6 @@ def run_publish(
     )
     from kamiwaza_extensions.validators.compose import ComposeValidator
     from kamiwaza_extensions.validators.metadata import MetadataValidator
-
-    # 0. Fail fast on bad --revision before any side effects (build, push,
-    # registry tag pollution). Previously this validated inside
-    # CatalogPublisher.publish, after image push had already happened —
-    # invalid revisions like 'foo/bar' or 'BAD CASE' would leak orphan
-    # tags into the registry (review re-review PR #84 M2).
-    if revision is not None:
-        try:
-            CatalogDedupGuard.validate_revision(revision)
-        except ValueError as exc:
-            console.print(f"[red]Error:[/red] {exc}")
-            raise typer.Exit(code=int(ExitCode.VALIDATION)) from exc
-
-    # Same fail-fast intent for --digest: reject malformed input before any
-    # build/push side effects. Format guard only — buildable-count check
-    # happens after compose data is loaded.
-    if digest is not None:
-        try:
-            validate_digest(digest)
-        except ValueError as exc:
-            # The exception text contains the user-supplied digest verbatim;
-            # rich console treats `[…]` as markup, so disable interpretation
-            # to avoid silent stripping or a markup-injection vector.
-            console.print("[red]Error:[/red] ", end="")
-            console.print(str(exc), markup=False)
-            raise typer.Exit(code=int(ExitCode.VALIDATION)) from exc
-
-    # 1. Detect extension
-    detector = ExtensionDetector()
-    info = detector.detect()
 
     if info.compose_data is None:
         console.print("[red]Error:[/red] No docker-compose.yml found.")
@@ -758,3 +726,83 @@ def run_publish(
         ]
         console.print(f"  Images:  {', '.join(pinned)}")
     console.print(f"  Catalog: {result.catalog_file}")
+
+
+def run_publish(
+    *,
+    stage: str,
+    dry_run: bool = False,
+    force: bool = False,
+    no_build: bool = False,
+    no_push: bool = False,
+    verbose: bool = False,
+    revision: Optional[str] = None,
+    digest: Optional[str] = None,
+    catalog_schema: int = DEFAULT_CATALOG_SCHEMA,
+    publish_all: bool = False,
+) -> None:
+    """Build, push, and publish extension(s) to catalog."""
+    from kamiwaza_extensions.catalog_publisher import CatalogDedupGuard
+    from kamiwaza_extensions.exit_codes import ExitCode
+    from kamiwaza_extensions.extension_detector import (
+        ExtensionDetector,
+        MultipleExtensionsError,
+    )
+    from kamiwaza_extensions.image_pusher import validate_digest
+
+    # 0. Fail fast on bad --revision before any side effects (build, push,
+    # registry tag pollution). Previously this validated inside
+    # CatalogPublisher.publish, after image push had already happened —
+    # invalid revisions like 'foo/bar' or 'BAD CASE' would leak orphan
+    # tags into the registry (review re-review PR #84 M2).
+    if revision is not None:
+        try:
+            CatalogDedupGuard.validate_revision(revision)
+        except ValueError as exc:
+            console.print(f"[red]Error:[/red] {exc}")
+            raise typer.Exit(code=int(ExitCode.VALIDATION)) from exc
+
+    # Same fail-fast intent for --digest: reject malformed input before any
+    # build/push side effects.
+    if digest is not None:
+        try:
+            validate_digest(digest)
+        except ValueError as exc:
+            # The exception text contains the user-supplied digest verbatim;
+            # rich console treats `[…]` as markup, so disable interpretation
+            # to avoid silent stripping or a markup-injection vector.
+            console.print("[red]Error:[/red] ", end="")
+            console.print(str(exc), markup=False)
+            raise typer.Exit(code=int(ExitCode.VALIDATION)) from exc
+
+    if publish_all and digest is not None:
+        console.print(
+            "[red]Error:[/red] --all cannot be combined with --digest. "
+            "--digest pins one image; omit it to auto-resolve each extension."
+        )
+        raise typer.Exit(code=int(ExitCode.VALIDATION))
+
+    detector = ExtensionDetector()
+    try:
+        infos = detector.detect_all() if publish_all else [detector.detect()]
+    except MultipleExtensionsError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        console.print(
+            "Re-run with [bold]--all[/bold] to publish every detected extension, "
+            "or run from inside a specific extension directory."
+        )
+        raise typer.Exit(code=1) from exc
+
+    for info in infos:
+        _publish_one(
+            info,
+            stage=stage,
+            dry_run=dry_run,
+            force=force,
+            no_build=no_build,
+            no_push=no_push,
+            verbose=verbose,
+            revision=revision,
+            digest=digest,
+            catalog_schema=catalog_schema,
+        )

--- a/kamiwaza_extensions/extension_detector.py
+++ b/kamiwaza_extensions/extension_detector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import yaml
 
@@ -84,6 +84,20 @@ class ExtensionDetector:
         """
         root = start_dir or Path.cwd()
         ext_dir = self._find_root(root)
+        return self._load_info(ext_dir)
+
+    def detect_all(self, start_dir: Optional[Path] = None) -> List[ExtensionInfo]:
+        """Find every extension under *start_dir* and load metadata.
+
+        Root-level ``kamiwaza.json`` keeps the existing single-extension
+        behavior and wins over nested monorepo manifests. Otherwise this
+        returns all unique manifests discovered by the same shallow +
+        monorepo-convention search used by ``detect()``.
+        """
+        root = start_dir or Path.cwd()
+        return [self._load_info(ext_dir) for ext_dir in self._find_roots(root)]
+
+    def _load_info(self, ext_dir: Path) -> ExtensionInfo:
         metadata = self._load_metadata(ext_dir)
         compose_path, compose_data = self._load_compose(ext_dir)
         raw_basename = metadata.get("image_basename")
@@ -123,8 +137,18 @@ class ExtensionDetector:
     # ------------------------------------------------------------------
 
     def _find_root(self, start: Path) -> Path:
+        unique = self._find_roots(start)
+        if len(unique) == 1:
+            return unique[0]
+        dirs = ", ".join(str(d.relative_to(start)) for d in unique)
+        raise MultipleExtensionsError(
+            f"Multiple kamiwaza.json found: {dirs}. "
+            "Run from inside a specific extension directory."
+        )
+
+    def _find_roots(self, start: Path) -> List[Path]:
         if (start / "kamiwaza.json").exists():
-            return start
+            return [start]
 
         candidates: list[Path] = []
         # Shallow search: any direct subdirectory containing kamiwaza.json.
@@ -140,14 +164,8 @@ class ExtensionDetector:
             {c.resolve(): c for c in candidates}.values(),
             key=lambda p: (p.parent.name, p.name),
         )
-        if len(unique) == 1:
-            return unique[0]
-        if len(unique) > 1:
-            dirs = ", ".join(str(d.relative_to(start)) for d in unique)
-            raise MultipleExtensionsError(
-                f"Multiple kamiwaza.json found: {dirs}. "
-                "Run from inside a specific extension directory."
-            )
+        if unique:
+            return unique
 
         raise ExtensionNotFoundError(
             "No kamiwaza.json found. "

--- a/tests/unit/extensions/test_extension_detector.py
+++ b/tests/unit/extensions/test_extension_detector.py
@@ -157,6 +157,23 @@ class TestMonorepoDiscovery:
         assert "apps/foo" in str(exc.value)
         assert "tools/bar" in str(exc.value)
 
+    def test_detect_all_returns_every_monorepo_extension(self, detector, tmp_path):
+        for sub, ext_type in (("apps/foo", "app"), ("tools/bar", "tool")):
+            d = tmp_path / sub
+            d.mkdir(parents=True)
+            (d / "kamiwaza.json").write_text(
+                json.dumps({"name": d.name, "version": "1.0.0", "type": ext_type})
+            )
+            (d / "docker-compose.yml").write_text("services: {}")
+
+        infos = detector.detect_all(tmp_path)
+
+        assert [info.name for info in infos] == ["foo", "bar"]
+        assert [info.path.relative_to(tmp_path).as_posix() for info in infos] == [
+            "apps/foo",
+            "tools/bar",
+        ]
+
     def test_root_kamiwaza_json_wins_over_monorepo(self, detector, tmp_path):
         (tmp_path / "kamiwaza.json").write_text(json.dumps({"name": "root"}))
         (tmp_path / "apps").mkdir()
@@ -167,3 +184,15 @@ class TestMonorepoDiscovery:
 
         assert info.path == tmp_path
         assert info.name == "root"
+
+    def test_detect_all_root_kamiwaza_json_wins_over_monorepo(self, detector, tmp_path):
+        (tmp_path / "kamiwaza.json").write_text(json.dumps({"name": "root"}))
+        nested = tmp_path / "apps" / "decoy"
+        nested.mkdir(parents=True)
+        (nested / "kamiwaza.json").write_text(json.dumps({"name": "decoy"}))
+
+        infos = detector.detect_all(tmp_path)
+
+        assert len(infos) == 1
+        assert infos[0].path == tmp_path
+        assert infos[0].name == "root"

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -7,9 +7,11 @@ from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
+import typer
 from click.exceptions import Exit as ClickExit
 
 pytestmark = pytest.mark.unit
+CLI_EXIT_TYPES = (SystemExit, ClickExit, typer.Exit)
 
 
 def _make_extension_info(
@@ -182,6 +184,93 @@ class TestPublishHappyPath:
         mock_pusher.push.assert_called_once()
         mock_reg_builder.build_entry.assert_called_once()
         mock_publisher.publish.assert_called_once()
+
+
+class TestPublishAll:
+    @patch("kamiwaza_extensions.commands.publish._publish_one")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_publish_all_detects_and_publishes_every_extension(
+        self,
+        mock_detector_cls,
+        mock_publish_one,
+        tmp_path,
+    ):
+        infos = [
+            _make_extension_info(tmp_path / "apps" / "connector-builder", name="connector-builder"),
+            _make_extension_info(
+                tmp_path / "tools" / "tool-data-connector-runtime",
+                name="tool-data-connector-runtime",
+            ),
+        ]
+        mock_detector = MagicMock()
+        mock_detector.detect_all.return_value = infos
+        mock_detector_cls.return_value = mock_detector
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev", publish_all=True, revision="abc1234", no_build=True)
+
+        mock_detector.detect_all.assert_called_once()
+        mock_detector.detect.assert_not_called()
+        assert mock_publish_one.call_count == 2
+        assert [call.args[0].name for call in mock_publish_one.call_args_list] == [
+            "connector-builder",
+            "tool-data-connector-runtime",
+        ]
+        for call in mock_publish_one.call_args_list:
+            assert call.kwargs["stage"] == "dev"
+            assert call.kwargs["revision"] == "abc1234"
+            assert call.kwargs["no_build"] is True
+
+    @patch("kamiwaza_extensions.commands.publish._publish_one")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_publish_without_all_keeps_single_extension_detection(
+        self,
+        mock_detector_cls,
+        mock_publish_one,
+        tmp_path,
+    ):
+        info = _make_extension_info(tmp_path)
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = info
+        mock_detector_cls.return_value = mock_detector
+
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        run_publish(stage="dev")
+
+        mock_detector.detect.assert_called_once()
+        mock_detector.detect_all.assert_not_called()
+        mock_publish_one.assert_called_once()
+        assert mock_publish_one.call_args.args[0] is info
+
+    def test_publish_all_rejects_digest(self):
+        from kamiwaza_extensions.commands.publish import run_publish
+
+        with pytest.raises(CLI_EXIT_TYPES):
+            run_publish(
+                stage="dev",
+                publish_all=True,
+                digest="sha256:" + "a" * 64,
+            )
+
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_multi_extension_root_without_all_guides_user(self, mock_detector_cls, capsys):
+        from kamiwaza_extensions.commands.publish import run_publish
+        from kamiwaza_extensions.extension_detector import MultipleExtensionsError
+
+        mock_detector = MagicMock()
+        mock_detector.detect.side_effect = MultipleExtensionsError(
+            "Multiple kamiwaza.json found: apps/foo, tools/bar. "
+            "Run from inside a specific extension directory."
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        with pytest.raises(CLI_EXIT_TYPES):
+            run_publish(stage="dev")
+
+        captured = capsys.readouterr()
+        assert "--all" in captured.err
 
 
 class TestPublishWithInfoFindings:
@@ -1074,7 +1163,7 @@ class TestPublishValidationFailure:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="dev")
 
         # Build should never be called
@@ -1336,7 +1425,7 @@ class TestPublishProfileNotFound:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="nonexistent")
 
 
@@ -1364,7 +1453,7 @@ class TestPublishNoCompose:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="dev")
 
 # ------------------------------------------------------------------
@@ -1525,7 +1614,7 @@ class TestPublishDigest:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="dev")
 
         # Preflight ran; push and resolve never did.
@@ -1779,7 +1868,7 @@ class TestPublishDigest:
     ):
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="dev", digest="not-a-digest")
 
         # Detection should NOT happen when format is bad — we fail fast.
@@ -1809,7 +1898,7 @@ class TestPublishDigest:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="dev", digest=_DIGEST_USER_SUPPLIED)
 
         # Should never have built or pushed.
@@ -1842,7 +1931,7 @@ class TestPublishDigest:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="dev", no_push=True)
 
         # Should never have built or attempted to resolve.
@@ -2137,7 +2226,7 @@ class TestPublishDigest:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="dev", no_build=True, no_push=True)
 
     @patch("kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest")
@@ -2308,7 +2397,7 @@ class TestPublishDigest:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="dev", digest=_DIGEST_USER_SUPPLIED)  # not _DIGEST_BACKEND
 
         # Catalog publish never happened.
@@ -2352,7 +2441,7 @@ class TestPublishDigest:
 
         from kamiwaza_extensions.commands.publish import run_publish
 
-        with pytest.raises((SystemExit, ClickExit)):
+        with pytest.raises(CLI_EXIT_TYPES):
             run_publish(stage="dev")
 
         wired["reg_builder"].build_entry.assert_not_called()


### PR DESCRIPTION
## Summary
- add ExtensionDetector.detect_all() for multi-extension repo roots
- add kz-ext publish --all to publish every discovered extension while keeping single-extension publish unchanged
- reject --all with --digest because digest pins one image
- add coverage for monorepo detection and publish-all routing

## Tests
- temporary Python 3.12 venv: pytest tests/unit/extensions/test_extension_detector.py tests/unit/extensions/test_publish_cmd.py -q (104 passed)
- .venv/bin/ruff check touched SDK files
- Python 3.12 py_compile touched SDK files
- CLI help smoke confirms publish --help includes --all