### PR TITLE
Refresh AI context for 1.0 GA-tail surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,15 @@ All Pydantic models must use `Config.extra = "allow"` to handle new API fields g
 ### Progress Tracking
 Long-running operations (downloads, batch processing) should use the progress tracking framework with context managers. See examples in @.ai/knowledge/successful/service-patterns.md.
 
+### Async Deployment Waits (ENG-6530)
+The server accepts `POST /serving/deploy_model` asynchronously (202 + deployment id immediately); readiness is observed client-side:
+
+- `serving.deploy_model(..., wait=True, timeout_seconds=3600, poll_interval_seconds=5.0)` — `wait=True` is the **default** and polls until `DEPLOYED`; `wait=False` returns the id immediately.
+- `serving.wait_deployment_ready(deployment_id, timeout_seconds=..., poll_interval_seconds=...)` — poll an existing deployment to readiness.
+- `DeploymentFailedError` (subclasses `KamiwazaError` **and** `RuntimeError` for back-compat with old `wait_for_deployment` callers) is raised on a terminal `FAILED`/`ERROR`/`MUST_REDOWNLOAD` status; carries `.status`, `.last_error_code`, `.last_error_message`, `.deployment_id`. The timeout path raises `TimeoutError`, which also carries `.deployment_id` for cleanup.
+- `ModelDeployment` now exposes `last_error_code` / `last_error_message`.
+- When a caller owns its own wait loop (the CLI's `serve deploy --wait`, integration fixtures), pass `wait=False` so two timeouts never stack.
+
 ### OpenAI Compatibility
 The `openai` service provides drop-in compatibility with OpenAI's client library, translating between Kamiwaza and OpenAI formats transparently.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,15 @@ All Pydantic models must use `Config.extra = "allow"` to handle new API fields g
 ### Progress Tracking
 Long-running operations (downloads, batch processing) should use the progress tracking framework with context managers. See examples in @.ai/knowledge/successful/service-patterns.md.
 
+### Async Deployment Waits (ENG-6530)
+The server accepts `POST /serving/deploy_model` asynchronously (202 + deployment id immediately); readiness is observed client-side:
+
+- `serving.deploy_model(..., wait=True, timeout_seconds=3600, poll_interval_seconds=5.0)` — `wait=True` is the **default** and polls until `DEPLOYED`; `wait=False` returns the id immediately.
+- `serving.wait_deployment_ready(deployment_id, timeout_seconds=..., poll_interval_seconds=...)` — poll an existing deployment to readiness.
+- `DeploymentFailedError` (subclasses `KamiwazaError` **and** `RuntimeError` for back-compat with old `wait_for_deployment` callers) is raised on a terminal `FAILED`/`ERROR`/`MUST_REDOWNLOAD` status; carries `.status`, `.last_error_code`, `.last_error_message`, `.deployment_id`. The timeout path raises `TimeoutError`, which also carries `.deployment_id` for cleanup.
+- `ModelDeployment` now exposes `last_error_code` / `last_error_message`.
+- When a caller owns its own wait loop (the CLI's `serve deploy --wait`, integration fixtures), pass `wait=False` so two timeouts never stack.
+
 ### OpenAI Compatibility
 The `openai` service provides drop-in compatibility with OpenAI's client library, translating between Kamiwaza and OpenAI formats transparently.
 


### PR DESCRIPTION
## Summary

Close-feature Gate 4 (AI-context refresh) for Model Placement 1.0 GA tail. Patterns were extracted from the promotion merge diff (4d3a1a6, PR #152) and compared against CLAUDE.md / AGENTS.md / .ai/rules/*. Surgical additions only; CLAUDE.md and AGENTS.md mirror each other and were updated identically.

## Gaps closed

| Extracted pattern | Context file | Status |
|---|---|---|
| deploy_model(wait=True default, timeout_seconds, poll_interval_seconds) async-accept + client-side poll semantics (ENG-6530) | CLAUDE.md + AGENTS.md Important Implementation Notes | was silent → added |
| wait_deployment_ready public method | same section | was silent → added |
| DeploymentFailedError (KamiwazaError + RuntimeError dual-subclass; .status/.last_error_code/.last_error_message/.deployment_id) and TimeoutError carrying .deployment_id | same section | was silent → added |
| ModelDeployment.last_error_code/last_error_message schema fields | same section | was silent → added |
| wait=False rule when the caller owns the wait loop (CLI serve deploy --wait, fixtures) | same section | was silent → added |

Customer-facing docs were already updated in the GA-tail branch itself (docs/services/serving/README.md); this PR covers the AI-context layer only.