### PR TITLE
kz-ext dev publishes a local catalog overlay so new workrooms get the dev build (ENG-6802)

### DIFF
--- a/kamiwaza_extensions/catalog_overlay.py
+++ b/kamiwaza_extensions/catalog_overlay.py
@@ -1,0 +1,163 @@
+"""Local catalog overlay client — ENG-6802.
+
+``kz-ext dev`` publishes the in-development build as a catalog overlay
+("shadow") on the connected cluster so NEW workrooms launched via the
+workroom manager pick up the dev build instead of the upstream catalog
+entry. The overlay is written through the cluster's own authenticated API
+(``PUT /apps/app_templates/catalog/overlay/{name}``); existing digest-pinned
+workrooms are unaffected.
+
+HARD INVARIANT (ENG-6802): the dev path — this module plus
+``commands/dev.py`` — must never import ``catalog_publisher``,
+``profile_manager``, or ``boto3``. The overlay can only target the
+connected cluster's API; there is structurally no code path by which
+``kz-ext dev`` can write a shared R2 catalog (dev-info/stage-info/info),
+even with a misconfigured publish profile. Enforced by
+``tests/unit/extensions/test_catalog_overlay.py::TestImportInvariant``.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+import subprocess
+from typing import Any, Callable, Dict, List, Optional
+
+import yaml
+
+OVERLAY_PATH = "/apps/app_templates/catalog/overlay"
+
+# Matches the platform's app_templates.version column (String(40)).
+MAX_VERSION_LENGTH = 40
+
+_BRANCH_SLUG_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def get_git_branch(cwd: Optional[str] = None) -> Optional[str]:
+    """Return the current git branch name, or None outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    # Detached HEAD reports the literal string "HEAD" — not a branch.
+    return branch if branch and branch != "HEAD" else None
+
+
+def build_overlay_version(
+    base_version: str,
+    *,
+    branch: Optional[str],
+    sha: Optional[str],
+    dirty: bool,
+) -> str:
+    """Shadow version: ``{base}-dev.{branch_slug}.{sha7|dirty}``.
+
+    Distinguishable from any catalog version (shadow, don't impersonate),
+    and intentionally NOT PEP440-parseable — the platform's version
+    comparison treats unparseable versions as never-replaceable, a second
+    guard against catalog syncs clobbering the shadow.
+    """
+    sha_part = "dirty" if dirty else (sha or "nogit")[:7]
+    slug = _BRANCH_SLUG_RE.sub("-", (branch or "nobranch").lower()).strip("-")
+
+    # Fit within the platform's 40-char version column: the branch slug is
+    # the elastic part; base version, separators, and sha are kept intact.
+    slug_budget = MAX_VERSION_LENGTH - len(base_version) - len("-dev..") - len(sha_part)
+    slug = slug[: max(slug_budget, 1)].strip("-") or "x"
+    return f"{base_version}-dev.{slug}.{sha_part}"[:MAX_VERSION_LENGTH]
+
+
+def build_overlay_entry(
+    *,
+    version: str,
+    transformed_compose: Dict[str, Any],
+    canonical_refs: Dict[str, str],
+    push_ref_map: Optional[Dict[str, str]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+    git_sha: Optional[str] = None,
+    git_branch: Optional[str] = None,
+    dirty: bool = False,
+    resolve_digest: Optional[Callable[[str], str]] = None,
+    warn: Optional[Callable[[str], None]] = None,
+) -> Dict[str, Any]:
+    """Build the overlay entry payload from the dev deploy's own artifacts.
+
+    The compose is the SAME transformed compose ``run_dev_remote`` deploys
+    — its image refs are the exact in-cluster-resolvable refs running pods
+    pull — with each built service ref digest-pinned to match the catalog
+    format. Digest resolution queries the registry via the host-reachable
+    push ref (``push_ref_map``) but pins the digest onto the canonical
+    in-cluster ref. Degrades to tag-only refs with a warning when the
+    digest cannot be resolved; the revision tag is unique per build, so
+    the entry stays unambiguous.
+    """
+    compose = copy.deepcopy(transformed_compose)
+    services = compose.get("services") or {}
+    push_ref_map = push_ref_map or {}
+
+    for service_name, canonical_ref in canonical_refs.items():
+        svc = services.get(service_name)
+        if not isinstance(svc, dict) or svc.get("image") != canonical_ref:
+            continue
+        if resolve_digest is None:
+            continue
+        lookup_ref = push_ref_map.get(canonical_ref, canonical_ref)
+        try:
+            digest = resolve_digest(lookup_ref)
+        except Exception as exc:
+            if warn is not None:
+                warn(
+                    f"could not resolve digest for {lookup_ref}: {exc} — "
+                    "overlay entry will use the tag-only ref"
+                )
+            continue
+        svc["image"] = f"{canonical_ref}@{digest}"
+
+    metadata = metadata or {}
+    entry: Dict[str, Any] = {
+        "version": version,
+        "compose_yml": yaml.safe_dump(compose, sort_keys=False),
+        "shadow": {
+            "git_sha": git_sha,
+            "git_branch": git_branch,
+            "dirty": dirty,
+        },
+    }
+    env_defaults = metadata.get("env_defaults")
+    if isinstance(env_defaults, dict) and env_defaults:
+        entry["env_defaults"] = {k: str(v) for k, v in env_defaults.items()}
+    for key in ("display_name", "description"):
+        value = metadata.get(key)
+        if isinstance(value, str) and value:
+            entry[key] = value
+    ext_type = metadata.get("type") or metadata.get("template_type")
+    if isinstance(ext_type, str) and ext_type in ("app", "tool", "service"):
+        entry["template_type"] = ext_type
+    return entry
+
+
+def publish_overlay(client: Any, name: str, entry: Dict[str, Any]) -> Dict[str, Any]:
+    """PUT the overlay entry. Returns the apply response dict."""
+    response = client.put(f"{OVERLAY_PATH}/{name}", json=entry)
+    return response if isinstance(response, dict) else {}
+
+
+def remove_overlay(client: Any, name: str) -> Dict[str, Any]:
+    """DELETE the overlay entry. Returns the remove response dict."""
+    response = client.delete(f"{OVERLAY_PATH}/{name}")
+    return response if isinstance(response, dict) else {}
+
+
+def list_overlays(client: Any) -> List[Dict[str, Any]]:
+    """GET all active overlays on the connected cluster."""
+    response = client.get(OVERLAY_PATH)
+    return response if isinstance(response, list) else []

--- a/kamiwaza_extensions/catalog_overlay.py
+++ b/kamiwaza_extensions/catalog_overlay.py
@@ -22,6 +22,7 @@ import copy
 import re
 import subprocess
 from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import quote
 
 import yaml
 
@@ -69,11 +70,14 @@ def build_overlay_version(
     sha_part = "dirty" if dirty else (sha or "nogit")[:7]
     slug = _BRANCH_SLUG_RE.sub("-", (branch or "nobranch").lower()).strip("-")
 
-    # Fit within the platform's 40-char version column: the branch slug is
-    # the elastic part; base version, separators, and sha are kept intact.
-    slug_budget = MAX_VERSION_LENGTH - len(base_version) - len("-dev..") - len(sha_part)
+    # Fit within the platform's 40-char version column. The branch slug is
+    # the elastic part; the sha (the uniqueness component) is never cut, so
+    # for pathologically long base versions the base itself is trimmed.
+    overhead = len("-dev.") + 1 + len(".") + len(sha_part)  # 1 = min slug char
+    base = base_version[: max(MAX_VERSION_LENGTH - overhead, 1)]
+    slug_budget = MAX_VERSION_LENGTH - len(base) - len("-dev..") - len(sha_part)
     slug = slug[: max(slug_budget, 1)].strip("-") or "x"
-    return f"{base_version}-dev.{slug}.{sha_part}"[:MAX_VERSION_LENGTH]
+    return f"{base}-dev.{slug}.{sha_part}"
 
 
 def build_overlay_entry(
@@ -135,9 +139,34 @@ def build_overlay_entry(
     env_defaults = metadata.get("env_defaults")
     if isinstance(env_defaults, dict) and env_defaults:
         entry["env_defaults"] = {k: str(v) for k, v in env_defaults.items()}
-    for key in ("display_name", "description"):
+    if isinstance(metadata.get("env_metadata"), dict):
+        entry["env_metadata"] = metadata["env_metadata"]
+    # Platform-consumed catalog metadata: forward everything kamiwaza.json
+    # declares so the shadow template behaves like a published catalog entry
+    # would (required_env_vars gates launch env, strip_path_prefix shapes
+    # routing, etc.). Omitted keys keep the pre-shadow row values.
+    for key, expected_type in (
+        ("display_name", str),
+        ("description", str),
+        ("category", str),
+        ("author", str),
+        ("license", str),
+        ("homepage", str),
+        ("image", str),
+        ("kamiwaza_version", str),
+        ("preferred_model_type", str),
+        ("preferred_model_name", str),
+        ("tags", list),
+        ("capabilities", list),
+        ("required_env_vars", list),
+        ("strip_path_prefix", bool),
+        ("fail_if_model_type_unavailable", bool),
+        ("fail_if_model_name_unavailable", bool),
+    ):
         value = metadata.get(key)
-        if isinstance(value, str) and value:
+        if isinstance(value, expected_type) and (
+            expected_type is bool or value
+        ):
             entry[key] = value
     ext_type = metadata.get("type") or metadata.get("template_type")
     if isinstance(ext_type, str) and ext_type in ("app", "tool", "service"):
@@ -147,13 +176,13 @@ def build_overlay_entry(
 
 def publish_overlay(client: Any, name: str, entry: Dict[str, Any]) -> Dict[str, Any]:
     """PUT the overlay entry. Returns the apply response dict."""
-    response = client.put(f"{OVERLAY_PATH}/{name}", json=entry)
+    response = client.put(f"{OVERLAY_PATH}/{quote(name, safe='')}", json=entry)
     return response if isinstance(response, dict) else {}
 
 
 def remove_overlay(client: Any, name: str) -> Dict[str, Any]:
     """DELETE the overlay entry. Returns the remove response dict."""
-    response = client.delete(f"{OVERLAY_PATH}/{name}")
+    response = client.delete(f"{OVERLAY_PATH}/{quote(name, safe='')}")
     return response if isinstance(response, dict) else {}
 
 

--- a/kamiwaza_extensions/catalog_overlay.py
+++ b/kamiwaza_extensions/catalog_overlay.py
@@ -137,14 +137,21 @@ def build_overlay_entry(
         },
     }
     env_defaults = metadata.get("env_defaults")
-    if isinstance(env_defaults, dict) and env_defaults:
-        entry["env_defaults"] = {k: str(v) for k, v in env_defaults.items()}
+    if isinstance(env_defaults, dict):
+        # JSON-faithful string coercion: booleans render lowercase, as a
+        # JSON-serialized published catalog entry would carry them.
+        entry["env_defaults"] = {
+            k: (str(v).lower() if isinstance(v, bool) else str(v))
+            for k, v in env_defaults.items()
+        }
     if isinstance(metadata.get("env_metadata"), dict):
         entry["env_metadata"] = metadata["env_metadata"]
     # Platform-consumed catalog metadata: forward everything kamiwaza.json
     # declares so the shadow template behaves like a published catalog entry
     # would (required_env_vars gates launch env, strip_path_prefix shapes
-    # routing, etc.). Omitted keys keep the pre-shadow row values.
+    # routing, etc.). Presence-based: an explicit empty list is a deliberate
+    # clear and must reach the platform; only ABSENT keys keep the
+    # pre-shadow row values.
     for key, expected_type in (
         ("display_name", str),
         ("description", str),
@@ -164,9 +171,7 @@ def build_overlay_entry(
         ("fail_if_model_name_unavailable", bool),
     ):
         value = metadata.get(key)
-        if isinstance(value, expected_type) and (
-            expected_type is bool or value
-        ):
+        if isinstance(value, expected_type):
             entry[key] = value
     ext_type = metadata.get("type") or metadata.get("template_type")
     if isinstance(ext_type, str) and ext_type in ("app", "tool", "service"):

--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -223,6 +223,11 @@ def dev_callback(
         "--sdk-repo",
         help="Path to local kamiwaza-sdk checkout — bakes local runtime libs into images",
     ),
+    unload: bool = typer.Option(
+        False,
+        "--unload",
+        help="Remove this extension's local catalog overlay, restoring the upstream catalog entry for new workrooms",
+    ),
 ) -> None:
     """Build, push, and deploy extension to Kamiwaza cluster.
 
@@ -230,6 +235,15 @@ def dev_callback(
     Use 'kz-ext dev local' for local Docker Compose development.
     """
     if ctx.invoked_subcommand is not None:
+        return
+    if unload:
+        from kamiwaza_extensions.commands.dev import run_dev_unload
+        try:
+            run_dev_unload()
+        except typer.Exit:
+            raise
+        except Exception as exc:
+            _handle_exception(exc)
         return
     # No subcommand → run remote deploy
     from kamiwaza_extensions.commands.dev import run_dev_remote

--- a/kamiwaza_extensions/cli.py
+++ b/kamiwaza_extensions/cli.py
@@ -235,6 +235,15 @@ def dev_callback(
     Use 'kz-ext dev local' for local Docker Compose development.
     """
     if ctx.invoked_subcommand is not None:
+        if unload:
+            # Callback options don't apply to subcommands; don't let the
+            # user believe the overlay was removed.
+            typer.secho(
+                "Warning: --unload is ignored with a subcommand. "
+                "Run plain `kz-ext dev --unload`.",
+                err=True,
+                fg="yellow",
+            )
         return
     if unload:
         from kamiwaza_extensions.commands.dev import run_dev_unload

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -152,6 +152,46 @@ def _resume_revision(prior_state: Any, rev_tag: str, resumable: bool) -> Optiona
     return None
 
 
+def _prior_artifacts_in_registry(
+    info: Any,
+    prior_revision: str,
+    *,
+    registry: str,
+    push_registry: str,
+) -> bool:
+    """True when every buildable service's prior-revision image resolves.
+
+    Probes via the host-reachable push refs. Extensions with no buildable
+    services have nothing to verify (trivially true). Any probe failure —
+    missing manifest, docker unavailable, registry hiccup — returns False:
+    the safe answer is always "rebuild".
+    """
+    from kamiwaza_extensions.compose_transformer import compute_canonical_refs
+    from kamiwaza_extensions.image_pusher import ImagePusher
+    from kamiwaza_extensions.registry_resolution import build_push_ref_map
+
+    try:
+        canonical_refs = compute_canonical_refs(
+            (info.compose_data or {}).get("services") or {},
+            registry=registry,
+            extension_name=info.name,
+            revision_tag=prior_revision,
+            image_basename=info.image_basename,
+        )
+        if not canonical_refs:
+            return True
+        push_ref_map = build_push_ref_map(
+            list(canonical_refs.values()),
+            image_registry=registry,
+            push_registry=push_registry,
+        )
+        for ref in canonical_refs.values():
+            ImagePusher.resolve_digest(push_ref_map.get(ref, ref))
+        return True
+    except Exception:
+        return False
+
+
 # Match the default ``RevisionTagger.generate_tag`` format:
 # ``{version}-dev-{sha7+}.{epoch}`` where the sha portion is the git short
 # SHA (typically 7-12 hex chars). The epoch suffix is the only thing that
@@ -496,14 +536,31 @@ def run_dev_remote(
     # Adopt the prior run's revision tag BEFORE the skip decisions print it:
     # resume reuses the prior build/push artifacts, and those carry the
     # prior tag — deploying this run's freshly-stamped tag would reference
-    # an image that was never pushed (ImagePullBackOff).
+    # an image that was never pushed (ImagePullBackOff). Trust-but-verify:
+    # dev-state can record a revision whose artifacts never reached the
+    # registry (state written by a pre-fix CLI, or a `--no-push` run whose
+    # apply step recorded the tag), so probe the registry before adopting —
+    # on a miss, fall back to the full pipeline instead of resuming.
     prior_revision = _resume_revision(prior_state, rev_tag, resumable)
     if prior_revision is not None:
-        console.print(
-            f"[dim]Resuming with prior revision {prior_revision} "
-            f"(same commit; artifacts already in the registry).[/dim]"
-        )
-        rev_tag = prior_revision
+        if _prior_artifacts_in_registry(
+            info,
+            prior_revision,
+            registry=registry,
+            push_registry=push_registry,
+        ):
+            console.print(
+                f"[dim]Resuming with prior revision {prior_revision} "
+                f"(same commit; artifacts verified in the registry).[/dim]"
+            )
+            rev_tag = prior_revision
+        else:
+            console.print(
+                f"[yellow]Prior revision {prior_revision} is not in the "
+                f"registry — dev-state is stale. Running the full "
+                f"pipeline.[/yellow]"
+            )
+            resumable = False
     if resumable and not no_build and prior_state.is_step_complete("build"):
         console.print(
             f"[dim]Skipping build — revision {rev_tag} already built in prior run.[/dim]"

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -902,3 +902,205 @@ def run_dev_remote(
             console.print(
                 "  [dim](no external URL reported — check kz-ext status)[/dim]"
             )
+
+        # 12. Publish the local catalog overlay (ENG-6802) so NEW workrooms
+        # launched via the workroom manager get this build. Runs after the
+        # rollout proved the build starts; never fatal — the hot-swap above
+        # already succeeded.
+        _publish_catalog_overlay(
+            client,
+            info,
+            transformed=transformed,
+            canonical_refs=canonical_refs,
+            registry=registry,
+            push_registry=push_registry,
+            no_push=no_push,
+            service_filter=service,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Local catalog overlay (ENG-6802)
+# ---------------------------------------------------------------------------
+
+
+def _publish_catalog_overlay(
+    client: Any,
+    info: Any,
+    *,
+    transformed: Dict[str, Any],
+    canonical_refs: Dict[str, str],
+    registry: str,
+    push_registry: str,
+    no_push: bool,
+    service_filter: Optional[str],
+) -> None:
+    """Write this build into the cluster's local catalog overlay.
+
+    Shadows the extension's catalog template so new workrooms launch this
+    build. Skipped when the image can't be everything a fresh workroom
+    needs (``--no-push``: never reached the registry; ``--service``:
+    sibling services were not pushed at this revision). All failures are
+    non-fatal warnings — the dev hot-swap already succeeded.
+    """
+    from kamiwaza_extensions.catalog_overlay import (
+        build_overlay_entry,
+        build_overlay_version,
+        get_git_branch,
+        publish_overlay,
+    )
+    from kamiwaza_extensions.image_pusher import ImagePushError, ImagePusher
+    from kamiwaza_extensions.registry_resolution import build_push_ref_map
+    from kamiwaza_extensions.revision_tagger import RevisionTagger
+    from kamiwaza_sdk.exceptions import APIError
+
+    if no_push:
+        console.print(
+            "\n[dim]Catalog overlay skipped (--no-push: the cluster can't "
+            "pull an unpushed image).[/dim]"
+        )
+        return
+    if service_filter:
+        console.print(
+            "\n[dim]Catalog overlay skipped (--service: sibling services "
+            "were not pushed at this revision). Run kz-ext dev without "
+            "--service to shadow the catalog template.[/dim]"
+        )
+        return
+
+    sha, dirty = RevisionTagger.get_git_info()
+    branch = get_git_branch(cwd=str(info.path))
+    overlay_version = build_overlay_version(
+        info.version, branch=branch, sha=sha, dirty=dirty
+    )
+
+    push_ref_map = build_push_ref_map(
+        list(canonical_refs.values()),
+        image_registry=registry,
+        push_registry=push_registry,
+    )
+
+    def _resolve(ref: str) -> str:
+        try:
+            return ImagePusher.resolve_digest(ref)
+        except ImagePushError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    entry = build_overlay_entry(
+        version=overlay_version,
+        transformed_compose=transformed,
+        canonical_refs=canonical_refs,
+        push_ref_map=push_ref_map,
+        metadata=info.metadata,
+        git_sha=sha,
+        git_branch=branch,
+        dirty=dirty,
+        resolve_digest=_resolve,
+        warn=lambda msg: console.print(f"  [yellow]Warning:[/yellow] {msg}"),
+    )
+
+    try:
+        response = publish_overlay(client, info.name, entry)
+    except APIError as exc:
+        if exc.status_code in (404, 405):
+            console.print(
+                "\n[dim]Platform does not support catalog overlays — new "
+                "workrooms will keep using the upstream catalog build.[/dim]"
+            )
+            return
+        console.print(
+            f"\n[yellow]Warning:[/yellow] catalog overlay write failed: {exc}\n"
+            "  New workrooms will keep using the upstream catalog build."
+        )
+        return
+    except Exception as exc:
+        console.print(
+            f"\n[yellow]Warning:[/yellow] catalog overlay write failed: {exc}\n"
+            "  New workrooms will keep using the upstream catalog build."
+        )
+        return
+
+    shadow = response.get("shadow") or {}
+    shadows_version = shadow.get("shadows_version")
+    shadows_label = (
+        f" (shadows {shadows_version})" if shadows_version else " (no upstream entry)"
+    )
+    console.print(
+        f"\n  [green]✓[/green] Catalog overlay: [bold]{info.name}[/bold] "
+        f"{overlay_version}{shadows_label} — new workrooms will use this build."
+    )
+    running = response.get("running_deployments") or []
+    if running:
+        count = len(running)
+        plural = "s" if count != 1 else ""
+        console.print(
+            f"  [yellow]{count} running instance{plural}[/yellow] still on the "
+            "pre-shadow build — relaunch to pick up the dev build."
+        )
+    console.print("  [dim]Undo with: kz-ext dev --unload[/dim]")
+
+
+def run_dev_unload() -> None:
+    """Remove this extension's catalog overlay, restoring the upstream entry.
+
+    Leaves the running dev extension instance untouched — only new
+    workroom launches are affected.
+    """
+    from kamiwaza_extensions.catalog_overlay import remove_overlay
+    from kamiwaza_extensions.connections import ConnectionManager
+    from kamiwaza_extensions.constants import ssl_env_override
+    from kamiwaza_extensions.extension_detector import ExtensionDetector
+    from kamiwaza_sdk import KamiwazaClient
+    from kamiwaza_sdk.exceptions import APIError
+
+    detector = ExtensionDetector()
+    info = detector.detect()
+
+    conn_mgr = ConnectionManager()
+    connection = conn_mgr.get_active_connection()
+    if connection is None:
+        console.print("[red]Error:[/red] No Kamiwaza connection configured.")
+        console.print("  Run: [bold]kz-ext login <url>[/bold]")
+        raise typer.Exit(code=1)
+    token = conn_mgr.get_token()
+    if token is None:
+        console.print("[red]Error:[/red] Connection token expired or missing.")
+        console.print("  Run: [bold]kz-ext login[/bold] to re-authenticate.")
+        raise typer.Exit(code=1)
+
+    with ssl_env_override(connection):
+        client = KamiwazaClient(base_url=connection.url, api_key=token.access_token)
+        try:
+            response = remove_overlay(client, info.name)
+        except APIError as exc:
+            if exc.status_code == 404:
+                console.print(
+                    f"No catalog overlay exists for [bold]{info.name}[/bold] "
+                    f"on {connection.url}."
+                )
+                raise typer.Exit(code=1) from exc
+            if exc.status_code == 405:
+                console.print(
+                    "[red]Error:[/red] Platform does not support catalog overlays."
+                )
+                raise typer.Exit(code=1) from exc
+            console.print(f"[red]Error:[/red] Failed to remove overlay: {exc}")
+            raise typer.Exit(code=1) from exc
+
+    restored = response.get("restored_version")
+    if restored:
+        console.print(
+            f"  [green]✓[/green] Restored [bold]{info.name}[/bold] to upstream "
+            f"{restored} — new workrooms will use the catalog build."
+        )
+    elif response.get("template_removed"):
+        console.print(
+            f"  [green]✓[/green] Removed overlay for [bold]{info.name}[/bold] "
+            "(the template had no upstream catalog entry)."
+        )
+    else:
+        console.print(f"  [green]✓[/green] Removed overlay for [bold]{info.name}[/bold].")
+    console.print(
+        "  [dim]The running dev extension instance is unaffected — only new "
+        "workroom launches change.[/dim]"
+    )

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -127,6 +127,31 @@ def _build_patch_service_specs(payload: Any) -> List[Any]:
     return patch_services
 
 
+def _resume_revision(prior_state: Any, rev_tag: str, resumable: bool) -> Optional[str]:
+    """Return the prior run's revision when this run must deploy its artifacts.
+
+    ``generate_tag`` stamps a fresh epoch suffix every invocation, so a
+    resumed run (same commit, clean tree) skips build/push while holding a
+    tag that was NEVER pushed — the deploy would PATCH the CR to a
+    nonexistent image and the rollout dies in ImagePullBackOff. Whenever
+    resume will reuse prior build/push artifacts, the deploy (and the
+    catalog overlay) must reference the prior revision tag those artifacts
+    actually carry. Returns None when no adoption is needed.
+    """
+    if (
+        resumable
+        and prior_state is not None
+        and prior_state.last_revision
+        and prior_state.last_revision != rev_tag
+        and (
+            prior_state.is_step_complete("build")
+            or prior_state.is_step_complete("push")
+        )
+    ):
+        return str(prior_state.last_revision)
+    return None
+
+
 # Match the default ``RevisionTagger.generate_tag`` format:
 # ``{version}-dev-{sha7+}.{epoch}`` where the sha portion is the git short
 # SHA (typically 7-12 hex chars). The epoch suffix is the only thing that
@@ -468,6 +493,17 @@ def run_dev_remote(
         push_registry=push_registry,
         image_basename=info.image_basename,
     )
+    # Adopt the prior run's revision tag BEFORE the skip decisions print it:
+    # resume reuses the prior build/push artifacts, and those carry the
+    # prior tag — deploying this run's freshly-stamped tag would reference
+    # an image that was never pushed (ImagePullBackOff).
+    prior_revision = _resume_revision(prior_state, rev_tag, resumable)
+    if prior_revision is not None:
+        console.print(
+            f"[dim]Resuming with prior revision {prior_revision} "
+            f"(same commit; artifacts already in the registry).[/dim]"
+        )
+        rev_tag = prior_revision
     if resumable and not no_build and prior_state.is_step_complete("build"):
         console.print(
             f"[dim]Skipping build — revision {rev_tag} already built in prior run.[/dim]"

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -453,6 +453,11 @@ def run_dev_remote(
     notice = resume_message(prior_state)
     if notice:
         console.print(f"[dim]{notice}[/dim]")
+    # The catalog overlay (step 12) keys off the USER's --no-push intent.
+    # Resume flips `no_push` below when the prior run already pushed — but
+    # in that case the image IS in the registry, so the overlay must still
+    # be written.
+    user_no_push = no_push
     resumable = _is_resumable(
         prior_state,
         rev_tag,
@@ -920,7 +925,7 @@ def run_dev_remote(
             canonical_refs=canonical_refs,
             registry=registry,
             push_registry=push_registry,
-            no_push=no_push,
+            no_push=user_no_push,
             service_filter=service,
         )
 
@@ -949,6 +954,38 @@ def _publish_catalog_overlay(
     sibling services were not pushed at this revision). All failures are
     non-fatal warnings — the dev hot-swap already succeeded.
     """
+    try:
+        _publish_catalog_overlay_inner(
+            client,
+            info,
+            transformed=transformed,
+            canonical_refs=canonical_refs,
+            registry=registry,
+            push_registry=push_registry,
+            no_push=no_push,
+            service_filter=service_filter,
+        )
+    except Exception as exc:
+        # Belt-and-braces: the inner helper already handles the realistic
+        # failure modes; nothing in overlay publication may fail a dev run
+        # whose rollout already succeeded.
+        console.print(
+            f"\n[yellow]Warning:[/yellow] catalog overlay write failed: {exc}\n"
+            "  New workrooms will keep using the upstream catalog build."
+        )
+
+
+def _publish_catalog_overlay_inner(
+    client: Any,
+    info: Any,
+    *,
+    transformed: Dict[str, Any],
+    canonical_refs: Dict[str, str],
+    registry: str,
+    push_registry: str,
+    no_push: bool,
+    service_filter: Optional[str],
+) -> None:
     from kamiwaza_extensions.catalog_overlay import (
         build_overlay_entry,
         build_overlay_version,

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -544,6 +544,12 @@ def run_dev_remote(
         registry=registry,
         image_basename=info.image_basename,
     )
+    # The catalog overlay (step 12) is a template destination: the platform
+    # performs install-time env substitution on catalog compose, so it must
+    # keep `${VAR}` / `${VAR:?required}` placeholders. Capture the
+    # pre-resolution compose for it; the K8s deploy payload below gets the
+    # resolved copy (resolve_env_placeholders returns a new dict).
+    catalog_compose = transformed
     transformed = transformer.resolve_env_placeholders(transformed)
 
     # Canonical image refs for every build-context service. Single
@@ -910,7 +916,7 @@ def run_dev_remote(
         _publish_catalog_overlay(
             client,
             info,
-            transformed=transformed,
+            transformed=catalog_compose,
             canonical_refs=canonical_refs,
             registry=registry,
             push_registry=push_registry,
@@ -968,8 +974,11 @@ def _publish_catalog_overlay(
         )
         return
 
+    # Both from the process cwd, matching RevisionTagger.generate_tag's
+    # earlier sha/dirty derivation — sha and branch must describe the same
+    # repo state.
     sha, dirty = RevisionTagger.get_git_info()
-    branch = get_git_branch(cwd=str(info.path))
+    branch = get_git_branch()
     overlay_version = build_overlay_version(
         info.version, branch=branch, sha=sha, dirty=dirty
     )

--- a/kamiwaza_extensions/commands/status.py
+++ b/kamiwaza_extensions/commands/status.py
@@ -20,6 +20,8 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
     from kamiwaza_extensions.constants import extract_user_id
     from kamiwaza_extensions.dev_state import read_state
 
+    extension_name: Optional[str] = None
+
     # Resolve connection + auth
     conn_mgr = ConnectionManager()
     connection = conn_mgr.get_active_connection()
@@ -41,6 +43,7 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
 
         detector = ExtensionDetector()
         info = detector.detect()
+        extension_name = info.name
 
         # Prefer the dev-state file's `last_dev_name` (written by `kz-ext dev`
         # — see §4.2.9 / ENG-3887). Falls back to deriving the name from the
@@ -139,6 +142,89 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
             )
 
         console.print(svc_table)
+
+        # Catalog overlay shadow (ENG-6802) — only in auto-detect mode,
+        # where the extension's catalog name is known.
+        if extension_name:
+            _print_overlay_status(client, extension_name)
+
+
+# Nudge once a shadow is old enough that "my env silently runs a stale
+# dev build" becomes the likely failure mode.
+SHADOW_STALENESS_DAYS = 7
+
+
+def _print_overlay_status(client: Any, extension_name: str) -> None:
+    """Show this extension's local catalog overlay shadow, if any.
+
+    Tolerates platforms without overlay support (pre-ENG-6802): any API
+    failure renders nothing — the overlay line is informational.
+    """
+    from kamiwaza_extensions.catalog_overlay import list_overlays
+
+    try:
+        overlays = list_overlays(client)
+    except Exception:
+        return
+
+    shadow = next(
+        (o for o in overlays if o.get("template_name") == extension_name), None
+    )
+    if shadow is None:
+        return
+
+    build = shadow.get("git_sha") or shadow.get("shadow_version") or "unknown"
+    branch = shadow.get("git_branch")
+    branch_label = f" (branch {branch})" if branch else ""
+    if shadow.get("dirty"):
+        build = f"{build}, dirty tree"
+
+    shadows_version = shadow.get("shadows_version")
+    shadowing = (
+        f"shadowing upstream {shadows_version}"
+        if shadows_version
+        else "no upstream catalog entry"
+    )
+
+    age_days = _age_days(shadow.get("updated_at"))
+    age_label = f", published {_format_age(age_days)}" if age_days is not None else ""
+
+    console.print()
+    console.print(
+        f"Catalog overlay: local dev build [bold]{build}[/bold]{branch_label}, "
+        f"{shadowing}{age_label}"
+    )
+    console.print("  [dim]New workrooms launch this build. Undo: kz-ext dev --unload[/dim]")
+    if age_days is not None and age_days >= SHADOW_STALENESS_DAYS:
+        console.print(
+            f"  [yellow]This shadow is {age_days} days old — re-run "
+            "kz-ext dev for a fresh build, or kz-ext dev --unload to "
+            "fall back to the catalog.[/yellow]"
+        )
+
+
+def _age_days(timestamp: Optional[str]) -> Optional[int]:
+    """Days elapsed since an ISO timestamp, or None when unparseable."""
+    if not timestamp or not isinstance(timestamp, str):
+        return None
+    from datetime import datetime, timezone
+
+    try:
+        parsed = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    delta = datetime.now(timezone.utc) - parsed
+    return max(delta.days, 0)
+
+
+def _format_age(days: int) -> str:
+    if days == 0:
+        return "today"
+    if days == 1:
+        return "1 day ago"
+    return f"{days} days ago"
 
 
 def _read_annotation(ext: Any, key: str) -> Optional[str]:

--- a/kamiwaza_extensions/commands/status.py
+++ b/kamiwaza_extensions/commands/status.py
@@ -102,6 +102,11 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
             if exc.status_code == 404:
                 console.print(f"[red]Error:[/red] Extension '{dev_name}' not found.")
                 console.print("  Run: [bold]kz-ext dev[/bold] to deploy first.")
+                # A lingering catalog shadow is MOST dangerous exactly when
+                # the dev instance is gone — still steering new workrooms
+                # with nothing visibly running. Surface it before exiting.
+                if extension_name:
+                    _print_overlay_status(client, extension_name)
                 raise typer.Exit(code=1) from exc
             raise
 

--- a/kamiwaza_extensions/commands/status.py
+++ b/kamiwaza_extensions/commands/status.py
@@ -14,7 +14,7 @@ console = Console(stderr=True)
 def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
     """Display extension deployment status."""
     from kamiwaza_sdk import KamiwazaClient
-    from kamiwaza_sdk.exceptions import APIError
+    from kamiwaza_sdk.exceptions import APIError, NotFoundError
 
     from kamiwaza_extensions.connections import ConnectionManager
     from kamiwaza_extensions.constants import extract_user_id
@@ -98,8 +98,14 @@ def run_status(*, name: Optional[str] = None, verbose: bool = False) -> None:
         # endpoint only when it's available.
         try:
             ext = client.extensions.get_extension(dev_name)
-        except APIError as exc:
-            if exc.status_code == 404:
+        except (NotFoundError, APIError) as exc:
+            # get_extension converts a 404 into NotFoundError (which does
+            # NOT subclass APIError); keep the APIError/404 arm for older
+            # SDK behavior.
+            is_missing = isinstance(exc, NotFoundError) or (
+                getattr(exc, "status_code", None) == 404
+            )
+            if is_missing:
                 console.print(f"[red]Error:[/red] Extension '{dev_name}' not found.")
                 console.print("  Run: [bold]kz-ext dev[/bold] to deploy first.")
                 # A lingering catalog shadow is MOST dangerous exactly when

--- a/tests/unit/extensions/test_catalog_overlay.py
+++ b/tests/unit/extensions/test_catalog_overlay.py
@@ -194,6 +194,29 @@ class TestBuildOverlayEntry:
         assert entry["env_metadata"] == {"API_KEY": {"type": "secret"}}
         assert entry["fail_if_model_type_unavailable"] is True
 
+    def test_explicit_empty_metadata_is_forwarded(self):
+        # An explicit empty list is a deliberate clear of an upstream value
+        # (e.g. the dev build dropped its required env var) — it must reach
+        # the platform; only ABSENT keys keep pre-shadow values.
+        entry = build_overlay_entry(
+            version="v",
+            transformed_compose=TRANSFORMED,
+            canonical_refs={},
+            metadata={"required_env_vars": [], "env_defaults": {}},
+        )
+        assert entry["required_env_vars"] == []
+        assert entry["env_defaults"] == {}
+        assert "capabilities" not in entry  # absent stays absent
+
+    def test_bool_env_defaults_render_json_style(self):
+        entry = build_overlay_entry(
+            version="v",
+            transformed_compose=TRANSFORMED,
+            canonical_refs={},
+            metadata={"env_defaults": {"DEBUG": True, "VERBOSE": False}},
+        )
+        assert entry["env_defaults"] == {"DEBUG": "true", "VERBOSE": "false"}
+
     def test_env_placeholders_survive_in_compose(self):
         # The overlay is a template destination — install-time substitution
         # happens platform-side, so `${VAR:?required}` must NOT be resolved.

--- a/tests/unit/extensions/test_catalog_overlay.py
+++ b/tests/unit/extensions/test_catalog_overlay.py
@@ -59,6 +59,18 @@ class TestBuildOverlayVersion:
         version = build_overlay_version("1.0.0", branch=None, sha=None, dirty=False)
         assert version == "1.0.0-dev.nobranch.nogit"
 
+    def test_long_base_version_never_cuts_sha(self):
+        version = build_overlay_version(
+            "1.0.0-rc1.post2.dev3.extremely.long.base",
+            branch="feat-x",
+            sha="abc1234",
+            dirty=False,
+        )
+        assert len(version) <= MAX_VERSION_LENGTH
+        # The sha is the uniqueness component — it must survive intact.
+        assert version.endswith(".abc1234")
+        assert "-dev." in version
+
     def test_not_pep440_parseable(self):
         # The unparseable version is itself a clobber guard on the platform.
         from packaging.version import InvalidVersion, Version
@@ -157,6 +169,47 @@ class TestBuildOverlayEntry:
             "dirty": True,
         }
 
+    def test_platform_consumed_metadata_forwarded(self):
+        # The platform reads these off template rows; a shadow that drops
+        # them would behave differently from a published catalog entry.
+        entry = build_overlay_entry(
+            version="v",
+            transformed_compose=TRANSFORMED,
+            canonical_refs={},
+            metadata={
+                "required_env_vars": ["API_KEY"],
+                "capabilities": ["graph"],
+                "tags": ["dev"],
+                "strip_path_prefix": False,
+                "kamiwaza_version": ">=0.7.0",
+                "env_metadata": {"API_KEY": {"type": "secret"}},
+                "fail_if_model_type_unavailable": True,
+            },
+        )
+        assert entry["required_env_vars"] == ["API_KEY"]
+        assert entry["capabilities"] == ["graph"]
+        assert entry["tags"] == ["dev"]
+        assert entry["strip_path_prefix"] is False
+        assert entry["kamiwaza_version"] == ">=0.7.0"
+        assert entry["env_metadata"] == {"API_KEY": {"type": "secret"}}
+        assert entry["fail_if_model_type_unavailable"] is True
+
+    def test_env_placeholders_survive_in_compose(self):
+        # The overlay is a template destination — install-time substitution
+        # happens platform-side, so `${VAR:?required}` must NOT be resolved.
+        compose = {
+            "services": {
+                "app": {
+                    "image": "registry/app:v1",
+                    "environment": {"API_KEY": "${API_KEY:?required}"},
+                }
+            }
+        }
+        entry = build_overlay_entry(
+            version="v", transformed_compose=compose, canonical_refs={}
+        )
+        assert "${API_KEY:?required}" in entry["compose_yml"]
+
 
 class TestOverlayClient:
     def test_publish_overlay(self):
@@ -187,6 +240,18 @@ class TestOverlayClient:
 
         assert list_overlays(client) == [{"template_name": "kaizen"}]
         client.get.assert_called_once_with("/apps/app_templates/catalog/overlay")
+
+    def test_names_are_url_quoted(self):
+        client = MagicMock()
+        client.put.return_value = {}
+        client.delete.return_value = {}
+
+        publish_overlay(client, "odd/name x", {"version": "v"})
+        remove_overlay(client, "odd/name x")
+
+        expected = "/apps/app_templates/catalog/overlay/odd%2Fname%20x"
+        assert client.put.call_args[0][0] == expected
+        assert client.delete.call_args[0][0] == expected
 
 
 class TestImportInvariant:

--- a/tests/unit/extensions/test_catalog_overlay.py
+++ b/tests/unit/extensions/test_catalog_overlay.py
@@ -1,0 +1,255 @@
+"""Tests for the local catalog overlay client — ENG-6802."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+from kamiwaza_extensions.catalog_overlay import (
+    MAX_VERSION_LENGTH,
+    build_overlay_entry,
+    build_overlay_version,
+    list_overlays,
+    publish_overlay,
+    remove_overlay,
+)
+
+pytestmark = pytest.mark.unit
+
+TRANSFORMED = {
+    "services": {
+        "app": {"image": "registry.kamiwaza.test/kaizen-app:1.0.0-dev-abc1234.5"},
+        "db": {"image": "postgres:16"},
+    }
+}
+CANONICAL_REFS = {"app": "registry.kamiwaza.test/kaizen-app:1.0.0-dev-abc1234.5"}
+
+
+class TestBuildOverlayVersion:
+    def test_clean_tree(self):
+        version = build_overlay_version(
+            "1.0.0", branch="feat-x", sha="abc1234def", dirty=False
+        )
+        assert version == "1.0.0-dev.feat-x.abc1234"
+
+    def test_dirty_tree_uses_dirty_marker(self):
+        version = build_overlay_version(
+            "1.0.0", branch="feat-x", sha="abc1234", dirty=True
+        )
+        assert version == "1.0.0-dev.feat-x.dirty"
+
+    def test_branch_is_slugified(self):
+        version = build_overlay_version(
+            "1.0.0", branch="Feature/ENG-6802!x", sha="abc1234", dirty=False
+        )
+        assert version == "1.0.0-dev.feature-eng-6802-x.abc1234"
+
+    def test_long_branch_truncated_to_column_limit(self):
+        version = build_overlay_version(
+            "1.0.0", branch="x" * 100, sha="abc1234", dirty=False
+        )
+        assert len(version) <= MAX_VERSION_LENGTH
+        assert version.endswith(".abc1234")
+        assert version.startswith("1.0.0-dev.")
+
+    def test_no_git_info(self):
+        version = build_overlay_version("1.0.0", branch=None, sha=None, dirty=False)
+        assert version == "1.0.0-dev.nobranch.nogit"
+
+    def test_not_pep440_parseable(self):
+        # The unparseable version is itself a clobber guard on the platform.
+        from packaging.version import InvalidVersion, Version
+
+        version = build_overlay_version(
+            "1.0.0", branch="feat-x", sha="abc1234", dirty=False
+        )
+        with pytest.raises(InvalidVersion):
+            Version(version)
+
+
+class TestBuildOverlayEntry:
+    def test_digest_pins_built_services_only(self):
+        entry = build_overlay_entry(
+            version="1.0.0-dev.feat-x.abc1234",
+            transformed_compose=TRANSFORMED,
+            canonical_refs=CANONICAL_REFS,
+            resolve_digest=lambda ref: "sha256:" + "a" * 64,
+        )
+        compose = yaml.safe_load(entry["compose_yml"])
+        assert compose["services"]["app"]["image"] == (
+            "registry.kamiwaza.test/kaizen-app:1.0.0-dev-abc1234.5@sha256:" + "a" * 64
+        )
+        # External (non-built) services are untouched.
+        assert compose["services"]["db"]["image"] == "postgres:16"
+
+    def test_digest_resolution_uses_push_ref(self):
+        seen = []
+
+        def resolver(ref):
+            seen.append(ref)
+            return "sha256:" + "b" * 64
+
+        build_overlay_entry(
+            version="v",
+            transformed_compose=TRANSFORMED,
+            canonical_refs=CANONICAL_REFS,
+            push_ref_map={
+                CANONICAL_REFS["app"]: "127.0.0.1:30010/kaizen-app:1.0.0-dev-abc1234.5"
+            },
+            resolve_digest=resolver,
+        )
+        # Queried via the host-reachable push ref...
+        assert seen == ["127.0.0.1:30010/kaizen-app:1.0.0-dev-abc1234.5"]
+
+    def test_digest_failure_degrades_to_tag_only(self):
+        warnings = []
+
+        def resolver(ref):
+            raise RuntimeError("registry unreachable")
+
+        entry = build_overlay_entry(
+            version="v",
+            transformed_compose=TRANSFORMED,
+            canonical_refs=CANONICAL_REFS,
+            resolve_digest=resolver,
+            warn=warnings.append,
+        )
+        compose = yaml.safe_load(entry["compose_yml"])
+        assert compose["services"]["app"]["image"] == CANONICAL_REFS["app"]
+        assert len(warnings) == 1
+        assert "registry unreachable" in warnings[0]
+
+    def test_source_compose_not_mutated(self):
+        original = yaml.safe_dump(TRANSFORMED)
+        build_overlay_entry(
+            version="v",
+            transformed_compose=TRANSFORMED,
+            canonical_refs=CANONICAL_REFS,
+            resolve_digest=lambda ref: "sha256:" + "c" * 64,
+        )
+        assert yaml.safe_dump(TRANSFORMED) == original
+
+    def test_metadata_fields_forwarded(self):
+        entry = build_overlay_entry(
+            version="v",
+            transformed_compose=TRANSFORMED,
+            canonical_refs={},
+            metadata={
+                "env_defaults": {"FOO": "bar", "PORT": 8080},
+                "display_name": "Kaizen",
+                "description": "desc",
+                "type": "app",
+            },
+            git_sha="abc1234",
+            git_branch="feat-x",
+            dirty=True,
+        )
+        assert entry["env_defaults"] == {"FOO": "bar", "PORT": "8080"}
+        assert entry["display_name"] == "Kaizen"
+        assert entry["description"] == "desc"
+        assert entry["template_type"] == "app"
+        assert entry["shadow"] == {
+            "git_sha": "abc1234",
+            "git_branch": "feat-x",
+            "dirty": True,
+        }
+
+
+class TestOverlayClient:
+    def test_publish_overlay(self):
+        client = MagicMock()
+        client.put.return_value = {"shadow": {"shadows_version": "1.0.0"}}
+
+        response = publish_overlay(client, "kaizen", {"version": "v"})
+
+        client.put.assert_called_once_with(
+            "/apps/app_templates/catalog/overlay/kaizen", json={"version": "v"}
+        )
+        assert response["shadow"]["shadows_version"] == "1.0.0"
+
+    def test_remove_overlay(self):
+        client = MagicMock()
+        client.delete.return_value = {"restored_version": "1.0.0"}
+
+        response = remove_overlay(client, "kaizen")
+
+        client.delete.assert_called_once_with(
+            "/apps/app_templates/catalog/overlay/kaizen"
+        )
+        assert response["restored_version"] == "1.0.0"
+
+    def test_list_overlays(self):
+        client = MagicMock()
+        client.get.return_value = [{"template_name": "kaizen"}]
+
+        assert list_overlays(client) == [{"template_name": "kaizen"}]
+        client.get.assert_called_once_with("/apps/app_templates/catalog/overlay")
+
+
+class TestImportInvariant:
+    """ENG-6802 hard invariant: kz-ext dev can NEVER write a shared catalog.
+
+    Enforced structurally — the dev path's import graph must not contain
+    the S3/R2 publishing machinery. If this test fails, a change wired
+    `catalog_publisher`, `profile_manager`, or `boto3` into the dev path;
+    that is forbidden regardless of intent.
+    """
+
+    FORBIDDEN = (
+        "kamiwaza_extensions.catalog_publisher",
+        "kamiwaza_extensions.profile_manager",
+        "boto3",
+    )
+
+    def _assert_clean_import_graph(self, module_name: str) -> None:
+        import subprocess
+
+        # Fresh interpreter so previously-imported modules can't mask a
+        # module-level import sneaking in.
+        code = (
+            "import sys; "
+            f"import {module_name}; "
+            "import json; "
+            "print(json.dumps(sorted(sys.modules.keys())))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, timeout=60
+        )
+        assert result.returncode == 0, result.stderr
+        import json
+
+        loaded = set(json.loads(result.stdout.strip().splitlines()[-1]))
+        forbidden_loaded = loaded & set(self.FORBIDDEN)
+        assert not forbidden_loaded, (
+            f"{module_name} pulled forbidden shared-catalog modules into the "
+            f"dev path: {sorted(forbidden_loaded)}"
+        )
+
+    def test_catalog_overlay_never_imports_shared_catalog_machinery(self):
+        self._assert_clean_import_graph("kamiwaza_extensions.catalog_overlay")
+
+    def test_dev_command_never_imports_shared_catalog_machinery(self):
+        self._assert_clean_import_graph("kamiwaza_extensions.commands.dev")
+
+    def test_overlay_module_source_mentions_no_forbidden_imports(self):
+        # Static belt-and-braces: lazy in-function imports would evade the
+        # module-import probe above.
+        from pathlib import Path
+
+        import kamiwaza_extensions.catalog_overlay as overlay_mod
+        import kamiwaza_extensions.commands.dev as dev_mod
+
+        for mod in (overlay_mod, dev_mod):
+            source = Path(mod.__file__).read_text()
+            for forbidden in ("catalog_publisher", "profile_manager", "boto3"):
+                assert f"import {forbidden}" not in source, (
+                    f"{mod.__name__} imports {forbidden} — forbidden on the "
+                    "dev path (ENG-6802 hard invariant)"
+                )
+                assert f"from kamiwaza_extensions.{forbidden}" not in source, (
+                    f"{mod.__name__} imports from {forbidden} — forbidden on "
+                    "the dev path (ENG-6802 hard invariant)"
+                )

--- a/tests/unit/extensions/test_dev_overlay.py
+++ b/tests/unit/extensions/test_dev_overlay.py
@@ -269,6 +269,64 @@ class TestResumeRevisionAdoption:
         assert _resume_revision(None, "2.2.0-dev-0b1fbba.200", resumable=True) is None
 
 
+class TestPriorArtifactProbe:
+    """Adoption is trust-but-verify: dev-state can carry a revision whose
+    artifacts never reached the registry (pre-fix CLI state, --no-push
+    apply). Found live: a poisoned state file kept redeploying an
+    unpushed tag."""
+
+    def _info(self, with_build=True):
+        services = {"server": {"build": "."}} if with_build else {"db": {"image": "postgres:16"}}
+        return SimpleNamespace(
+            name="tool-omniparse",
+            compose_data={"services": services},
+            image_basename=None,
+        )
+
+    def test_true_when_all_digests_resolve(self):
+        from kamiwaza_extensions.commands.dev import _prior_artifacts_in_registry
+
+        with patch(
+            "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest",
+            return_value="sha256:" + "a" * 64,
+        ):
+            assert _prior_artifacts_in_registry(
+                self._info(),
+                "2.2.0-dev-0b1fbba.100",
+                registry="127.0.0.1:30010",
+                push_registry="host.docker.internal:30010",
+            )
+
+    def test_false_when_manifest_missing(self):
+        from kamiwaza_extensions.commands.dev import _prior_artifacts_in_registry
+        from kamiwaza_extensions.image_pusher import ImagePushError
+
+        with patch(
+            "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest",
+            side_effect=ImagePushError("manifest unknown"),
+        ):
+            assert not _prior_artifacts_in_registry(
+                self._info(),
+                "2.2.0-dev-0b1fbba.100",
+                registry="127.0.0.1:30010",
+                push_registry="host.docker.internal:30010",
+            )
+
+    def test_true_when_nothing_buildable(self):
+        from kamiwaza_extensions.commands.dev import _prior_artifacts_in_registry
+
+        with patch(
+            "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest",
+            side_effect=AssertionError("must not be called"),
+        ):
+            assert _prior_artifacts_in_registry(
+                self._info(with_build=False),
+                "2.2.0-dev-0b1fbba.100",
+                registry="127.0.0.1:30010",
+                push_registry="host.docker.internal:30010",
+            )
+
+
 class TestStatusMissingInstanceShowsOverlay:
     def test_overlay_shown_when_extension_not_found(self, monkeypatch, capsys):
         # get_extension raises NotFoundError (NOT an APIError subclass) for

--- a/tests/unit/extensions/test_dev_overlay.py
+++ b/tests/unit/extensions/test_dev_overlay.py
@@ -207,6 +207,58 @@ class TestRunDevUnload:
         assert "No catalog overlay exists" in capsys.readouterr().err
 
 
+class TestStatusMissingInstanceShowsOverlay:
+    def test_overlay_shown_when_extension_not_found(self, monkeypatch, capsys):
+        # get_extension raises NotFoundError (NOT an APIError subclass) for
+        # missing instances — the lingering-shadow display must still fire.
+        from kamiwaza_sdk.exceptions import NotFoundError
+
+        from kamiwaza_extensions.commands.status import run_status
+
+        connection = SimpleNamespace(
+            url="https://kamiwaza.test",
+            name="dev",
+            verify_ssl=True,
+            effective_verify_ssl=lambda: True,
+        )
+        conn_mgr = MagicMock()
+        conn_mgr.get_active_connection.return_value = connection
+        conn_mgr.get_token.return_value = SimpleNamespace(
+            access_token="x.eyJzdWIiOiJ1MSJ9.x"
+        )
+        monkeypatch.setattr(
+            "kamiwaza_extensions.connections.ConnectionManager", lambda: conn_mgr
+        )
+        monkeypatch.setattr(
+            "kamiwaza_extensions.extension_detector.ExtensionDetector.detect",
+            lambda self: _info(),
+        )
+        monkeypatch.setattr(
+            "kamiwaza_extensions.dev_state.read_state", lambda path: None
+        )
+
+        client = MagicMock()
+        client.extensions.get_extension.side_effect = NotFoundError("gone")
+        client.get.return_value = [
+            {
+                "template_name": "kaizen",
+                "shadow_version": "1.0.0-dev.feat-x.abc1234",
+                "git_sha": "abc1234",
+                "shadows_version": "1.0.0",
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ]
+        monkeypatch.setattr("kamiwaza_sdk.KamiwazaClient", lambda **kwargs: client)
+
+        with pytest.raises(typer.Exit):
+            run_status(name=None)
+
+        err = capsys.readouterr().err
+        assert "not found" in err
+        assert "Catalog overlay" in err
+        assert "abc1234" in err
+
+
 class TestStatusOverlayRendering:
     def _shadow(self, **overrides):
         shadow = {

--- a/tests/unit/extensions/test_dev_overlay.py
+++ b/tests/unit/extensions/test_dev_overlay.py
@@ -124,6 +124,21 @@ class TestPublishCatalogOverlay:
 
         assert "overlay write failed" in capsys.readouterr().err
 
+    def test_entry_construction_errors_warn_but_do_not_fail(self, capsys):
+        # The non-fatal guarantee covers the WHOLE helper, not just the PUT:
+        # a rollout that already succeeded must never be failed by overlay
+        # bookkeeping.
+        client = MagicMock()
+        with patch(
+            "kamiwaza_extensions.registry_resolution.build_push_ref_map",
+            side_effect=RuntimeError("boom in entry construction"),
+        ):
+            _publish(client)  # must not raise
+
+        err = capsys.readouterr().err
+        assert "overlay write failed" in err
+        client.put.assert_not_called()
+
 
 class TestRunDevUnload:
     def _setup(self, monkeypatch, client):

--- a/tests/unit/extensions/test_dev_overlay.py
+++ b/tests/unit/extensions/test_dev_overlay.py
@@ -207,6 +207,68 @@ class TestRunDevUnload:
         assert "No catalog overlay exists" in capsys.readouterr().err
 
 
+class TestResumeRevisionAdoption:
+    """Resume must deploy the PRIOR run's tag — the freshly stamped epoch
+    tag was never built/pushed (found live: ImagePullBackOff during
+    ENG-6802 verification)."""
+
+    def _state(self, step="poll", revision="2.2.0-dev-0b1fbba.100"):
+        from kamiwaza_extensions.dev_state import DevState
+
+        return DevState(last_revision=revision, last_successful_step=step)
+
+    def test_adopts_prior_revision_when_push_complete(self):
+        from kamiwaza_extensions.commands.dev import _resume_revision
+
+        adopted = _resume_revision(
+            self._state(), "2.2.0-dev-0b1fbba.200", resumable=True
+        )
+        assert adopted == "2.2.0-dev-0b1fbba.100"
+
+    def test_adopts_when_only_build_complete(self):
+        # The local image store holds the prior tag; the push must push it.
+        from kamiwaza_extensions.commands.dev import _resume_revision
+
+        adopted = _resume_revision(
+            self._state(step="build"), "2.2.0-dev-0b1fbba.200", resumable=True
+        )
+        assert adopted == "2.2.0-dev-0b1fbba.100"
+
+    def test_no_adoption_when_not_resumable(self):
+        from kamiwaza_extensions.commands.dev import _resume_revision
+
+        assert (
+            _resume_revision(self._state(), "2.2.0-dev-0b1fbba.200", resumable=False)
+            is None
+        )
+
+    def test_no_adoption_when_no_steps_complete(self):
+        from kamiwaza_extensions.commands.dev import _resume_revision
+
+        assert (
+            _resume_revision(
+                self._state(step=""), "2.2.0-dev-0b1fbba.200", resumable=True
+            )
+            is None
+        )
+
+    def test_no_adoption_when_tags_already_match(self):
+        # Custom --revision: identical tags, nothing to adopt.
+        from kamiwaza_extensions.commands.dev import _resume_revision
+
+        assert (
+            _resume_revision(
+                self._state(revision="pinned-rev"), "pinned-rev", resumable=True
+            )
+            is None
+        )
+
+    def test_no_adoption_without_prior_state(self):
+        from kamiwaza_extensions.commands.dev import _resume_revision
+
+        assert _resume_revision(None, "2.2.0-dev-0b1fbba.200", resumable=True) is None
+
+
 class TestStatusMissingInstanceShowsOverlay:
     def test_overlay_shown_when_extension_not_found(self, monkeypatch, capsys):
         # get_extension raises NotFoundError (NOT an APIError subclass) for

--- a/tests/unit/extensions/test_dev_overlay.py
+++ b/tests/unit/extensions/test_dev_overlay.py
@@ -1,0 +1,257 @@
+"""Tests for the kz-ext dev catalog-overlay hook and --unload — ENG-6802."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from kamiwaza_extensions.commands.dev import _publish_catalog_overlay, run_dev_unload
+
+pytestmark = pytest.mark.unit
+
+
+def _info(tmp_path=None):
+    return SimpleNamespace(
+        path=Path(tmp_path) if tmp_path else Path("/tmp/ext"),
+        name="kaizen",
+        version="1.0.0",
+        metadata={"display_name": "Kaizen"},
+        image_basename=None,
+    )
+
+
+TRANSFORMED = {
+    "services": {"app": {"image": "registry.kamiwaza.test/kaizen-app:1.0.0-dev-abc.5"}}
+}
+CANONICAL = {"app": "registry.kamiwaza.test/kaizen-app:1.0.0-dev-abc.5"}
+
+
+def _publish(client, *, no_push=False, service_filter=None):
+    return _publish_catalog_overlay(
+        client,
+        _info(),
+        transformed=TRANSFORMED,
+        canonical_refs=CANONICAL,
+        registry="registry.kamiwaza.test",
+        push_registry="127.0.0.1:30010",
+        no_push=no_push,
+        service_filter=service_filter,
+    )
+
+
+@pytest.fixture
+def git_mocks():
+    with patch(
+        "kamiwaza_extensions.revision_tagger.RevisionTagger.get_git_info",
+        return_value=("abc1234", False),
+    ), patch(
+        "kamiwaza_extensions.catalog_overlay.get_git_branch",
+        return_value="feat-x",
+    ), patch(
+        "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest",
+        return_value="sha256:" + "a" * 64,
+    ):
+        yield
+
+
+class TestPublishCatalogOverlay:
+    def test_skips_on_no_push(self, capsys):
+        client = MagicMock()
+        _publish(client, no_push=True)
+        client.put.assert_not_called()
+        assert "Catalog overlay skipped" in capsys.readouterr().err
+
+    def test_skips_on_service_filter(self, capsys):
+        client = MagicMock()
+        _publish(client, service_filter="app")
+        client.put.assert_not_called()
+        assert "--service" in capsys.readouterr().err
+
+    def test_happy_path_publishes_and_prints(self, git_mocks, capsys):
+        client = MagicMock()
+        client.put.return_value = {
+            "shadow": {"shadows_version": "1.0.0"},
+            "running_deployments": ["kaizen-room-1", "kaizen-room-2"],
+        }
+
+        _publish(client)
+
+        path, kwargs = client.put.call_args[0][0], client.put.call_args[1]
+        assert path == "/apps/app_templates/catalog/overlay/kaizen"
+        entry = kwargs["json"]
+        assert entry["version"] == "1.0.0-dev.feat-x.abc1234"
+        assert entry["shadow"]["git_branch"] == "feat-x"
+        assert "@sha256:" in entry["compose_yml"]
+
+        err = capsys.readouterr().err
+        assert "Catalog overlay" in err
+        assert "shadows 1.0.0" in err
+        assert "2 running instances" in err
+        assert "--unload" in err
+
+    def test_old_platform_404_is_tolerated(self, git_mocks, capsys):
+        from kamiwaza_sdk.exceptions import APIError
+
+        client = MagicMock()
+        client.put.side_effect = APIError("not found", status_code=404)
+
+        _publish(client)  # must not raise
+
+        assert "does not support catalog overlays" in capsys.readouterr().err
+
+    def test_other_api_errors_warn_but_do_not_fail(self, git_mocks, capsys):
+        from kamiwaza_sdk.exceptions import APIError
+
+        client = MagicMock()
+        client.put.side_effect = APIError("boom", status_code=500)
+
+        _publish(client)  # must not raise
+
+        err = capsys.readouterr().err
+        assert "overlay write failed" in err
+        assert "upstream catalog build" in err
+
+    def test_unexpected_errors_warn_but_do_not_fail(self, git_mocks, capsys):
+        client = MagicMock()
+        client.put.side_effect = RuntimeError("connection reset")
+
+        _publish(client)  # must not raise
+
+        assert "overlay write failed" in capsys.readouterr().err
+
+
+class TestRunDevUnload:
+    def _setup(self, monkeypatch, client):
+        connection = SimpleNamespace(
+            url="https://kamiwaza.test",
+            name="dev",
+            verify_ssl=True,
+            effective_verify_ssl=lambda: True,
+        )
+        monkeypatch.setattr(
+            "kamiwaza_extensions.extension_detector.ExtensionDetector.detect",
+            lambda self: _info(),
+        )
+        conn_mgr = MagicMock()
+        conn_mgr.get_active_connection.return_value = connection
+        conn_mgr.get_token.return_value = SimpleNamespace(access_token="tok")
+        monkeypatch.setattr(
+            "kamiwaza_extensions.connections.ConnectionManager",
+            lambda: conn_mgr,
+        )
+        monkeypatch.setattr(
+            "kamiwaza_sdk.KamiwazaClient", lambda **kwargs: client
+        )
+
+    def test_unload_restores_upstream(self, monkeypatch, capsys):
+        client = MagicMock()
+        client.delete.return_value = {
+            "template_name": "kaizen",
+            "restored_version": "1.0.0",
+            "template_removed": False,
+        }
+        self._setup(monkeypatch, client)
+
+        run_dev_unload()
+
+        client.delete.assert_called_once_with(
+            "/apps/app_templates/catalog/overlay/kaizen"
+        )
+        err = capsys.readouterr().err
+        assert "Restored" in err and "1.0.0" in err
+        assert "unaffected" in err
+
+    def test_unload_removed_template(self, monkeypatch, capsys):
+        client = MagicMock()
+        client.delete.return_value = {
+            "template_name": "kaizen",
+            "restored_version": None,
+            "template_removed": True,
+        }
+        self._setup(monkeypatch, client)
+
+        run_dev_unload()
+
+        assert "no upstream catalog entry" in capsys.readouterr().err
+
+    def test_unload_without_overlay_exits_with_message(self, monkeypatch, capsys):
+        from kamiwaza_sdk.exceptions import APIError
+
+        client = MagicMock()
+        client.delete.side_effect = APIError("missing", status_code=404)
+        self._setup(monkeypatch, client)
+
+        with pytest.raises(typer.Exit):
+            run_dev_unload()
+
+        assert "No catalog overlay exists" in capsys.readouterr().err
+
+
+class TestStatusOverlayRendering:
+    def _shadow(self, **overrides):
+        shadow = {
+            "template_name": "kaizen",
+            "shadow_version": "1.0.0-dev.feat-x.abc1234",
+            "git_sha": "abc1234",
+            "git_branch": "feat-x",
+            "dirty": False,
+            "shadows_version": "1.0.0",
+            "upstream_exists": True,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        shadow.update(overrides)
+        return shadow
+
+    def test_renders_shadow_line(self, capsys):
+        from kamiwaza_extensions.commands.status import _print_overlay_status
+
+        client = MagicMock()
+        client.get.return_value = [self._shadow()]
+
+        _print_overlay_status(client, "kaizen")
+
+        err = capsys.readouterr().err
+        assert "abc1234" in err
+        # rich may soft-wrap mid-phrase; assert the parts.
+        assert "shadowing upstream" in err
+        assert "1.0.0" in err
+        assert "published today" in err
+        assert "--unload" in err
+
+    def test_staleness_nudge(self, capsys):
+        from kamiwaza_extensions.commands.status import _print_overlay_status
+
+        old = (datetime.now(timezone.utc) - timedelta(days=18)).isoformat()
+        client = MagicMock()
+        client.get.return_value = [self._shadow(updated_at=old)]
+
+        _print_overlay_status(client, "kaizen")
+
+        err = capsys.readouterr().err
+        assert "published 18 days ago" in err
+        assert "18 days old" in err
+
+    def test_silent_without_shadow(self, capsys):
+        from kamiwaza_extensions.commands.status import _print_overlay_status
+
+        client = MagicMock()
+        client.get.return_value = []
+
+        _print_overlay_status(client, "kaizen")
+
+        assert capsys.readouterr().err == ""
+
+    def test_silent_on_old_platform(self, capsys):
+        from kamiwaza_extensions.commands.status import _print_overlay_status
+
+        client = MagicMock()
+        client.get.side_effect = RuntimeError("404")
+
+        _print_overlay_status(client, "kaizen")
+
+        assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Summary

`kz-ext dev` built, pushed to the local registry, and hot-swapped the dev instance — but never touched the catalog, so workrooms created via the workroom manager silently launched the upstream (`develop`) build instead of the dev build ([ENG-6802](https://linear.app/kamiwaza/issue/ENG-6802)).

CLI half of the overlay (platform half: kamiwaza#1949):

- **`kz-ext dev`** — after a successful rollout, PUTs the build to the cluster's catalog overlay API. The entry reuses the *same* transformed compose the deploy used (the exact refs running pods pull), digest-pins each built service ref (resolved via the host-reachable push ref, pinned onto the in-cluster canonical ref; degrades to tag-only with a warning), and stamps a distinguishable shadow version `{base}-dev.{branch}.{sha7}` (intentionally not PEP440-parseable — a second clobber guard platform-side). Prints the shadow line, a hint when running instances remain on the pre-shadow build, and the undo command.
  - Skipped with explanation on `--no-push` (cluster can't pull an unpushed image) and `--service` (sibling services weren't pushed at this revision).
  - Non-fatal everywhere: 404/405 from older platforms prints a dim notice; any other failure warns — the hot-swap already succeeded.
- **`kz-ext dev --unload`** — removes the overlay, printing what was restored; reminds that the running dev instance is unaffected.
- **`kz-ext status`** — shows the active shadow (`local dev build f9b70f6 (branch feat-x), shadowing upstream 0.4.0, published 18 days ago`) with a staleness nudge after 7 days, guarding against "my env silently runs a 3-week-old dev build".

## Hard invariant

`kz-ext dev` must be *incapable* of writing a shared R2 catalog (dev-info/stage-info/info), even with a misconfigured publish profile. Holds structurally: the dev path (`commands/dev.py` + `catalog_overlay.py`) never imports `catalog_publisher`, `profile_manager`, or `boto3` — enforced by an import-graph test that fails if anyone wires them in (`tests/unit/extensions/test_catalog_overlay.py::TestImportInvariant`).

## Testing

- `tests/unit/extensions/test_catalog_overlay.py` — version stamping (slugging/truncation/dirty/not-PEP440), digest pinning via push ref, tag-only degradation, client paths, import-graph invariant (17 tests)
- `tests/unit/extensions/test_dev_overlay.py` — dev-flow hook (skip conditions, happy path, 404 tolerance, non-fatal errors), `--unload` (restore/remove/missing), status rendering + staleness nudge (13 tests)
- Full `tests/unit/extensions` suite: 1579 passed; ruff and mypy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-06-11T23:09:06.066Z
pr:
  repo: kamiwaza-ai/kamiwaza-sdk
  number: 155
linear_issues:
  - ENG-6802
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: All 7 GitHub checks green at bundle-author time on head 8543ed6 (Build
      Package, Coverage, Complexity, Mypy, Ruff, Unit Tests,
      check-linear-issue). Gate will re-verify.
  - kind: pr-evidence
    required: false
    status: skipped
    detail: This PR is dev-box CLI tooling (kz-ext), not cluster-deployed code; the
      cluster-touching half is kamiwaza-internal/kamiwaza#1949. pr-evidence not
      applicable.
  - kind: linear-issue-present
    required: true
    status: pass
    detail: "Found: ENG-6802 (in PR title and head branch)."
  - kind: no-debug-statements
    required: true
    status: pass
    detail: Diff scanned (pdb.set_trace, breakpoint(), console.log, debugger, TODO
      REMOVE); no matches in added lines.
  - kind: pr-review-approved
    required: true
    status: pass
    detail: "Multi-engine /pr-review (Claude + Codex, 3 iterations) verdict APPROVE
      posted:
      https://github.com/kamiwaza-ai/kamiwaza-sdk/pull/155#issuecomment-4685601\
      607. Three later commits (1328764, a43aad3, 8543ed6) are fix-forward from
      that review's final P2s and from this verification session's live
      findings; unit suite green on head 8543ed6."
manual_steps:
  - id: ms-1
    description: In an extension repo (kamiwaza-extensions-omniparse) on a cluster
      whose core includes kamiwaza#1949, run `kz-ext dev` and report the Catalog
      overlay line printed after rollout.
    observation: "✓ Catalog overlay: tool-omniparse 2.2.0-dev.develop.0b1fbba
      (shadows 2.2.0) — new workrooms will use this build. / 1 running instance
      still on the pre-shadow build — relaunch to pick up the dev build. / Undo
      with: kz-ext dev --unload. Earlier attempts surfaced two defects fixed
      during this verification: overlay PUT 403 for non-admin dev users (fixed
      platform-side, kamiwaza#1949 @ 92909f02f) and a pre-existing resume bug
      deploying a never-pushed epoch tag → ImagePullBackOff (fixed in this PR @
      a43aad3 + 8543ed6); the final run printed 'Prior revision
      2.2.0-dev-0b1fbba.1781217447 is not in the registry — dev-state is stale.
      Running the full pipeline.', rebuilt, and completed end-to-end."
    status: pass
  - id: ms-2
    description: Check the version the platform's template now serves for
      tool-omniparse (App Garden card or GET
      /apps/app_templates?template_type=tool). What version does it show?
    observation: It's working - I see the updated version tag (the template shows
      the dev shadow version, not upstream 2.2.0).
    status: pass
  - id: ms-3
    description: Run `kz-ext status` in the extension repo. What does the Catalog
      overlay line report (build sha/branch, shadowing what, published when)?
    observation: "Extension: tool-omniparse-dev-9580ae, Phase: Running,
      omniparse-server 1/1 ready; 'Catalog overlay: local dev build 0b1fbba
      (branch develop), shadowing upstream 2.2.0, pub…' (operator's paste
      truncated at 'pub' — the published-when suffix)."
    status: pass
  - id: ms-4
    description: As an admin, trigger a remote catalog sync (App Garden sync/import
      or POST /apps/app_templates/remote/sync). Does the shadowed template
      survive, and what version does it show right after?
    observation: It still shows the dev version (sync did not clobber the shadow).
    status: pass
  - id: ms-5
    description: Run `kz-ext dev --unload`, then re-check the template. What message
      prints and what version does the template show afterwards?
    observation: ✓ Restored tool-omniparse to upstream 2.2.0 — new workrooms will
      use the catalog build. The running dev extension instance is unaffected —
      only new workroom launches change.
    status: pass
verdict:
  decision: approve
  rationale: All required auto-checks passed (required-checks,
    linear-issue-present, no-debug-statements, pr-review-approved); 5 manual
    steps verified.
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
linear:
  - id: ENG-6802
    url: https://linear.app/kamiwaza/issue/ENG-6802
    cached_description: >-
      ## Problem


      `kz-ext dev` expresses the intent "load my in-development extension into
      my local Kamiwaza environment" — but it only builds, pushes to the local
      registry (`:30010`), and hot-swaps the dev/global workroom instance. It
      never touches the catalog.


      Meanwhile, the workroom manager provisions each new workroom by resolving
      the extension version from the **catalog at create-time** and freezing the
      resolved image digests into the `KamiwazaExtension` CR's
      `spec.services[].image`. The extension-operator just reconciles pods from
      those pinned digests — it has no catalog config of its own.


      Result: a split-brain between "the version `kz-ext dev` loaded" and "the
      version the manager hands out." Launching kaizen in a fresh workroom
      silently serves the catalog build (e.g. `develop` from the shared
      `dev-info` R2 bucket), not the dev build.


      ## Intended semantics


      `kz-ext dev` = "this build is THE version of this extension throughout my
      local environment." New workrooms launched via the workroom manager should
      get the dev build.


      ## Design


      1. Local catalog overlay: ordered source list local overlay → shared R2
      catalog; kz-ext dev writes the overlay entry by default. Hard invariant:
      kz-ext dev must be incapable of writing a shared catalog (R2
      dev-info/stage-info/info).

      2. Identity: shadow, don't impersonate — distinguishable version e.g.
      0.4.0-dev.<branch>.<sha>, marked as shadows develop.

      3. Staleness: kz-ext status shows active shadows; kz-ext dev --unload
      drops the overlay; optional age nudge.

      4. Already-running workrooms: new-workrooms-only; hint when running
      instances remain on the upstream build.
    cached_at: 2026-06-11T22:26:56Z
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->