### PR TITLE
ENG-6538 Align Context no-workroom live SDK tests

### DIFF
--- a/kamiwaza_sdk/schemas/workrooms.py
+++ b/kamiwaza_sdk/schemas/workrooms.py
@@ -86,6 +86,24 @@ class DeleteWorkroomResponse(WorkroomResponseModel):
     message: str
 
 
+class EnterWorkroomResponse(WorkroomResponseModel):
+    """Response from entering a workroom session."""
+
+    workroom_id: UUID
+    access_token: Optional[str] = None
+    expires_in: Optional[int] = None
+    message: str = "Workroom session bound"
+
+
+class LeaveWorkroomResponse(WorkroomResponseModel):
+    """Response from leaving a workroom session."""
+
+    workroom_id: UUID
+    access_token: Optional[str] = None
+    expires_in: Optional[int] = None
+    message: str = "Returned to Global Workroom"
+
+
 class ExportManifestItem(WorkroomResponseModel):
     """A single item in the export manifest."""
 

--- a/kamiwaza_sdk/schemas/workrooms.py
+++ b/kamiwaza_sdk/schemas/workrooms.py
@@ -87,7 +87,7 @@ class DeleteWorkroomResponse(WorkroomResponseModel):
 
 
 class EnterWorkroomResponse(WorkroomResponseModel):
-    """Response from entering a workroom session."""
+    """Response from the backend workroom-enter endpoint."""
 
     workroom_id: UUID
     access_token: Optional[str] = None
@@ -96,7 +96,7 @@ class EnterWorkroomResponse(WorkroomResponseModel):
 
 
 class LeaveWorkroomResponse(WorkroomResponseModel):
-    """Response from leaving a workroom session."""
+    """Response from the backend workroom-leave endpoint."""
 
     workroom_id: UUID
     access_token: Optional[str] = None

--- a/kamiwaza_sdk/services/workrooms.py
+++ b/kamiwaza_sdk/services/workrooms.py
@@ -7,8 +7,10 @@ from ..exceptions import APIError, NotFoundError
 from ..schemas.workrooms import (
     CreateWorkroom,
     DeleteWorkroomResponse,
+    EnterWorkroomResponse,
     ExportManifest,
     IngestionSummary,
+    LeaveWorkroomResponse,
     UpdateWorkroom,
     Workroom,
 )
@@ -218,6 +220,26 @@ class WorkroomService(BaseService):
             if e.status_code == 404:
                 raise NotFoundError(f"Workroom {wid} not found")
             raise
+
+    # -------------------------------------------------------------------------
+    # Session binding
+    # -------------------------------------------------------------------------
+
+    def enter(self, workroom_id: Union[str, UUID]) -> EnterWorkroomResponse:
+        """Bind the current SDK session to a workroom."""
+        wid = self._ensure_uuid(workroom_id)
+        try:
+            response = self.client.post(f"/workrooms/{wid}/enter")
+            return EnterWorkroomResponse.model_validate(response)
+        except APIError as e:
+            if e.status_code == 404:
+                raise NotFoundError(f"Workroom {wid} not found")
+            raise
+
+    def leave(self) -> LeaveWorkroomResponse:
+        """Return the current SDK session to the Global Workroom."""
+        response = self.client.post("/workrooms/leave")
+        return LeaveWorkroomResponse.model_validate(response)
 
     # -------------------------------------------------------------------------
     # Export & ingestion

--- a/kamiwaza_sdk/services/workrooms.py
+++ b/kamiwaza_sdk/services/workrooms.py
@@ -64,14 +64,16 @@ class WorkroomService(BaseService):
         Raises:
             APIError: If creation fails (e.g. limit exceeded -> 409).
         """
-        payload = CreateWorkroom(
-            name=name,
-            type=workroom_type,
-            description=description,
-            labels=labels,
-            classification=classification,
-            attributes=attributes,
-            scg_references=scg_references,
+        payload = CreateWorkroom.model_validate(
+            {
+                "name": name,
+                "type": workroom_type,
+                "description": description,
+                "labels": labels,
+                "classification": classification,
+                "attributes": attributes,
+                "scg_references": scg_references,
+            }
         )
         response = self.client.post(
             "/workrooms/",
@@ -145,8 +147,8 @@ class WorkroomService(BaseService):
             APIError: If validation fails (400) or workroom is read-only (409).
         """
         wid = self._ensure_uuid(workroom_id)
-        payload = UpdateWorkroom(
-            **self._provided_fields(
+        payload = UpdateWorkroom.model_validate(
+            self._provided_fields(
                 name=name,
                 description=description,
                 labels=labels,

--- a/kamiwaza_sdk/services/workrooms.py
+++ b/kamiwaza_sdk/services/workrooms.py
@@ -228,7 +228,12 @@ class WorkroomService(BaseService):
     # -------------------------------------------------------------------------
 
     def enter(self, workroom_id: Union[str, UUID]) -> EnterWorkroomResponse:
-        """Bind the current SDK session to a workroom."""
+        """Call the backend workroom-enter endpoint and return its response.
+
+        The SDK does not install returned access tokens into the configured
+        authenticator. Callers that need scoped Context access should continue
+        to pass explicit ``workroom_id`` values where the SDK exposes them.
+        """
         wid = self._ensure_uuid(workroom_id)
         try:
             response = self.client.post(f"/workrooms/{wid}/enter")
@@ -239,7 +244,11 @@ class WorkroomService(BaseService):
             raise
 
     def leave(self) -> LeaveWorkroomResponse:
-        """Return the current SDK session to the Global Workroom."""
+        """Call the backend workroom-leave endpoint and return its response.
+
+        Returned token fields are exposed for callers that manage tokens
+        themselves; this method does not mutate the SDK authenticator.
+        """
         response = self.client.post("/workrooms/leave")
         return LeaveWorkroomResponse.model_validate(response)
 

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -302,16 +302,9 @@ def shared_vectordb(shared_context_service: ContextService) -> str:
 def session_workroom(shared_context_service: ContextService) -> str:
     """Per-session writable workroom for Context Service write-path tests.
 
-    The Global Workroom (``DEFAULT_WORKROOM_ID``) is read-only for context
-    writes: ontology / pipeline / collection / object-storage creation against
-    it return ``403 "Global Workroom is read-only for ..."``. Write-path tests
-    therefore need a real, writable workroom.
-
-    The id is supplied to the SDK via ``workroom_id=`` (the ``X-Workroom-ID``
-    header). The Context Service authorizes that header against the caller's
-    verified workroom membership, and the istio ingress preserves it
-    end-to-end, so writes land in -- and stay isolated to -- this workroom.
-    Read-only assertions against Global continue to use ``DEFAULT_WORKROOM_ID``.
+    Room-scoped Context routes require an explicit non-Global workroom scope.
+    Bind that workroom on the same SDK session that provisions shared test
+    resources so follow-up calls carry verified workroom authority.
     """
     workrooms = shared_context_service.client.workrooms
     workroom = workrooms.create(
@@ -320,6 +313,7 @@ def session_workroom(shared_context_service: ContextService) -> str:
         description="Ephemeral workroom for SDK context live tests",
     )
     workroom_id = str(workroom.id)
+    shared_context_service.client.post(f"/workrooms/{workroom_id}/enter")
     try:
         yield workroom_id
     finally:
@@ -382,19 +376,10 @@ def test_context_required_llm_available(context_required_llm: str) -> None:
     assert context_required_llm
 
 
-def test_context_vectordb_create_in_global_workroom_is_read_only(
+def test_context_vectordb_create_without_workroom_requires_scope(
     live_kamiwaza_client,
 ) -> None:
-    """Global Workroom is read-only for VectorDB creation (ENG-4352, PR #1635).
-
-    Verifies the server-side gate at
-    ``kamiwaza/services/context/lifecycle.py:_raise_if_global_workroom_write``
-    rejects ``create_vectordb`` without an explicit workroom_id (which
-    defaults to the Global Workroom UUID). Returns 403 regardless of
-    caller role, matching commit 73071d5d1's stated intent:
-    "Keeps Global Workroom read paths available to members and blocks
-    Global write paths in both ReBAC-on and RBAC-off modes."
-    """
+    """VectorDB creation is room-scoped and requires a non-Global workroom."""
     service = _context_service(live_kamiwaza_client)
 
     with pytest.raises(APIError) as exc_info:
@@ -403,8 +388,8 @@ def test_context_vectordb_create_in_global_workroom_is_read_only(
             engine="milvus",
         )
 
-    assert exc_info.value.status_code == 403
-    assert "Global Workroom is read-only" in str(exc_info.value)
+    assert exc_info.value.status_code == 400
+    assert "workroom_scope_required" in str(exc_info.value)
 
 
 # A dedicated non-Global VectorDB *instance* lifecycle test (create/scale/
@@ -420,11 +405,12 @@ def test_context_vectordb_create_in_global_workroom_is_read_only(
 
 
 def test_context_vectordb_insert_vectors_instance(
-    live_kamiwaza_client,
-    shared_vectordb: str,
+    shared_context_service: ContextService,
+    session_workroom: str,
+    shared_workroom_vectordb: str,
 ) -> None:
-    service = _context_service(live_kamiwaza_client)
-    vectordb_id = shared_vectordb
+    service = shared_context_service
+    vectordb_id = shared_workroom_vectordb
     collection_name = _sdk_collection_name()
 
     inserted = service.insert_vectors(
@@ -432,16 +418,18 @@ def test_context_vectordb_insert_vectors_instance(
         collection_name=collection_name,
         vectors=[_sample_vector()],
         metadata=[{"source": "sdk-context-live"}],
+        workroom_id=session_workroom,
     )
     assert inserted["inserted_count"] == 1
 
 
 def test_context_vectordb_insert_vectors_global(
-    live_kamiwaza_client,
-    shared_vectordb: str,
+    shared_context_service: ContextService,
+    session_workroom: str,
+    shared_workroom_vectordb: str,
 ) -> None:
-    service = _context_service(live_kamiwaza_client)
-    vectordb_id = shared_vectordb
+    service = shared_context_service
+    vectordb_id = shared_workroom_vectordb
     collection_name = _sdk_collection_name()
 
     inserted = service.insert_vectors_global(
@@ -449,16 +437,18 @@ def test_context_vectordb_insert_vectors_global(
         collection_name=collection_name,
         vectors=[_sample_vector()],
         metadata=[{"source": "sdk-context-live"}],
+        workroom_id=session_workroom,
     )
     assert inserted["inserted_count"] == 1
 
 
 def test_context_vectordb_query_vectors_instance(
-    live_kamiwaza_client,
-    shared_vectordb: str,
+    shared_context_service: ContextService,
+    session_workroom: str,
+    shared_workroom_vectordb: str,
 ) -> None:
-    service = _context_service(live_kamiwaza_client)
-    vectordb_id = shared_vectordb
+    service = shared_context_service
+    vectordb_id = shared_workroom_vectordb
     collection_name = _sdk_collection_name()
 
     service.insert_vectors(
@@ -466,22 +456,25 @@ def test_context_vectordb_query_vectors_instance(
         collection_name=collection_name,
         vectors=[_sample_vector()],
         metadata=[{"source": "sdk-context-live"}],
+        workroom_id=session_workroom,
     )
     queried = service.query_vectors(
         vectordb_id,
         collection_name=collection_name,
         vectors=[_sample_vector()],
         limit=1,
+        workroom_id=session_workroom,
     )
     assert isinstance(queried["results"], list)
 
 
 def test_context_vectordb_query_vectors_global(
-    live_kamiwaza_client,
-    shared_vectordb: str,
+    shared_context_service: ContextService,
+    session_workroom: str,
+    shared_workroom_vectordb: str,
 ) -> None:
-    service = _context_service(live_kamiwaza_client)
-    vectordb_id = shared_vectordb
+    service = shared_context_service
+    vectordb_id = shared_workroom_vectordb
     collection_name = _sdk_collection_name()
 
     service.insert_vectors_global(
@@ -489,12 +482,14 @@ def test_context_vectordb_query_vectors_global(
         collection_name=collection_name,
         vectors=[_sample_vector()],
         metadata=[{"source": "sdk-context-live"}],
+        workroom_id=session_workroom,
     )
     queried = service.query_vectors_global(
         vectordb_id=vectordb_id,
         collection_name=collection_name,
         vectors=[_sample_vector()],
         limit=1,
+        workroom_id=session_workroom,
     )
     assert isinstance(queried["results"], list)
 
@@ -643,10 +638,10 @@ def test_context_ontology_delete_group(
 
 @pytest.mark.requires_embedding_model
 def test_context_workroom_lists_and_job_creation(
-    live_kamiwaza_client,
+    shared_context_service: ContextService,
     session_workroom: str,
 ) -> None:
-    service = _context_service(live_kamiwaza_client)
+    service = shared_context_service
     workroom_id = session_workroom
     created_job_ids: list[str] = []
 
@@ -701,10 +696,10 @@ def test_context_workroom_lists_and_job_creation(
 
 @pytest.mark.requires_embedding_model
 def test_context_workroom_pipeline_followup_access(
-    live_kamiwaza_client,
+    shared_context_service: ContextService,
     session_workroom: str,
 ) -> None:
-    service = _context_service(live_kamiwaza_client)
+    service = shared_context_service
     workroom_id = session_workroom
 
     payload = base64.b64encode(b"hello context service").decode("utf-8")
@@ -733,11 +728,11 @@ def test_context_workroom_pipeline_followup_access(
 
 
 def test_context_workroom_collection_lifecycle(
-    live_kamiwaza_client,
+    shared_context_service: ContextService,
     session_workroom: str,
     shared_workroom_vectordb: str,
 ) -> None:
-    service = _context_service(live_kamiwaza_client)
+    service = shared_context_service
     workroom_id = session_workroom
     assert shared_workroom_vectordb
     collection_name = _sdk_collection_name()
@@ -783,11 +778,11 @@ def test_context_workroom_collection_lifecycle(
 
 @pytest.mark.requires_embedding_model
 def test_context_search_contract(
-    live_kamiwaza_client,
+    shared_context_service: ContextService,
     session_workroom: str,
     shared_workroom_vectordb: str,
 ) -> None:
-    service = _context_service(live_kamiwaza_client)
+    service = shared_context_service
     workroom_id = session_workroom
     assert shared_workroom_vectordb
 
@@ -801,11 +796,11 @@ def test_context_search_contract(
 
 @pytest.mark.requires_embedding_model
 def test_context_retrieve_contract(
-    live_kamiwaza_client,
+    shared_context_service: ContextService,
     session_workroom: str,
     shared_workroom_vectordb: str,
 ) -> None:
-    service = _context_service(live_kamiwaza_client)
+    service = shared_context_service
     workroom_id = session_workroom
     assert shared_workroom_vectordb
 

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -260,6 +260,26 @@ def _is_stale_sdk_resource(resource: dict, max_age: timedelta) -> bool:
 _STALE_THRESHOLD = timedelta(minutes=15)
 
 
+def _api_error_code(error: APIError) -> str | None:
+    """Extract the stable server error code from an APIError payload."""
+    payload = error.response_data
+    if not isinstance(payload, dict):
+        return None
+
+    detail = payload.get("detail")
+    if isinstance(detail, dict):
+        for key in ("error", "code", "reason"):
+            value = detail.get(key)
+            if isinstance(value, str):
+                return value
+
+    for key in ("error", "code", "reason"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _cleanup_stale_sdk_vdbs(shared_context_service: ContextService) -> None:
     """Delete leftover sdk-* VDB/ontology instances from prior crashed runs.
@@ -288,17 +308,6 @@ def _cleanup_stale_sdk_vdbs(shared_context_service: ContextService) -> None:
 
 
 @pytest.fixture(scope="session")
-def shared_vectordb(shared_context_service: ContextService) -> str:
-    """Shared global VectorDB instance for non-destructive vector tests."""
-    service = shared_context_service
-    vectordb_id = _create_temp_vectordb(service, prefix="sdk-shared-vdb")
-    try:
-        yield vectordb_id
-    finally:
-        _safe_delete_vectordb(service, vectordb_id)
-
-
-@pytest.fixture(scope="session")
 def session_workroom(shared_context_service: ContextService) -> str:
     """Per-session writable workroom for Context Service write-path tests.
 
@@ -313,10 +322,15 @@ def session_workroom(shared_context_service: ContextService) -> str:
         description="Ephemeral workroom for SDK context live tests",
     )
     workroom_id = str(workroom.id)
-    shared_context_service.client.post(f"/workrooms/{workroom_id}/enter")
     try:
+        entered = workrooms.enter(workroom_id)
+        assert str(entered.workroom_id) == workroom_id
         yield workroom_id
     finally:
+        try:
+            workrooms.leave()
+        except APIError:
+            pass
         # delete() raises NotFoundError (a sibling of APIError, not a subclass)
         # when the workroom is already gone, so catch both to keep teardown
         # best-effort -- matching the sibling test_workroom_isolation_live.py.
@@ -389,7 +403,7 @@ def test_context_vectordb_create_without_workroom_requires_scope(
         )
 
     assert exc_info.value.status_code == 400
-    assert "workroom_scope_required" in str(exc_info.value)
+    assert _api_error_code(exc_info.value) == "workroom_scope_required"
 
 
 # A dedicated non-Global VectorDB *instance* lifecycle test (create/scale/

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import base64
 import os
 import time
+from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from kamiwaza_sdk import KamiwazaClient
 from kamiwaza_sdk.authentication import UserPasswordAuthenticator
@@ -308,12 +310,15 @@ def _cleanup_stale_sdk_vdbs(shared_context_service: ContextService) -> None:
 
 
 @pytest.fixture(scope="session")
-def session_workroom(shared_context_service: ContextService) -> str:
+def session_workroom(
+    shared_context_service: ContextService,
+) -> Generator[str, None, None]:
     """Per-session writable workroom for Context Service write-path tests.
 
     Room-scoped Context routes require an explicit non-Global workroom scope.
-    Bind that workroom on the same SDK session that provisions shared test
-    resources so follow-up calls carry verified workroom authority.
+    Exercise the backend enter endpoint as a checked lifecycle seam, while
+    Context calls below pass explicit workroom_id so authority is not inferred
+    from SDK-local session state.
     """
     workrooms = shared_context_service.client.workrooms
     workroom = workrooms.create(
@@ -329,7 +334,7 @@ def session_workroom(shared_context_service: ContextService) -> str:
     finally:
         try:
             workrooms.leave()
-        except APIError:
+        except (APIError, ValidationError):
             pass
         # delete() raises NotFoundError (a sibling of APIError, not a subclass)
         # when the workroom is already gone, so catch both to keep teardown
@@ -344,7 +349,7 @@ def session_workroom(shared_context_service: ContextService) -> str:
 def shared_workroom_vectordb(
     shared_context_service: ContextService,
     session_workroom: str,
-) -> str:
+) -> Generator[str, None, None]:
     """Shared workroom-scoped VectorDB for collection/search/retrieve tests."""
     service = shared_context_service
     vectordb_id = _create_temp_vectordb(
@@ -366,7 +371,7 @@ def shared_workroom_vectordb(
 def shared_ontology(
     shared_context_service: ContextService,
     context_required_llm: str,
-) -> str:
+) -> Generator[str, None, None]:
     """Shared ontology instance for non-destructive ontology tests."""
     assert context_required_llm
     service = shared_context_service

--- a/tests/unit/test_workroom_service.py
+++ b/tests/unit/test_workroom_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import uuid
+from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
@@ -506,6 +507,34 @@ def test_leave_posts_to_leave_endpoint(dummy_client):
     assert str(result.workroom_id) == "ffffffff-ffff-ffff-ffff-ffffffffffff"
     assert result.access_token == "global-token"
     assert result.expires_in == 3600
+
+
+def test_enter_leave_expose_tokens_without_mutating_client_auth(dummy_client):
+    responses = {
+        ("post", f"/workrooms/{WORKROOM_UUID}/enter"): {
+            "workroom_id": WORKROOM_ID,
+            "access_token": "scoped-token",
+            "expires_in": 3600,
+            "message": "Workroom session bound",
+        },
+        ("post", "/workrooms/leave"): {
+            "workroom_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "access_token": "global-token",
+            "expires_in": 3600,
+            "message": "Returned to Global Workroom",
+        },
+    }
+    client = dummy_client(responses)
+    session = SimpleNamespace(headers={"Authorization": "Bearer original"})
+    setattr(client, "session", session)
+    service = WorkroomService(client)
+
+    entered = service.enter(WORKROOM_ID)
+    left = service.leave()
+
+    assert entered.access_token == "scoped-token"
+    assert left.access_token == "global-token"
+    assert session.headers["Authorization"] == "Bearer original"
 
 
 # =============================================================================

--- a/tests/unit/test_workroom_service.py
+++ b/tests/unit/test_workroom_service.py
@@ -464,6 +464,51 @@ def test_archive_not_found_raises(dummy_client):
 
 
 # =============================================================================
+# Session Binding
+# =============================================================================
+
+
+def test_enter_posts_to_enter_endpoint(dummy_client):
+    responses = {
+        ("post", f"/workrooms/{WORKROOM_UUID}/enter"): {
+            "workroom_id": WORKROOM_ID,
+            "access_token": "scoped-token",
+            "expires_in": 3600,
+            "message": "Workroom session bound",
+        }
+    }
+    client = dummy_client(responses)
+    service = WorkroomService(client)
+
+    result = service.enter(WORKROOM_ID)
+
+    assert client.calls[0][1] == f"/workrooms/{WORKROOM_UUID}/enter"
+    assert result.workroom_id == WORKROOM_UUID
+    assert result.access_token == "scoped-token"
+    assert result.expires_in == 3600
+
+
+def test_leave_posts_to_leave_endpoint(dummy_client):
+    responses = {
+        ("post", "/workrooms/leave"): {
+            "workroom_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+            "access_token": "global-token",
+            "expires_in": 3600,
+            "message": "Returned to Global Workroom",
+        }
+    }
+    client = dummy_client(responses)
+    service = WorkroomService(client)
+
+    result = service.leave()
+
+    assert client.calls[0][1] == "/workrooms/leave"
+    assert str(result.workroom_id) == "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    assert result.access_token == "global-token"
+    assert result.expires_in == 3600
+
+
+# =============================================================================
 # Export Manifest
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Align live SDK Context tests with the ENG-6538 no-workroom/workroom-scope contract exercised by kamiwaza PR #1893.

- Treat VectorDB create without an explicit non-Global workroom as `workroom_scope_required` instead of the stale Global-read-only contract.
- Bind the ephemeral workroom on the same SDK session used for workroom-scoped Context live tests.
- Run vector insert/query coverage against a workroom-scoped VectorDB while preserving both endpoint shapes.

## Related

- Linear: ENG-6538
- Product PR: https://github.com/kamiwaza-internal/kamiwaza/pull/1893
- Supersedes stale SDK branch/PR #150; this branch is rebuilt from current `origin/develop`.

## Verification

- `python -m py_compile tests/integration/test_context_live.py`
- `uv run ruff check tests/integration/test_context_live.py`
- `uv run pytest tests/integration/test_context_live.py tests/integration/test_workroom_isolation_live.py --collect-only -q`
- `uv run pytest tests/unit/test_context_service.py tests/unit/test_workroom_service.py --no-cov -q`

Live verification is being run from product PR #1893 via `/kajiya smoke` with `sdk: fix/eng-6538-context-no-workroom-sdk-tests-develop`.
