### PR TITLE
ENG-6898: add ContextService.agentic_search + correct context coverage matrix

### DIFF
--- a/kamiwaza_sdk/services/context.py
+++ b/kamiwaza_sdk/services/context.py
@@ -551,6 +551,56 @@ class ContextService(BaseService):
             headers=self._merge_headers(workroom_id=workroom_id),
         )
 
+    def agentic_search(
+        self,
+        *,
+        workroom_id: str,
+        query: str,
+        collection_name: str | None = None,
+        top_k: int = 10,
+        score_threshold: float | None = None,
+        vectordb_id: str | None = None,
+        max_iterations: int = 1,
+        relevance_threshold: float = 0.7,
+        enable_graph_search: bool = False,
+        ontology_id: str | None = None,
+        group_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Run agentic search with LLM synthesis over a workroom's collections.
+
+        Targets the canonical unified search endpoint with ``synthesize=True``.
+        The legacy ``/context/search/agentic`` route is deprecated server-side
+        in favour of ``/context/search/unified``; this method wraps the latter so
+        callers stay on the supported path and receive the unified response shape
+        (``results``/``sources``/``synthesis``/``citations``). Set
+        ``max_iterations`` > 1 for iterative query refinement, or
+        ``enable_graph_search`` with ``ontology_id``/``group_ids`` to fold
+        knowledge-graph results into the synthesis.
+        """
+        payload: dict[str, Any] = {
+            "query": query,
+            "top_k": top_k,
+            "synthesize": True,
+            "max_iterations": max_iterations,
+            "relevance_threshold": relevance_threshold,
+            "enable_graph_search": enable_graph_search,
+        }
+        if collection_name is not None:
+            payload["collection_name"] = collection_name
+        if score_threshold is not None:
+            payload["score_threshold"] = score_threshold
+        if vectordb_id is not None:
+            payload["vectordb_id"] = vectordb_id
+        if ontology_id is not None:
+            payload["ontology_id"] = ontology_id
+        if group_ids is not None:
+            payload["group_ids"] = group_ids
+        return self.client.post(
+            f"{self._BASE_PATH}/search/unified",
+            json=payload,
+            headers=self._merge_headers(workroom_id=workroom_id),
+        )
+
     def upload_file(
         self,
         *,

--- a/kamiwaza_sdk/services/context.py
+++ b/kamiwaza_sdk/services/context.py
@@ -575,7 +575,9 @@ class ContextService(BaseService):
         (``results``/``sources``/``synthesis``/``citations``). Set
         ``max_iterations`` > 1 for iterative query refinement, or
         ``enable_graph_search`` with ``ontology_id``/``group_ids`` to fold
-        knowledge-graph results into the synthesis.
+        knowledge-graph results into the synthesis. ``ontology_id`` and
+        ``group_ids`` only take effect when ``enable_graph_search`` is True; the
+        server ignores them otherwise.
         """
         payload: dict[str, Any] = {
             "query": query,

--- a/tests/integration/context_endpoint_coverage_matrix.md
+++ b/tests/integration/context_endpoint_coverage_matrix.md
@@ -1,6 +1,8 @@
-# Context Endpoint Coverage Matrix (Feb 27, 2026)
+# Context Endpoint Coverage Matrix (updated Jun 12, 2026)
 
-Source of truth routes: `kamiwaza/services/context/api/*.py` (35 endpoints).
+Routes are defined in `kamiwaza/services/context/api/*.py`. This matrix tracks
+the subset of Context endpoints the SDK wraps — it is **not** the full server
+surface (see "Not yet wrapped by the SDK" below).
 
 | # | Method | Endpoint | SDK Method | Unit | Live | Assertion Strength |
 |---|---|---|---|---|---|---|
@@ -8,8 +10,8 @@ Source of truth routes: `kamiwaza/services/context/api/*.py` (35 endpoints).
 | 2 | `GET` | `/context/vectordbs` | `list_vectordbs` | Y | Y | strict |
 | 3 | `GET` | `/context/vectordbs/{vectordb_id}` | `get_vectordb` | Y | Y | strict |
 | 4 | `POST` | `/context/vectordbs` | `create_vectordb` | Y | Y | strict |
-| 5 | `PUT` | `/context/vectordbs/{vectordb_id}` | `update_vectordb` | Y | Y | strict |
-| 6 | `POST` | `/context/vectordbs/{vectordb_id}/scale` | `scale_vectordb` | Y | Y | strict |
+| 5 | `PUT` | `/context/vectordbs/{vectordb_id}` | `update_vectordb` | Y | N | unit-only |
+| 6 | `POST` | `/context/vectordbs/{vectordb_id}/scale` | `scale_vectordb` | Y | N | unit-only |
 | 7 | `DELETE` | `/context/vectordbs/{vectordb_id}` | `delete_vectordb` | Y | Y | strict |
 | 8 | `POST` | `/context/vectordbs/{vectordb_id}/insert` | `insert_vectors` | Y | Y | strict |
 | 9 | `POST` | `/context/vectordbs/insert` | `insert_vectors_global` | Y | Y | strict |
@@ -37,16 +39,32 @@ Source of truth routes: `kamiwaza/services/context/api/*.py` (35 endpoints).
 | 31 | `DELETE` | `/context/pipelines/{job_id}` | `cancel_pipeline_job` | Y | Y | strict |
 | 32 | `POST` | `/context/search` | `search` | Y | Y | strict |
 | 33 | `POST` | `/context/retrieve` | `retrieve` | Y | Y | strict |
-| 34 | `POST` | `/context/agentic/search` | `agentic_search` | Y | Y | strict |
+| 34 | `POST` | `/context/search/unified` | `agentic_search` | Y | Y | strict |
 | 35 | `POST` | `/context/upload/` | `upload_file` | Y | Y | strict |
+
+`agentic_search` wraps the canonical unified endpoint (`synthesize=True`). The
+legacy `/context/search/agentic` route is deprecated server-side ("use POST
+/search with synthesize=true instead"), so the SDK intentionally targets
+`/context/search/unified` rather than the deprecated path the row originally
+listed.
 
 ## Coverage Summary
 
-- Total endpoints: **35**
-- Unit coverage by method call presence: **35/35**
-- Live coverage by method call presence: **35/35**
-- All endpoint contracts in this matrix now run under strict assertions.
+- Rows with an SDK method: **35/35**.
+- Unit coverage of wrapped methods: **35/35**.
+- Live coverage of wrapped methods: **33/35** — `update_vectordb` and `scale_vectordb` are unit-only (live coverage was dropped during the per-session-workroom refactor and not restored).
+
+## Not yet wrapped by the SDK
+
+These live `/context` routes have no SDK method and are not tracked above. Triage
+each for intentional exclusion vs. a real gap before treating coverage as complete:
+
+- Search: `/search/simple`; `/search/agentic` and `/search/retrieve` are deprecated server-side (the SDK wraps the canonical `/search` + `/search/unified` paths instead)
+- Pipelines: `/pipelines/import-options` (GET/POST), `/pipelines/imports`, `/pipelines/items`, `/pipelines/items/rerun`, `/pipelines/{job_id}/items`, `/pipelines/{job_id}/retry`, `/pipelines/{job_id}/rerun`, `POST /pipelines/{job_id}/cancel`
+- Other: `/global-settings`, `/omniparses` CRUD, `/storage/*`, `/documents/{source_urn}`, audio-readiness
+- Embedding-model routes (`/embedding-model`) are intentionally out of scope.
 
 ## Next Actions
 
-- Maintain strict assertions for all routes and keep regressions failing fast.
+- Restore live coverage for `update_vectordb` / `scale_vectordb`, or accept unit-only and document why.
+- Triage the "Not yet wrapped" routes so the tracked denominator reflects the real surface.

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -836,7 +836,12 @@ def test_context_agentic_search_contract(
     shared_context_service: ContextService,
     session_workroom: str,
     shared_workroom_vectordb: str,
+    context_required_llm: str,
 ) -> None:
+    # agentic_search always sends synthesize=True, so it needs a context LLM in
+    # addition to an embedding model -- gate on both prerequisites (like the
+    # ontology tests) so the test skips, rather than fails, on an LLM-less host.
+    assert context_required_llm
     service = shared_context_service
     workroom_id = session_workroom
     assert shared_workroom_vectordb
@@ -848,3 +853,8 @@ def test_context_agentic_search_contract(
     )
     assert isinstance(result.get("results"), list)
     assert isinstance(result.get("sources"), list)
+    # synthesize=True is always sent, so the unified response must carry the
+    # synthesis/citations fields (content depends on the LLM); assert presence
+    # so a server-side regression that silently drops synthesis is caught.
+    assert "synthesis" in result
+    assert "citations" in result

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -829,3 +829,22 @@ def test_context_retrieve_contract(
         vectordb_id=shared_workroom_vectordb,
     )
     assert isinstance(retrieve.get("sources"), list)
+
+
+@pytest.mark.requires_embedding_model
+def test_context_agentic_search_contract(
+    shared_context_service: ContextService,
+    session_workroom: str,
+    shared_workroom_vectordb: str,
+) -> None:
+    service = shared_context_service
+    workroom_id = session_workroom
+    assert shared_workroom_vectordb
+
+    result = service.agentic_search(
+        workroom_id=workroom_id,
+        query="hello context",
+        vectordb_id=shared_workroom_vectordb,
+    )
+    assert isinstance(result.get("results"), list)
+    assert isinstance(result.get("sources"), list)

--- a/tests/unit/test_context_service.py
+++ b/tests/unit/test_context_service.py
@@ -635,3 +635,63 @@ def test_retrieve_builds_payload(dummy_client):
     assert kwargs["json"]["collection_names"] == ["c1", "c2"]
     assert kwargs["json"]["top_k"] == 3
     assert kwargs["json"]["score_threshold"] == 0.4
+
+
+def test_agentic_search_targets_unified_endpoint_with_synthesis(dummy_client):
+    responses = {("post", "/context/search/unified"): {"results": []}}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.agentic_search(
+        workroom_id="ffffffff-ffff-ffff-ffff-ffffffffffff",
+        query="why is the sky blue",
+    )
+
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("post", "/context/search/unified")
+    assert kwargs["json"] == {
+        "query": "why is the sky blue",
+        "top_k": 10,
+        "synthesize": True,
+        "max_iterations": 1,
+        "relevance_threshold": 0.7,
+        "enable_graph_search": False,
+    }
+    assert kwargs["headers"]["X-Workroom-ID"] == "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+
+def test_agentic_search_includes_optional_graph_and_vector_fields(dummy_client):
+    responses = {("post", "/context/search/unified"): {"results": []}}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.agentic_search(
+        workroom_id="ffffffff-ffff-ffff-ffff-ffffffffffff",
+        query="summarize incidents",
+        collection_name="docs",
+        top_k=5,
+        score_threshold=0.55,
+        vectordb_id="vdb-1",
+        max_iterations=3,
+        relevance_threshold=0.8,
+        enable_graph_search=True,
+        ontology_id="ont-1",
+        group_ids=["g1", "g2"],
+    )
+
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("post", "/context/search/unified")
+    assert kwargs["json"] == {
+        "query": "summarize incidents",
+        "top_k": 5,
+        "synthesize": True,
+        "max_iterations": 3,
+        "relevance_threshold": 0.8,
+        "enable_graph_search": True,
+        "collection_name": "docs",
+        "score_threshold": 0.55,
+        "vectordb_id": "vdb-1",
+        "ontology_id": "ont-1",
+        "group_ids": ["g1", "g2"],
+    }
+    assert kwargs["headers"]["X-Workroom-ID"] == "ffffffff-ffff-ffff-ffff-ffffffffffff"


### PR DESCRIPTION
Live-stack verify skipped: `agentic_search` is a thin SDK wrapper whose wire
contract (POST `/context/search/unified` with `synthesize=True` + the
`X-Workroom-ID` header) is fully asserted by the new unit tests, and the target
endpoint pre-exists and is tested server-side in the `kamiwaza` repo. A
workroom-scoped live contract test (`test_context_agentic_search_contract`) is
added and runs in the SDK's live CI lane (requires an embedding model). Local
provisioning of Milvus + an embedding model for a wrapper method was judged
disproportionate; RML review + CI are the next defenses.


## Summary

Adds `ContextService.agentic_search(...)` to the Kamiwaza SDK — a first-class
agentic-search method (LLM synthesis over a workroom's collections).

The matrix and ticket originally targeted `POST /context/search/agentic`, but
that route is **deprecated server-side** ("use POST /search with
`synthesize=true` instead"). The implementation therefore targets the
canonical unified endpoint `POST /context/search/unified` with
`synthesize=True`, returning the unified response shape
(`results`/`sources`/`synthesis`/`citations`). `max_iterations` > 1 enables
iterative refinement; `enable_graph_search` + `ontology_id`/`group_ids` fold
in knowledge-graph results.

Also corrects `tests/integration/context_endpoint_coverage_matrix.md`, which
had overstated coverage:
- row 34 (`agentic_search`) was marked covered while unimplemented, with the
  wrong path — now points at the canonical endpoint and reflects real status;
- `update_vectordb` / `scale_vectordb` were marked live-covered though they are
  unit-only since the per-session-workroom refactor;
- adds a "Not yet wrapped by the SDK" section so the tracked denominator
  reflects the real server surface (and notes which routes are deprecated).

## Test plan

- `uv run pytest tests/unit/test_context_service.py` — adds two unit tests
  asserting the `/context/search/unified` path, the `synthesize=True` payload,
  optional graph/vector fields, and the `X-Workroom-ID` header.
- `make test` — full unit + contract suite (2343 passed locally).
- Adds `test_context_agentic_search_contract` (live lane,
  `requires_embedding_model`) for the SDK's live CI against a provisioned
  cluster.

Refs ENG-6898
