### PR TITLE
feat(context): wrap OmniParse instance lifecycle CRUD in ContextService (ENG-6909)

### DIFF
--- a/docs/services/context/README.md
+++ b/docs/services/context/README.md
@@ -204,6 +204,48 @@ client.context.update_raw_file(
 )
 ```
 
+## OmniParse Instances
+
+The SDK wraps the workroom-scoped OmniParse instance lifecycle CRUD surface
+(`/context/omniparses`). OmniParse instances are the document-parsing runtimes
+that ingest pipelines depend on; wrapping them lets callers provision and manage
+OmniParse from automation rather than relying only on implicit lazy
+provisioning. These methods are keyword-only, take an explicit `workroom_id`
+(sent as the `X-Workroom-ID` header), and return raw `dict` / `list[dict]`
+records rather than typed models.
+
+### Available Methods
+
+- `list_omniparses(*, workroom_id)` — list OmniParse instances for a workroom
+  (`GET /context/omniparses`), returning a list of instance records.
+- `get_omniparse(omniparse_id, *, workroom_id)` — fetch one instance by id
+  (`GET /context/omniparses/{omniparse_id}`).
+- `create_omniparse(*, name, workroom_id, template_name="tool-omniparse", config=None)`
+  — provision an OmniParse runtime instance (`POST /context/omniparses`).
+  `template_name` selects the App Garden tool template; `config` carries optional
+  OmniParse environment configuration and is forwarded only when set.
+- `update_omniparse(omniparse_id, *, workroom_id, config=None)` — update an
+  instance's environment configuration (`PUT /context/omniparses/{omniparse_id}`).
+- `delete_omniparse(omniparse_id, *, workroom_id)` — delete an instance
+  (`DELETE /context/omniparses/{omniparse_id}`).
+
+```python
+# my_workroom_id is a workroom you own.
+instance = client.context.create_omniparse(
+    name="docs-parser",
+    workroom_id=my_workroom_id,
+    config={"replicas": 1},
+)
+instance_id = instance["id"]
+
+client.context.update_omniparse(
+    instance_id,
+    workroom_id=my_workroom_id,
+    config={"replicas": 2},
+)
+client.context.delete_omniparse(instance_id, workroom_id=my_workroom_id)
+```
+
 ## Error Handling
 
 ```python

--- a/kamiwaza_sdk/services/context.py
+++ b/kamiwaza_sdk/services/context.py
@@ -943,3 +943,83 @@ class ContextService(BaseService):
             json={"content": content},
             headers=headers,
         )
+
+    # OmniParse instance lifecycle CRUD
+
+    def list_omniparses(
+        self,
+        *,
+        workroom_id: str,
+    ) -> list[dict[str, Any]]:
+        """List OmniParse runtime instances for a workroom."""
+        return self.client.get(
+            f"{self._BASE_PATH}/omniparses",
+            headers=self._merge_headers(workroom_id=workroom_id),
+        )
+
+    def get_omniparse(
+        self,
+        omniparse_id: str,
+        *,
+        workroom_id: str,
+    ) -> dict[str, Any]:
+        """Get one OmniParse instance by ID within a workroom scope."""
+        return self.client.get(
+            f"{self._BASE_PATH}/omniparses/{omniparse_id}",
+            headers=self._merge_headers(workroom_id=workroom_id),
+        )
+
+    def create_omniparse(
+        self,
+        *,
+        name: str,
+        workroom_id: str,
+        template_name: str = "tool-omniparse",
+        config: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        """Provision an OmniParse runtime instance.
+
+        ``name`` is the instance name; ``template_name`` selects the App Garden
+        tool template (defaults to ``tool-omniparse``); ``config`` carries
+        optional OmniParse environment configuration.
+        """
+        payload: dict[str, Any] = {
+            "name": name,
+            "template_name": template_name,
+        }
+        if config is not None:
+            payload["config"] = config
+        return self.client.post(
+            f"{self._BASE_PATH}/omniparses",
+            json=payload,
+            headers=self._merge_headers(workroom_id=workroom_id),
+        )
+
+    def update_omniparse(
+        self,
+        omniparse_id: str,
+        *,
+        workroom_id: str,
+        config: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        """Update an OmniParse instance's environment configuration."""
+        payload: dict[str, Any] = {}
+        if config is not None:
+            payload["config"] = config
+        return self.client.put(
+            f"{self._BASE_PATH}/omniparses/{omniparse_id}",
+            json=payload,
+            headers=self._merge_headers(workroom_id=workroom_id),
+        )
+
+    def delete_omniparse(
+        self,
+        omniparse_id: str,
+        *,
+        workroom_id: str,
+    ) -> dict[str, Any]:
+        """Delete an OmniParse runtime instance."""
+        return self.client.delete(
+            f"{self._BASE_PATH}/omniparses/{omniparse_id}",
+            headers=self._merge_headers(workroom_id=workroom_id),
+        )

--- a/tests/integration/context_endpoint_coverage_matrix.md
+++ b/tests/integration/context_endpoint_coverage_matrix.md
@@ -54,6 +54,11 @@ surface (see "Not yet wrapped by the SDK" below).
 | 46 | `GET` | `/context/storage/raw` | `list_raw_files` | Y | conditional | strict |
 | 47 | `GET` | `/context/storage/raw/{file_id}` | `get_raw_file` | Y | conditional | round-trip |
 | 48 | `PUT` | `/context/storage/raw/{file_id}` | `update_raw_file` | Y | conditional | round-trip |
+| 49 | `GET` | `/context/omniparses` | `list_omniparses` | Y | Y | strict |
+| 50 | `GET` | `/context/omniparses/{omniparse_id}` | `get_omniparse` | Y | deferred | round-trip |
+| 51 | `POST` | `/context/omniparses` | `create_omniparse` | Y | deferred | round-trip |
+| 52 | `PUT` | `/context/omniparses/{omniparse_id}` | `update_omniparse` | Y | deferred | round-trip |
+| 53 | `DELETE` | `/context/omniparses/{omniparse_id}` | `delete_omniparse` | Y | deferred | round-trip |
 
 `agentic_search` wraps the canonical unified endpoint (`synthesize=True`). The
 legacy `/context/search/agentic` route is deprecated server-side ("use POST
@@ -85,6 +90,15 @@ data plane provisioned does not stand it up, so those rows fall back to the mock
 unit tests with the live-debt recorded in the PR body. The PUT edit asserts the
 stale-`If-Match` 409 optimistic-concurrency contract.
 
+OmniParse instance-lifecycle rows (49–53): the list route (row 49) is
+metadata-only and live-smokeable against bare core (a fresh workroom lists no
+instances). The create/get/update/delete CRUD (rows 50–53) provision an
+OmniParse runtime via App Garden (tool template + container images), which is
+**data-plane-heavy and not available on the bare-core TRCM box**, so their live
+coverage is **deferred**: the `create → get → update → delete` round-trip test
+attempts a create and `skip`s when the data plane is unprovisioned. These rows
+fall back to mocked unit tests and the live-debt is recorded in the PR body.
+
 `update_vectordb` and `scale_vectordb` (rows 5 & 6) carry **round-trip**
 assertion strength rather than **strict**: the live tests confirm the SDK call
 is accepted and the requested change is observable (the `update` config marker
@@ -95,19 +109,19 @@ API round-trip is the meaningful, non-flaky contract these tests guard.
 
 ## Coverage Summary
 
-These figures describe coverage **of the 48 wrapped routes above**, not of the
+These figures describe coverage **of the 53 wrapped routes above**, not of the
 full Context server surface (see "Not yet wrapped by the SDK" for the unwrapped
 remainder):
 
-- Wrapped rows with an SDK method: **48/48**.
-- Unit coverage of wrapped methods: **48/48**.
-- Live coverage of wrapped methods: **35/48** — the 9 Gap A pipeline rows are unit-covered (rows 36, 37, 39, and 44 also live against bare core; rows 38 and 40–43 are **deferred**), and the 4 raw-file rows (45–48) carry **conditional** live coverage that runs only when the host reports `workroom_object_storage` and otherwise skips (see the notes above). All 48 are unit-covered.
+- Wrapped rows with an SDK method: **53/53**.
+- Unit coverage of wrapped methods: **53/53**.
+- Live coverage of wrapped methods: **36/53** — the 9 Gap A pipeline rows are unit-covered (rows 36, 37, 39, and 44 also live against bare core; rows 38 and 40–43 are **deferred**), the 4 raw-file rows (45–48) carry **conditional** live coverage that runs only when the host reports `workroom_object_storage` and otherwise skips, and the 5 OmniParse rows (49–53) cover the list route live against bare core (row 49) with the create/get/update/delete CRUD (rows 50–53) **deferred** to mocked unit tests pending the App Garden data plane (see the notes above). All 53 are unit-covered.
 
 ## Not yet wrapped by the SDK
 
-The 48 rows above are **not** the full Context surface — they are the subset the
-SDK wraps today. The live `/context` router exposes **12** additional enumerated
-user-facing routes — **3** intentional exclusions plus **9** real-gap routes
+The 53 rows above are **not** the full Context surface — they are the subset the
+SDK wraps today. The live `/context` router exposes **7** additional enumerated
+user-facing routes — **3** intentional exclusions plus **4** real-gap routes
 (verified against `kamiwaza/services/context/api/*.py`); the out-of-scope
 `/embedding-model/*` family lives entirely outside this count. Each is triaged
 below as either an **intentional exclusion** (with a one-line rationale) or a
@@ -142,15 +156,12 @@ grouped into coherent follow-up areas for later waves:
 | `GET` | `/context/storage/raw/{file_id}` | Get one raw-file record (optional presigned download URL). |
 | `PUT` | `/context/storage/raw/{file_id}` | Edit plain-text raw-file content (If-Match concurrency). |
 
-**Gap B — OmniParse instance lifecycle CRUD** (`/context/omniparses*`, 5 routes):
-
-| Method | Endpoint | Note |
-|---|---|---|
-| `GET` | `/context/omniparses` | List OmniParse instances for the workroom. |
-| `GET` | `/context/omniparses/{omniparse_id}` | Get one instance. |
-| `POST` | `/context/omniparses` | Create a workroom-scoped instance. |
-| `PUT` | `/context/omniparses/{omniparse_id}` | Update an instance. |
-| `DELETE` | `/context/omniparses/{omniparse_id}` | Delete an instance. |
+> **Gap B (OmniParse instance lifecycle CRUD) is now wrapped** (rows 49–53
+> above): `list_omniparses` / `get_omniparse` / `create_omniparse` /
+> `update_omniparse` / `delete_omniparse`. The list route is live-smokeable
+> against bare core; the create/get/update/delete CRUD live coverage is
+> **deferred** pending the App Garden OmniParse data plane (mocked-unit covered).
+> The remaining gap below keeps its letter for continuity.
 
 **Gap C — Misc workroom config / document retrieval** (`/context/*`, 4 routes):
 
@@ -163,14 +174,14 @@ grouped into coherent follow-up areas for later waves:
 
 ## Coverage scope note
 
-This matrix tracks **44 wrapped routes** against a live Context surface of
-**60 enumerated user-facing routes**: 44 wrapped + 3 intentional exclusions
-(the deprecated `/search/*` legacy paths) + 13 real-gap routes across Gaps A–C
-(4 + 5 + 4). The out-of-scope `/embedding-model/*` family is a wildcard
-counted **outside** this 60 — it is not enumerated here. The "44/44" unit figure
-in the Coverage Summary describes coverage **of the wrapped subset only**, not of
-the full server surface — every unwrapped route is accounted for above.
+This matrix tracks **53 wrapped routes** against a live Context surface of
+**60 enumerated user-facing routes**: 53 wrapped + 3 intentional exclusions
+(the deprecated `/search/*` legacy paths) + 4 real-gap routes in Gap C. The
+out-of-scope `/embedding-model/*` family is a wildcard counted **outside** this
+60 — it is not enumerated here. The "53/53" unit figure in the Coverage Summary
+describes coverage **of the wrapped subset only**, not of the full server
+surface — every unwrapped route is accounted for above.
 
 ## Next Actions
 
-- File the Gap A–C follow-up tickets (one per area) to wrap the remaining real gaps in later waves.
+- Wrap the remaining Gap C real gaps (misc workroom config / document retrieval) in a later wave.

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -1085,3 +1085,67 @@ def test_context_list_raw_files_empty_contract(
     listing = service.list_raw_files(workroom_id=session_workroom, limit=5)
     assert isinstance(listing.get("items"), list)
     assert isinstance(listing.get("count"), int)
+
+
+# --- OmniParse instance lifecycle CRUD ---
+
+
+def test_context_list_omniparses_contract(
+    shared_context_service: ContextService,
+    session_workroom: str,
+) -> None:
+    """Listing OmniParse instances returns a list for a fresh workroom.
+
+    The list route is metadata-only (it reads the instance registry) and works
+    against bare core -- a freshly created workroom has no instances, so an
+    empty list is the expected contract. The create/update/delete routes
+    provision an OmniParse runtime via App Garden (template + container images),
+    which is data-plane-heavy and NOT available on the bare-core TRCM box, so
+    the full lifecycle is covered by the mocked unit tests and deferred here.
+    """
+    service = shared_context_service
+    listing = service.list_omniparses(workroom_id=session_workroom)
+    assert isinstance(listing, list)
+
+
+def test_context_omniparse_lifecycle_round_trip(
+    shared_context_service: ContextService,
+    session_workroom: str,
+) -> None:
+    """create -> get -> update -> delete an OmniParse instance.
+
+    Skips when the App Garden OmniParse data plane (tool template + images) is
+    not provisioned on this host -- the route is mocked-unit covered in that
+    case and the live debt is recorded in the PR body. Bare core cannot
+    provision the runtime, so this skip is expected on the TRCM box.
+    """
+    service = shared_context_service
+    workroom_id = session_workroom
+
+    try:
+        created = service.create_omniparse(
+            name=f"sdk-omniparse-{uuid4().hex[:8]}",
+            workroom_id=workroom_id,
+        )
+    except APIError as exc:
+        pytest.skip(
+            f"OmniParse data plane not provisioned on this host (status "
+            f"{exc.status_code}); lifecycle deferred to mocked unit tests"
+        )
+
+    instance_id = str(created["id"])
+    try:
+        fetched = service.get_omniparse(instance_id, workroom_id=workroom_id)
+        assert str(fetched["id"]) == instance_id
+
+        updated = service.update_omniparse(
+            instance_id,
+            workroom_id=workroom_id,
+            config={"sdk_live_marker": uuid4().hex[:8]},
+        )
+        assert str(updated["id"]) == instance_id
+    finally:
+        try:
+            service.delete_omniparse(instance_id, workroom_id=workroom_id)
+        except (APIError, NotFoundError):
+            pass

--- a/tests/unit/test_context_service.py
+++ b/tests/unit/test_context_service.py
@@ -1110,3 +1110,117 @@ def test_update_raw_file_sets_if_match_header(dummy_client):
     _, _, kwargs = client.calls[0]
     assert kwargs["headers"]["If-Match"] == "2026-06-12T00:00:00+00:00"
     assert kwargs["headers"]["X-Workroom-ID"] == WORKROOM
+
+
+# --- OmniParse instance lifecycle CRUD ---
+
+
+def test_list_omniparses_sets_workroom_header(dummy_client):
+    responses = {("get", "/context/omniparses"): []}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.list_omniparses(workroom_id=WORKROOM)
+
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("get", "/context/omniparses")
+    assert kwargs["headers"]["X-Workroom-ID"] == WORKROOM
+
+
+def test_get_omniparse_calls_expected_path(dummy_client):
+    responses = {("get", "/context/omniparses/op-1"): {"id": "op-1"}}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.get_omniparse("op-1", workroom_id=WORKROOM)
+
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("get", "/context/omniparses/op-1")
+    assert kwargs["headers"]["X-Workroom-ID"] == WORKROOM
+
+
+def test_create_omniparse_builds_payload_with_defaults(dummy_client):
+    responses = {("post", "/context/omniparses"): {"id": "op-1"}}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.create_omniparse(name="parser-a", workroom_id=WORKROOM)
+
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("post", "/context/omniparses")
+    assert kwargs["json"] == {
+        "name": "parser-a",
+        "template_name": "tool-omniparse",
+    }
+    assert kwargs["headers"]["X-Workroom-ID"] == WORKROOM
+
+
+def test_create_omniparse_includes_optional_fields(dummy_client):
+    responses = {("post", "/context/omniparses"): {"id": "op-1"}}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.create_omniparse(
+        name="parser-b",
+        workroom_id=WORKROOM,
+        template_name="tool-omniparse-gpu",
+        config={"replicas": 2},
+    )
+
+    _, _, kwargs = client.calls[0]
+    assert kwargs["json"] == {
+        "name": "parser-b",
+        "template_name": "tool-omniparse-gpu",
+        "config": {"replicas": 2},
+    }
+
+
+def test_create_omniparse_omits_config_when_absent(dummy_client):
+    responses = {("post", "/context/omniparses"): {"id": "op-1"}}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.create_omniparse(name="parser-c", workroom_id=WORKROOM)
+
+    _, _, kwargs = client.calls[0]
+    assert "config" not in kwargs["json"]
+
+
+def test_update_omniparse_sends_config(dummy_client):
+    responses = {("put", "/context/omniparses/op-1"): {"id": "op-1"}}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.update_omniparse(
+        "op-1",
+        workroom_id=WORKROOM,
+        config={"timeout": 30},
+    )
+
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("put", "/context/omniparses/op-1")
+    assert kwargs["json"] == {"config": {"timeout": 30}}
+    assert kwargs["headers"]["X-Workroom-ID"] == WORKROOM
+
+
+def test_update_omniparse_sends_empty_body_when_config_absent(dummy_client):
+    responses = {("put", "/context/omniparses/op-1"): {"id": "op-1"}}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.update_omniparse("op-1", workroom_id=WORKROOM)
+
+    _, _, kwargs = client.calls[0]
+    assert kwargs["json"] == {}
+
+
+def test_delete_omniparse_calls_expected_path(dummy_client):
+    responses = {("delete", "/context/omniparses/op-1"): {"message": "deleted"}}
+    client = dummy_client(responses)
+    service = ContextService(client)
+
+    service.delete_omniparse("op-1", workroom_id=WORKROOM)
+
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("delete", "/context/omniparses/op-1")
+    assert kwargs["headers"]["X-Workroom-ID"] == WORKROOM


### PR DESCRIPTION
## Summary

Wraps the workroom-scoped **OmniParse instance lifecycle CRUD** surface (`/context/omniparses`) in `ContextService`, closing **Gap B** from the W6 triage (ENG-6903) of the Context endpoint coverage matrix. OmniParse instances are the document-parsing runtimes that ingest pipelines depend on; SDK coverage lets callers provision and manage them from automation rather than relying only on implicit lazy provisioning.

Implements ENG-6909 (maestro wave 7, serialized on top of ENG-6907/6908).

## Routes wrapped

| SDK method | HTTP route |
|---|---|
| `list_omniparses(*, workroom_id)` | `GET /context/omniparses` |
| `get_omniparse(omniparse_id, *, workroom_id)` | `GET /context/omniparses/{omniparse_id}` |
| `create_omniparse(*, name, workroom_id, template_name="tool-omniparse", config=None)` | `POST /context/omniparses` |
| `update_omniparse(omniparse_id, *, workroom_id, config=None)` | `PUT /context/omniparses/{omniparse_id}` |
| `delete_omniparse(omniparse_id, *, workroom_id)` | `DELETE /context/omniparses/{omniparse_id}` |

Methods follow the existing `context.py` conventions exactly: keyword-only args, explicit `workroom_id` sent as the `X-Workroom-ID` header via `_merge_headers`, `_BASE_PATH`-rooted paths, `self.client.{get,post,put,delete}`, and raw `dict` / `list[dict]` returns (no new Pydantic models). Request/response shapes cross-referenced against `kamiwaza/services/context/api/router.py` + `schemas/omniparse.py`.

## Test coverage

- **Unit (merge gate):** 8 new mocked-client tests in `tests/unit/test_context_service.py` covering all 5 routes, including create-with-defaults, optional-`config` include/omit, update empty-body, and path/header assertions. Full unit suite: **1657 passed**.
- **Live (`@pytest.mark.live`):** `tests/integration/test_context_live.py` adds a list-contract test (live-smokeable against bare core) and a `create → get → update → delete` round-trip that skips gracefully when the data plane is unprovisioned.
- **Coverage matrix:** rows 49–53 flipped to Wrapped=Y in `tests/integration/context_endpoint_coverage_matrix.md`; Gap B marked wrapped; counts reconciled.
- **Docs:** new "OmniParse Instances" section in `docs/services/context/README.md`.

## Deferred live verification (live-debt)

The create/get/update/delete CRUD (rows 50–53) provision an OmniParse runtime via **App Garden** (tool template + container images) — **data-plane-heavy and not available on the bare-core TRCM box**. Per the pre-flight contract, the data plane was **not** stood up. The lifecycle round-trip live test attempts a create and `pytest.skip`s on `APIError` when provisioning is unavailable, so these routes fall back to the mocked unit tests. The list route (row 49) is metadata-only and runs live against bare core.

## Local pre-validation (CI parity)

- `uv run pytest -m unit` — 1657 passed, 1 skipped.
- ruff on changed files — clean (CI lint scopes to changed `.py` files).
- mypy `--follow-imports=silent kamiwaza_sdk/services/context.py` — clean (CI mypy parity).
- radon — all new methods grade A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)