### PR TITLE
M5: connector-spec SDK verification + capability markers

### DIFF
--- a/kamiwaza_sdk/schemas/connector_spec.py
+++ b/kamiwaza_sdk/schemas/connector_spec.py
@@ -1,0 +1,71 @@
+"""Typed connector-spec models for ``catalog.register_from_spec`` (ENG-6964).
+
+These mirror the engine's published connector contract (CSE-SPEC-1) so SDK
+callers get IDE help + light validation. The engine is the authoritative
+validator (``extra='forbid'`` drift guard); these models use ``extra='allow'``
+for forward compatibility per SDK convention and let the engine reject any
+genuinely-unknown field.
+
+A connector spec NEVER carries secret values — credentials are referenced by a
+catalog secret URN via ``auth.credential_ref`` (INF-CB5).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EndpointSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    method: Literal["GET", "POST"]
+    path: str
+    body_template: dict[str, Any] = Field(default_factory=dict)
+    items_path: str
+
+
+class PaginationSpec(BaseModel):
+    """Bounded pagination; no full-corpus scroll."""
+
+    model_config = ConfigDict(extra="allow")
+
+    max_pages: int = Field(ge=1)
+    page_size: int = Field(default=100, ge=1)
+    max_records: int | None = Field(default=None, ge=1)
+
+
+class AuthSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    kind: Literal["none", "api_key", "basic", "bearer", "sigv4"]
+    # A secret URN (e.g. ``urn:li:secret:...``), never a secret value (INF-CB5).
+    credential_ref: str | None = None
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class GateSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    type: str = Field(min_length=1)  # a gate classpath string, not code
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class ConnectorSpec(BaseModel):
+    """The published connector contract (mirrors the engine's CSE-SPEC-1)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    spec_version: Literal["connector-spec.v1"] = "connector-spec.v1"
+    platform: str  # lineage metadata, not a dispatch key (DP-1)
+    base_url: str = Field(pattern=r"^https?://.+")
+    endpoint: EndpointSpec
+    index: str
+    pagination: PaginationSpec
+    auth: AuthSpec
+    data_attribute_fields: list[str]  # projected onto every record (INF-CB4)
+    gate: GateSpec
+    field_mappings: dict[str, str] | None = None  # renaming only
+    time_field: str | None = None
+    filterable_fields: list[str] = Field(default_factory=list)

--- a/kamiwaza_sdk/services/catalog.py
+++ b/kamiwaza_sdk/services/catalog.py
@@ -18,6 +18,7 @@ from ..schemas.catalog import (
     Secret,
     SecretCreate,
 )
+from ..schemas.connector_spec import ConnectorSpec
 from ..utils import reveal_secrets
 
 
@@ -42,6 +43,51 @@ class DatasetClient(BaseService):
         if callable(note):
             note(urn)
         return urn
+
+    def register_from_spec(self, spec: "ConnectorSpec | dict[str, Any]") -> str:
+        """Register a standing governed dataset from a connector spec (CSE).
+
+        ``spec`` may be a :class:`ConnectorSpec` or a plain dict. Returns the
+        new dataset URN. The engine validates the spec (``extra='forbid'``) and
+        pulls nothing at registration time; credentials are referenced by a
+        catalog secret URN, never inlined.
+        """
+        if isinstance(spec, ConnectorSpec):
+            body = spec.model_dump(exclude_none=True, mode="json")
+        else:
+            body = dict(spec)
+        response = self.client.post(
+            f"{self._BASE_PATH}/register-from-spec", json=body
+        )
+        urn = self._unwrap_dataset_urn(response)
+        note = getattr(self.client, "_note_recent_dataset_change", None)
+        if callable(note):
+            note(urn)
+        return urn
+
+    def add_publisher(self, subject_user_id: str) -> None:
+        """Grant a subject the cluster-level ``publisher`` relation (admin)."""
+        self.client.post(
+            f"{self._BASE_PATH}/publishers",
+            json={"subject_user_id": subject_user_id},
+        )
+
+    def remove_publisher(self, subject_user_id: str) -> None:
+        """Revoke a subject's cluster-level ``publisher`` relation (admin)."""
+        self.client.delete(
+            f"{self._BASE_PATH}/publishers",
+            json={"subject_user_id": subject_user_id},
+        )
+
+    @staticmethod
+    def _unwrap_dataset_urn(response: Any) -> str:
+        """Return the dataset URN from a register-from-spec response."""
+        if isinstance(response, dict):
+            for key in ("dataset_urn", "urn"):
+                value = response.get(key)
+                if value:
+                    return str(value)
+        return str(response)
 
     def list(self, query: Optional[str] = None) -> List[Dataset]:
         params = {"query": query} if query else None
@@ -279,6 +325,18 @@ class CatalogService(BaseService):
         dataset_urn = self.datasets.create(payload)
         dataset = self.datasets.get(dataset_urn)
         return self._normalize_dataset(dataset)
+
+    def register_from_spec(self, spec: "ConnectorSpec | dict[str, Any]") -> str:
+        """Register a governed dataset from a connector spec; return its URN (CSE)."""
+        return self.datasets.register_from_spec(spec)
+
+    def add_publisher(self, subject_user_id: str) -> None:
+        """Grant a subject the cluster-level ``publisher`` relation (admin)."""
+        self.datasets.add_publisher(subject_user_id)
+
+    def remove_publisher(self, subject_user_id: str) -> None:
+        """Revoke a subject's cluster-level ``publisher`` relation (admin)."""
+        self.datasets.remove_publisher(subject_user_id)
 
     def list_containers(self, query: Optional[str] = None) -> List[Container]:
         return self.containers.list(query=query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,11 @@ markers = [
     "requires_deployable_model: live tests that require the host to deploy the integration test model; skips on hosts without compatible inference capacity (e.g. x86 CPU smoke vs an MLX model)",
     "extension_regression: D210 12-issue regression checklist (UAC-17 / EDX-OPS-2). See tests/unit/extensions/regression/inventory.yaml.",
     "live_extension: live extension-contract tests against a real cluster (relocated from kamiwaza, env-gated by RUN_LIVE_EXTENSION_TESTS=1)",
+    "min_gpu_count: live tests needing >= N GPU devices, e.g. @pytest.mark.min_gpu_count(2); skips on hosts with fewer (M5)",
+    "min_gpu_mem: live tests needing at least one GPU with >= N GB memory, e.g. @pytest.mark.min_gpu_mem(40); skips otherwise (M5)",
+    "gpu_vendor: live tests needing a GPU vendor — gpu_vendor('nvidia'|'amd') — or a CPU-only host — gpu_vendor('none'); skips otherwise (M5)",
+    "gpu_mig_support: live tests needing a MIG-capable GPU; skips on hosts without MIG (M5)",
+    "min_node_count: live tests needing >= N running nodes, e.g. @pytest.mark.min_node_count(2); skips on smaller clusters (M5)",
 ]
 
 [tool.black]

--- a/tests/integration/capability_markers.py
+++ b/tests/integration/capability_markers.py
@@ -1,0 +1,267 @@
+"""Parametric capability-marker logic for the live integration suite (M5).
+
+Pure, cluster-free helpers that decide whether a capability-marked test can run
+on the current host. The integration ``conftest`` wires these into a
+``pytest.skip``-not-fail gate so under-provisioned hosts skip (never fail).
+
+Markers (all skip-not-fail):
+
+    @pytest.mark.min_gpu_count(N)         # >= N GPU devices across the cluster
+    @pytest.mark.min_gpu_mem(GB)          # at least one GPU with >= GB memory
+    @pytest.mark.gpu_vendor("nvidia")     # an nvidia GPU is present
+    @pytest.mark.gpu_vendor("amd")        # an amd GPU is present
+    @pytest.mark.gpu_vendor("none")       # CPU-only host (no GPU present)
+    @pytest.mark.gpu_mig_support          # a MIG-capable GPU is present
+    @pytest.mark.min_node_count(N)        # >= N running nodes
+
+Design principle: when a capability cannot be *determined* from the cluster
+inventory (e.g. the GPU dicts don't carry a memory field), the test is
+**skipped, not failed** — an undeterminable capability is treated as unmet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+CAPABILITY_MARKER_NAMES = (
+    "min_gpu_count",
+    "min_gpu_mem",
+    "gpu_vendor",
+    "gpu_mig_support",
+    "min_node_count",
+)
+
+
+@dataclass(frozen=True)
+class ClusterCapabilitySnapshot:
+    """A point-in-time view of the cluster's GPU/node inventory."""
+
+    gpu_count: int = 0
+    gpu_mem_gb: tuple[float, ...] = ()  # per-GPU memory in GB; empty => unknown
+    gpu_vendors: frozenset[str] = frozenset()
+    mig_supported: Optional[bool] = None  # None => undeterminable
+    node_count: int = 0
+
+
+# --------------------------------------------------------------------------- #
+# Defensive parsing of the untyped GPU dicts (Hardware.gpus: List[Dict])
+# --------------------------------------------------------------------------- #
+_VENDOR_KEYS = ("vendor", "gpu_vendor", "brand", "manufacturer")
+_NAME_KEYS = ("name", "model", "product", "product_name", "gpu_name")
+_MEM_GB_KEYS = ("memory_gb", "mem_gb", "vram_gb")
+_MEM_MB_KEYS = ("memory_mb", "mem_mb", "vram_mb", "memory_total_mb")
+_MEM_BYTES_KEYS = ("memory_bytes", "memory_total", "mem_bytes", "total_memory")
+_MIG_KEYS = ("mig", "mig_enabled", "mig_capable", "mig_support", "mig_supported")
+
+_NVIDIA_HINTS = ("nvidia", "cuda", "tesla", "geforce", "quadro", "rtx")
+_AMD_HINTS = ("amd", "radeon", "instinct", "rocm")
+
+
+def _canon_vendor(value: str) -> Optional[str]:
+    token = value.strip().lower()
+    if not token:
+        return None
+    if token in ("nvidia", "amd", "none"):
+        return token
+    if any(hint in token for hint in _NVIDIA_HINTS):
+        return "nvidia"
+    if any(hint in token for hint in _AMD_HINTS):
+        return "amd"
+    return None
+
+
+def _detect_vendor(gpu: dict) -> Optional[str]:
+    for key in _VENDOR_KEYS:
+        value = gpu.get(key)
+        if isinstance(value, str) and value.strip():
+            canon = _canon_vendor(value)
+            if canon:
+                return canon
+    for key in _NAME_KEYS:
+        value = gpu.get(key)
+        if isinstance(value, str):
+            canon = _canon_vendor(value)
+            if canon:
+                return canon
+    return None
+
+
+def _num(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _detect_mem_gb(gpu: dict) -> Optional[float]:
+    for key in _MEM_GB_KEYS:
+        value = _num(gpu.get(key))
+        if value is not None:
+            return value
+    for key in _MEM_MB_KEYS:
+        value = _num(gpu.get(key))
+        if value is not None:
+            return value / 1024.0
+    for key in _MEM_BYTES_KEYS:
+        value = _num(gpu.get(key))
+        if value is not None:
+            return value / (1024.0**3)
+    return None
+
+
+def _detect_mig(gpu: dict) -> Optional[bool]:
+    for key in _MIG_KEYS:
+        if key in gpu:
+            value = gpu[key]
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (int, float)):
+                return bool(value)
+            if isinstance(value, str):
+                return value.strip().lower() in ("1", "true", "yes", "on", "enabled")
+    return None
+
+
+def _hardware_gpus(hardware: Any) -> Optional[list]:
+    gpus = getattr(hardware, "gpus", None)
+    if gpus is None and isinstance(hardware, dict):
+        gpus = hardware.get("gpus")
+    return gpus
+
+
+def _hardware_node_key(hardware: Any) -> str:
+    node_id = getattr(hardware, "node_id", None) or getattr(
+        hardware, "local_node_id", None
+    )
+    if node_id is None and isinstance(hardware, dict):
+        node_id = hardware.get("node_id") or hardware.get("local_node_id")
+    return str(node_id) if node_id is not None else f"_anon_{id(hardware)}"
+
+
+def build_capability_snapshot(
+    hardware_entries: Iterable[Any],
+    node_count: Optional[int] = None,
+) -> ClusterCapabilitySnapshot:
+    """Aggregate a cluster snapshot from SDK ``Hardware`` entries.
+
+    ``hardware_entries`` may be SDK ``Hardware`` models or plain dicts.
+    ``node_count`` should come from ``cluster.get_running_nodes()`` when
+    available; otherwise it is inferred from distinct hardware node ids.
+    """
+    entries = list(hardware_entries or [])
+    gpu_dicts: list[dict] = []
+    for hardware in entries:
+        gpus = _hardware_gpus(hardware)
+        if gpus:
+            gpu_dicts.extend(gpu for gpu in gpus if isinstance(gpu, dict))
+
+    mem_gb: list[float] = []
+    vendors: set[str] = set()
+    mig_flags: list[bool] = []
+    for gpu in gpu_dicts:
+        mem = _detect_mem_gb(gpu)
+        if mem is not None:
+            mem_gb.append(mem)
+        vendor = _detect_vendor(gpu)
+        if vendor:
+            vendors.add(vendor)
+        mig = _detect_mig(gpu)
+        if mig is not None:
+            mig_flags.append(mig)
+
+    if node_count is None:
+        node_count = len({_hardware_node_key(hw) for hw in entries})
+
+    return ClusterCapabilitySnapshot(
+        gpu_count=len(gpu_dicts),
+        gpu_mem_gb=tuple(mem_gb),
+        gpu_vendors=frozenset(vendors),
+        mig_supported=(any(mig_flags) if mig_flags else None),
+        node_count=node_count or 0,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Marker collection + evaluation
+# --------------------------------------------------------------------------- #
+def collect_capability_requirements(marks: Iterable[Any]) -> dict:
+    """Build a requirements dict from pytest ``Mark`` objects (``.name``/``.args``)."""
+    requirements: dict = {}
+    for mark in marks:
+        name = getattr(mark, "name", None)
+        if name not in CAPABILITY_MARKER_NAMES:
+            continue
+        args = getattr(mark, "args", ()) or ()
+        if name in ("min_gpu_count", "min_node_count"):
+            requirements[name] = int(args[0]) if args else 1
+        elif name == "min_gpu_mem":
+            requirements[name] = float(args[0]) if args else 0.0
+        elif name == "gpu_vendor":
+            requirements[name] = str(args[0]).strip().lower() if args else "any"
+        elif name == "gpu_mig_support":
+            requirements[name] = True
+    return requirements
+
+
+def evaluate_capability_requirements(
+    snapshot: Optional[ClusterCapabilitySnapshot],
+    requirements: dict,
+) -> Optional[str]:
+    """Return a skip reason if any requirement is unmet/undeterminable, else None."""
+    if snapshot is None:
+        return (
+            "cluster capability snapshot unavailable; cannot verify "
+            + ", ".join(sorted(requirements))
+        )
+
+    for name, want in requirements.items():
+        if name == "min_gpu_count":
+            if snapshot.gpu_count < want:
+                return f"requires >= {want} GPU(s); cluster reports {snapshot.gpu_count}"
+        elif name == "min_node_count":
+            if snapshot.node_count < want:
+                return f"requires >= {want} node(s); cluster reports {snapshot.node_count}"
+        elif name == "min_gpu_mem":
+            if not snapshot.gpu_mem_gb:
+                return (
+                    f"requires a GPU with >= {want} GB; "
+                    "GPU memory not reported by cluster inventory"
+                )
+            if max(snapshot.gpu_mem_gb) < want:
+                return (
+                    f"requires a GPU with >= {want} GB; "
+                    f"largest GPU reports {max(snapshot.gpu_mem_gb):.1f} GB"
+                )
+        elif name == "gpu_vendor":
+            if want == "none":
+                if snapshot.gpu_count > 0:
+                    return (
+                        "requires a CPU-only host (gpu_vendor=none); "
+                        f"cluster reports {snapshot.gpu_count} GPU(s)"
+                    )
+            elif want == "any":
+                if snapshot.gpu_count == 0:
+                    return "requires a GPU; cluster reports none"
+            else:  # specific vendor: nvidia / amd / other
+                if not snapshot.gpu_vendors:
+                    return (
+                        f"requires a {want} GPU; "
+                        "GPU vendor not reported by cluster inventory"
+                    )
+                if want not in snapshot.gpu_vendors:
+                    return (
+                        f"requires a {want} GPU; "
+                        f"cluster reports {sorted(snapshot.gpu_vendors)}"
+                    )
+        elif name == "gpu_mig_support":
+            if snapshot.mig_supported is not True:
+                state = "not reported" if snapshot.mig_supported is None else "unsupported"
+                return f"requires a MIG-capable GPU; cluster MIG support {state}"
+    return None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,6 +29,12 @@ from kamiwaza_sdk.exceptions import APIError, AuthenticationError, KamiwazaError
 from kamiwaza_sdk.schemas.auth import PATCreate
 from kamiwaza_sdk.token_store import StoredToken, TokenStore
 
+# Co-located capability-marker helpers (M5). Add this directory to the path so
+# the import resolves regardless of pytest's package-import mode (this conftest
+# is loaded by name, not as part of the ``integration`` package).
+sys.path.insert(0, str(Path(__file__).parent))
+import capability_markers as _cap  # noqa: E402
+
 DOCKER_COMPOSE_FILE = Path(__file__).parent / "docker" / "docker-compose.yml"
 SEED_SCRIPT = Path(__file__).parent / "docker" / "seed_minio.py"
 
@@ -1398,6 +1404,57 @@ def _require_two_clusters_for_marked_tests(request: pytest.FixtureRequest) -> No
             "requires_two_clusters: --live-peer-base-url is set but "
             "--live-peer-api-key / KAMIWAZA_PEER_API_KEY is missing."
         )
+
+
+@pytest.fixture(scope="session")
+def cluster_capability_snapshot(
+    live_kamiwaza_session_client: KamiwazaClient,
+) -> _cap.ClusterCapabilitySnapshot | None:
+    """Session-cached GPU/node inventory backing the capability markers (M5).
+
+    Built once from the live cluster via the SDK client. Returns ``None`` when
+    inventory can't be fetched so capability-marked tests skip (not fail) with a
+    clear reason rather than erroring.
+    """
+    client = live_kamiwaza_session_client
+    try:
+        hardware = client.cluster.list_hardware()
+    except Exception:  # noqa: BLE001 - inventory unavailable => undeterminable
+        hardware = None
+    node_count: int | None = None
+    try:
+        nodes = client.cluster.get_running_nodes()
+        node_count = sum(
+            1 for node in nodes if getattr(node, "alive", True) is not False
+        )
+    except Exception:  # noqa: BLE001
+        node_count = None
+    if hardware is None and node_count is None:
+        return None
+    return _cap.build_capability_snapshot(hardware or [], node_count=node_count)
+
+
+@pytest.fixture(autouse=True)
+def _enforce_capability_markers(request: pytest.FixtureRequest) -> None:
+    """Skip (never fail) capability-marked tests on under-provisioned hosts (M5).
+
+    Honors ``@pytest.mark.min_gpu_count(N)`` / ``min_gpu_mem(GB)`` /
+    ``gpu_vendor("nvidia"|"amd"|"none")`` / ``gpu_mig_support`` /
+    ``min_node_count(N)``. Tests without a capability marker are unaffected
+    (the snapshot fixture — and the live client it needs — are never touched).
+    """
+    marks = [
+        mark
+        for mark in request.node.iter_markers()
+        if mark.name in _cap.CAPABILITY_MARKER_NAMES
+    ]
+    if not marks:
+        return
+    requirements = _cap.collect_capability_requirements(marks)
+    snapshot = request.getfixturevalue("cluster_capability_snapshot")
+    reason = _cap.evaluate_capability_requirements(snapshot, requirements)
+    if reason:
+        pytest.skip(reason)
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_connector_spec_live.py
+++ b/tests/integration/test_connector_spec_live.py
@@ -1,0 +1,166 @@
+"""Connector-spec engine smoke — control plane (ENG-6952).
+
+skip-not-fail: the whole module skips where the ``register-from-spec`` route is
+absent (e.g. a develop baseline without the connector-spec engine), so the suite
+stays green there and *exercises* on a feature-branch build that ships the
+engine. kajiya runs ``pytest tests/integration`` with no ``-m`` filter, so these
+collect everywhere and self-skip.
+
+Scope: the deterministic control plane — register-from-spec happy path, spec
+validation (inline-secret / missing-platform / extra-field rejections), and
+publisher grant/revoke. The *data-plane* gated round-trip (register a Kamiwaza
+self-connector and materialize gated records) needs the engine's
+``allow_private_hosts`` toggle plus a reachable source, so it is built and
+validated live in the M6 demo (ENG-6965), not here.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import SecretStr
+
+from kamiwaza_sdk.exceptions import APIError
+from kamiwaza_sdk.schemas.catalog import SecretCreate
+
+pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
+
+_GATE_CLASSPATH = "kamiwaza.services.authz.gates.attribute_gate.AttributeGate"
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}-{uuid4().hex[:8]}"
+
+
+def _resolve_owner(client) -> str:
+    try:
+        profile = client.get("/auth/users/me")
+    except Exception:  # pragma: no cover - live guard
+        profile = {}
+    username = (profile.get("username") or "sdk-integration").replace("@", "-")
+    return profile.get("urn") or f"urn:li:corpuser:{username}"
+
+
+def _engine_present(client) -> bool:
+    """True when the POST register-from-spec route exists.
+
+    A baseline without the engine answers the POST with 404 (no path) or 405:
+    the path is shadowed by ``GET /catalog/datasets/{urn}``, so POST is
+    Method-Not-Allowed. A present engine validates the empty spec and returns
+    400/422. Treat 404 and 405 as 'engine absent' so the module skips (not
+    fails) on a develop baseline, and only exercises on a feature-branch build.
+    """
+    try:
+        client.catalog.register_from_spec({})
+    except APIError as exc:
+        return getattr(exc, "status_code", None) not in (404, 405)
+    return True  # an empty spec was accepted? the route certainly exists
+
+
+@pytest.fixture(scope="module")
+def cs_engine(live_kamiwaza_session_client):
+    if not _engine_present(live_kamiwaza_session_client):
+        pytest.skip(
+            "connector-spec engine not present on this deployment "
+            "(register-from-spec -> 404/405); feature-branch build not installed"
+        )
+    return live_kamiwaza_session_client
+
+
+@pytest.fixture
+def brokered_secret(cs_engine):
+    """Mint a catalog secret and yield its URN as a valid credential_ref."""
+    client = cs_engine
+    owner = _resolve_owner(client)
+    payload = SecretCreate(
+        name=_unique("cs-smoke-secret"),
+        value=SecretStr("integration-bearer-token"),
+        owner=owner,
+    )
+    secret_urn = client.catalog.secrets.create(payload, clobber=True)
+    try:
+        yield secret_urn
+    finally:
+        try:
+            client.catalog.secrets.delete(secret_urn)
+        except APIError:
+            pass
+
+
+def _spec(index: str, credential_ref: str) -> dict:
+    """A minimal valid connector spec; base_url is never fetched at register."""
+    return {
+        "platform": "kamiwaza",
+        "base_url": "https://example.test/api",
+        "endpoint": {"method": "GET", "path": "/v1/items", "items_path": "items"},
+        "index": index,
+        "pagination": {"max_pages": 1, "page_size": 50},
+        "auth": {"kind": "bearer", "credential_ref": credential_ref},
+        "data_attribute_fields": ["data_class"],
+        "gate": {"type": _GATE_CLASSPATH, "config": {"data_class_field": "data_class"}},
+    }
+
+
+# --------------------------------------------------------------------------- #
+# register-from-spec — happy path
+# --------------------------------------------------------------------------- #
+def test_register_from_spec_returns_dataset_urn(cs_engine, brokered_secret):
+    client = cs_engine
+    index = _unique("cs-smoke")
+    dataset_urn: str | None = None
+    try:
+        dataset_urn = client.catalog.register_from_spec(_spec(index, brokered_secret))
+        assert dataset_urn and dataset_urn.startswith("urn:li:dataset:")
+        # The standing dataset is queryable through the catalog.
+        fetched = client.catalog.get_dataset(dataset_urn)
+        assert fetched.urn == dataset_urn
+    finally:
+        if dataset_urn:
+            try:
+                client.catalog.datasets.delete(dataset_urn)
+            except APIError:
+                pass
+
+
+# --------------------------------------------------------------------------- #
+# register-from-spec — spec validation (engine is authoritative: extra=forbid)
+# --------------------------------------------------------------------------- #
+def test_register_rejects_inline_secret_value(cs_engine):
+    """credential_ref must be a secret URN, never a raw secret value (INF-CB5)."""
+    spec = _spec(_unique("cs-bad-inline"), credential_ref="raw-bearer-token-not-a-urn")
+    with pytest.raises(APIError) as exc:
+        cs_engine.catalog.register_from_spec(spec)
+    status = exc.value.status_code
+    assert status is not None and 400 <= status < 500
+
+
+def test_register_rejects_missing_platform(cs_engine, brokered_secret):
+    spec = _spec(_unique("cs-bad-platform"), brokered_secret)
+    spec.pop("platform")
+    with pytest.raises(APIError) as exc:
+        cs_engine.catalog.register_from_spec(spec)
+    status = exc.value.status_code
+    assert status is not None and 400 <= status < 500
+
+
+def test_register_rejects_unknown_field(cs_engine, brokered_secret):
+    """The drift guard: a producer cannot smuggle a field the engine ignores."""
+    spec = _spec(_unique("cs-bad-extra"), brokered_secret)
+    spec["totally_unknown_field"] = "drift"
+    with pytest.raises(APIError) as exc:
+        cs_engine.catalog.register_from_spec(spec)
+    status = exc.value.status_code
+    assert status is not None and 400 <= status < 500
+
+
+# --------------------------------------------------------------------------- #
+# publisher grant / revoke (admin-gated, native-realm)
+# --------------------------------------------------------------------------- #
+def test_publisher_grant_then_revoke(cs_engine):
+    client = cs_engine
+    subject = f"urn:li:corpuser:cs-smoke-{uuid4().hex[:8]}"
+    # Admin grant + revoke should both succeed (204, no exception). Revoke is
+    # idempotent-friendly; the grant is cleaned up by the revoke itself.
+    client.catalog.add_publisher(subject)
+    client.catalog.remove_publisher(subject)

--- a/tests/integration/test_inference_matrix_live.py
+++ b/tests/integration/test_inference_matrix_live.py
@@ -1,0 +1,273 @@
+"""Capability-marked engine deploy+infer + fractional co-location (ENG-6948).
+
+Lifts the API-observable outcomes of ``kamiwaza-smoke.py`` ``cmd_full`` +
+``cmd_fractional`` into the SDK live suite, for the engines the suite does NOT
+already cover:
+
+- llamacpp (GGUF, CPU-capable) and vllm (NVIDIA-only): download -> deploy with an
+  explicit ``engine_name`` -> wait ready -> serve a prompt. The mlx arm is
+  already covered by ``test_serving_workflow.py`` and is intentionally not
+  re-added.
+- fractional / MIG co-location: deploy 2 copies of one model on a single GPU and
+  assert BOTH reach DEPLOYED (the co-location proof — a whole-GPU scheduler would
+  leave the 2nd Pending) AND each serves a prompt.
+
+What is NOT lifted (operator-only, left in the smoke script): the kubectl-based
+pod / device-node inspection (``_verify_fractional_placement`` /
+``_assert_gpu_offload``), ``undeploy_all`` purges, and whisper transcription
+(``cmd_full``'s ggml arm) — whisper needs a raw multipart route the SDK does not
+expose, so it stays in the operator matrix. These tests assert the API-observable
+outcome only.
+
+skip-not-fail: every test is gated so under-provisioned hosts SKIP rather than
+fail. GPU/MIG gating uses the M5 capability markers (autouse-enforced via
+``conftest._enforce_capability_markers`` + ``cluster_capability_snapshot``);
+deployability uses ``requires_deployable_model`` and a 5xx/timeout -> skip wrap.
+
+CAVEAT: ``ensure_repo_ready`` selects a GGUF quant but cannot pin one exact
+filename the way the smoke's ``files_to_download`` does, so the GGUF tests
+register the repo best-effort and skip-not-fail if it cannot be made ready.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kamiwaza_sdk.exceptions import APIError
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.live,
+    pytest.mark.withoutresponses,
+]
+
+# Engine repos mirror cmd_full's defaults. GGUF is file-pinned in the smoke via
+# files_to_download; the SDK download surface cannot reproduce that pin, so the
+# GGUF tests skip-not-fail if the repo can't be made ready.
+LLAMACPP_REPO = "unsloth/Qwen3-4B-Instruct-2507-GGUF"
+LLAMACPP_QUANT = "q4_k_m"
+VLLM_REPO = "Qwen/Qwen3-4B-Instruct-2507"
+
+WAIT_TIMEOUT = 600
+FRACTIONAL_COPIES = 2
+
+_CHAT_PROMPT = [{"role": "user", "content": "Reply with a single short greeting."}]
+
+
+def _ensure_repo_or_skip(ensure_repo_ready, client, repo_id, **kwargs):
+    """Register a repo in the live catalog, skip-not-fail on capability failure.
+
+    A 5xx (host cannot fetch / register the model) or a download timeout is a
+    capability/infra failure -> skip. A 4xx is a real regression and is
+    re-raised. Mirrors ``deployable_model_prerequisite`` + ``_ensure_model_cached``.
+    """
+    try:
+        return ensure_repo_ready(client, repo_id, **kwargs)
+    except (TimeoutError, RuntimeError, ValueError) as exc:
+        pytest.skip(
+            f"Host cannot make repo '{repo_id}' ready for the inference matrix "
+            f"(file-pinned download unavailable via SDK): {type(exc).__name__}: {exc}"
+        )
+    except APIError as exc:
+        status_code = getattr(exc, "status_code", None)
+        if status_code is None or status_code < 500:
+            raise
+        pytest.skip(
+            f"Host cannot make repo '{repo_id}' ready for the inference matrix: "
+            f"APIError {status_code}: {exc}"
+        )
+
+
+def _deploy_or_skip(client, model, *, engine_name):
+    """Deploy one copy with an explicit engine_name; skip-not-fail on 5xx refusal.
+
+    Returns the deployment id (str). A falsy deploy_model return (False) or a 5xx
+    means the host cannot bring the engine up -> skip; a 4xx is re-raised as a
+    real regression.
+    """
+    configs = client.models.get_model_configs(model.id)
+    if not configs:
+        pytest.skip(f"No model configs available for '{engine_name}' test model")
+    default_config = next((c for c in configs if c.default), configs[0])
+
+    try:
+        raw_deployment_id = client.serving.deploy_model(
+            model_id=str(model.id),
+            m_config_id=default_config.id,
+            engine_name=engine_name,
+            lb_port=0,
+            autoscaling=False,
+            min_copies=1,
+            starting_copies=1,
+        )
+    except APIError as exc:
+        status_code = getattr(exc, "status_code", None)
+        if status_code is None or status_code < 500:
+            raise
+        pytest.skip(
+            f"Host refused to deploy engine '{engine_name}': "
+            f"APIError {status_code}: {exc}"
+        )
+
+    if not raw_deployment_id:
+        pytest.skip(
+            f"deploy_model returned no id for engine '{engine_name}' "
+            "(deploy refused on this host)."
+        )
+    return str(raw_deployment_id)
+
+
+def _wait_or_skip(client, deployment_id, *, engine_name):
+    """Wait for DEPLOYED; skip-not-fail when the instance can't load on this host."""
+    try:
+        return client.serving.wait_for_deployment(
+            deployment_id,
+            poll_interval=5,
+            timeout=WAIT_TIMEOUT,
+        )
+    except (RuntimeError, TimeoutError) as exc:
+        pytest.skip(
+            f"Engine '{engine_name}' deployment {deployment_id} did not reach "
+            f"DEPLOYED on this host: {type(exc).__name__}: {exc}"
+        )
+
+
+def _stop_quietly(client, deployment_id):
+    if not deployment_id:
+        return
+    try:
+        client.serving.stop_deployment(deployment_id=deployment_id, force=True)
+    except Exception:  # noqa: BLE001 — teardown is best-effort
+        pass
+
+
+def _assert_chat_completion(client, deployment_id):
+    """Serve a chat prompt via the OpenAI-compatible client and assert a reply."""
+    openai_client = client.openai.get_client(deployment_id=deployment_id)
+    response = openai_client.chat.completions.create(
+        model="kamiwaza",
+        messages=_CHAT_PROMPT,
+        temperature=0.0,
+    )
+    assert response.choices, "deployment returned no chat choices"
+
+
+# --------------------------------------------------------------------------- #
+# Engine matrix tests
+# --------------------------------------------------------------------------- #
+@pytest.mark.requires_deployable_model
+def test_deploy_and_infer_llamacpp_gguf(live_kamiwaza_client, ensure_repo_ready):
+    """llamacpp arm of cmd_full: download GGUF, deploy engine_name='llamacpp', infer.
+
+    Covers the CPU-capable GGUF inference path the SDK suite does not yet cover
+    (test_serving_workflow only covers MLX). No GPU marker — gate on
+    requires_deployable_model where it actually deploys.
+    """
+    client = live_kamiwaza_client
+    model = _ensure_repo_or_skip(
+        ensure_repo_ready, client, LLAMACPP_REPO, quantization=LLAMACPP_QUANT
+    )
+
+    deployment_id = None
+    try:
+        deployment_id = _deploy_or_skip(client, model, engine_name="llamacpp")
+        details = _wait_or_skip(client, deployment_id, engine_name="llamacpp")
+        assert details.instances, "llamacpp deployment should report instances"
+        _assert_chat_completion(client, deployment_id)
+    finally:
+        _stop_quietly(client, deployment_id)
+
+
+@pytest.mark.gpu_vendor("nvidia")
+@pytest.mark.min_gpu_count(1)
+@pytest.mark.min_gpu_mem(16)
+def test_deploy_and_infer_vllm_nvidia(live_kamiwaza_client, ensure_repo_ready):
+    """vllm arm of cmd_full: download safetensors, deploy engine_name='vllm', infer.
+
+    The only engine arm that genuinely needs a discrete NVIDIA GPU; the SDK suite
+    has zero vllm deploy+infer coverage. Capability-gated so it SKIPS (never
+    fails) on CPU / Apple / AMD hosts.
+    """
+    client = live_kamiwaza_client
+    model = _ensure_repo_or_skip(ensure_repo_ready, client, VLLM_REPO)
+
+    deployment_id = None
+    try:
+        deployment_id = _deploy_or_skip(client, model, engine_name="vllm")
+        details = _wait_or_skip(client, deployment_id, engine_name="vllm")
+        assert details.instances, "vllm deployment should report instances"
+        _assert_chat_completion(client, deployment_id)
+    finally:
+        _stop_quietly(client, deployment_id)
+
+
+# --------------------------------------------------------------------------- #
+# Fractional / MIG co-location tests
+# --------------------------------------------------------------------------- #
+def _certify_fractional_colocation(client, model):
+    """Deploy FRACTIONAL_COPIES of one model and assert co-location + serve.
+
+    Lifts the API-observable subset of _run_fractional_cert: deploy N copies,
+    assert ALL reach DEPLOYED (the co-location proof on a single-GPU host — the
+    whole-GPU path would leave the 2nd deployment never reaching DEPLOYED), and
+    assert EACH serves a chat prompt. Excludes the kubectl pod/device-node
+    inspection (operator-only). Cleans up every deployment it creates.
+    """
+    deployment_ids: list[str] = []
+    try:
+        for _ in range(FRACTIONAL_COPIES):
+            deployment_id = _deploy_or_skip(client, model, engine_name="llamacpp")
+            deployment_ids.append(deployment_id)
+
+        # ALL must reach DEPLOYED — on a single 1-GPU node this is only possible
+        # if they share the device. This IS the co-location certification.
+        for deployment_id in deployment_ids:
+            details = _wait_or_skip(client, deployment_id, engine_name="llamacpp")
+            assert (
+                details.instances
+            ), f"co-located deployment {deployment_id} reported no instances"
+
+        # Each co-located instance must accept a prompt and return a response.
+        for deployment_id in deployment_ids:
+            _assert_chat_completion(client, deployment_id)
+    finally:
+        for deployment_id in deployment_ids:
+            _stop_quietly(client, deployment_id)
+
+
+@pytest.mark.requires_deployable_model
+@pytest.mark.min_gpu_count(1)
+@pytest.mark.min_gpu_mem(8)
+def test_fractional_colocation_two_models_one_gpu(
+    live_kamiwaza_client, ensure_repo_ready
+):
+    """Fractional cert: 2 copies of one model co-located on a single GPU, each serving.
+
+    Lifts the API-observable outcome of cmd_fractional / _run_fractional_cert.
+    Capability-gated for a GPU host with headroom for 2 small replicas so it
+    SKIPS on CPU / laptop hosts.
+    """
+    client = live_kamiwaza_client
+    model = _ensure_repo_or_skip(
+        ensure_repo_ready, client, LLAMACPP_REPO, quantization=LLAMACPP_QUANT
+    )
+    _certify_fractional_colocation(client, model)
+
+
+@pytest.mark.requires_deployable_model
+@pytest.mark.gpu_mig_support
+@pytest.mark.min_gpu_count(1)
+def test_fractional_colocation_mig_partitioned_gpu(
+    live_kamiwaza_client, ensure_repo_ready
+):
+    """MIG variant of the fractional cert: 2 co-located copies, each serving.
+
+    Captures cmd_full's fractional MIG branch at the only level the SDK can
+    observe — 2 replicas co-resident and each serving. Gated to a MIG-capable
+    GPU so it SKIPS on non-MIG NVIDIA / AMD / CPU hosts.
+    """
+    client = live_kamiwaza_client
+    model = _ensure_repo_or_skip(
+        ensure_repo_ready, client, LLAMACPP_REPO, quantization=LLAMACPP_QUANT
+    )
+    _certify_fractional_colocation(client, model)

--- a/tests/integration/test_platform_scenarios_live.py
+++ b/tests/integration/test_platform_scenarios_live.py
@@ -1,0 +1,72 @@
+"""WS-M2 demo-bullet platform scenarios (ENG-6949).
+
+Lifts the API-level outcomes of ``kamiwaza-smoke.py`` ``cmd_m2`` / ``cmd_diagnose``
+/ ``cmd_capabilities`` / ``cmd_gates_discover`` / ``cmd_operations`` into the SDK
+live suite as the cohesive WS-M2 demo-bullet contract.
+
+Already covered elsewhere and NOT duplicated here:
+- cluster CRUD/read endpoints -> ``test_cluster_live.py``
+- the recoverable-job flow -> ``test_jobs_recoverable_drop_recovery.py``
+- the WS-M3 subject/gate lifecycle -> ``test_m3_walkthrough_live.py``
+
+This file adds the M2 *scenario* surfaces those do not exercise as typed live
+SDK calls: ``cluster.diagnose``, the typed ``cluster.capabilities`` M2-field
+contract, ``gates.discover``, and ``cluster.operations``. The dataset auto-grant
+(ENG-4506 ReBAC bridge) arm of cmd_m2 needs ReBAC tuple inspection
+(kubectl/psql) and stays operator-only in the smoke script.
+
+skip-not-fail: the ``live_kamiwaza_client`` fixture skips when no deployment is
+reachable; each call additionally skips on 403/404/501 so a baseline that does
+not expose a given M2 surface skips rather than fails.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kamiwaza_sdk.exceptions import APIError
+
+pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
+
+# The platform's always-importable execution gate (cmd_gates_discover default).
+_ALLOW_ALL_GATE = "kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate"
+
+
+def _call_or_skip(fn, *args):
+    """Invoke a live M2 surface, skip-not-fail when the deployment lacks it."""
+    try:
+        return fn(*args)
+    except APIError as exc:
+        status = getattr(exc, "status_code", None)
+        if status in (403, 404, 501):
+            pytest.skip(f"M2 surface not available on this deployment: {status}")
+        raise
+
+
+def test_m2_diagnose(live_kamiwaza_client) -> None:
+    """cmd_diagnose: cluster.diagnose() returns a structured diagnostics run."""
+    result = _call_or_skip(live_kamiwaza_client.cluster.diagnose)
+    assert result.cluster_id, "diagnose should report a cluster_id"
+    assert isinstance(result.issues, list)
+
+
+def test_m2_capabilities_demo_bullet_fields(live_kamiwaza_client) -> None:
+    """cmd_capabilities: the M2 demo-bullet fields are present and typed."""
+    caps = _call_or_skip(live_kamiwaza_client.cluster.capabilities)
+    assert isinstance(caps.federation_count, int)
+    assert isinstance(caps.active_deployments, int)
+    assert isinstance(caps.ray_ready, bool)
+
+
+def test_m2_gates_discover(live_kamiwaza_client) -> None:
+    """cmd_gates_discover: gates.discover instantiates the platform gate."""
+    discovery = _call_or_skip(live_kamiwaza_client.gates.discover, _ALLOW_ALL_GATE)
+    assert discovery.kind in ("execution", "attribute")
+    assert discovery.name, "discovered gate should report a name"
+
+
+def test_m2_operations_unified_shape(live_kamiwaza_client) -> None:
+    """cmd_operations: operations() returns the unified jobs + retrievals view."""
+    ops = _call_or_skip(live_kamiwaza_client.cluster.operations)
+    assert isinstance(ops.jobs, list)
+    assert isinstance(ops.retrievals, list)

--- a/tests/unit/test_capability_markers.py
+++ b/tests/unit/test_capability_markers.py
@@ -1,0 +1,187 @@
+"""Unit tests for the parametric capability-marker logic (M5).
+
+The pure helpers live in ``tests/integration/capability_markers.py`` so the
+integration ``conftest`` can wire them into a ``pytest.skip``-not-fail gate.
+These tests exercise the pure logic with synthetic inventory — no live cluster.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import namedtuple
+from pathlib import Path
+
+import pytest
+
+# The helper is co-located with the integration conftest that consumes it.
+# Add that directory to the path so this unit test can import it directly
+# without making ``tests`` a package.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "integration"))
+
+import capability_markers as cap  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+_Mark = namedtuple("_Mark", ["name", "args"])
+
+
+def _hw(gpus):
+    """A hardware-entry dict shaped like the SDK ``Hardware`` model."""
+    return {"gpus": gpus, "node_id": "node-1"}
+
+
+# --------------------------------------------------------------------------- #
+# build_capability_snapshot
+# --------------------------------------------------------------------------- #
+def test_build_snapshot_counts_gpus_across_hardware_entries():
+    snap = cap.build_capability_snapshot(
+        [_hw([{"vendor": "NVIDIA"}, {"vendor": "NVIDIA"}]), _hw([{"vendor": "NVIDIA"}])],
+        node_count=2,
+    )
+    assert snap.gpu_count == 3
+    assert snap.node_count == 2
+
+
+def test_build_snapshot_parses_memory_mb_to_gb():
+    snap = cap.build_capability_snapshot([_hw([{"memory_mb": 81920}])])
+    assert snap.gpu_mem_gb and snap.gpu_mem_gb[0] == pytest.approx(80.0, abs=0.01)
+
+
+def test_build_snapshot_parses_memory_bytes_to_gb():
+    snap = cap.build_capability_snapshot([_hw([{"memory_total": 24 * 1024**3}])])
+    assert snap.gpu_mem_gb and snap.gpu_mem_gb[0] == pytest.approx(24.0, abs=0.01)
+
+
+def test_build_snapshot_detects_vendor_from_explicit_key():
+    snap = cap.build_capability_snapshot([_hw([{"vendor": "AMD"}])])
+    assert snap.gpu_vendors == frozenset({"amd"})
+
+
+def test_build_snapshot_detects_vendor_from_model_name():
+    snap = cap.build_capability_snapshot([_hw([{"name": "NVIDIA A100-SXM4-80GB"}])])
+    assert snap.gpu_vendors == frozenset({"nvidia"})
+
+
+def test_build_snapshot_mig_supported_true_when_any_gpu_reports_mig():
+    snap = cap.build_capability_snapshot(
+        [_hw([{"vendor": "nvidia", "mig_capable": False}, {"vendor": "nvidia", "mig_capable": True}])]
+    )
+    assert snap.mig_supported is True
+
+
+def test_build_snapshot_mig_undeterminable_when_key_absent():
+    snap = cap.build_capability_snapshot([_hw([{"vendor": "nvidia"}])])
+    assert snap.mig_supported is None
+
+
+def test_build_snapshot_empty_inventory_is_cpu_only():
+    snap = cap.build_capability_snapshot([], node_count=1)
+    assert snap.gpu_count == 0
+    assert snap.gpu_mem_gb == ()
+    assert snap.node_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# collect_capability_requirements
+# --------------------------------------------------------------------------- #
+def test_collect_requirements_reads_marker_args():
+    marks = [
+        _Mark("min_gpu_count", (2,)),
+        _Mark("min_gpu_mem", (40,)),
+        _Mark("gpu_vendor", ("nvidia",)),
+        _Mark("gpu_mig_support", ()),
+        _Mark("min_node_count", (2,)),
+        _Mark("integration", ()),  # ignored — not a capability marker
+    ]
+    req = cap.collect_capability_requirements(marks)
+    assert req == {
+        "min_gpu_count": 2,
+        "min_gpu_mem": 40.0,
+        "gpu_vendor": "nvidia",
+        "gpu_mig_support": True,
+        "min_node_count": 2,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# evaluate_capability_requirements  (returns a skip reason, or None to run)
+# --------------------------------------------------------------------------- #
+def _snap(**kw):
+    return cap.ClusterCapabilitySnapshot(**kw)
+
+
+def test_evaluate_none_snapshot_always_skips():
+    reason = cap.evaluate_capability_requirements(None, {"min_gpu_count": 1})
+    assert reason and "unavailable" in reason
+
+
+def test_evaluate_min_gpu_count_skips_when_insufficient():
+    assert cap.evaluate_capability_requirements(_snap(gpu_count=1), {"min_gpu_count": 2})
+
+
+def test_evaluate_min_gpu_count_runs_when_sufficient():
+    assert cap.evaluate_capability_requirements(_snap(gpu_count=4), {"min_gpu_count": 2}) is None
+
+
+def test_evaluate_min_node_count_skips_when_insufficient():
+    assert cap.evaluate_capability_requirements(_snap(node_count=1), {"min_node_count": 2})
+
+
+def test_evaluate_min_gpu_mem_skips_when_memory_undeterminable():
+    reason = cap.evaluate_capability_requirements(
+        _snap(gpu_count=1, gpu_mem_gb=()), {"min_gpu_mem": 40.0}
+    )
+    assert reason and "not reported" in reason
+
+
+def test_evaluate_min_gpu_mem_skips_when_too_small():
+    assert cap.evaluate_capability_requirements(
+        _snap(gpu_mem_gb=(24.0,)), {"min_gpu_mem": 40.0}
+    )
+
+
+def test_evaluate_min_gpu_mem_runs_when_large_enough():
+    assert (
+        cap.evaluate_capability_requirements(_snap(gpu_mem_gb=(24.0, 80.0)), {"min_gpu_mem": 40.0})
+        is None
+    )
+
+
+def test_evaluate_gpu_vendor_nvidia_runs_when_present():
+    assert (
+        cap.evaluate_capability_requirements(
+            _snap(gpu_count=1, gpu_vendors=frozenset({"nvidia"})), {"gpu_vendor": "nvidia"}
+        )
+        is None
+    )
+
+
+def test_evaluate_gpu_vendor_nvidia_skips_when_absent():
+    assert cap.evaluate_capability_requirements(
+        _snap(gpu_count=1, gpu_vendors=frozenset({"amd"})), {"gpu_vendor": "nvidia"}
+    )
+
+
+def test_evaluate_gpu_vendor_skips_when_vendor_undeterminable():
+    reason = cap.evaluate_capability_requirements(
+        _snap(gpu_count=1, gpu_vendors=frozenset()), {"gpu_vendor": "nvidia"}
+    )
+    assert reason and "not reported" in reason
+
+
+def test_evaluate_gpu_vendor_none_requires_cpu_only_host():
+    assert cap.evaluate_capability_requirements(
+        _snap(gpu_count=1), {"gpu_vendor": "none"}
+    )
+    assert (
+        cap.evaluate_capability_requirements(_snap(gpu_count=0), {"gpu_vendor": "none"}) is None
+    )
+
+
+def test_evaluate_gpu_mig_support_skips_when_unsupported_or_unreported():
+    assert cap.evaluate_capability_requirements(_snap(mig_supported=False), {"gpu_mig_support": True})
+    assert cap.evaluate_capability_requirements(_snap(mig_supported=None), {"gpu_mig_support": True})
+    assert (
+        cap.evaluate_capability_requirements(_snap(mig_supported=True), {"gpu_mig_support": True})
+        is None
+    )

--- a/tests/unit/test_kamiwaza_catalog_connector_spec.py
+++ b/tests/unit/test_kamiwaza_catalog_connector_spec.py
@@ -1,0 +1,97 @@
+"""Unit tests for the connector-spec SDK bindings (ENG-6964).
+
+Covers ``catalog.register_from_spec`` + publisher grant/revoke and the typed
+``ConnectorSpec`` schema. HTTP is mocked — no live cluster.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from kamiwaza_sdk.schemas.connector_spec import ConnectorSpec
+from kamiwaza_sdk.services.catalog import CatalogService, DatasetClient
+
+pytestmark = pytest.mark.unit
+
+
+def _spec_dict() -> dict:
+    return {
+        "platform": "kamiwaza",
+        "base_url": "https://example.test/api",
+        "endpoint": {"method": "GET", "path": "/models", "items_path": "items"},
+        "index": "platform-models",
+        "pagination": {"max_pages": 1, "page_size": 100},
+        "auth": {"kind": "bearer", "credential_ref": "urn:li:secret:demo"},
+        "data_attribute_fields": ["data_class"],
+        "gate": {
+            "type": "kamiwaza.services.authz.gates.attribute_gate.AttributeGate",
+            "config": {"data_class_field": "data_class"},
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# ConnectorSpec schema
+# --------------------------------------------------------------------------- #
+def test_connector_spec_builds_and_dumps_expected_keys():
+    body = ConnectorSpec(**_spec_dict()).model_dump(exclude_none=True, mode="json")
+    assert body["spec_version"] == "connector-spec.v1"
+    assert body["platform"] == "kamiwaza"
+    assert body["endpoint"]["method"] == "GET"
+    assert body["endpoint"]["items_path"] == "items"
+    assert body["pagination"]["page_size"] == 100
+    assert body["auth"]["kind"] == "bearer"
+    assert body["data_attribute_fields"] == ["data_class"]
+    # None-valued optionals are excluded so the engine sees its own defaults.
+    assert "time_field" not in body
+    assert "field_mappings" not in body
+
+
+# --------------------------------------------------------------------------- #
+# register_from_spec
+# --------------------------------------------------------------------------- #
+def test_register_from_spec_posts_dict_and_returns_urn():
+    client = Mock()
+    client.post.return_value = {"dataset_urn": "urn:li:dataset:(x,platform-models,PROD)"}
+    urn = DatasetClient(client).register_from_spec(_spec_dict())
+    assert urn == "urn:li:dataset:(x,platform-models,PROD)"
+    args, kwargs = client.post.call_args
+    assert args[0] == "/catalog/datasets/register-from-spec"
+    assert kwargs["json"]["index"] == "platform-models"
+
+
+def test_register_from_spec_accepts_typed_model_via_facade():
+    client = Mock()
+    client.post.return_value = {"dataset_urn": "urn:li:dataset:abc"}
+    urn = CatalogService(client).register_from_spec(ConnectorSpec(**_spec_dict()))
+    assert urn == "urn:li:dataset:abc"
+    _, kwargs = client.post.call_args
+    assert kwargs["json"]["spec_version"] == "connector-spec.v1"
+    assert kwargs["json"]["auth"]["credential_ref"] == "urn:li:secret:demo"
+
+
+def test_register_from_spec_unwraps_bare_string_response():
+    client = Mock()
+    client.post.return_value = "urn:li:dataset:bare"
+    assert DatasetClient(client).register_from_spec(_spec_dict()) == "urn:li:dataset:bare"
+
+
+# --------------------------------------------------------------------------- #
+# publisher grant / revoke
+# --------------------------------------------------------------------------- #
+def test_add_publisher_posts_subject_user_id():
+    client = Mock()
+    CatalogService(client).add_publisher("urn:li:corpuser:steward")
+    args, kwargs = client.post.call_args
+    assert args[0] == "/catalog/datasets/publishers"
+    assert kwargs["json"] == {"subject_user_id": "urn:li:corpuser:steward"}
+
+
+def test_remove_publisher_deletes_with_subject_body():
+    client = Mock()
+    CatalogService(client).remove_publisher("urn:li:corpuser:steward")
+    args, kwargs = client.delete.call_args
+    assert args[0] == "/catalog/datasets/publishers"
+    assert kwargs["json"] == {"subject_user_id": "urn:li:corpuser:steward"}


### PR DESCRIPTION
## M5 — Connector-Spec Engine: Verification & SDK test-harness consolidation

Lifts smoke coverage into the SDK integration suite and adds the SDK surface for the connector-spec engine. Part of the Connector-Spec Engine (v1 Walking Skeleton) project; held unmerged pending review (self-review is the merge gate).

### Included
- **ENG-6947** — parametric capability-marker taxonomy: `min_gpu_count(N)`, `min_gpu_mem(GB)`, `gpu_vendor(nvidia|amd|none)`, `gpu_mig_support`, `min_node_count(N)`; pure logic unit-tested (21 tests) + autouse skip-not-fail conftest gate.
- **ENG-6964** — typed SDK bindings: `catalog.register_from_spec()` + `add_publisher()`/`remove_publisher()` + `ConnectorSpec` schemas. Federated-job + retrieval were already bound; connector-spec rejects the federated Ray-job path by design (M4).
- **ENG-6952** — connector-spec engine control-plane smoke (skip-not-fail; data-plane gated round-trip is built in M6/ENG-6965).
- **ENG-6948** — capability-marked engine deploy matrix (llamacpp / vllm) + fractional / MIG co-location.
- **ENG-6949** — WS-M2 platform scenarios (diagnose / capabilities / gates-discover / operations) — verified live: 4 passed.

### Validation
- 2185 unit tests pass; +27 new unit tests; ruff + mypy clean on new code.
- Integration collects clean (220 tests). cs-smoke + inference matrix skip-not-fail on baselines (verified vs kamiwaza.test: register-from-spec -> 405 -> skip); the M2 scenarios passed live.
- kajiya runs `pytest tests/integration` with no `-m` flag, so capability-marked tests are collected everywhere and self-skip on under-provisioned hosts.