### PR TITLE
ENG-6931: seeder SDK — external models, Kaizen agents/conversations, install-by-name, M365 connector + kamiwaza-seed CLI

### DIFF
--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -526,6 +526,29 @@ class KamiwazaClient:
             response_text=response.text,
         )
 
+    def _assert_same_host(self, base_url: str) -> None:
+        """Require base_url to share the platform's scheme/host/port.
+
+        The platform bearer is attached to every request, so an off-host
+        base_url would leak the credential. In-cluster extensions (Kaizen)
+        share the platform ingress, so this never fires in normal use.
+        """
+        from urllib.parse import urlparse
+
+        _default_ports = {"https": 443, "http": 80}
+
+        def _origin(url: str) -> tuple:
+            p = urlparse(url)
+            return (p.scheme, p.hostname, p.port or _default_ports.get(p.scheme))
+
+        if _origin(base_url) != _origin(self.base_url):
+            home = urlparse(self.base_url)
+            raise ValueError(
+                f"base_url '{base_url}' is not on the platform host "
+                f"'{home.scheme}://{home.netloc}'; refusing to send the platform "
+                "credential off-host."
+            )
+
     def _request(
         self,
         method: str,
@@ -533,9 +556,16 @@ class KamiwazaClient:
         *,
         expect_json: bool = True,
         skip_auth: bool = False,
+        base_url: Optional[str] = None,
         **kwargs,
     ):
-        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        # base_url targets an in-cluster extension (e.g. Kaizen) on the platform
+        # ingress; it must stay same-host since the platform bearer is attached
+        # to every request.
+        if base_url is not None:
+            self._assert_same_host(base_url)
+        root = (base_url or self.base_url).rstrip("/")
+        url = f"{root}/{endpoint.lstrip('/')}"
         path = endpoint.lstrip("/")
         self.logger.debug(f"Making {method} request to {url}")
         kwargs = self._prepare_request_kwargs(skip_auth, kwargs)
@@ -796,3 +826,30 @@ class KamiwazaClient:
         if not hasattr(self, '_workrooms'):
             self._workrooms = WorkroomService(self)
         return self._workrooms
+
+    @property
+    def connectors(self):
+        """Cluster-wide external connectors (M365, Google, …)."""
+        if not hasattr(self, "_connectors"):
+            from .services.connectors import ConnectorService
+
+            self._connectors = ConnectorService(self)
+        return self._connectors
+
+    @property
+    def agents(self):
+        """Kaizen agents (per-workroom extension; methods take a base_url)."""
+        if not hasattr(self, "_agents"):
+            from .services.kaizen import AgentService
+
+            self._agents = AgentService(self)
+        return self._agents
+
+    @property
+    def conversations(self):
+        """Kaizen conversations (per-workroom extension; methods take a base_url)."""
+        if not hasattr(self, "_conversations"):
+            from .services.kaizen import ConversationService
+
+            self._conversations = ConversationService(self)
+        return self._conversations

--- a/kamiwaza_sdk/schemas/connectors.py
+++ b/kamiwaza_sdk/schemas/connectors.py
@@ -1,0 +1,64 @@
+# kamiwaza_sdk/schemas/connectors.py
+
+"""Pydantic models for the external-connectors API (M365, Google, …).
+
+This covers the cluster-wide connector *app registration* (admin-scoped): the
+tenant/client identifiers an operator registers once per cluster. The per-user
+OAuth connection (Device Code Flow) is a separate, interactive flow and is not
+modeled here — users connect themselves.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Default M365 Graph scopes, matching the platform connector UI defaults.
+M365_DEFAULT_SCOPES: List[str] = [
+    "User.Read",
+    "Files.ReadWrite.All",
+    "Sites.ReadWrite.All",
+    "Mail.ReadWrite",
+    "Calendars.ReadWrite",
+]
+
+
+class M365ConnectorConfig(BaseModel):
+    """Cluster-wide M365 app-registration config (Device Code Flow, public client).
+
+    Both fields are public Azure AD identifiers — not secrets. No client_secret
+    is used (Device Code Flow is a public-client flow).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    tenant_id: str = Field(..., min_length=1, description="Azure AD tenant ID")
+    client_id: str = Field(..., min_length=1, description="App registration client ID")
+
+
+class ExternalConnectorCreate(BaseModel):
+    """Request to register a cluster-wide connector (admin-scoped)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str = Field(..., min_length=1, max_length=255)
+    connector_type: Literal["m365", "google", "confluence"]
+    config: Dict[str, Any] = Field(..., description="Provider-specific configuration")
+    scopes: List[str] = Field(..., min_length=1, description="OAuth scopes")
+    enabled: bool = True
+
+
+class ExternalConnector(BaseModel):
+    """Connector response (sensitive config is never echoed back)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: UUID
+    name: str
+    connector_type: str
+    enabled: bool
+    scopes: List[str] = []
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    redirect_uri: Optional[str] = None

--- a/kamiwaza_sdk/schemas/kaizen.py
+++ b/kamiwaza_sdk/schemas/kaizen.py
@@ -1,0 +1,63 @@
+# kamiwaza_sdk/schemas/kaizen.py
+
+"""Pydantic models for the Kaizen agent extension API.
+
+Kaizen is a per-workroom extension (one deployment per workroom, pinned via
+``KAMIWAZA_WORKROOM_ID``), reached at its own ingress rather than the platform
+API root. These models mirror ``kamiwaza-extensions-kaizen`` request/response
+shapes for the agent + conversation create paths.
+"""
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LLMConfig(BaseModel):
+    """Model binding for an agent (``agent_config.llm``).
+
+    A Kamiwaza-deployed model uses ``provider="kamiwaza"`` + ``endpoint_path``;
+    a custom OpenAI-compatible endpoint omits ``provider`` and sets ``base_url``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str = Field(..., description="Model name passed to the agent runtime")
+    provider: Optional[str] = Field(
+        default=None, description="'kamiwaza' for a platform deployment, else omit"
+    )
+    base_url: Optional[str] = Field(
+        default=None, description="Custom OpenAI-compatible endpoint URL"
+    )
+    endpoint_path: Optional[str] = Field(
+        default=None, description="Kamiwaza deployment path (provider=kamiwaza)"
+    )
+    temperature: Optional[float] = None
+    timeout: Optional[int] = None
+
+
+class Agent(BaseModel):
+    """Agent response from Kaizen."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: Optional[str] = None
+    description: Optional[str] = None
+    workroom_id: Optional[str] = None
+    agent_config: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+
+
+class Conversation(BaseModel):
+    """Conversation response from Kaizen (sandbox auto-started on create)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    agent_id: str
+    workroom_id: Optional[str] = None
+    title: Optional[str] = None
+    execution_status: Optional[str] = None
+    container_status: Optional[str] = None
+    created_at: Optional[str] = None

--- a/kamiwaza_sdk/schemas/models/external_endpoint.py
+++ b/kamiwaza_sdk/schemas/models/external_endpoint.py
@@ -1,0 +1,117 @@
+# kamiwaza_sdk/schemas/models/external_endpoint.py
+
+"""Typed request shapes for registering external (vendor-hosted) models.
+
+These mirror the platform's submission contract at
+``kamiwaza/services/models/endpoints/schemas/`` — the *inline* shape an
+operator POSTs to ``/models/``, where the credential travels as a plaintext
+``credential_secret`` blob that the platform normalizes into a Catalog secret
+URN server-side. They are deliberately the pre-normalization shape: no
+``credential_secret_urn`` field, since the SDK caller supplies the plaintext
+credential separately via :meth:`ModelService.register_external_model`.
+"""
+
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ---------------------------------------------------------------------------
+# Credentials — serialized to the inline ``credential_secret`` JSON string.
+# ---------------------------------------------------------------------------
+
+
+class AWSBedrockBearerCredential(BaseModel):
+    """AWS Bedrock API key (bearer token) auth."""
+
+    model_config = ConfigDict(extra="allow")
+
+    auth_type: Literal["bearer"] = "bearer"
+    bearer_token: str = Field(..., min_length=1)
+
+
+class AWSBedrockIamCredential(BaseModel):
+    """AWS IAM credentials — long-lived access key or STS-assumed-role."""
+
+    model_config = ConfigDict(extra="allow")
+
+    auth_type: Literal["iam"] = "iam"
+    aws_access_key_id: str = Field(..., min_length=1)
+    aws_secret_access_key: str = Field(..., min_length=1)
+    aws_session_token: Optional[str] = None
+
+
+class AWSTranscribeCredential(BaseModel):
+    """AWS IAM credentials for Transcribe (access key or STS-assumed-role)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    aws_access_key_id: str = Field(..., min_length=1)
+    aws_secret_access_key: str = Field(..., min_length=1)
+    aws_session_token: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints — the ``external_endpoint`` blob (minus the credential).
+# ---------------------------------------------------------------------------
+
+
+class AWSBedrockChatEndpoint(BaseModel):
+    """AWS Bedrock chat endpoint via LiteLLM Converse."""
+
+    model_config = ConfigDict(extra="allow")
+
+    protocol: Literal["aws_bedrock"] = "aws_bedrock"
+    region: str = Field(..., min_length=1, description="AWS region (e.g. us-east-1)")
+    model_id: str = Field(
+        ...,
+        min_length=1,
+        description="Bedrock model id (e.g. anthropic.claude-3-sonnet-20240229-v1:0).",
+    )
+    endpoint_url: Optional[str] = Field(
+        default=None,
+        description="Optional Bedrock runtime endpoint override (VPC PrivateLink, etc.).",
+    )
+    inference_profile_arn: Optional[str] = Field(
+        default=None,
+        description="Optional Bedrock inference-profile ARN (provisioned throughput).",
+    )
+    extra_body: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Operator-set knobs forwarded to the provider (guardrails, etc.).",
+    )
+    display_name: Optional[str] = Field(default=None, max_length=200)
+
+
+class AWSTranscribeEndpoint(BaseModel):
+    """AWS Transcribe (speech-to-text) endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    protocol: Literal["aws_transcribe"] = "aws_transcribe"
+    region: str = Field(
+        ..., min_length=1, description="AWS region; must match the s3_bucket region."
+    )
+    s3_bucket: str = Field(
+        ...,
+        min_length=3,
+        max_length=63,
+        description="S3 bucket for transcription job audio + transcript artifacts.",
+    )
+    s3_prefix: str = Field(default="transcribe-jobs/", max_length=512)
+    language_code: str = Field(
+        default="",
+        max_length=16,
+        description="BCP-47 language code (e.g. en-US). Empty = auto-detect.",
+    )
+    media_format: str = Field(default="wav")
+    sample_rate: int = Field(default=16000, ge=8000, le=48000)
+    show_speaker_labels: bool = Field(default=False)
+    max_speaker_labels: int = Field(default=2, ge=2, le=10)
+    vocabulary_name: Optional[str] = Field(default=None, max_length=200)
+    vocabulary_filter_name: Optional[str] = Field(default=None, max_length=200)
+    vocabulary_filter_method: Optional[str] = None
+    redact_pii: bool = Field(default=False)
+    pii_entity_types: list[str] = Field(default_factory=list)
+    job_poll_interval: float = Field(default=2.0, gt=0.0, le=60.0)
+    job_timeout_seconds: float = Field(default=900.0, gt=0.0)
+    display_name: Optional[str] = Field(default=None, max_length=200)

--- a/kamiwaza_sdk/schemas/models/model.py
+++ b/kamiwaza_sdk/schemas/models/model.py
@@ -21,6 +21,12 @@ class CreateModel(BaseModel):
     private: Optional[bool] = None
     m_files: List[ModelFile] = []
     modelcard: Optional[str] = None
+    # External-model registration: the platform reads an ``external_endpoint``
+    # blob out of ``default_config.system_config`` and resolves any inline
+    # ``credential_secret`` into a Catalog URN server-side. Left as a free-form
+    # dict to mirror the platform's CreateModel; built type-safely by
+    # ModelService.register_external_model.
+    default_config: Optional[Dict[str, Any]] = None
 
     def __str__(self):
         return (

--- a/kamiwaza_sdk/seeding/__init__.py
+++ b/kamiwaza_sdk/seeding/__init__.py
@@ -1,0 +1,14 @@
+# kamiwaza_sdk/seeding/
+
+"""Generic, parameterized seeding helpers + CLI for the Kamiwaza platform.
+
+This package is deliberately profile-free: it exposes deterministic operations
+(create a workroom, register an external model, install an extension by name,
+create an agent/conversation) that take explicit arguments. Environment-specific
+data (which models, which extensions, which workroom) belongs to the caller —
+e.g. the nightly UAT seeding profile — not here.
+"""
+
+from .client import build_client_from_env, scoped_client_for_workroom
+
+__all__ = ["build_client_from_env", "scoped_client_for_workroom"]

--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -1,0 +1,306 @@
+# kamiwaza_sdk/seeding/cli.py
+
+"""``kamiwaza-seed`` — a thin, generic seeding CLI over the SDK.
+
+Each subcommand is a deterministic, parameterized wrapper around an SDK method:
+explicit args in, created-resource ids out (as JSON). No random generation and
+no environment-specific data — the UAT/nightly profile lives in the caller.
+
+Example::
+
+    kamiwaza-seed create-workroom --name uat
+    kamiwaza-seed install-extension --name kaizen --workroom-id <wid>
+    kamiwaza-seed register-external-model --protocol aws_bedrock \\
+        --name claude --region us-east-1 \\
+        --model-id anthropic.claude-3-sonnet-20240229-v1:0 \\
+        --credential-env AWS_BEDROCK_CREDENTIAL_JSON
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Callable, Dict, Optional, Union
+
+from ..schemas.kaizen import LLMConfig
+from ..schemas.models.external_endpoint import (
+    AWSBedrockChatEndpoint,
+    AWSTranscribeEndpoint,
+)
+from .client import build_client_from_env, scoped_client_for_workroom
+
+
+def _parse_env(pairs: Optional[list[str]]) -> Optional[Dict[str, str]]:
+    """Parse repeated ``KEY=VALUE`` args into an env dict."""
+    if not pairs:
+        return None
+    env: Dict[str, str] = {}
+    for pair in pairs:
+        key, sep, value = pair.partition("=")
+        if not sep:
+            raise SystemExit(f"--env expects KEY=VALUE, got '{pair}'")
+        env[key] = value
+    return env
+
+
+def _read_env_secret(env_var: Optional[str], *, what: str) -> Optional[str]:
+    """Read a secret from a named env var; exit if the var is named but empty."""
+    if not env_var:
+        return None
+    value = os.environ.get(env_var)
+    if not value:
+        raise SystemExit(f"Env var '{env_var}' (for {what}) is unset or empty.")
+    return value
+
+
+def _read_credential(args: argparse.Namespace) -> str:
+    """Resolve the inline credential JSON from an env var.
+
+    Credentials are read from an env var only — never argv — so they don't leak
+    into shell history or process listings.
+    """
+    value = _read_env_secret(args.credential_env, what="model credential")
+    if value is None:
+        raise SystemExit(
+            "Provide credentials via --credential-env (env var holding the credential JSON)."
+        )
+    return value
+
+
+def _client_for_workroom(client, workroom_id: Optional[str]):
+    """Scope the client to a workroom (via enter) when one is requested."""
+    if not workroom_id:
+        return client
+    return scoped_client_for_workroom(client, workroom_id)
+
+
+# --- subcommand handlers ---------------------------------------------------
+
+
+def cmd_create_workroom(args: argparse.Namespace, *, client) -> dict:
+    ids = []
+    for i in range(args.count):
+        name = args.name if args.count == 1 else f"{args.name}-{i + 1}"
+        workroom = client.workrooms.create(
+            name=name, workroom_type=args.type, description=args.description
+        )
+        ids.append(str(workroom.id))
+    return {"workroom_ids": ids}
+
+
+def cmd_register_external_model(args: argparse.Namespace, *, client) -> dict:
+    credential = _read_credential(args)
+    endpoint: Union[AWSBedrockChatEndpoint, AWSTranscribeEndpoint]
+    if args.protocol == "aws_bedrock":
+        if not args.model_id:
+            raise SystemExit("--model-id is required for aws_bedrock.")
+        endpoint = AWSBedrockChatEndpoint(
+            region=args.region, model_id=args.model_id, endpoint_url=args.endpoint_url
+        )
+    else:
+        if not args.s3_bucket:
+            raise SystemExit("--s3-bucket is required for aws_transcribe.")
+        endpoint = AWSTranscribeEndpoint(region=args.region, s3_bucket=args.s3_bucket)
+    model = client.models.register_external_model(
+        name=args.name,
+        endpoint=endpoint,
+        credential=credential,
+        force_replace_credentials=args.force_replace,
+        description=args.description,
+    )
+    return {"model_id": str(model.id)}
+
+
+def cmd_install_extension(args: argparse.Namespace, *, client) -> dict:
+    client = _client_for_workroom(client, args.workroom_id)
+    deployment = client.apps.install_by_name(
+        args.name,
+        version=args.version,
+        deployment_name=args.deployment_name,
+        env_vars=_parse_env(args.env),
+        workroom_id=args.workroom_id,
+        sync_if_missing=not args.no_sync,
+    )
+    return {"deployment_id": str(deployment.id), "name": deployment.name}
+
+
+def cmd_create_agent(args: argparse.Namespace, *, client) -> dict:
+    llm = LLMConfig(
+        model=args.model,
+        provider=args.provider,
+        endpoint_path=args.endpoint_path,
+        base_url=args.llm_base_url,
+    )
+    api_key = _read_env_secret(args.llm_api_key_env, what="custom-endpoint LLM key")
+    client = _client_for_workroom(client, args.workroom_id)
+    agent = client.agents.create(
+        base_url=args.kaizen_base_url,
+        name=args.name,
+        llm=llm,
+        description=args.description,
+        custom_instructions=args.custom_instructions,
+        llm_api_key=api_key,
+        workroom_id=args.workroom_id,
+    )
+    return {"agent_id": agent.id}
+
+
+def cmd_create_conversation(args: argparse.Namespace, *, client) -> dict:
+    client = _client_for_workroom(client, args.workroom_id)
+    conversation = client.conversations.create(
+        base_url=args.kaizen_base_url,
+        agent_id=args.agent_id,
+        title=args.title,
+        max_iterations=args.max_iterations,
+        ephemeral=args.ephemeral,
+        workroom_id=args.workroom_id,
+    )
+    return {"conversation_id": conversation.id}
+
+
+def cmd_configure_m365(args: argparse.Namespace, *, client) -> dict:
+    conn = client.connectors.create_m365(
+        tenant_id=args.tenant_id,
+        client_id=args.client_id,
+        name=args.name,
+        scopes=args.scope or None,
+    )
+    return {"connector_id": str(conn.id), "name": conn.name}
+
+
+def cmd_import_skill(args: argparse.Namespace, *, client) -> dict:
+    path = Path(args.file)
+    result = client.skills.import_skill_package(
+        filename=path.name, file_content=path.read_bytes()
+    )
+    skill_id = getattr(result, "id", None)
+    return {"skill_id": str(skill_id) if skill_id is not None else None}
+
+
+# --- parser ----------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kamiwaza-seed", description="Generic Kamiwaza seeding operations."
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Cluster API root; defaults to KAMIWAZA_BASE_URL.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    p = sub.add_parser("create-workroom", help="Create one or more workrooms.")
+    p.add_argument("--name", required=True)
+    p.add_argument("--type", default="persistent", help="ephemeral or persistent")
+    p.add_argument("--description", default=None)
+    p.add_argument("--count", type=int, default=1, help="Create N suffixed workrooms.")
+    p.set_defaults(func=cmd_create_workroom)
+
+    p = sub.add_parser("register-external-model", help="Register an external model.")
+    p.add_argument(
+        "--protocol", required=True, choices=["aws_bedrock", "aws_transcribe"]
+    )
+    p.add_argument("--name", required=True)
+    p.add_argument("--region", required=True)
+    p.add_argument("--model-id", default=None, help="Bedrock model id (aws_bedrock).")
+    p.add_argument("--s3-bucket", default=None, help="S3 bucket (aws_transcribe).")
+    p.add_argument("--endpoint-url", default=None)
+    p.add_argument("--description", default=None)
+    p.add_argument(
+        "--credential-env",
+        required=True,
+        help="Env var holding the credential JSON (read from env, never argv).",
+    )
+    p.add_argument(
+        "--force-replace", action="store_true", help="Rotate an existing credential."
+    )
+    p.set_defaults(func=cmd_register_external_model)
+
+    p = sub.add_parser("install-extension", help="Install a catalog extension by name.")
+    p.add_argument("--name", required=True)
+    p.add_argument("--version", default=None)
+    p.add_argument("--deployment-name", default=None)
+    p.add_argument("--workroom-id", default=None)
+    p.add_argument("--env", action="append", help="KEY=VALUE (repeatable).")
+    p.add_argument(
+        "--no-sync", action="store_true", help="Don't import the catalog if missing."
+    )
+    p.set_defaults(func=cmd_install_extension)
+
+    p = sub.add_parser("create-agent", help="Create a Kaizen agent.")
+    p.add_argument(
+        "--kaizen-base-url",
+        required=True,
+        help="Kaizen instance API root (per-workroom).",
+    )
+    p.add_argument("--name", required=True)
+    p.add_argument("--model", required=True)
+    p.add_argument(
+        "--provider", default=None, help="'kamiwaza' for a platform deployment."
+    )
+    p.add_argument("--endpoint-path", default=None)
+    p.add_argument(
+        "--llm-base-url", default=None, help="Custom OpenAI-compatible endpoint."
+    )
+    p.add_argument("--description", default=None)
+    p.add_argument("--custom-instructions", default=None)
+    p.add_argument(
+        "--llm-api-key-env", default=None, help="Env var holding a custom-endpoint key."
+    )
+    p.add_argument("--workroom-id", default=None)
+    p.set_defaults(func=cmd_create_agent)
+
+    p = sub.add_parser("create-conversation", help="Start a Kaizen conversation.")
+    p.add_argument(
+        "--kaizen-base-url",
+        required=True,
+        help="Kaizen instance API root (per-workroom).",
+    )
+    p.add_argument("--agent-id", required=True)
+    p.add_argument("--title", default=None)
+    p.add_argument("--max-iterations", type=int, default=500)
+    p.add_argument("--ephemeral", action="store_true")
+    p.add_argument("--workroom-id", default=None)
+    p.set_defaults(func=cmd_create_conversation)
+
+    p = sub.add_parser("import-skill", help="Import a skill package (.zip).")
+    p.add_argument("--file", required=True)
+    p.set_defaults(func=cmd_import_skill)
+
+    p = sub.add_parser(
+        "configure-m365",
+        help="Register the cluster-wide M365 connector (tenant + client id).",
+    )
+    p.add_argument("--tenant-id", required=True, help="Azure AD tenant ID (not secret).")
+    p.add_argument("--client-id", required=True, help="App-registration client ID (not secret).")
+    p.add_argument("--name", default="Microsoft 365")
+    p.add_argument("--scope", action="append", help="Graph scope (repeatable; defaults to the standard set).")
+    p.set_defaults(func=cmd_configure_m365)
+
+    return parser
+
+
+def main(
+    argv: Optional[list[str]] = None,
+    *,
+    client_factory: Callable[..., object] = build_client_from_env,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "func", None):
+        parser.error("a subcommand is required")
+    # The client targets the platform API root (global --base-url or env). The
+    # Kaizen commands carry their own per-workroom --kaizen-base-url, passed to
+    # the agent/conversation calls as a base_url override.
+    client = client_factory(base_url=args.base_url)
+    result = args.func(args, client=client)
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/kamiwaza_sdk/seeding/client.py
+++ b/kamiwaza_sdk/seeding/client.py
@@ -1,0 +1,63 @@
+# kamiwaza_sdk/seeding/client.py
+
+"""Build an authenticated client from the environment.
+
+A single place to construct a :class:`KamiwazaClient` for on-box seeding and
+off-box smoke runs, so both draw from one helper instead of re-deriving auth
+and TLS settings. Honors the same env vars the client and live tests already
+use (``KAMIWAZA_BASE_URL`` / ``KAMIWAZA_API_KEY`` / ``KAMIWAZA_VERIFY_SSL``).
+"""
+
+import os
+from typing import Optional, Union
+from uuid import UUID
+
+from ..client import KamiwazaClient
+
+
+def scoped_client_for_workroom(
+    client: KamiwazaClient, workroom_id: Union[str, UUID]
+) -> KamiwazaClient:
+    """Return a client whose calls are scoped to ``workroom_id``.
+
+    Workroom *enter* re-mints a JWT carrying the workroom claim; using that
+    token scopes subsequent platform deploys and Kaizen agent creation via the
+    trusted identity (``identity.workroom_id``) — the durable path, rather than
+    the legacy ``X-Workroom-Id`` transport hint. Falls back to the original
+    client when the platform does not remint a token (e.g. the Global workroom).
+    """
+    response = client.workrooms.enter(workroom_id)
+    token = getattr(response, "access_token", None)
+    if not token:
+        return client
+    scoped = KamiwazaClient(base_url=client.base_url, api_key=token)
+    # Carry over the TLS setting (e.g. self-signed dev cert) from the parent.
+    scoped.session.verify = client.session.verify
+    return scoped
+
+
+def build_client_from_env(
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> KamiwazaClient:
+    """Construct an authenticated client from explicit args or the environment.
+
+    Args:
+        base_url: Override for ``KAMIWAZA_BASE_URL`` / ``KAMIWAZA_BASE_URI``.
+        api_key: Override for ``KAMIWAZA_API_KEY`` / ``KAMIWAZA_API_TOKEN``.
+
+    Returns:
+        A KamiwazaClient. TLS verification follows ``KAMIWAZA_VERIFY_SSL``
+        (the client honors it natively), which the on-box nightly sets for the
+        self-signed cluster cert.
+    """
+    resolved_base = (
+        base_url
+        or os.environ.get("KAMIWAZA_BASE_URL")
+        or os.environ.get("KAMIWAZA_BASE_URI")
+    )
+    if not resolved_base:
+        raise SystemExit(
+            "Set KAMIWAZA_BASE_URL (or pass --base-url) to point the seeder at a cluster."
+        )
+    return KamiwazaClient(base_url=resolved_base, api_key=api_key)

--- a/kamiwaza_sdk/services/apps.py
+++ b/kamiwaza_sdk/services/apps.py
@@ -57,6 +57,7 @@ class AppService(BaseService):
         min_copies: int = 1,
         starting_copies: int = 1,
         max_copies: Optional[int] = None,
+        workroom_id: Optional[str] = None,
     ) -> AppDeployment:
         """
         Deploy a new application from a template.
@@ -68,6 +69,10 @@ class AppService(BaseService):
             min_copies: Minimum number of instances
             starting_copies: Initial number of instances
             max_copies: Maximum number of instances (for autoscaling)
+            workroom_id: Workroom to deploy into. The platform derives the
+                deployment's workroom from the caller's resolved context, so
+                this is sent as the ``X-Workroom-Id`` header rather than a body
+                field.
 
         Returns:
             AppDeployment object with deployment details
@@ -85,15 +90,96 @@ class AppService(BaseService):
             max_copies=max_copies,
         )
 
+        headers = {"X-Workroom-Id": str(workroom_id)} if workroom_id else None
         try:
             response = self.client.post(
-                "/apps/deploy_app", json=deployment_request.model_dump()
+                "/apps/deploy_app",
+                # mode="json" so template_id (UUID) serializes to a string;
+                # the requests JSON encoder can't adapt a raw UUID.
+                json=deployment_request.model_dump(mode="json"),
+                headers=headers,
             )
             return AppDeployment.model_validate(response)
         except APIError as e:
             if "404" in str(e):
                 raise NotFoundError(f"Template {template_id} not found")
             raise
+
+    def find_template(
+        self, name: str, version: Optional[str] = None
+    ) -> Optional[AppTemplate]:
+        """Find a catalog template by name (and optional version).
+
+        Args:
+            name: Template name (exact match).
+            version: Optional version to disambiguate when multiple revisions
+                of the same name exist.
+
+        Returns:
+            The matching AppTemplate, or None if no template matches.
+        """
+        for template in self.list_templates():
+            if template.name != name:
+                continue
+            if version is not None and template.version != version:
+                continue
+            return template
+        return None
+
+    def install_by_name(
+        self,
+        name: str,
+        *,
+        version: Optional[str] = None,
+        deployment_name: Optional[str] = None,
+        env_vars: Optional[Dict[str, str]] = None,
+        workroom_id: Optional[str] = None,
+        min_copies: int = 1,
+        starting_copies: int = 1,
+        max_copies: Optional[int] = None,
+        sync_if_missing: bool = True,
+    ) -> AppDeployment:
+        """Install a catalog extension by name, resolving its template id.
+
+        This is the current install-by-name path: it resolves the named
+        catalog template and deploys it via the App Garden, so callers don't
+        hand-author a full extension CR. When the template isn't in the local
+        catalog yet and ``sync_if_missing`` is set, it imports the garden
+        catalog once and retries the lookup.
+
+        Args:
+            name: Catalog template/extension name (e.g. "kaizen").
+            version: Optional version to pin.
+            deployment_name: Name for the deployment (defaults to ``name``).
+            env_vars: Optional environment variables for the deployment.
+            workroom_id: Workroom to install into (X-Workroom-Id header).
+            min_copies / starting_copies / max_copies: Scaling parameters.
+            sync_if_missing: Import the garden catalog and retry if the named
+                template isn't found locally.
+
+        Returns:
+            AppDeployment for the installed extension.
+
+        Raises:
+            NotFoundError: If no template matches after an optional sync.
+        """
+        template = self.find_template(name, version)
+        if template is None and sync_if_missing:
+            self.import_garden_apps()
+            template = self.find_template(name, version)
+        if template is None:
+            suffix = f" (version {version})" if version else ""
+            raise NotFoundError(f"No catalog template named '{name}'{suffix} found")
+
+        return self.deploy(
+            template_id=template.id,
+            name=deployment_name or name,
+            env_vars=env_vars,
+            min_copies=min_copies,
+            starting_copies=starting_copies,
+            max_copies=max_copies,
+            workroom_id=workroom_id,
+        )
 
     def list_deployments(self) -> List[AppDeployment]:
         """

--- a/kamiwaza_sdk/services/connectors.py
+++ b/kamiwaza_sdk/services/connectors.py
@@ -1,0 +1,95 @@
+# kamiwaza_sdk/services/connectors.py
+
+"""Client service for cluster-wide external connectors (M365, Google, …).
+
+Registers the connector *app* (admin-scoped, one per type per cluster) — e.g.
+the M365 tenant/client identifiers. The per-user OAuth connection is a separate
+interactive Device Code Flow and is intentionally not wrapped here.
+"""
+
+from typing import List, Optional, Union
+from uuid import UUID
+
+from .base_service import BaseService
+from ..exceptions import APIError, NotFoundError
+from ..schemas.connectors import (
+    M365_DEFAULT_SCOPES,
+    ExternalConnector,
+    ExternalConnectorCreate,
+    M365ConnectorConfig,
+)
+
+
+class ConnectorService(BaseService):
+    """Manage cluster-wide connector registrations."""
+
+    def list(self) -> List[ExternalConnector]:
+        """List registered connectors."""
+        response = self.client.get("/connectors")
+        items = (
+            response.get("items", response) if isinstance(response, dict) else response
+        )
+        return [ExternalConnector.model_validate(item) for item in items]
+
+    def get(self, connector_id: Union[str, UUID]) -> ExternalConnector:
+        """Get a connector by id."""
+        try:
+            response = self.client.get(f"/connectors/{connector_id}")
+            return ExternalConnector.model_validate(response)
+        except APIError as e:
+            if e.status_code == 404:
+                raise NotFoundError(f"Connector '{connector_id}' not found") from e
+            raise
+
+    def create(self, request: ExternalConnectorCreate) -> ExternalConnector:
+        """Register a connector (admin-scoped, cluster-wide)."""
+        response = self.client.post(
+            "/connectors", json=request.model_dump(mode="json")
+        )
+        return ExternalConnector.model_validate(response)
+
+    def create_m365(
+        self,
+        *,
+        tenant_id: str,
+        client_id: str,
+        name: str = "Microsoft 365",
+        scopes: Optional[List[str]] = None,
+        enabled: bool = True,
+    ) -> ExternalConnector:
+        """Register the cluster-wide M365 connector.
+
+        ``tenant_id`` and ``client_id`` are public Azure AD identifiers (not
+        secrets); no client secret is used (Device Code Flow). Each user later
+        connects their own account interactively.
+
+        Args:
+            tenant_id: Azure AD tenant ID.
+            client_id: App-registration client ID.
+            name: Display name for the connector.
+            scopes: Graph scopes to request; defaults to the standard M365 set.
+            enabled: Whether the connector is enabled.
+
+        Returns:
+            ExternalConnector: The registered connector.
+        """
+        request = ExternalConnectorCreate(
+            name=name,
+            connector_type="m365",
+            config=M365ConnectorConfig(
+                tenant_id=tenant_id, client_id=client_id
+            ).model_dump(),
+            scopes=scopes or list(M365_DEFAULT_SCOPES),
+            enabled=enabled,
+        )
+        return self.create(request)
+
+    def delete(self, connector_id: Union[str, UUID]) -> bool:
+        """Delete a connector by id."""
+        try:
+            self.client.delete(f"/connectors/{connector_id}")
+            return True
+        except APIError as e:
+            if e.status_code == 404:
+                raise NotFoundError(f"Connector '{connector_id}' not found") from e
+            raise

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -1,0 +1,286 @@
+# kamiwaza_sdk/services/kaizen.py
+
+"""Client services for the Kaizen agent extension.
+
+Kaizen runs as a per-workroom extension behind its own ingress, so every call
+takes an explicit ``base_url`` (the Kaizen instance API root). Resolve it once
+from the platform extensions API with :func:`resolve_base_url`, then pass it to
+``agents.create`` / ``conversations.create``.
+
+Workroom scope is carried as the ``X-Workroom-Id`` header. The authoritative
+scope is the caller's identity; with a global PAT (no workroom claim) the
+platform honors this header. A workroom-scoped token is the durable fix
+(tracked for the nightly-seeding work).
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from ..schemas.kaizen import Agent, Conversation, LLMConfig
+from .base_service import BaseService
+
+# Kaizen route prefixes, relative to the extension's ingress root.
+_AGENTS_PATH = "api/agents/"
+_CONVERSATIONS_PATH = "api/conversations/"
+
+
+def _workroom_headers(workroom_id: Optional[Union[str, object]]) -> Dict[str, str]:
+    """Build the X-Workroom-Id header that scopes a Kaizen call to a workroom."""
+    if workroom_id is None:
+        return {}
+    return {"X-Workroom-Id": str(workroom_id)}
+
+
+def resolve_base_url(
+    client, extension_name: str = "kaizen", *, public: bool = False
+) -> str:
+    """Best-effort lookup of a Kaizen instance's ingress root from the platform.
+
+    Reads the extension's resolved endpoints. Raises ValueError when no endpoint
+    is published yet (extension still provisioning) — callers that already know
+    the URL should pass ``base_url`` directly instead.
+    """
+    extension = client.extensions.get_extension(extension_name)
+    endpoints = getattr(extension, "endpoints", None)
+    candidates = []
+    if endpoints is not None:
+        # ``external`` is the ingress-reachable URL; some deployments instead
+        # surface ``public_api_url`` / ``api_url`` (extra fields). Prefer the
+        # public-facing field when ``public`` is set, else the ingress URL.
+        order = (
+            ("public_api_url", "api_url", "external")
+            if public
+            else ("external", "api_url", "public_api_url")
+        )
+        for attr in order:
+            value = getattr(endpoints, attr, None)
+            if value:
+                candidates.append(value)
+    if not candidates:
+        raise ValueError(
+            f"Extension '{extension_name}' has no published endpoint yet; "
+            "wait for it to become ready or pass base_url explicitly."
+        )
+    return str(candidates[0]).rstrip("/")
+
+
+class AgentService(BaseService):
+    """Create and list Kaizen agents within a workroom."""
+
+    def create(
+        self,
+        *,
+        base_url: str,
+        name: str,
+        llm: Union[LLMConfig, Dict[str, Any]],
+        description: Optional[str] = None,
+        agent_config: Optional[Dict[str, Any]] = None,
+        custom_instructions: Optional[str] = None,
+        llm_api_key: Optional[str] = None,
+        mcp_headers: Optional[Dict[str, Dict[str, str]]] = None,
+        workroom_id: Optional[Union[str, object]] = None,
+    ) -> Agent:
+        """Create an agent bound to a model via ``agent_config.llm``.
+
+        Args:
+            base_url: The Kaizen instance API root (see :func:`resolve_base_url`).
+            name: Agent display name.
+            llm: Model binding (``LLMConfig`` or a raw dict). Merged into
+                ``agent_config["llm"]``.
+            description: Optional agent description.
+            agent_config: Optional base agent config; ``llm`` is merged in.
+            custom_instructions: Optional behavior instructions.
+            llm_api_key: Optional custom-endpoint API key (encrypted server-side).
+            mcp_headers: Optional per-MCP-server headers.
+            workroom_id: Workroom to scope the agent to (X-Workroom-Id header).
+
+        Returns:
+            Agent: The created agent.
+        """
+        llm_dict = (
+            llm.model_dump(exclude_none=True)
+            if isinstance(llm, LLMConfig)
+            else dict(llm)
+        )
+        merged_config: Dict[str, Any] = dict(agent_config or {})
+        merged_config["llm"] = llm_dict
+
+        body: Dict[str, Any] = {"name": name, "agent_config": merged_config}
+        if description is not None:
+            body["description"] = description
+        if custom_instructions is not None:
+            body["custom_instructions"] = custom_instructions
+        if llm_api_key is not None:
+            body["llm_api_key"] = llm_api_key
+        if mcp_headers is not None:
+            body["mcp_headers"] = mcp_headers
+
+        response = self.client._request(
+            "POST",
+            _AGENTS_PATH,
+            base_url=base_url,
+            json=body,
+            headers=_workroom_headers(workroom_id),
+        )
+        return Agent.model_validate(response)
+
+    def list(
+        self,
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+    ) -> List[Agent]:
+        """List agents visible in the workroom scope."""
+        response = self.client._request(
+            "GET",
+            _AGENTS_PATH,
+            base_url=base_url,
+            headers=_workroom_headers(workroom_id),
+        )
+        items = (
+            response.get("agents", response) if isinstance(response, dict) else response
+        )
+        return [Agent.model_validate(item) for item in items]
+
+    def bind_skill(
+        self,
+        agent_id: str,
+        skill_id: Union[str, object],
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+    ) -> Agent:
+        """Attach a published library skill to an agent.
+
+        Kaizen rejects ``skill_bindings`` at agent-create time; skills must be
+        attached through this managed endpoint after the agent exists. The skill
+        must be published (draft skills are rejected with 404).
+
+        Args:
+            agent_id: The agent to attach the skill to.
+            skill_id: The published skill's id.
+            base_url: The Kaizen instance API root.
+            workroom_id: Workroom scope (X-Workroom-Id header).
+
+        Returns:
+            Agent: The updated agent (including the new binding).
+        """
+        response = self.client._request(
+            "POST",
+            f"api/agents/{agent_id}/skill-bindings",
+            base_url=base_url,
+            json={"skill_id": str(skill_id)},
+            headers=_workroom_headers(workroom_id),
+        )
+        return Agent.model_validate(response)
+
+
+class ConversationService(BaseService):
+    """Create Kaizen conversations (auto-starts the agent sandbox)."""
+
+    def create(
+        self,
+        *,
+        base_url: str,
+        agent_id: str,
+        title: Optional[str] = None,
+        max_iterations: int = 500,
+        stuck_detection: bool = True,
+        ephemeral: bool = False,
+        workroom_id: Optional[Union[str, object]] = None,
+    ) -> Conversation:
+        """Start a conversation with an agent; provisions the sandbox container.
+
+        Args:
+            base_url: The Kaizen instance API root.
+            agent_id: The agent to converse with.
+            title: Optional conversation title.
+            max_iterations: Agent step ceiling (Kaizen default 500).
+            stuck_detection: Enable Kaizen's stuck-loop detection.
+            ephemeral: Ephemeral (non-persisted) conversation; rejected by
+                Kaizen in shared workrooms.
+            workroom_id: Workroom scope (X-Workroom-Id header).
+
+        Returns:
+            Conversation: The created conversation.
+        """
+        body: Dict[str, Any] = {
+            "agent_id": agent_id,
+            "max_iterations": max_iterations,
+            "stuck_detection": stuck_detection,
+            "ephemeral": ephemeral,
+        }
+        if title is not None:
+            body["title"] = title
+
+        response = self.client._request(
+            "POST",
+            _CONVERSATIONS_PATH,
+            base_url=base_url,
+            json=body,
+            headers=_workroom_headers(workroom_id),
+        )
+        return Conversation.model_validate(response)
+
+    def send_message(
+        self,
+        conversation_id: str,
+        message: str,
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+    ) -> None:
+        """Enqueue a user message on a conversation.
+
+        The message is queued; call :meth:`run` to have the agent process it.
+        Returns None (the endpoint responds 204 No Content).
+        """
+        self.client._request(
+            "POST",
+            f"api/conversations/{conversation_id}/messages",
+            base_url=base_url,
+            json={"message": message},
+            headers=_workroom_headers(workroom_id),
+            expect_json=False,
+        )
+
+    def run(
+        self,
+        conversation_id: str,
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+    ) -> None:
+        """Trigger the agent to process queued messages (runs in the background).
+
+        Observe progress/results via :meth:`get_events`. Returns None (204).
+        """
+        self.client._request(
+            "POST",
+            f"api/conversations/{conversation_id}/run",
+            base_url=base_url,
+            headers=_workroom_headers(workroom_id),
+            expect_json=False,
+        )
+
+    def get_events(
+        self,
+        conversation_id: str,
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+        offset: int = 0,
+        limit: int = 200,
+    ) -> Dict[str, Any]:
+        """Fetch conversation events (agent messages, tool calls, errors).
+
+        Returns the raw events envelope ``{events, total, offset, limit}``.
+        Event ``kind`` values include ``MessageEvent`` (the ``llm_message`` with
+        role/content), ``ConversationErrorEvent``, tool events, etc.
+        """
+        return self.client._request(
+            "GET",
+            f"api/conversations/{conversation_id}/events",
+            base_url=base_url,
+            params={"offset": offset, "limit": limit},
+            headers=_workroom_headers(workroom_id),
+        )

--- a/kamiwaza_sdk/services/models/base.py
+++ b/kamiwaza_sdk/services/models/base.py
@@ -1,7 +1,12 @@
+import json
 from typing import List, Optional, Union, Dict, Any
 from uuid import UUID
-from ...exceptions import APIError
+from pydantic import BaseModel
 from ...schemas.models.model import Model, CreateModel
+from ...schemas.models.external_endpoint import (
+    AWSBedrockChatEndpoint,
+    AWSTranscribeEndpoint,
+)
 from ...schemas.guide import ModelGuide
 from ...utils.quant_manager import QuantizationManager
 from ..base_service import BaseService
@@ -77,6 +82,84 @@ class ModelService(BaseService,
         response = self.client._request("POST", "/models/", json=model.model_dump())
         return Model.model_validate(response)
 
+    def register_external_model(
+        self,
+        *,
+        name: str,
+        endpoint: Union[AWSBedrockChatEndpoint, AWSTranscribeEndpoint],
+        credential: Union[BaseModel, Dict[str, Any], str],
+        force_replace_credentials: bool = False,
+        description: Optional[str] = None,
+        modelfamily: Optional[str] = None,
+        config_name: Optional[str] = None,
+    ) -> Model:
+        """Register an external (vendor-hosted) model via ``POST /models/``.
+
+        Wraps the platform's external-endpoint registration: the ``endpoint``
+        blob plus an inline ``credential_secret`` (the plaintext credential,
+        serialized to JSON) is submitted under ``default_config.system_config``.
+        The platform validates it, stores the credential as an encrypted Catalog
+        secret, strips the plaintext, and persists only the resolved URN.
+
+        Args:
+            name: Model name shown in the platform.
+            endpoint: Protocol-specific endpoint config (Bedrock chat or
+                Transcribe). The ``protocol`` discriminator is carried on it.
+            credential: Inline credential — a typed credential model (e.g.
+                ``AWSBedrockIamCredential``), a dict, or a pre-serialized JSON
+                string. Always stored encrypted server-side.
+            force_replace_credentials: When the deterministic Catalog secret
+                name already exists, rotate the stored value in place instead
+                of failing with 409. Makes re-registration idempotent.
+            description: Optional model description.
+            modelfamily: Optional model family label.
+            config_name: Optional name for the default config row.
+
+        Returns:
+            Model: The created model (credential normalized to a URN).
+        """
+        blob: Dict[str, Any] = endpoint.model_dump(exclude_none=True)
+        blob["credential_secret"] = self._serialize_credential(credential)
+
+        # The blob lives in ``system_config`` (not ``config``): the platform
+        # JSON-stringifies system_config values before persisting them, whereas
+        # config values are stored raw and a nested dict fails to adapt at the
+        # DB layer. This also matches where the platform normalizes credentials.
+        default_config: Dict[str, Any] = {
+            "default": True,
+            "name": config_name or f"{name} External Endpoint",
+            "config": {},
+            "system_config": {"external_endpoint": blob},
+        }
+        model = CreateModel(
+            name=name,
+            description=description,
+            modelfamily=modelfamily,
+            default_config=default_config,
+        )
+
+        params = (
+            {"force_replace_credentials": True} if force_replace_credentials else None
+        )
+        response = self.client._request(
+            "POST",
+            "/models/",
+            params=params,
+            json=model.model_dump(exclude_none=True),
+        )
+        return Model.model_validate(response)
+
+    @staticmethod
+    def _serialize_credential(
+        credential: Union[BaseModel, Dict[str, Any], str],
+    ) -> str:
+        """Normalize a credential into the inline JSON string the platform expects."""
+        if isinstance(credential, str):
+            return credential
+        if isinstance(credential, BaseModel):
+            return credential.model_dump_json(exclude_none=True)
+        return json.dumps(credential)
+
     def delete_model(self, model_id: Union[str, UUID]) -> dict:
         """
         Delete a specific model by its ID.
@@ -111,13 +194,13 @@ class ModelService(BaseService,
         response = self.client._request("GET", "/models/", params={"load_files": load_files})
         return [Model.model_validate(item) for item in response]
 
-    def get_model_by_repo_id(self, repo_id: str) -> Model:
+    def get_model_by_repo_id(self, repo_id: str) -> Optional[Model]:
         """
         Retrieve a model by its repo_modelId by searching through the models list.
-        
+
         Args:
             repo_id (str): The repository ID of the model to retrieve.
-            
+
         Returns:
             Model: The model object, or None if not found.
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 kz-ext = "kamiwaza_extensions.cli:app"
+kamiwaza-seed = "kamiwaza_sdk.seeding.cli:main"
 
 # `kamiwaza-extensions-lib` is published as its own PyPI distribution
 # from `kamiwaza_extensions_lib/pyproject.toml`. For local dev / tests we

--- a/tests/integration/test_seeding_live.py
+++ b/tests/integration/test_seeding_live.py
@@ -1,0 +1,39 @@
+"""Live coverage for the seeding surfaces, reusing the shared live fixtures.
+
+These exercise the generic seeding building blocks against a running platform
+using the same authenticated client/auth helpers as the smoke tests
+(``tests/integration/conftest.py``), so seeding and smoke draw from one
+library. The environment-specific UAT profile (which models/extensions) lives
+in the nightly seeding job, not here.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from kamiwaza_sdk.seeding import scoped_client_for_workroom
+
+pytestmark = [pytest.mark.integration, pytest.mark.live]
+
+
+def test_find_template_resolves_against_live_catalog(live_write_client):
+    """install_by_name's resolver must query the live catalog without error.
+
+    A name we never publish resolves to None rather than raising — proving the
+    lookup path is sound regardless of catalog contents.
+    """
+    assert live_write_client.apps.find_template("seed-probe-does-not-exist") is None
+
+
+def test_workroom_create_enter_scopes_a_client(live_write_client):
+    """Create a workroom, mint a workroom-scoped client via enter, then clean up."""
+    name = f"seed-probe-{uuid4().hex[:8]}"
+    workroom = live_write_client.workrooms.create(name=name, workroom_type="persistent")
+    try:
+        scoped = scoped_client_for_workroom(live_write_client, workroom.id)
+        # Either a reminted-token client or a graceful fall back to the parent.
+        assert scoped is not None
+    finally:
+        live_write_client.workrooms.delete(workroom.id)

--- a/tests/unit/test_apps_install_by_name.py
+++ b/tests/unit/test_apps_install_by_name.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import uuid
+import warnings
+
+import pytest
+
+from kamiwaza_sdk.exceptions import NotFoundError
+from kamiwaza_sdk.services.apps import AppService
+
+pytestmark = pytest.mark.unit
+
+_TS = "2026-01-01T00:00:00Z"
+
+
+def _template(name: str, version: str = "1.0.0") -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "name": name,
+        "version": version,
+        "source_type": "kamiwaza",
+        "visibility": "private",
+        "compose_yml": "services: {}",
+        "risk_tier": 1,
+        "created_at": _TS,
+    }
+
+
+def _deployment(name: str) -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "name": name,
+        "requested_at": _TS,
+        "created_at": _TS,
+        "status": "UNINITIALIZED",
+    }
+
+
+class DummyClient:
+    """Records calls; serves template-list pages in sequence."""
+
+    def __init__(self, template_pages, deploy_response):
+        self._template_pages = list(template_pages)
+        self._deploy_response = deploy_response
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def get(self, path: str, **kwargs):
+        self.calls.append(("GET", path, kwargs))
+        if path == "/apps/app_templates":
+            return self._template_pages.pop(0)
+        raise AssertionError(f"Unexpected GET {path}")
+
+    def post(self, path: str, **kwargs):
+        self.calls.append(("POST", path, kwargs))
+        if path == "/apps/deploy_app":
+            return self._deploy_response
+        if path == "/apps/garden/import":
+            return {"imported_count": 1}
+        raise AssertionError(f"Unexpected POST {path}")
+
+
+def _service(client) -> AppService:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return AppService(client)
+
+
+def test_install_by_name_resolves_template_and_deploys_with_workroom_header():
+    template = _template("kaizen", "2.0.2")
+    client = DummyClient([[template]], _deployment("kaizen"))
+    service = _service(client)
+
+    deployment = service.install_by_name("kaizen", version="2.0.2", workroom_id="wr-1")
+
+    assert deployment.name == "kaizen"
+    post_calls = [c for c in client.calls if c[0] == "POST"]
+    assert len(post_calls) == 1
+    _, path, kwargs = post_calls[0]
+    assert path == "/apps/deploy_app"
+    assert str(kwargs["json"]["template_id"]) == template["id"]
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}
+
+
+def test_install_by_name_syncs_catalog_when_template_missing():
+    template = _template("skills-library")
+    # First lookup empty, then (after import) the template appears.
+    client = DummyClient([[], [template]], _deployment("skills-library"))
+    service = _service(client)
+
+    service.install_by_name("skills-library")
+
+    paths = [(c[0], c[1]) for c in client.calls]
+    assert paths == [
+        ("GET", "/apps/app_templates"),
+        ("POST", "/apps/garden/import"),
+        ("GET", "/apps/app_templates"),
+        ("POST", "/apps/deploy_app"),
+    ]
+
+
+def test_install_by_name_raises_when_not_found_and_no_sync():
+    client = DummyClient([[]], _deployment("nope"))
+    service = _service(client)
+
+    with pytest.raises(NotFoundError, match="No catalog template named 'nope'"):
+        service.install_by_name("nope", sync_if_missing=False)
+
+    # No deploy attempted.
+    assert not any(c[1] == "/apps/deploy_app" for c in client.calls)

--- a/tests/unit/test_client_base_url_override.py
+++ b/tests/unit/test_client_base_url_override.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from kamiwaza_sdk.client import KamiwazaClient
+
+pytestmark = pytest.mark.unit
+
+
+class _StubResponse:
+    status_code = 200
+    headers = {"content-type": "application/json"}
+    text = "{}"
+
+    def json(self) -> object:
+        return {"ok": True}
+
+
+def _client_capturing_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[KamiwazaClient, list[str]]:
+    client = KamiwazaClient(base_url="https://example.test/api")
+    seen: list[str] = []
+
+    def fake_request(method, url, **kwargs):
+        seen.append(url)
+        return _StubResponse()
+
+    monkeypatch.setattr(client.session, "request", fake_request)
+    return client, seen
+
+
+def test_request_uses_platform_base_url_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, seen = _client_capturing_url(monkeypatch)
+
+    client._request("GET", "models/")
+
+    assert seen == ["https://example.test/api/models/"]
+
+
+def test_request_base_url_override_same_host_extension_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, seen = _client_capturing_url(monkeypatch)
+
+    # In-cluster extensions (e.g. Kaizen) sit on the platform host at a
+    # different path; the override is allowed.
+    client._request(
+        "POST", "api/agents/", base_url="https://example.test/runtime/apps/kaizen-1"
+    )
+
+    assert seen == ["https://example.test/runtime/apps/kaizen-1/api/agents/"]
+
+
+def test_request_base_url_override_rejects_foreign_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, seen = _client_capturing_url(monkeypatch)
+
+    # A cross-host base_url must not receive the platform bearer token.
+    with pytest.raises(ValueError, match="not on the platform host"):
+        client._request("POST", "api/agents/", base_url="https://evil.example/kaizen")
+
+    assert seen == []

--- a/tests/unit/test_connectors_service.py
+++ b/tests/unit/test_connectors_service.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from kamiwaza_sdk.exceptions import APIError, NotFoundError
+from kamiwaza_sdk.schemas.connectors import M365_DEFAULT_SCOPES
+from kamiwaza_sdk.services.connectors import ConnectorService
+
+pytestmark = pytest.mark.unit
+
+_TS = "2026-01-01T00:00:00Z"
+
+
+class DummyClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def post(self, path, **kwargs):
+        self.calls.append(("POST", path, kwargs))
+        return self.responses[("POST", path)]
+
+    def get(self, path, **kwargs):
+        self.calls.append(("GET", path, kwargs))
+        return self.responses[("GET", path)]
+
+
+def _connector(name="Microsoft 365"):
+    return {
+        "id": str(uuid.uuid4()),
+        "name": name,
+        "connector_type": "m365",
+        "enabled": True,
+        "scopes": M365_DEFAULT_SCOPES,
+        "created_at": _TS,
+    }
+
+
+def test_create_m365_builds_config_and_default_scopes():
+    resp = _connector()
+    client = DummyClient({("POST", "/connectors"): resp})
+    service = ConnectorService(client)
+
+    conn = service.create_m365(tenant_id="tenant-abc", client_id="client-xyz")
+
+    assert conn.connector_type == "m365"
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("POST", "/connectors")
+    body = kwargs["json"]
+    assert body["connector_type"] == "m365"
+    assert body["config"] == {"tenant_id": "tenant-abc", "client_id": "client-xyz"}
+    # tenant/client are the only config — no client_secret.
+    assert "client_secret" not in body["config"]
+    assert body["scopes"] == M365_DEFAULT_SCOPES
+    assert body["name"] == "Microsoft 365"
+
+
+def test_create_m365_custom_name_and_scopes():
+    resp = _connector(name="Corp M365")
+    client = DummyClient({("POST", "/connectors"): resp})
+    service = ConnectorService(client)
+
+    service.create_m365(
+        tenant_id="t", client_id="c", name="Corp M365", scopes=["User.Read"]
+    )
+
+    body = client.calls[0][2]["json"]
+    assert body["name"] == "Corp M365"
+    assert body["scopes"] == ["User.Read"]
+
+
+def test_list_unwraps_items_envelope():
+    client = DummyClient({("GET", "/connectors"): {"items": [_connector()]}})
+    service = ConnectorService(client)
+
+    out = service.list()
+
+    assert len(out) == 1
+    assert out[0].connector_type == "m365"
+
+
+class _RaisingClient:
+    """Raises a 404 APIError on get/delete to exercise NotFoundError mapping."""
+
+    def get(self, path, **kwargs):
+        raise APIError("not found", status_code=404)
+
+    def delete(self, path, **kwargs):
+        raise APIError("not found", status_code=404)
+
+
+def test_get_maps_404_to_not_found():
+    service = ConnectorService(_RaisingClient())
+    with pytest.raises(NotFoundError):
+        service.get(uuid.uuid4())
+
+
+def test_delete_maps_404_to_not_found():
+    service = ConnectorService(_RaisingClient())
+    with pytest.raises(NotFoundError):
+        service.delete(uuid.uuid4())

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from kamiwaza_sdk.schemas.kaizen import LLMConfig
+from kamiwaza_sdk.services.kaizen import (
+    AgentService,
+    ConversationService,
+    resolve_base_url,
+)
+
+pytestmark = pytest.mark.unit
+
+KAIZEN_URL = "https://kamiwaza.test/kaizen"
+
+
+class DummyClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def _request(self, method: str, path: str, **kwargs):
+        self.calls.append((method, path, kwargs))
+        return self.responses[(method, path)]
+
+
+def test_agent_create_merges_llm_and_targets_kaizen_base_url():
+    responses = {("POST", "api/agents/"): {"id": "agent-1", "name": "seed-agent"}}
+    client = DummyClient(responses)
+    service = AgentService(client)
+
+    agent = service.create(
+        base_url=KAIZEN_URL,
+        name="seed-agent",
+        llm=LLMConfig(provider="kamiwaza", model="llama-3", endpoint_path="/dep/abc"),
+        description="seeded",
+        workroom_id="wr-123",
+    )
+
+    assert agent.id == "agent-1"
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("POST", "api/agents/")
+    assert kwargs["base_url"] == KAIZEN_URL
+    # llm is merged under agent_config; model binding preserved.
+    assert kwargs["json"]["agent_config"]["llm"] == {
+        "model": "llama-3",
+        "provider": "kamiwaza",
+        "endpoint_path": "/dep/abc",
+    }
+    assert kwargs["json"]["description"] == "seeded"
+    # Workroom scope rides the header, never the body.
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-123"}
+    assert "workroom_id" not in kwargs["json"]
+
+
+def test_agent_create_accepts_raw_llm_dict_and_no_workroom():
+    responses = {("POST", "api/agents/"): {"id": "agent-2"}}
+    client = DummyClient(responses)
+    service = AgentService(client)
+
+    service.create(
+        base_url=KAIZEN_URL,
+        name="a",
+        llm={"model": "gpt-4o", "base_url": "https://vendor.example/v1"},
+    )
+
+    _, _, kwargs = client.calls[0]
+    assert kwargs["json"]["agent_config"]["llm"]["model"] == "gpt-4o"
+    # No workroom_id -> no scoping header.
+    assert kwargs["headers"] == {}
+
+
+def test_conversation_create_builds_body_and_header():
+    responses = {
+        ("POST", "api/conversations/"): {"id": "conv-1", "agent_id": "agent-1"}
+    }
+    client = DummyClient(responses)
+    service = ConversationService(client)
+
+    conv = service.create(
+        base_url=KAIZEN_URL,
+        agent_id="agent-1",
+        title="seed convo",
+        workroom_id="wr-123",
+    )
+
+    assert conv.id == "conv-1"
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("POST", "api/conversations/")
+    assert kwargs["base_url"] == KAIZEN_URL
+    assert kwargs["json"] == {
+        "agent_id": "agent-1",
+        "max_iterations": 500,
+        "stuck_detection": True,
+        "ephemeral": False,
+        "title": "seed convo",
+    }
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-123"}
+
+
+def test_resolve_base_url_reads_extension_endpoint():
+    extension = SimpleNamespace(
+        endpoints=SimpleNamespace(
+            external="https://kamiwaza.test/kaizen/", public_api_url=None
+        )
+    )
+    client = SimpleNamespace(
+        extensions=SimpleNamespace(get_extension=lambda name: extension)
+    )
+
+    assert resolve_base_url(client) == "https://kamiwaza.test/kaizen"
+
+
+def test_resolve_base_url_falls_back_to_api_url():
+    # Deployment exposes only api_url (no external/public_api_url).
+    extension = SimpleNamespace(
+        endpoints=SimpleNamespace(
+            external=None, public_api_url=None, api_url="https://kamiwaza.test/kaizen-api/"
+        )
+    )
+    client = SimpleNamespace(
+        extensions=SimpleNamespace(get_extension=lambda name: extension)
+    )
+
+    assert resolve_base_url(client) == "https://kamiwaza.test/kaizen-api"
+
+
+def test_resolve_base_url_raises_when_no_endpoint():
+    extension = SimpleNamespace(
+        endpoints=SimpleNamespace(external=None, public_api_url=None)
+    )
+    client = SimpleNamespace(
+        extensions=SimpleNamespace(get_extension=lambda name: extension)
+    )
+
+    with pytest.raises(ValueError, match="no published endpoint"):
+        resolve_base_url(client, "kaizen")
+
+
+def test_agent_list_unwraps_agents_envelope():
+    responses = {("GET", "api/agents/"): {"agents": [{"id": "agent-1", "name": "a"}]}}
+    client = DummyClient(responses)
+    service = AgentService(client)
+
+    agents = service.list(base_url=KAIZEN_URL, workroom_id="wr-1")
+
+    assert [a.id for a in agents] == ["agent-1"]
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("GET", "api/agents/")
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}
+
+
+def test_agent_bind_skill_posts_to_managed_endpoint():
+    responses = {("POST", "api/agents/agent-1/skill-bindings"): {"id": "agent-1"}}
+    client = DummyClient(responses)
+    service = AgentService(client)
+
+    service.bind_skill("agent-1", "skill-9", base_url=KAIZEN_URL, workroom_id="wr-1")
+
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("POST", "api/agents/agent-1/skill-bindings")
+    assert kwargs["base_url"] == KAIZEN_URL
+    assert kwargs["json"] == {"skill_id": "skill-9"}
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}
+
+
+def test_conversation_send_message_enqueues_without_json_response():
+    responses = {("POST", "api/conversations/conv-1/messages"): None}
+    client = DummyClient(responses)
+    service = ConversationService(client)
+
+    result = service.send_message("conv-1", "hello", base_url=KAIZEN_URL, workroom_id="wr-1")
+
+    assert result is None
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("POST", "api/conversations/conv-1/messages")
+    assert kwargs["json"] == {"message": "hello"}
+    assert kwargs["expect_json"] is False
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}
+
+
+def test_conversation_run_triggers_processing():
+    responses = {("POST", "api/conversations/conv-1/run"): None}
+    client = DummyClient(responses)
+    service = ConversationService(client)
+
+    service.run("conv-1", base_url=KAIZEN_URL)
+
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("POST", "api/conversations/conv-1/run")
+    assert kwargs["expect_json"] is False
+    assert kwargs["headers"] == {}
+
+
+def test_conversation_get_events_passes_pagination():
+    responses = {("GET", "api/conversations/conv-1/events"): {"events": [], "total": 0}}
+    client = DummyClient(responses)
+    service = ConversationService(client)
+
+    out = service.get_events("conv-1", base_url=KAIZEN_URL, workroom_id="wr-1", offset=5, limit=50)
+
+    assert out == {"events": [], "total": 0}
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("GET", "api/conversations/conv-1/events")
+    assert kwargs["params"] == {"offset": 5, "limit": 50}
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}

--- a/tests/unit/test_model_service.py
+++ b/tests/unit/test_model_service.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import json
 import uuid
 
 import pytest
 
+from kamiwaza_sdk.schemas.models.external_endpoint import (
+    AWSBedrockChatEndpoint,
+    AWSBedrockIamCredential,
+    AWSTranscribeCredential,
+    AWSTranscribeEndpoint,
+)
 from kamiwaza_sdk.schemas.models.model import CreateModel
 from kamiwaza_sdk.services.models.base import ModelService
 
@@ -172,3 +179,76 @@ def test_create_and_delete_model():
 
     service.delete_model(model_id)
     assert client.calls[1][0] == "DELETE"
+
+
+def test_register_external_model_bedrock_builds_endpoint_blob():
+    model_id = str(uuid.uuid4())
+    responses = {("POST", "/models/"): {"id": model_id, "name": "bedrock-claude"}}
+    client = DummyClient(responses)
+    service = ModelService(client)
+
+    created = service.register_external_model(
+        name="bedrock-claude",
+        endpoint=AWSBedrockChatEndpoint(
+            region="us-east-1",
+            model_id="anthropic.claude-3-sonnet-20240229-v1:0",
+        ),
+        credential=AWSBedrockIamCredential(
+            aws_access_key_id="AKIAEXAMPLE",
+            aws_secret_access_key="secret",
+        ),
+    )
+
+    assert created.id == uuid.UUID(model_id)
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("POST", "/models/")
+    # No rotation requested -> no query param sent.
+    assert kwargs.get("params") is None
+
+    blob = kwargs["json"]["default_config"]["system_config"]["external_endpoint"]
+    assert blob["protocol"] == "aws_bedrock"
+    assert blob["region"] == "us-east-1"
+    assert blob["model_id"] == "anthropic.claude-3-sonnet-20240229-v1:0"
+
+    # Credential travels inline as a JSON string, never as a structured dict.
+    cred = json.loads(blob["credential_secret"])
+    assert cred == {
+        "auth_type": "iam",
+        "aws_access_key_id": "AKIAEXAMPLE",
+        "aws_secret_access_key": "secret",
+    }
+    assert kwargs["json"]["default_config"]["default"] is True
+
+
+def test_register_external_model_transcribe_force_replace_passes_query_param():
+    responses = {("POST", "/models/"): {"id": str(uuid.uuid4()), "name": "transcribe"}}
+    client = DummyClient(responses)
+    service = ModelService(client)
+
+    service.register_external_model(
+        name="transcribe",
+        endpoint=AWSTranscribeEndpoint(region="us-west-2", s3_bucket="my-bucket"),
+        credential=AWSTranscribeCredential(
+            aws_access_key_id="AKIAEXAMPLE",
+            aws_secret_access_key="secret",
+        ),
+        force_replace_credentials=True,
+    )
+
+    _, _, kwargs = client.calls[0]
+    assert kwargs["params"] == {"force_replace_credentials": True}
+    blob = kwargs["json"]["default_config"]["system_config"]["external_endpoint"]
+    assert blob["protocol"] == "aws_transcribe"
+    assert blob["s3_bucket"] == "my-bucket"
+    # Defaults are mirrored from the platform schema.
+    assert blob["s3_prefix"] == "transcribe-jobs/"
+
+
+def test_register_external_model_accepts_raw_credential_forms():
+    responses = {("POST", "/models/"): {"id": str(uuid.uuid4()), "name": "m"}}
+    service = ModelService(DummyClient(responses))
+
+    # dict credential is JSON-serialized verbatim
+    assert service._serialize_credential({"api_key": "k"}) == '{"api_key": "k"}'
+    # str credential passes through untouched (already-serialized)
+    assert service._serialize_credential('{"api_key": "k"}') == '{"api_key": "k"}'

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from kamiwaza_sdk.seeding import cli
+
+pytestmark = pytest.mark.unit
+
+
+class RecordingService:
+    def __init__(self, result):
+        self._result = result
+        self.calls: list[dict] = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append({"args": args, "kwargs": kwargs})
+        return self._result
+
+
+class FakeClient:
+    """A client whose service methods record their calls."""
+
+    def __init__(self):
+        self.workrooms = SimpleNamespace(
+            create=RecordingService(SimpleNamespace(id="wr-1"))
+        )
+        self.models = SimpleNamespace(
+            register_external_model=RecordingService(SimpleNamespace(id="model-1"))
+        )
+        self.apps = SimpleNamespace(
+            install_by_name=RecordingService(SimpleNamespace(id="dep-1", name="kaizen"))
+        )
+        self.agents = SimpleNamespace(
+            create=RecordingService(SimpleNamespace(id="agent-1"))
+        )
+        self.conversations = SimpleNamespace(
+            create=RecordingService(SimpleNamespace(id="conv-1"))
+        )
+        self.skills = SimpleNamespace(
+            import_skill_package=RecordingService(SimpleNamespace(id="skill-1"))
+        )
+        self.connectors = SimpleNamespace(
+            create_m365=RecordingService(SimpleNamespace(id="conn-1", name="Microsoft 365"))
+        )
+
+
+def _run(argv, client):
+    rc = cli.main(argv, client_factory=lambda **_kw: client)
+    return rc
+
+
+def test_create_workroom_count_suffixes_names(capsys):
+    client = FakeClient()
+
+    _run(["create-workroom", "--name", "uat", "--count", "2"], client)
+
+    calls = client.workrooms.create.calls
+    assert [c["kwargs"]["name"] for c in calls] == ["uat-1", "uat-2"]
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"workroom_ids": ["wr-1", "wr-1"]}
+
+
+def test_register_external_model_bedrock_reads_credential_env(capsys, monkeypatch):
+    client = FakeClient()
+    monkeypatch.setenv(
+        "AWS_CRED",
+        '{"auth_type":"iam","aws_access_key_id":"AK","aws_secret_access_key":"s"}',
+    )
+
+    _run(
+        [
+            "register-external-model",
+            "--protocol",
+            "aws_bedrock",
+            "--name",
+            "claude",
+            "--region",
+            "us-east-1",
+            "--model-id",
+            "anthropic.claude-3-sonnet-20240229-v1:0",
+            "--credential-env",
+            "AWS_CRED",
+        ],
+        client,
+    )
+
+    call = client.models.register_external_model.calls[0]["kwargs"]
+    assert call["endpoint"].protocol == "aws_bedrock"
+    assert call["endpoint"].model_id == "anthropic.claude-3-sonnet-20240229-v1:0"
+    assert (
+        call["credential"]
+        == '{"auth_type":"iam","aws_access_key_id":"AK","aws_secret_access_key":"s"}'
+    )
+    assert call["force_replace_credentials"] is False
+    assert json.loads(capsys.readouterr().out) == {"model_id": "model-1"}
+
+
+def test_register_external_model_missing_credential_exits(monkeypatch):
+    client = FakeClient()
+    with pytest.raises(SystemExit):
+        _run(
+            [
+                "register-external-model",
+                "--protocol",
+                "aws_transcribe",
+                "--name",
+                "t",
+                "--region",
+                "us-west-2",
+                "--s3-bucket",
+                "b",
+            ],
+            client,
+        )
+
+
+def test_install_extension_passes_workroom_and_sync(capsys, monkeypatch):
+    client = FakeClient()
+    scoped_calls: list = []
+    monkeypatch.setattr(
+        cli,
+        "scoped_client_for_workroom",
+        lambda c, wid: scoped_calls.append(wid) or c,
+    )
+
+    _run(
+        ["install-extension", "--name", "kaizen", "--workroom-id", "wr-9", "--no-sync"],
+        client,
+    )
+
+    # Workroom-scoped install enters the workroom for a scoped token.
+    assert scoped_calls == ["wr-9"]
+    call = client.apps.install_by_name.calls[0]
+    assert call["args"] == ("kaizen",)
+    assert call["kwargs"]["workroom_id"] == "wr-9"
+    assert call["kwargs"]["sync_if_missing"] is False
+    assert json.loads(capsys.readouterr().out) == {
+        "deployment_id": "dep-1",
+        "name": "kaizen",
+    }
+
+
+def test_create_agent_uses_kaizen_base_url(capsys, monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    _run(
+        [
+            "create-agent",
+            "--kaizen-base-url",
+            "https://kamiwaza.test/kaizen",
+            "--name",
+            "seed-agent",
+            "--model",
+            "llama-3",
+            "--provider",
+            "kamiwaza",
+            "--endpoint-path",
+            "/dep/abc",
+            "--workroom-id",
+            "wr-1",
+        ],
+        client,
+    )
+
+    call = client.agents.create.calls[0]["kwargs"]
+    assert call["base_url"] == "https://kamiwaza.test/kaizen"
+    assert call["llm"].model == "llama-3"
+    assert call["workroom_id"] == "wr-1"
+    assert json.loads(capsys.readouterr().out) == {"agent_id": "agent-1"}
+
+
+def test_create_agent_missing_llm_api_key_env_exits(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+    monkeypatch.delenv("MISSING_KEY_VAR", raising=False)
+
+    with pytest.raises(SystemExit):
+        _run(
+            [
+                "create-agent",
+                "--kaizen-base-url", "https://kamiwaza.test/kaizen",
+                "--name", "a",
+                "--model", "m",
+                "--llm-api-key-env", "MISSING_KEY_VAR",
+            ],
+            client,
+        )
+
+
+def test_create_conversation(capsys):
+    client = FakeClient()
+
+    _run(
+        [
+            "create-conversation",
+            "--kaizen-base-url",
+            "https://kamiwaza.test/kaizen",
+            "--agent-id",
+            "agent-1",
+        ],
+        client,
+    )
+
+    call = client.conversations.create.calls[0]["kwargs"]
+    assert call["base_url"] == "https://kamiwaza.test/kaizen"
+    assert call["agent_id"] == "agent-1"
+    assert json.loads(capsys.readouterr().out) == {"conversation_id": "conv-1"}
+
+
+def test_import_skill_reads_file(capsys, tmp_path):
+    client = FakeClient()
+    pkg = tmp_path / "my-skill.zip"
+    pkg.write_bytes(b"PK\x03\x04zip-bytes")
+
+    _run(["import-skill", "--file", str(pkg)], client)
+
+    call = client.skills.import_skill_package.calls[0]["kwargs"]
+    assert call["filename"] == "my-skill.zip"
+    assert call["file_content"] == b"PK\x03\x04zip-bytes"
+    assert json.loads(capsys.readouterr().out) == {"skill_id": "skill-1"}
+
+
+def test_configure_m365_passes_tenant_and_client(capsys):
+    client = FakeClient()
+
+    _run(
+        ["configure-m365", "--tenant-id", "tenant-abc", "--client-id", "client-xyz"],
+        client,
+    )
+
+    call = client.connectors.create_m365.calls[0]["kwargs"]
+    assert call["tenant_id"] == "tenant-abc"
+    assert call["client_id"] == "client-xyz"
+    assert call["scopes"] is None  # default set applied in the service
+    assert json.loads(capsys.readouterr().out) == {
+        "connector_id": "conn-1",
+        "name": "Microsoft 365",
+    }
+
+
+def test_no_subcommand_errors():
+    with pytest.raises(SystemExit):
+        cli.main([], client_factory=lambda **_kw: FakeClient())
+
+
+def test_parse_env_rejects_bad_pair():
+    with pytest.raises(SystemExit):
+        cli._parse_env(["NOTAVALIDPAIR"])

--- a/tests/unit/test_seeding_client.py
+++ b/tests/unit/test_seeding_client.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from kamiwaza_sdk.client import KamiwazaClient
+from kamiwaza_sdk.seeding.client import (
+    build_client_from_env,
+    scoped_client_for_workroom,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _platform_client() -> KamiwazaClient:
+    client = KamiwazaClient(base_url="https://example.test/api", api_key="global-pat")
+    client.session.verify = False
+    return client
+
+
+def test_scoped_client_uses_workroom_enter_token():
+    client = _platform_client()
+    client._workrooms = SimpleNamespace(
+        enter=lambda wid: SimpleNamespace(
+            access_token="workroom-token", workroom_id=wid
+        )
+    )
+
+    scoped = scoped_client_for_workroom(client, "wr-1")
+
+    assert scoped is not client
+    assert scoped.base_url == "https://example.test/api"
+    # The scoped client authenticates with the workroom-scoped token.
+    assert scoped.authenticator.api_key == "workroom-token"
+    # TLS setting carries over from the parent.
+    assert scoped.session.verify is False
+
+
+def test_scoped_client_falls_back_when_no_token_reminted():
+    client = _platform_client()
+    client._workrooms = SimpleNamespace(
+        enter=lambda wid: SimpleNamespace(access_token=None, workroom_id=wid)
+    )
+
+    scoped = scoped_client_for_workroom(client, "global")
+
+    # No reminted token (e.g. Global workroom) -> reuse the original client.
+    assert scoped is client
+
+
+def test_build_client_from_env_requires_base_url(monkeypatch):
+    monkeypatch.delenv("KAMIWAZA_BASE_URL", raising=False)
+    monkeypatch.delenv("KAMIWAZA_BASE_URI", raising=False)
+
+    with pytest.raises(SystemExit):
+        build_client_from_env()
+
+
+def test_build_client_from_env_uses_explicit_args():
+    client = build_client_from_env(base_url="https://example.test/api", api_key="k")
+    assert client.base_url == "https://example.test/api"
+    assert client.authenticator.api_key == "k"


### PR DESCRIPTION
## What this ships

Typed SDK methods + a thin `kamiwaza-seed` CLI to seed a Kamiwaza box — the reusable half of the daily-UAT seeding effort (ENG-6931; unblocks ENG-6932).

## Surface

| Area | Added |
|------|-------|
| External models | `models.register_external_model` (AWS Bedrock/Transcribe; inline credential → Catalog URN server-side; `force_replace_credentials`) |
| Extensions | `apps.install_by_name` / `find_template` (resolve catalog template by name → deploy) |
| Kaizen | `client.agents` (create/list/bind_skill), `client.conversations` (create/send_message/run/get_events), `resolve_base_url`; `_request` `base_url` override (same-host-guarded) |
| Connectors | `client.connectors.create_m365` (cluster-wide M365 app registration) |
| CLI | `kamiwaza-seed`: create-workroom · register-external-model · install-extension · create-agent · create-conversation · import-skill · configure-m365; `seeding.scoped_client_for_workroom` / `build_client_from_env` (shared with smoke) |

## Security posture

Credentials are read from env vars only (never argv); the `base_url` override is same-host-guarded so the platform bearer can't leak off-host; M365 `tenant_id`/`client_id` are public identifiers (no `client_secret`).

## Verification

46 new-code unit tests; full `make test` = 2441 passed (1 pre-existing, unrelated kz-ext failure); `ruff` + `mypy` clean. Live E2E on a k0s-lima cluster: external Bedrock model registered + deployed (`external_chat`), workroom + extensions + skills + agent (with bound skills) + conversation replying via Bedrock, and an M365 connector create/delete — every new method exercised. Details in the PR Evidence block below.

<!-- pr-evidence-start -->
<details>
<summary>PR Evidence (pr-evidence v0.3.2)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-06-14T19:06:51.907Z
manifest_hash: sha256:f44e9347287c55273e4ec8ae5ca85b065ce50c3bcf6632da64187675f93349ee
phase_a_complete: true
phase_b_complete: true
repos: []
clusters:
  - name: Default
    kubectl_context: Default
    identity:
      k8s_distribution: k0s
      k8s_version: v1.35.2+k0s
      container_runtime: containerd-cri
      host_vm_layer: macos-lima
      network_mode: kube-router
    health:
      pods_total: 63
      pods_by_phase:
        Running: 58
        Succeeded: 5
      non_running: []
      api_plane:
        url: https://kamiwaza.test/api/cluster/capabilities
        http_code: 401
        expected_code: 401
        match: true
```


# PR Evidence — generated 2026-06-14T19:06:51.907Z

## Cluster identity

| Cluster | k8s distro | Runtime | Host/VM | Network | k8s version |
|---------|-----------|---------|---------|---------|-------------|
| Default | k0s | containerd-cri | macos-lima | kube-router | v1.35.2+k0s |

## Cluster health

| Cluster | Total pods | By phase | Non-Running | API plane |
|---------|-----------|----------|-------------|-----------|
| Default | 63 | 58 Running, 5 Succeeded | 0 | 401 (✓) |


## Testing summary

**Delivery mode:** `not-applicable` — `kamiwaza-sdk` is a client library; it is not deployed to the cluster as code. It was exercised *against* the live cluster above (k0s-lima).

**Unit tests:** 46 new-code unit tests pass; full `make test` suite = 2441 passed, 1 skipped, 1 failed. The single failure (`tests/unit/extensions/test_dev_canonical_refs.py::...test_no_build_allows_stale_prior_engine_when_not_resumable`) is pre-existing and unrelated — it fails identically on clean `develop` (a kz-ext registry/env-dependent test). `ruff` + `mypy --follow-imports=silent` clean on all changed files.

**Live E2E (against the Default cluster above):** every new SDK surface was exercised end-to-end:
- `models.register_external_model` — registered an AWS Bedrock external endpoint (credential normalized to a Catalog URN); then `serving.deploy_model(engine_name="external_chat")` → DEPLOYED; chat completion returned a real Bedrock response.
- `apps.install_by_name` — installed `skills-library` + `workroom-manager` (Global) and `kaizen` (workroom-scoped); all reached Running.
- `skills.update_skill_metadata` — published `ontology-builder` + `context-processor`.
- `workrooms.create` + `seeding.scoped_client_for_workroom` — created a workroom and a workroom-scoped client (via `enter`).
- `agents.create` + `agents.bind_skill` — created a Kaizen agent bound to the deployed Bedrock model with both skills (bindings resolved).
- `conversations.create` / `send_message` / `run` / `get_events` — started a conversation, sent "hello", agent replied via Bedrock.
- `connectors.create_m365` / `list` / `delete` — registered and deleted a cluster-wide M365 connector.
- `client._request` same-host guard — verified it reaches the same-host Kaizen ingress and rejects a foreign host (no platform-credential leak).

</details>
<!-- pr-evidence-end -->
