### PR TITLE
ENG-7006: deterministic engine in stale-prior-engine dev test

### DIFF
--- a/tests/unit/extensions/test_dev_canonical_refs.py
+++ b/tests/unit/extensions/test_dev_canonical_refs.py
@@ -660,6 +660,14 @@ class TestDevRemoteBuildsAtCanonicalRefs:
                 "kamiwaza_extensions.registry_resolution._has_podman",
                 return_value=True,
             ),
+            # On macOS/Windows ``podman_push_available()`` gates on a running
+            # Podman machine; pin it so the engine choice doesn't depend on the
+            # host (ENG-7006 — without this, a host with no running machine
+            # falls back to 'docker' and the assertion below fails).
+            patch(
+                "kamiwaza_extensions.registry_resolution.running_podman_machine_name",
+                return_value="podman-machine-default",
+            ),
             patch(
                 "kamiwaza_extensions.dev_state.read_state",
                 return_value=prior_state,


### PR DESCRIPTION
## Summary

Fixes a host-dependent unit-test failure: `test_dev_canonical_refs.py::TestDevRemoteBuildsAtCanonicalRefs::test_no_build_allows_stale_prior_engine_when_not_resumable` failed on macOS while passing on Linux CI.

## Root cause

The test asserts the push engine resolves to `podman` (line 677). The engine comes from `select_push_engine()` → `podman_push_available()`, which on macOS/Windows gates on a **running Podman machine**:

```python
if platform.system() in ("Darwin", "Windows"):
    return running_podman_machine_name() is not None
return True  # Linux
```

Unlike all six of its sibling tests in the same class, this test never mocked `running_podman_machine_name`. So:

- **Linux CI** — `podman_push_available()` returns `True` directly, engine resolves to `podman`, test passes (the host dependency is masked).
- **macOS without a running podman machine** — the real call returns `None`, engine falls back to `docker`, and the assertion fails with the `+ docker` diff reported in the ticket.

This is a test-only host dependency, not a mismatch between the assertion and `build_engine` handling.

## Fix

Add the same `running_podman_machine_name` mock the sibling tests already use, so the engine choice is deterministic regardless of host. One-line behavior change; no production code touched.

## Testing

- Target test: passes (previously failed on macOS).
- `tests/unit/extensions/test_dev_canonical_refs.py`: 19 passed.
- `tests/unit/extensions/`: 1596 passed, 1 skipped (the unrelated BSD-sed skip the ticket already noted).

Closes ENG-7006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)