### PR TITLE
ENG-7019: kamiwaza-seed login subcommand for minting an admin token

### DIFF
--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -8,6 +8,7 @@ no environment-specific data — the UAT/nightly profile lives in the caller.
 
 Example::
 
+    export KAMIWAZA_API_KEY="$(kamiwaza-seed login --password-env ADMIN_PW --raw)"
     kamiwaza-seed create-workroom --name uat
     kamiwaza-seed install-extension --name kaizen --workroom-id <wid>
     kamiwaza-seed register-external-model --protocol aws_bedrock \\
@@ -77,6 +78,25 @@ def _client_for_workroom(client, workroom_id: Optional[str]):
 
 
 # --- subcommand handlers ---------------------------------------------------
+
+
+def cmd_login(args: argparse.Namespace, *, client) -> Optional[dict]:
+    """Mint an access token via the password grant.
+
+    The password is read from a named env var only — never argv — so it doesn't
+    leak into shell history or process listings. ``--raw`` prints just the bare
+    token so a caller can do ``export KAMIWAZA_API_KEY="$(... --raw)"``.
+    """
+    password = _read_env_secret(args.password_env, what="login password")
+    if password is None:
+        raise SystemExit(
+            "Provide the password via --password-env (env var holding the password)."
+        )
+    token = client.auth.login_with_password(args.username, password).access_token
+    if args.raw:
+        print(token)
+        return None
+    return {"access_token": token}
 
 
 def cmd_create_workroom(args: argparse.Namespace, *, client) -> dict:
@@ -193,6 +213,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sub = parser.add_subparsers(dest="command")
 
+    p = sub.add_parser("login", help="Mint an access token via the password grant.")
+    p.add_argument("--username", default="admin")
+    p.add_argument(
+        "--password-env",
+        required=True,
+        help="Env var holding the password (read from env, never argv).",
+    )
+    p.add_argument(
+        "--raw",
+        action="store_true",
+        help="Print only the bare token (for KAMIWAZA_API_KEY=\"$(... --raw)\").",
+    )
+    p.set_defaults(func=cmd_login)
+
     p = sub.add_parser("create-workroom", help="Create one or more workrooms.")
     p.add_argument("--name", required=True)
     p.add_argument("--type", default="persistent", help="ephemeral or persistent")
@@ -298,7 +332,9 @@ def main(
     # the agent/conversation calls as a base_url override.
     client = client_factory(base_url=args.base_url)
     result = args.func(args, client=client)
-    print(json.dumps(result))
+    # Handlers that emit their own output (e.g. `login --raw`) return None.
+    if result is not None:
+        print(json.dumps(result))
     return 0
 
 

--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -213,7 +213,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sub = parser.add_subparsers(dest="command")
 
-    p = sub.add_parser("login", help="Mint an access token via the password grant.")
+    # allow_abbrev=False: without it argparse accepts `--password` as a prefix of
+    # `--password-env`, silently treating a secret typed on argv as an env-var name.
+    p = sub.add_parser(
+        "login",
+        help="Mint an access token via the password grant.",
+        allow_abbrev=False,
+    )
     p.add_argument("--username", default="admin")
     p.add_argument(
         "--password-env",
@@ -234,7 +240,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--count", type=int, default=1, help="Create N suffixed workrooms.")
     p.set_defaults(func=cmd_create_workroom)
 
-    p = sub.add_parser("register-external-model", help="Register an external model.")
+    # allow_abbrev=False so `--credential` can't be accepted as a prefix of
+    # `--credential-env`, which would route a secret through argv.
+    p = sub.add_parser(
+        "register-external-model",
+        help="Register an external model.",
+        allow_abbrev=False,
+    )
     p.add_argument(
         "--protocol", required=True, choices=["aws_bedrock", "aws_transcribe"]
     )
@@ -265,7 +277,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.set_defaults(func=cmd_install_extension)
 
-    p = sub.add_parser("create-agent", help="Create a Kaizen agent.")
+    # allow_abbrev=False so `--llm-api-key` can't be accepted as a prefix of
+    # `--llm-api-key-env`, which would route a secret through argv.
+    p = sub.add_parser(
+        "create-agent", help="Create a Kaizen agent.", allow_abbrev=False
+    )
     p.add_argument(
         "--kaizen-base-url",
         required=True,

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -24,6 +24,11 @@ class FakeClient:
     """A client whose service methods record their calls."""
 
     def __init__(self):
+        self.auth = SimpleNamespace(
+            login_with_password=RecordingService(
+                SimpleNamespace(access_token="tok-123")
+            )
+        )
         self.workrooms = SimpleNamespace(
             create=RecordingService(SimpleNamespace(id="wr-1"))
         )
@@ -50,6 +55,53 @@ class FakeClient:
 def _run(argv, client):
     rc = cli.main(argv, client_factory=lambda **_kw: client)
     return rc
+
+
+def test_login_json_output_reads_password_from_env(capsys, monkeypatch):
+    client = FakeClient()
+    monkeypatch.setenv("ADMIN_PW", "s3cret")
+
+    _run(["login", "--username", "admin", "--password-env", "ADMIN_PW"], client)
+
+    call = client.auth.login_with_password.calls[0]
+    # Username is positional; the password comes from the env var, not argv.
+    assert call["args"] == ("admin", "s3cret")
+    assert json.loads(capsys.readouterr().out) == {"access_token": "tok-123"}
+
+
+def test_login_raw_prints_bare_token(capsys, monkeypatch):
+    client = FakeClient()
+    monkeypatch.setenv("ADMIN_PW", "s3cret")
+
+    _run(["login", "--password-env", "ADMIN_PW", "--raw"], client)
+
+    # --raw emits just the token (no JSON, no trailing structure) for $(...) capture.
+    assert capsys.readouterr().out.strip() == "tok-123"
+    # Username defaults to "admin".
+    assert client.auth.login_with_password.calls[0]["args"][0] == "admin"
+
+
+def test_login_empty_password_env_exits(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setenv("ADMIN_PW", "")
+
+    with pytest.raises(SystemExit):
+        _run(["login", "--password-env", "ADMIN_PW"], client)
+
+    # Fail closed: an empty password must never reach the login call.
+    assert client.auth.login_with_password.calls == []
+
+
+def test_login_missing_password_env_arg_exits():
+    # --password-env is required; omitting it must fail rather than prompt.
+    with pytest.raises(SystemExit):
+        _run(["login", "--username", "admin"], FakeClient())
+
+
+def test_login_rejects_password_on_argv():
+    # The password must never be accepted from argv — only via --password-env.
+    with pytest.raises(SystemExit):
+        _run(["login", "--password", "s3cret"], FakeClient())
 
 
 def test_create_workroom_count_suffixes_names(capsys):

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -98,10 +98,37 @@ def test_login_missing_password_env_arg_exits():
         _run(["login", "--username", "admin"], FakeClient())
 
 
-def test_login_rejects_password_on_argv():
-    # The password must never be accepted from argv — only via --password-env.
+def test_login_rejects_password_on_argv(monkeypatch):
+    # The password must never be accepted from argv. argparse abbreviation is
+    # disabled, so `--password` is an unrecognized flag (not a prefix alias for
+    # `--password-env`) and parsing fails before any login is attempted — even
+    # if a same-named env var happens to exist.
+    client = FakeClient()
+    monkeypatch.setenv("s3cret", "leaked")  # would be picked up if `--password` aliased
+
     with pytest.raises(SystemExit):
-        _run(["login", "--password", "s3cret"], FakeClient())
+        _run(["login", "--password", "s3cret"], client)
+
+    assert client.auth.login_with_password.calls == []
+
+
+def test_secret_env_flags_reject_abbreviation(monkeypatch):
+    # Sibling sweep: the other secret-bearing subcommands disable abbreviation too,
+    # so `--credential` / `--llm-api-key` can't alias their `-env` forms.
+    monkeypatch.setenv("AWS_CRED", '{"auth_type":"iam"}')
+    monkeypatch.setenv("LLM_KEY", "sk-leaked")
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            ["register-external-model", "--protocol", "aws_bedrock", "--name", "n",
+             "--region", "r", "--model-id", "m", "--credential", "AWS_CRED"]
+        )
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            ["create-agent", "--kaizen-base-url", "u", "--name", "n", "--model", "m",
+             "--llm-api-key", "LLM_KEY"]
+        )
 
 
 def test_create_workroom_count_suffixes_names(capsys):


### PR DESCRIPTION
## What this ships

A `kamiwaza-seed login` subcommand so the UAT/nightly seeding profile (and any seeding caller) can mint an admin token in one line, instead of shelling out to inline Python. Closes the gap where the seeding CLI built its client from `KAMIWAZA_API_KEY` but had no way to produce that token.

```bash
export KAMIWAZA_API_KEY="$(kamiwaza-seed login --username admin --password-env ADMIN_PW --raw)"
```

## Contract

| Arg | Behavior |
|-----|----------|
| `--username` | defaults to `admin` |
| `--password-env` | **required**; names the env var holding the password — read from env only, never argv (mirrors the existing `--credential-env` pattern) |
| `--raw` | print the bare token (for `$(...)` capture); default output is `{"access_token": "..."}` JSON like the other subcommands |
| `--base-url` | global; falls back to `KAMIWAZA_BASE_URL`. TLS via `KAMIWAZA_VERIFY_SSL` |

Calls `client.auth.login_with_password(username, password)` (password grant, `skip_auth=True`, so no api_key needed). `main()` now skips JSON-wrapping when a handler returns `None`, letting `--raw` emit a bare token.

## Security posture

Password is read only from the named env var, never from argv (no shell-history / `ps` leak); a `--password` flag is rejected. Empty/unset env fails closed before any login call.

## Out of scope

Token caching/refresh (ticket). The minted token is good ~4h on a standard install (`kamiwaza-platform` client `access.token.lifespan`), which outlasts a single seeding run; if seeding ever exceeds that, the right fix is switching the seeder to the auto-refreshing `UserPasswordAuthenticator`, not CLI retry.

## Verification

`pytest tests/unit/test_seeding_cli.py` — 16 pass (5 new: JSON + `--raw` output, empty-env fail-closed, missing required arg, argv rejection). ruff clean; no mypy errors in `cli.py`.


<!-- pr-evidence-start -->
<details>
<summary>PR Evidence (pr-evidence v0.3.2)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-06-15T05:32:39.537Z
manifest_hash: sha256:7f34a0484b4dbae280b25a45772848e4fbc669c4d9b562e083c0167d72f3a7a4
phase_a_complete: true
phase_b_complete: true
repos: []
clusters: []
```


# PR Evidence — generated 2026-06-15T05:32:39.537Z

## Cross-references

- Linear: `ENG-7019`
- PR: kamiwaza-ai/kamiwaza-sdk#169


## Testing summary

Unit tests only — no cluster interaction. This is a self-contained SDK CLI
addition (`kamiwaza-seed login`) with no code path that reaches a cluster as
part of the change.

- `uv run pytest tests/unit/test_seeding_cli.py` — 16 passed (5 new cases:
  JSON output, `--raw` bare token, empty-`--password-env` fail-closed, missing
  required arg, `--password`-on-argv rejection).
- `ruff check` clean on changed files; no mypy errors in `kamiwaza_sdk/seeding/cli.py`.

No `kw switch` / `kubectl` preflight performed — not applicable to a unit-only
SDK change. `repos: []` / `clusters: []` reflect that honestly.

</details>
<!-- pr-evidence-end -->
