### PR TITLE
ENG-7020: Seeder GHCR image — Dockerfile + build/push CI for kamiwaza-seed

### DIFF
--- a/.github/workflows/seeder-image.yml
+++ b/.github/workflows/seeder-image.yml
@@ -1,0 +1,106 @@
+name: Build Seeder Image
+
+# Build and publish the kamiwaza-seed CLI image.
+#
+# Standalone build, not the kamiwaza-internal shared container-build.yml:
+# that workflow is bake + R2-catalog machinery for *catalog* extensions and
+# needs the org's self-hosted runner group — neither applies to this single
+# pip-install image in the public kamiwaza-ai repo.
+#
+# The image ref follows the org's `<owner>/<repo>/images/<name>` convention
+# (-> ghcr.io/kamiwaza-ai/kamiwaza-sdk/images/seeder) so the extension
+# relocation rule maps it to localhost:5001/images/seeder:<tag>. Tag policy
+# mirrors the org TAG-POLICY (single tag per branch; digest is the identity):
+#   develop      -> :develop
+#   release/X.Y.Z -> :release-X.Y.Z
+#   main          -> :latest + :<pyproject version>
+#   pull_request  -> build + `kamiwaza-seed --help` smoke, no push (fork-safe)
+#
+# The package publishes private by default; consumers pull with a
+# read:packages PAT (see Dockerfile.seeder / the ticket's PAT path).
+
+on:
+  push:
+    branches: [develop, main, 'release/*']
+    paths:
+      - 'kamiwaza_sdk/**'
+      - 'kamiwaza_client/**'
+      - 'kamiwaza_extensions/**'
+      - 'pyproject.toml'
+      - 'Dockerfile.seeder'
+      - 'Dockerfile.seeder.dockerignore'
+      - '.github/workflows/seeder-image.yml'
+  pull_request:
+    paths:
+      - 'kamiwaza_sdk/**'
+      - 'kamiwaza_client/**'
+      - 'kamiwaza_extensions/**'
+      - 'pyproject.toml'
+      - 'Dockerfile.seeder'
+      - 'Dockerfile.seeder.dockerignore'
+      - '.github/workflows/seeder-image.yml'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: seeder-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/images/seeder
+
+jobs:
+  build:
+    name: Build seeder image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Read package version
+        id: ver
+        run: |
+          version=$(grep -m1 '^version' pyproject.toml | sed -E 's/.*"(.*)".*/\1/')
+          [ -n "$version" ] || { echo "::error::could not read version from pyproject.toml"; exit 1; }
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          flavor: latest=false
+          tags: |
+            type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=ref,event=branch,enable=${{ startsWith(github.ref, 'refs/heads/release/') }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+            type=raw,value=${{ steps.ver.outputs.version }},enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.seeder
+          platforms: linux/amd64
+          # Push branch builds to GHCR; on PRs load locally for the smoke test.
+          push: ${{ github.event_name == 'push' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: ${{ github.event_name == 'pull_request' && format('{0}:pr', env.IMAGE) || steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Smoke test (kamiwaza-seed --help)
+        if: github.event_name == 'pull_request'
+        run: docker run --rm ${{ env.IMAGE }}:pr --help

--- a/Dockerfile.seeder
+++ b/Dockerfile.seeder
@@ -1,0 +1,39 @@
+# Seeder image for the nightly UAT-box seeding step.
+#
+# Self-contained delivery of the `kamiwaza-seed` CLI: `pip install .` installs
+# the SDK and its console scripts (kamiwaza-seed, including the `login`
+# subcommand) and resolves the kamiwaza-extensions-lib dependency from PyPI.
+# The build VM pulls this from GHCR, bundles it, and it relocates into the
+# in-cluster local registry under the org's `<registry>/images/seeder:<tag>`
+# rule — no clone+pip/venv on the box.
+#
+# amd64 only: CI install boxes are x86_64 RHEL9/Ubuntu. The companion workflow
+# builds for linux/amd64; arm64 is deferred until a consumer needs it.
+#
+# Build context is the repo root; copied paths are scoped by
+# Dockerfile.seeder.dockerignore so the shared root .dockerignore (which
+# blocks everything for the echo-check build) does not apply here. BuildKit
+# (CI) auto-detects that sibling ignore file; podman/buildah does not, so
+# local podman builds must pass `--ignorefile Dockerfile.seeder.dockerignore`.
+FROM python:3.12-slim
+
+# Non-root runtime.
+RUN groupadd -r -g 1001 seeder \
+    && useradd -r -u 1001 -g seeder -d /app seeder
+
+WORKDIR /app
+
+# Only the source needed to build the wheel. kamiwaza-extensions-lib is a
+# declared dependency resolved from PyPI (pip ignores the uv workspace source),
+# so the in-repo workspace member is not copied.
+COPY pyproject.toml README.md LICENSE MANIFEST.in ./
+COPY kamiwaza_sdk/ ./kamiwaza_sdk/
+COPY kamiwaza_client/ ./kamiwaza_client/
+COPY kamiwaza_extensions/ ./kamiwaza_extensions/
+
+RUN pip install --no-cache-dir .
+
+USER 1001
+
+ENTRYPOINT ["kamiwaza-seed"]
+CMD ["--help"]

--- a/Dockerfile.seeder.dockerignore
+++ b/Dockerfile.seeder.dockerignore
@@ -1,0 +1,24 @@
+# Dockerfile-specific ignore for Dockerfile.seeder (BuildKit picks this over
+# the shared root .dockerignore, which is tailored to the echo-check build).
+#
+# Block everything, then unblock exactly the source the seeder wheel needs.
+**
+
+!pyproject.toml
+!README.md
+!LICENSE
+!MANIFEST.in
+!kamiwaza_sdk/
+!kamiwaza_sdk/**
+!kamiwaza_client/
+!kamiwaza_client/**
+!kamiwaza_extensions/
+!kamiwaza_extensions/**
+
+# Drop churn artifacts even from the unblocked trees.
+**/__pycache__/
+**/*.pyc
+**/.pytest_cache/
+**/.mypy_cache/
+**/.ruff_cache/
+**/*.egg-info/


### PR DESCRIPTION
## What this ships

A self-contained GHCR image that bakes the `kamiwaza-seed` CLI, for the nightly UAT-box seeding step. Standalone build/push workflow, amd64.

- `Dockerfile.seeder` — `python:3.12-slim`, `pip install .`, non-root, `ENTRYPOINT ["kamiwaza-seed"]`.
- `Dockerfile.seeder.dockerignore` — per-Dockerfile ignore (BuildKit auto-detects; podman needs `--ignorefile`) so the shared root `.dockerignore` (echo-check build) doesn't strip the needed source.
- `.github/workflows/seeder-image.yml` — build/push to `ghcr.io/kamiwaza-ai/kamiwaza-sdk/images/seeder`.

## Image ref + tags

Published to `…/images/seeder` so the extension relocation rule maps it to `localhost:5001/images/seeder:<tag>`. Tags mirror the org TAG-POLICY (single tag per branch; digest is the identity):

| Trigger | Tags |
|---|---|
| push `develop` | `:develop` |
| push `release/X.Y.Z` | `:release-X.Y.Z` |
| push `main` | `:latest`, `:<pyproject version>` |
| pull_request | build + `kamiwaza-seed --help` smoke, **no push** (fork-safe) |

## Load-bearing decisions

- **Standalone workflow, not the `kamiwaza-internal` reusable `container-build.yml`** — that one is bake + R2-catalog machinery for catalog extensions and needs the org's self-hosted runners; this is a single pip-install image in the public `kamiwaza-ai` repo.
- **GHCR package stays private** — consumers pull with a `read:packages` PAT (safer one-way door than anonymous-public).
- The `kamiwaza-seed login` subcommand lands on its own ticket; this image picks it up automatically once merged.

## Verification

Local podman build (arm64) + `kamiwaza-seed --help` smoke, runs non-root; deps resolve from PyPI. The new workflow runs the authoritative amd64 build + `--help` smoke on this PR.

<!-- pr-evidence-start -->
<details>
<summary>📋 <b>pr-evidence</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-06-15T06:22:38.642Z
manifest_hash: sha256:7aa59c62f60ee92d7ed654f8596b711cc729fc37e333e1294e57ef16b67055ec
phase_a_complete: true
phase_b_complete: true
repos:
  - name: kamiwaza-sdk
    path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-ENG-7020
    branch: feature/ENG-7020
    head_sha: 556f51972915b945311d4d196e2189cce593e15a
    head_sha_short: 556f51972
    dirty_files: 0
    ahead: 1
    behind: 0
    upstream: origin/develop
    delivery:
      mode: not-applicable
      verified: true
      note: Dockerfile + build/push CI only; image is published by CI, not source-mounted into a pod.
clusters: []
```

</details>

# PR Evidence — generated 2026-06-15T06:22:38.642Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| kamiwaza-sdk | feature/ENG-7020 | `556f51972` | +1 | not-applicable ✓ |

## Verification

CI/infra change (Dockerfile + build/push workflow). No cluster interaction — the
image is published by CI and (later) relocated; nothing is source-mounted into a pod
for this PR, hence `clusters: []`.

What was actually exercised locally:

- **Image build** via podman (native arm64): `podman build --ignorefile Dockerfile.seeder.dockerignore -f Dockerfile.seeder -t seeder:test .` — wheel built, `kamiwaza-extensions-lib==0.4.0` and all deps resolved from PyPI.
- **Smoke**: `podman run --rm seeder:test --help` → `kamiwaza-seed --help` exits 0 with the full subcommand list (the `--help` arg flows through the `ENTRYPOINT`).
- **Runtime user**: confirmed non-root (`uid=1001(seeder)`).
- Also validated `pip install .` + `kamiwaza-seed --help` in a clean host venv.

Authoritative amd64 image build is exercised by the new `Build Seeder Image` workflow
on the PR (build + `kamiwaza-seed --help` smoke, no push). The `kamiwaza-seed login`
subcommand and a live-cluster `login` run land with that separate ticket and a real
cluster.


<!-- pr-evidence-end -->