### PR TITLE
ENG-7046: Harden SDK live smoke helpers

### DIFF
--- a/tests/integration/test_cluster_live.py
+++ b/tests/integration/test_cluster_live.py
@@ -39,7 +39,12 @@ def _is_cluster_probe_not_authorized(error: APIError) -> bool:
     if not isinstance(payload, dict):
         return False
 
-    return payload.get("detail") == "not_authorized_to_probe_cluster"
+    detail = payload.get("detail")
+    if detail == "not_authorized_to_probe_cluster":
+        return True
+    if not isinstance(detail, dict):
+        return False
+    return detail.get("reason") == "not_authorized_to_probe_cluster"
 
 
 class TestClusterReadOperations:

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -52,7 +52,7 @@ def _assert_global_scope_if_exposed(resource: dict[str, object]) -> None:
     workroom_id = resource.get("workroom_id")
     if workroom_id is None:
         return
-    assert str(workroom_id) == DEFAULT_WORKROOM_ID
+    assert str(workroom_id) == ContextService.DEFAULT_WORKROOM_ID
 
 
 def _is_workroom_binding_unavailable(error: APIError) -> bool:

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -47,6 +47,14 @@ def _context_service(live_kamiwaza_client) -> ContextService:
     return service
 
 
+def _assert_global_scope_if_exposed(resource: dict[str, object]) -> None:
+    """Assert Global scope when the server includes explicit scope metadata."""
+    workroom_id = resource.get("workroom_id")
+    if workroom_id is None:
+        return
+    assert str(workroom_id) == DEFAULT_WORKROOM_ID
+
+
 def _is_workroom_binding_unavailable(error: APIError) -> bool:
     """Return True only for retryable Workrooms enter binding outages."""
     if error.status_code != 503:
@@ -460,6 +468,10 @@ def test_context_vectordb_create_without_workroom_uses_global_scope(
         )
         vectordb_id = created["id"]
         assert vectordb_id
+        _assert_global_scope_if_exposed(created)
+        _wait_for_vectordb_ready(service, vectordb_id)
+        ready = service.get_vectordb(vectordb_id)
+        _assert_global_scope_if_exposed(ready)
     finally:
         if vectordb_id:
             _safe_delete_vectordb(service, vectordb_id)

--- a/tests/unit/test_cluster_live_helpers.py
+++ b/tests/unit/test_cluster_live_helpers.py
@@ -16,12 +16,21 @@ def test_cluster_probe_not_authorized_detects_stable_rebac_denial() -> None:
     assert _is_cluster_probe_not_authorized(error) is True
 
 
+def test_cluster_probe_not_authorized_detects_structured_rebac_denial() -> None:
+    error = APIError(
+        "not authorized",
+        status_code=403,
+        response_data={"detail": {"reason": "not_authorized_to_probe_cluster"}},
+    )
+
+    assert _is_cluster_probe_not_authorized(error) is True
+
+
 @pytest.mark.parametrize(
     ("status_code", "response_data"),
     [
         (401, {"detail": "not_authorized_to_probe_cluster"}),
         (403, {"detail": "some_other_denial"}),
-        (403, {"detail": {"reason": "not_authorized_to_probe_cluster"}}),
         (403, None),
         (403, "not_authorized_to_probe_cluster"),
     ],

--- a/tests/unit/test_context_live_helpers.py
+++ b/tests/unit/test_context_live_helpers.py
@@ -4,7 +4,10 @@ from uuid import uuid4
 import pytest
 
 from kamiwaza_sdk.exceptions import APIError
+from kamiwaza_sdk.services.context import ContextService
+import tests.integration.test_context_live as context_live
 from tests.integration.test_context_live import (
+    _assert_global_scope_if_exposed,
     _is_workroom_binding_unavailable,
     session_workroom,
 )
@@ -27,6 +30,25 @@ def test_workroom_binding_unavailable_detects_structured_503() -> None:
     )
 
     assert _is_workroom_binding_unavailable(error) is True
+
+
+def test_global_scope_assertion_uses_fixed_global_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(context_live, "DEFAULT_WORKROOM_ID", str(uuid4()))
+
+    _assert_global_scope_if_exposed(
+        {"workroom_id": ContextService.DEFAULT_WORKROOM_ID}
+    )
+
+
+def test_global_scope_assertion_skips_when_scope_not_exposed() -> None:
+    _assert_global_scope_if_exposed({})
+
+
+def test_global_scope_assertion_rejects_non_global_scope() -> None:
+    with pytest.raises(AssertionError):
+        _assert_global_scope_if_exposed({"workroom_id": str(uuid4())})
 
 
 def test_workroom_binding_unavailable_detects_legacy_503_detail() -> None:


### PR DESCRIPTION
## Summary
- Accept both flat-string and structured `detail.reason` shapes for the cluster capabilities ReBAC denial skip.
- Strengthen the no-workroom VectorDB live test to wait for readiness before cleanup.
- Assert Global/default scope when the server exposes `workroom_id` metadata.

## Linear
- ENG-7046

## Test Plan
- `uv run pytest tests/unit/test_cluster_live_helpers.py --no-cov -q` -> 6 passed
- `uv run pytest tests/unit/test_cluster_live_helpers.py tests/unit/test_context_live_helpers.py --no-cov -q` -> 18 passed
- `uv run pytest tests/integration/test_context_live.py tests/integration/test_cluster_live.py --collect-only -q` -> 47 collected
- `uv run ruff check tests/integration/test_context_live.py tests/integration/test_cluster_live.py tests/unit/test_cluster_live_helpers.py tests/unit/test_context_live_helpers.py` -> passed
- `uv run python -m py_compile tests/integration/test_context_live.py tests/integration/test_cluster_live.py tests/unit/test_cluster_live_helpers.py tests/unit/test_context_live_helpers.py` -> passed
- `git diff --check` -> passed

## Notes
This is follow-up hardening from PR #171 review. It is test-harness-only; no production SDK client behavior changes.