### PR TITLE
ENG-7018: run core SDK CI on push to develop/main

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -14,6 +14,19 @@ on:
       - 'MANIFEST.in'
       - 'release.sh'
       - '.github/workflows/python-build.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - 'kamiwaza_sdk/**'
+      - 'kamiwaza_client/**'
+      - 'kamiwaza_extensions/**'
+      - 'kamiwaza_extensions_lib/**'
+      - 'kamiwaza-ai-extensions-lib/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'MANIFEST.in'
+      - 'release.sh'
+      - '.github/workflows/python-build.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/python-complexity.yml
+++ b/.github/workflows/python-complexity.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - '**.py'
       - '.github/workflows/python-complexity.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - '**.py'
+      - '.github/workflows/python-complexity.yml'
 
 permissions:
   contents: read
@@ -15,7 +20,10 @@ jobs:
     name: Cyclomatic Complexity
     runs-on: ubuntu-latest
     env:
-      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      # On push events there is no pull_request context, so base.sha is empty;
+      # fall back to the pre-push tip (github.event.before) so the changed-file
+      # diff resolves on both event types.
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -9,6 +9,14 @@ on:
       - 'uv.lock'
       - 'tests/**'
       - '.github/workflows/python-coverage.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'tests/**'
+      - '.github/workflows/python-coverage.yml'
 
 permissions:
   contents: read
@@ -18,7 +26,10 @@ jobs:
     name: Coverage Check
     runs-on: ubuntu-latest
     env:
-      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      # On push events there is no pull_request context, so base.sha is empty;
+      # fall back to the pre-push tip (github.event.before) so the changed-file
+      # diff resolves on both event types.
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -8,6 +8,13 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/python-lint.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/python-lint.yml'
 
 permissions:
   contents: read
@@ -17,7 +24,10 @@ jobs:
     name: Ruff Lint
     runs-on: ubuntu-latest
     env:
-      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      # On push events there is no pull_request context, so base.sha is empty;
+      # fall back to the pre-push tip (github.event.before) so the changed-file
+      # diff resolves on both event types.
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-mypy.yml
+++ b/.github/workflows/python-mypy.yml
@@ -8,6 +8,13 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/python-mypy.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/python-mypy.yml'
 
 permissions:
   contents: read
@@ -17,7 +24,10 @@ jobs:
     name: Mypy Type Check
     runs-on: ubuntu-latest
     env:
-      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      # On push events there is no pull_request context, so base.sha is empty;
+      # fall back to the pre-push tip (github.event.before) so the changed-file
+      # diff resolves on both event types.
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,6 +9,14 @@ on:
       - 'uv.lock'
       - 'tests/**'
       - '.github/workflows/python-tests.yml'
+  push:
+    branches: [main, develop]
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'tests/**'
+      - '.github/workflows/python-tests.yml'
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,27 @@ This project uses **uv** for dependency management and a **Makefile** for common
 - **By marker**: `uv run pytest -m "unit"`, `uv run pytest -m "live"`
 - **Exclude slow**: `uv run pytest -m "not integration and not live and not e2e"`
 
+## Continuous Integration
+
+CI lives in `.github/workflows/`. The core quality workflows — `python-tests`,
+`python-lint`, `python-mypy`, `python-complexity`, `python-coverage`,
+`python-build` — run on **pull requests** *and* on **push to `develop`/`main`**,
+so squash/rebase merges are re-validated on the commit that actually lands
+(PR-only CI never tested the merged tree). Each is path-filtered, so a merge that
+doesn't touch a workflow's paths correctly skips it; the changed-file diff jobs
+(lint/mypy/complexity/coverage) fall back to `github.event.before` for the diff
+base on push, since there's no `pull_request` context there.
+
+Two workflows are intentionally **not** push-triggered:
+
+- `extension-contract-live.yml` — hits a live, credentialed cluster; PR +
+  `workflow_dispatch` only (keeps cluster credentials out of post-merge runs).
+- `require-linear-issue.yml` — inspects PR title/body/branch, so it's PR-only by
+  nature.
+
+(`extension-go-reference-e2e.yml` already runs on push, path-gated to its own
+go-reference/identity paths.)
+
 ## Architecture Overview
 
 ### Client-Service Pattern


### PR DESCRIPTION
## What this ships

The six core quality workflows were `pull_request`-only, so squash/rebase merges landed on `develop`/`main` with **zero checks** — the merged tree was never validated. This adds a `push` trigger to each, so every landed commit re-runs its checks.

## Contract

| Workflow | Change |
|----------|--------|
| `python-tests`, `python-build` | add `push: [main, develop]` (paths mirror the existing `pull_request` block) |
| `python-lint`, `python-mypy`, `python-complexity`, `python-coverage` | same push trigger **+** `BASE_SHA` fallback: `github.event.pull_request.base.sha \|\| github.event.before` (no PR context on push) |
| `extension-contract-live`, `require-linear-issue` | untouched — credentialed / PR-only by design |
| `extension-go-reference-e2e` | already had push |

`CLAUDE.md` gains a CI section documenting the trigger model.

## Decisions

- **No concurrency group.** These workflows had none before; the only reason to add one would be to cancel superseded push runs — but every landed `develop`/`main` commit should validate to completion (the changed-file jobs diff only their own push, so a cancelled run would silently skip those files). No grouping ⇒ nothing is ever cancelled. Redundant runs on rapid merges are acceptable.
- Changed-file diff jobs already use `fetch-depth: 0`, so `github.event.before` is reachable for the push diff base.

## Verification

`actionlint` clean on all six (one pre-existing SC2086 on an untouched line); YAML parses with `[pull_request, push]` triggers and matching paths; Codex review: no findings. The push trigger itself is only exercisable post-merge on `develop`.

<!-- pr-evidence-start -->
<details>
<summary>📋 <b>pr-evidence</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-06-15T16:49:49.464Z
manifest_hash: sha256:5b5b13baf73de8865717366f7aa5478f1ad7684c43aff1e2706f9e952d9ed30e
phase_a_complete: true
phase_b_complete: true
repos:
  - name: kamiwaza-sdk
    path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-eng-7018
    branch: feature/eng-7018
    head_sha: 4331d46400a28f8a84d55afc0bd2d5b63a127da9
    head_sha_short: 4331d4640
    dirty_files: 0
    ahead: 0
    behind: 0
    upstream: origin/feature/eng-7018
    delivery:
      mode: not-applicable
      verified: true
clusters: []
```

</details>

# PR Evidence — generated 2026-06-15T16:49:49.464Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| kamiwaza-sdk | feature/eng-7018 | `4331d4640` | clean | not-applicable ✓ |

## Cross-references

- Linear: `ENG-7018`


## What was tested

CI-workflow YAML + docs only — no application code, no cluster interaction.

- `actionlint` on all six edited workflows: clean (the one SC2086 hit is a
  pre-existing unquoted `$FILES` on a line this PR does not touch).
- YAML parse + trigger assertion: all six resolve to `[pull_request, push]` with
  `push.branches: [main, develop]`; push `paths` match each workflow's
  `pull_request` paths.
- Codex review (final pass): no findings.

The push trigger itself can only be exercised once a commit lands on
`develop`/`main` post-merge — that is the change's whole purpose and is not
locally reproducible. No cluster preflight performed (not applicable).

<!-- pr-evidence-end -->