### PR TITLE
ENG-7051: target the advertised extension registry, not the model registry

### DIFF
--- a/kamiwaza_extensions/registry_resolution.py
+++ b/kamiwaza_extensions/registry_resolution.py
@@ -219,11 +219,35 @@ def resolve_push_registry(
         )
 
     if not is_loopback_registry(image_registry):
-        # Already a VM host alias (e.g. host.docker.internal:5001, the extension
-        # registry the installer advertises) or a real hostname: the build
-        # engine pushes to it as-is. For the docker-in-VM alias this is the only
-        # correct target -- pushing to 127.0.0.1 would hit the *VM's* loopback,
-        # not the host registry (ENG-7051).
+        # A VM host alias advertised by the platform (e.g. host.docker.internal:5001,
+        # the extension registry) is engine-specific: the docker daemon-in-VM
+        # resolves host.docker.internal, but a podman host-CLI push needs
+        # host.containers.internal. When the advertised alias doesn't match the
+        # active push engine, remap to the engine's alias so the push target
+        # stays reachable -- the embedded image ref keeps the advertised host
+        # (the node pulls via its certs.d), and the same registry is reachable
+        # under either alias (ENG-7051, Codex review). A real hostname has no
+        # alias engine and is returned unchanged.
+        alias_engine = push_registry_alias_engine(image_registry)
+        if (
+            alias_engine is not None
+            and alias_engine != engine
+            and build_engine_runs_in_vm()
+        ):
+            if engine == "podman" and running_podman_machine_name() is not None:
+                return (
+                    replace_registry_host(image_registry, PODMAN_VM_HOST_ALIAS),
+                    BUILD_VM_LOOPBACK_ALIAS_SOURCE,
+                )
+            if engine == "docker":
+                return (
+                    replace_registry_host(image_registry, DOCKER_VM_HOST_ALIAS),
+                    BUILD_VM_LOOPBACK_ALIAS_SOURCE,
+                )
+            # podman engine without a running machine: the host CLI resolves
+            # neither VM alias. Leave the registry as-is so
+            # validate_push_registry_for_engine surfaces an actionable error
+            # rather than silently pushing to an unreachable host.
         return image_registry, "image registry"
 
     if not build_engine_runs_in_vm():

--- a/kamiwaza_extensions/registry_resolution.py
+++ b/kamiwaza_extensions/registry_resolution.py
@@ -14,7 +14,15 @@ from urllib.parse import urlparse
 
 CORE_CONFIG_NAMESPACE = "kamiwaza"
 CORE_CONFIG_NAME = "core-config"
+# Host address of the in-cluster *model* registry, reachable from the build
+# host (e.g. macOS) for OCI model pulls. NOT a node-routable extension image
+# registry -- see REGISTRY_EXTENSION_HOST_KEY (ENG-7051).
 REGISTRY_EXTERNAL_HOST_KEY = "KAMIWAZA_REGISTRY_EXTERNAL_HOST"
+# Node-routable address of the local extension/app image registry the cluster
+# node's containerd is provisioned to pull from (e.g. host.docker.internal:5001
+# on k0s/lima). Published by the installer in core-config; the deployment image
+# reference must use this, not the model registry above (ENG-7051).
+REGISTRY_EXTENSION_HOST_KEY = "KAMIWAZA_EXTENSION_REGISTRY"
 _KUBE_CONTEXT_TRUSTED_SUFFIXES = (
     ".test",
     ".local",
@@ -109,6 +117,23 @@ def resolve_image_registry(
     # cannot pull them (ENG-5719). For non-local connections, skip it and fall
     # through to the connection-derived registry below.
     if _trusts_local_kube_context(connection.url):
+        # The extension/app image registry the installer published in core-config
+        # (e.g. host.docker.internal:5001). This is the registry the cluster node
+        # is provisioned to pull extension images from, so it is the correct
+        # value to embed in the deployment payload (ENG-7051).
+        extension_registry = detect_extension_registry()
+        if extension_registry:
+            return (
+                extension_registry,
+                f"{CORE_CONFIG_NAMESPACE}/{CORE_CONFIG_NAME} ({REGISTRY_EXTENSION_HOST_KEY})",
+            )
+
+        # No dedicated extension registry advertised: fall back to the
+        # historical behavior. KAMIWAZA_REGISTRY_EXTERNAL_HOST is really the
+        # *model* registry's host address, so on k0s/lima this can yield a ref
+        # the node cannot pull -- doctor surfaces that separately; here we keep
+        # resolution unchanged so the extension key is a purely additive
+        # override (ENG-7051).
         core_config_registry = detect_core_config_registry()
         if core_config_registry:
             return core_config_registry, f"{CORE_CONFIG_NAMESPACE}/{CORE_CONFIG_NAME}"
@@ -194,6 +219,11 @@ def resolve_push_registry(
         )
 
     if not is_loopback_registry(image_registry):
+        # Already a VM host alias (e.g. host.docker.internal:5001, the extension
+        # registry the installer advertises) or a real hostname: the build
+        # engine pushes to it as-is. For the docker-in-VM alias this is the only
+        # correct target -- pushing to 127.0.0.1 would hit the *VM's* loopback,
+        # not the host registry (ENG-7051).
         return image_registry, "image registry"
 
     if not build_engine_runs_in_vm():
@@ -268,8 +298,8 @@ def normalize_registry_env(var_name: str, raw: str) -> str:
     return value
 
 
-def detect_core_config_registry() -> Optional[str]:
-    """Best-effort read of the platform-advertised registry host."""
+def _read_core_config_key(key: str) -> Optional[str]:
+    """Best-effort read of a single ``core-config`` ConfigMap data key."""
 
     try:
         result = subprocess.run(
@@ -281,7 +311,7 @@ def detect_core_config_registry() -> Optional[str]:
                 "-n",
                 CORE_CONFIG_NAMESPACE,
                 "-o",
-                f"jsonpath={{.data.{REGISTRY_EXTERNAL_HOST_KEY}}}",
+                f"jsonpath={{.data.{key}}}",
             ],
             capture_output=True,
             text=True,
@@ -293,6 +323,25 @@ def detect_core_config_registry() -> Optional[str]:
         return None
     value = result.stdout.strip()
     return value or None
+
+
+def detect_core_config_registry() -> Optional[str]:
+    """Best-effort read of the platform-advertised *model* registry host."""
+
+    return _read_core_config_key(REGISTRY_EXTERNAL_HOST_KEY)
+
+
+def detect_extension_registry() -> Optional[str]:
+    """Best-effort read of the platform-advertised extension image registry.
+
+    This is the node-routable registry the cluster's containerd is provisioned
+    to pull extension/app images from (e.g. ``host.docker.internal:5001`` on
+    k0s/lima). Distinct from the model registry (:func:`detect_core_config_registry`):
+    the deployment image reference must use this value so the kubelet can pull
+    it (ENG-7051). Returns ``None`` when the installer has not published it.
+    """
+
+    return _read_core_config_key(REGISTRY_EXTENSION_HOST_KEY)
 
 
 def detect_kind_registry() -> Optional[str]:

--- a/tests/unit/extensions/conftest.py
+++ b/tests/unit/extensions/conftest.py
@@ -10,7 +10,32 @@ between tests so monkeypatch-based mutations work as authors expect.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_extension_registry():
+    """Keep the new extension-registry lookup from shelling out to a live
+    kubectl/cluster across the whole unit suite (ENG-7051).
+
+    ``resolve_image_registry`` now calls ``detect_extension_registry()`` before
+    the core-config lookup. Suites that only patch ``detect_core_config_registry``
+    (e.g. ``test_dev_canonical_refs``, ``test_doctor``) would otherwise resolve a
+    real ``KAMIWAZA_EXTENSION_REGISTRY`` from the developer's current kube
+    context. Default it to "unconfigured" (matching a fresh CI env); cases that
+    exercise it re-patch this with a value (the decorator patch wins)."""
+    try:
+        import kamiwaza_extensions.registry_resolution  # noqa: F401
+    except ImportError:
+        yield
+        return
+    with patch(
+        "kamiwaza_extensions.registry_resolution.detect_extension_registry",
+        return_value=None,
+    ):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/extensions/test_registry_resolution.py
+++ b/tests/unit/extensions/test_registry_resolution.py
@@ -41,6 +41,22 @@ def _clear_docker_info_cache():
     _reset_docker_registry_config_cache()
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_core_config():
+    """Default: nothing advertised in core-config, so resolution never shells
+    out to a live ``kubectl``/cluster. Cases that exercise a core-config or
+    extension registry re-patch these with values (the decorator wins)."""
+
+    with patch(
+        "kamiwaza_extensions.registry_resolution.detect_extension_registry",
+        return_value=None,
+    ), patch(
+        "kamiwaza_extensions.registry_resolution.detect_core_config_registry",
+        return_value=None,
+    ):
+        yield
+
+
 def _conn(url: str = "https://kamiwaza.test/api"):
     return SimpleNamespace(url=url)
 
@@ -330,6 +346,88 @@ class TestPushRegistryResolution:
 
         assert resolution.push_registry == "push.example:5000"
         assert resolution.push_registry_source == "KAMIWAZA_PUSH_REGISTRY"
+
+
+class TestExtensionRegistryResolution:
+    """ENG-7051: extension images must target the node-routable extension
+    registry the installer advertises in core-config, not the model registry."""
+
+    @patch(
+        "kamiwaza_extensions.registry_resolution.detect_extension_registry",
+        return_value="host.docker.internal:5001",
+    )
+    @patch(
+        "kamiwaza_extensions.registry_resolution.detect_core_config_registry",
+        return_value="127.0.0.1:30010",
+    )
+    @patch(
+        "kamiwaza_extensions.registry_resolution.build_engine_runs_in_vm",
+        return_value=True,
+    )
+    def test_extension_registry_embedded_and_pushed_via_alias(
+        self, _mock_vm, _mock_core, _mock_ext
+    ):
+        # The extension registry (the node-routable VM alias) is embedded AND is
+        # the push target: the docker daemon-in-VM reaches the host registry via
+        # the alias. Pushing to 127.0.0.1 would hit the VM's own loopback, not
+        # the host kind-registry -- so there is no split. The model registry
+        # (127.0.0.1:30010) is ignored for extension images.
+        resolution = resolve_dev_registries(
+            _conn(), kind_registry_detector=lambda: None, push_engine="docker"
+        )
+
+        assert resolution.image_registry == "host.docker.internal:5001"
+        assert resolution.image_registry_source == (
+            "kamiwaza/core-config (KAMIWAZA_EXTENSION_REGISTRY)"
+        )
+        assert resolution.push_registry == "host.docker.internal:5001"
+        assert resolution.push_split is False
+
+    @patch(
+        "kamiwaza_extensions.registry_resolution.detect_extension_registry",
+        return_value="host.docker.internal:5001",
+    )
+    @patch(
+        "kamiwaza_extensions.registry_resolution.build_engine_runs_in_vm",
+        return_value=True,
+    )
+    def test_extension_registry_preferred_over_model_core_config(
+        self, _mock_vm, _mock_ext
+    ):
+        # Even with the model registry present (autouse leaves it None, so set
+        # it here), the advertised extension registry is what gets embedded.
+        with patch(
+            "kamiwaza_extensions.registry_resolution.detect_core_config_registry",
+            return_value="127.0.0.1:30010",
+        ) as mock_core:
+            resolution = resolve_dev_registries(
+                _conn(), kind_registry_detector=lambda: None, push_engine="docker"
+            )
+
+        assert resolution.image_registry == "host.docker.internal:5001"
+        # The model registry is never consulted for the extension image ref.
+        mock_core.assert_not_called()
+
+    @patch(
+        "kamiwaza_extensions.registry_resolution.detect_extension_registry",
+        return_value="host.docker.internal:5001",
+    )
+    @patch(
+        "kamiwaza_extensions.registry_resolution.build_engine_runs_in_vm",
+        return_value=False,
+    )
+    def test_extension_registry_not_split_when_build_engine_native(
+        self, _mock_vm, _mock_ext
+    ):
+        # Native (non-VM) build host reaches the alias directly; no loopback
+        # remap, so push targets the same registry as the image ref.
+        resolution = resolve_dev_registries(
+            _conn(), kind_registry_detector=lambda: None, push_engine="docker"
+        )
+
+        assert resolution.image_registry == "host.docker.internal:5001"
+        assert resolution.push_registry == "host.docker.internal:5001"
+        assert resolution.push_split is False
 
 
 class TestEnvRegistryNormalization:

--- a/tests/unit/extensions/test_registry_resolution.py
+++ b/tests/unit/extensions/test_registry_resolution.py
@@ -412,6 +412,36 @@ class TestExtensionRegistryResolution:
     )
     @patch(
         "kamiwaza_extensions.registry_resolution.build_engine_runs_in_vm",
+        return_value=True,
+    )
+    @patch(
+        "kamiwaza_extensions.registry_resolution.running_podman_machine_name",
+        return_value="podman-machine-default",
+    )
+    def test_extension_registry_docker_alias_remapped_for_podman_push(
+        self, _mock_machine, _mock_vm, _mock_ext
+    ):
+        # The advertised extension registry is the *docker* VM alias, but a
+        # podman push (e.g. --no-build on an insecure connection with a running
+        # machine) must target the podman alias. The embedded image ref keeps
+        # the advertised docker alias (the node pulls via certs.d); only the
+        # push target is remapped, so the engine-match validation passes.
+        resolution = resolve_dev_registries(
+            _conn(), kind_registry_detector=lambda: None, push_engine="podman"
+        )
+
+        assert resolution.image_registry == "host.docker.internal:5001"
+        assert resolution.push_registry == "host.containers.internal:5001"
+        assert resolution.push_split is True
+        # The remapped push target validates cleanly against the podman engine.
+        validate_push_registry_for_engine(resolution.push_registry, "podman")
+
+    @patch(
+        "kamiwaza_extensions.registry_resolution.detect_extension_registry",
+        return_value="host.docker.internal:5001",
+    )
+    @patch(
+        "kamiwaza_extensions.registry_resolution.build_engine_runs_in_vm",
         return_value=False,
     )
     def test_extension_registry_not_split_when_build_engine_native(

--- a/tests/unit/extensions/test_registry_resolution.py
+++ b/tests/unit/extensions/test_registry_resolution.py
@@ -43,14 +43,12 @@ def _clear_docker_info_cache():
 
 @pytest.fixture(autouse=True)
 def _hermetic_core_config():
-    """Default: nothing advertised in core-config, so resolution never shells
-    out to a live ``kubectl``/cluster. Cases that exercise a core-config or
-    extension registry re-patch these with values (the decorator wins)."""
+    """Default the model-registry lookup to "unconfigured" for this module so
+    resolution never shells out to a live ``kubectl``/cluster. (The extension
+    registry is stubbed suite-wide in ``conftest.py``.) Cases that exercise a
+    core-config value re-patch this (the decorator wins)."""
 
     with patch(
-        "kamiwaza_extensions.registry_resolution.detect_extension_registry",
-        return_value=None,
-    ), patch(
         "kamiwaza_extensions.registry_resolution.detect_core_config_registry",
         return_value=None,
     ):


### PR DESCRIPTION
## Problem

`kz-ext dev` on k0s/lima embedded the **model** registry's external host (`KAMIWAZA_REGISTRY_EXTERNAL_HOST`, e.g. `127.0.0.1:30010`) as the **extension** image reference. The cluster node can't pull that host-loopback, so every dev deploy landed in `ImagePullBackOff` and stuck on `Provisioning`. Extension images also got pushed into the model registry, polluting it.

Root cause: the k0s/lima installer provisions the node to pull extension images from `host.docker.internal:5001`, but never advertises that registry to the SDK, so the SDK fell back to the model registry's external host. (Companion deploy PR kamiwaza-internal/deploy#418 adds the `KAMIWAZA_EXTENSION_REGISTRY` core-config key.)

## Change

- `registry_resolution.py`: new `detect_extension_registry()` reads `KAMIWAZA_EXTENSION_REGISTRY`; `resolve_image_registry()` **prefers** it. **Purely additive** — when the key is absent, resolution is byte-for-byte unchanged, so the ENG-5719/R6 push-remap contract and doctor's registry checks are untouched.
- The advertised value is the node-routable VM alias `host.docker.internal:5001`. It is embedded in the deployment **and is the push target**: the docker daemon runs inside the Docker Desktop VM and reaches the host registry via that alias. Pushing to `127.0.0.1` would hit the *VM's own* loopback, not the host kind-registry — so `image == push` and there is **no split**.
- `_read_core_config_key()` refactor: `detect_core_config_registry` and `detect_extension_registry` share one kubectl read path.
- New `TestExtensionRegistryResolution`; the extension-registry stub is in `conftest.py` so the whole unit suite stays hermetic against the new lookup.

### `insecure-registries` requirement
Because `host.docker.internal:5001` is an HTTP registry and **not** in Docker's default `127.0.0.0/8` insecure CIDR, the Docker daemon needs `host.docker.internal:5001` in `insecure-registries` (`~/.docker/daemon.json`) to push over HTTP. `kz-ext dev` already **fails loudly with the exact fix** if it's missing (no regression — same requirement ENG-5719 surfaced). Installer/docs adding this is a follow-up.

### Known cosmetic warning (non-blocking)
The catalog-overlay digest lookup runs from the plain macOS host (`docker buildx imagetools inspect`), where `host.docker.internal` doesn't resolve, so it warns and falls back to a **tag-only** overlay ref (unambiguous — the revision tag is unique per build). Eliminating it needs a host-reachable digest endpoint (`127.0.0.1:5001`) decoupled from the push target — follow-up.

## Validation

- Full extensions unit suite green (**1599 passed**), ruff clean. Verified hermetic even with `KAMIWAZA_EXTENSION_REGISTRY` set in the live cluster.
- **End-to-end against a live cluster** (core-config advertising the key, no `KAMIWAZA_REGISTRY` override): `kz-ext dev` resolves `host.docker.internal:5001 (KAMIWAZA_EXTENSION_REGISTRY)`, **pushes to `host.docker.internal:5001`**, deploys; pods reach `1/1` Running on `host.docker.internal:5001/...`; `✓ Rollout complete`. Only the known cosmetic digest warning remains.

> Note: an earlier iteration of this branch remapped the push target to `127.0.0.1:5001`; the live e2e caught that the docker-daemon-in-VM can't reach the host registry that way, and it was corrected to push via the alias (the current code). This description reflects the **merged** behavior.

## Follow-up

- Installer/docs: add `host.docker.internal:5001` to Docker Desktop `insecure-registries`.
- Decouple the digest-lookup endpoint (`127.0.0.1:5001`) to remove the cosmetic warning.
- Add a `doctor` diagnostic for "model registry advertised but not node-pullable as an extension ref."

Ticket: ENG-7051. Requires companion deploy PR kamiwaza-internal/deploy#418 (advertises `KAMIWAZA_EXTENSION_REGISTRY`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-06-15T20:20:32.477Z
pr:
  repo: kamiwaza-ai/kamiwaza-sdk
  number: 174
linear_issues:
  - ENG-7051
  - ENG-5719
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: All required GitHub checks green on head 85c840d (Build, Coverage,
      Complexity, Mypy, Ruff, Unit, check-linear). Gate re-verifies.
  - kind: pr-evidence
    required: false
    status: skipped
    detail: kz-ext is a developer CLI; this change does not touch cluster-running
      code, so cluster-smoke pr-evidence is not applicable.
  - kind: linear-issue-present
    required: true
    status: pass
    detail: ENG-7051 (and ENG-5719) present in PR title, head branch, and body.
  - kind: no-debug-statements
    required: true
    status: pass
    detail: Diff scanned (registry_resolution.py, conftest.py,
      test_registry_resolution.py); no stray debug statements.
  - kind: pr-review-approved
    required: true
    status: pass
    detail: Cron multi-engine /pr-review verdict APPROVE recorded on head 85c840d by
      jxstanford (prior Codex High resolved + tested).
manual_steps:
  - id: ms-1
    description: Run kz-ext dev (worktree SDK, no KAMIWAZA_REGISTRY override) for
      workroom-manager on the k0s/lima cluster; read the 'Registry:' line and
      the final pod/rollout status.
    observation: "kz-ext dev printed: 'Registry: host.docker.internal:5001
      (kamiwaza/core-config (KAMIWAZA_EXTENSION_REGISTRY))'. It built and pushed
      both images to host.docker.internal:5001, then printed 'Status: Running',
      'Pods: backend 1/1 ready, frontend 1/1 ready', and '✓ Rollout complete'. A
      non-fatal digest warning ('dial tcp: lookup host.docker.internal: no such
      host') fell back to a tag-only overlay ref."
    status: pass
  - id: ms-2
    description: Run kubectl get pods -n kamiwaza-extensions (NAME/STATUS/IMAGE) and
      read the workroom-manager pods' status and image registry host.
    observation: "Both workroom pods were STATUS Running on the extension registry:
      'workroom-manager-dev-9580ae-backend-764d888698-d6l5b  Running  host.dock\
      er.internal:5001/outcome-d563-workroom-manager-backend:0.8.0-dev-0822bcb.\
      1781552214' and
      'workroom-manager-dev-9580ae-frontend-6cc556b64d-8rpnf  Running  host.doc\
      ker.internal:5001/outcome-d563-workroom-manager-frontend:0.8.0-dev-0822bc\
      b.1781552214'."
    status: pass
verdict:
  decision: approve
  rationale: All required auto-checks passed (required-checks,
    linear-issue-present, no-debug-statements, pr-review-approved); 2 manual
    steps verified.
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
linear:
  - id: ENG-7051
    url: https://linear.app/kamiwaza/issue/ENG-7051
    cached_description: >
      ## Summary


      On a local k0s/lima dev cluster, kz-ext dev builds and pushes extension
      images to the in-cluster model registry (127.0.0.1:30010, NodePort for
      registry.registry.svc:5000) and embeds that address as the image reference
      in the Kubernetes Deployment. The k0s node cannot pull from
      127.0.0.1:30010, so every dev extension deploy lands in ImagePullBackOff
      and the extension is stuck Provisioning forever.


      Extension images are supposed to live in the host-side local registry at
      host.docker.internal:5001 (the registry:2 container named kind-registry),
      which the k0s node is provisioned to pull from. The SDK never targets it.


      ## Impact


      All local-dev extension deploys on k0s/lima fail to provision (build and
      push succeed, pods never become Ready). Extension images get pushed into
      the model registry, polluting it. Observed on workroom-manager; generic to
      any kz-ext dev against a local k0s/lima cluster.


      ## Root cause


      The k0s/lima installer provisions the node to pull extension images from
      host.docker.internal:5001, but never advertises that registry to the
      kz-ext SDK. With no extension-registry value to read, the SDK falls
      through to the model registry's external host
      (KAMIWAZA_REGISTRY_EXTERNAL_HOST = 127.0.0.1:30010) and ships extension
      images there. The model loopback is not node-routable in a nested-VM
      topology, so the embedded ref produces ImagePullBackOff.


      ## Fix


      The deploy repo advertises the extension registry via a new core-config
      key KAMIWAZA_EXTENSION_REGISTRY (Helm value scheduler.extensionRegistry),
      wired from container_registry. The kamiwaza-sdk reads that key in
      resolve_image_registry and prefers it, embedding the node-routable
      host.docker.internal:5001 and pushing via that alias. The change is purely
      additive: when the key is absent, resolution is unchanged.


      ## Acceptance criteria


      - kz-ext dev succeeds against a k0s/lima cluster with no KAMIWAZA_REGISTRY
      override when core-config advertises the extension registry.

      - The deployment image ref uses the node-routable extension registry, so
      pods reach Running instead of ImagePullBackOff.

      - When the key is absent, resolution behavior is unchanged (backwards
      compatible).

      - The new key is kept distinct from the model registry key
      KAMIWAZA_REGISTRY_EXTERNAL_HOST.


      ## Validation


      SDK unit suite passes (1599). End-to-end against a live cluster with
      core-config advertising the key resolves host.docker.internal:5001,
      pushes, deploys, and pods reach 1/1 Running.
    cached_at: 2026-06-15T19:34:44Z
  - id: ENG-5719
    url: https://linear.app/kamiwaza/issue/ENG-5719
    cached_description: >
      ## Summary


      The platform has moved to istio + k0s. kz-ext dev (remote build, push,
      deploy) does not work against these clusters out of the box. There are two
      distinct problems; both must be fixed for kz-ext dev to work on the
      now-default platform, especially the common macOS dev setup (Lima-based
      k0s VM plus a separate podman/Docker build VM). Fixes should be backwards
      compatible.


      ## Problem 1 — Registry host derivation doesn't match istio/k0s


      run_dev_remote resolves the registry from KAMIWAZA_REGISTRY, then the Kind
      local-registry-hosting configmap, then a registry.{hostname} convention.
      On istio/k0s none fit, so the push fails with an HTML response. The
      platform advertises the right values in the kamiwaza/core-config
      configmap. The fix adds a platform-advertised lookup to the chain, keeping
      the convention as the final fallback.


      ## Problem 2 — Push host vs image-ref host must differ on macOS nested-VM
      topology


      On macOS the build/push runs inside a separate VM where 127.0.0.1 is the
      VM's own loopback, not the Mac host loopback. The in-cluster kubelet must
      pull via 127.0.0.1:30010. There is no single address that is both
      VM-reachable and valid in-cluster. The fix separates the push registry
      (reachable from the build VM) from the image registry (embedded in the
      deployment ref, reachable in-cluster), defaulting the push host to
      host.docker.internal / host.containers.internal when the image registry is
      loopback and the build engine runs in a VM.


      ## Acceptance criteria


      - kz-ext dev succeeds against an istio/k0s cluster with no
      KAMIWAZA_REGISTRY set, including the macOS Lima-k0s plus build-VM setup.

      - Registry host is sourced from the platform-advertised external host
      before the convention.

      - Push target and deployment image-ref host can differ; defaults preserve
      current single-value behavior on Linux hosts.

      - Explicit KAMIWAZA_REGISTRY and a new push override still take
      precedence.

      - No regression on clusters that expose registry.{domain} ingress.

      - kz-ext doctor reports registry push/pull reachability.
    cached_at: 2026-06-15T19:34:44Z
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->