### PR TITLE
ENG-7048: kamiwaza-seed resolve-kaizen-url (workroom-scoped Kaizen ingress)

### DIFF
--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -11,6 +11,7 @@ Example::
     export KAMIWAZA_API_KEY="$(kamiwaza-seed login --password-env ADMIN_PW --raw)"
     kamiwaza-seed create-workroom --name uat
     kamiwaza-seed install-extension --name kaizen --workroom-id <wid>
+    URL="$(kamiwaza-seed resolve-kaizen-url --workroom-id <wid> --raw)"
     kamiwaza-seed register-external-model --protocol aws_bedrock \\
         --name claude --region us-east-1 \\
         --model-id anthropic.claude-3-sonnet-20240229-v1:0 \\
@@ -30,6 +31,7 @@ from ..schemas.models.external_endpoint import (
     AWSBedrockChatEndpoint,
     AWSTranscribeEndpoint,
 )
+from ..services.kaizen import wait_for_base_url
 from .client import build_client_from_env, scoped_client_for_workroom
 
 
@@ -144,6 +146,32 @@ def cmd_install_extension(args: argparse.Namespace, *, client) -> dict:
         sync_if_missing=not args.no_sync,
     )
     return {"deployment_id": str(deployment.id), "name": deployment.name}
+
+
+def cmd_resolve_kaizen_url(args: argparse.Namespace, *, client) -> Optional[dict]:
+    """Resolve a workroom's Kaizen ingress root, waiting for it to come up.
+
+    The operator names per-workroom CRs ``<name>-<hash>`` and stamps each with
+    its ``workroom_id``, so we enter the workroom (only then is its Kaizen
+    listed) and match on base name + workroom — never another workroom's Kaizen
+    or the first one we happen to see. ``--raw`` prints just the bare URL for
+    ``URL="$(... --raw)"``; a readiness timeout exits non-zero.
+    """
+    client = _client_for_workroom(client, args.workroom_id)
+    try:
+        url = wait_for_base_url(
+            client,
+            args.name,
+            workroom_id=args.workroom_id,
+            timeout_seconds=args.timeout,
+            poll_interval_seconds=args.poll_interval,
+        )
+    except TimeoutError as exc:
+        raise SystemExit(str(exc))
+    if args.raw:
+        print(url)
+        return None
+    return {"kaizen_base_url": url}
 
 
 def cmd_create_agent(args: argparse.Namespace, *, client) -> dict:
@@ -276,6 +304,39 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-sync", action="store_true", help="Don't import the catalog if missing."
     )
     p.set_defaults(func=cmd_install_extension)
+
+    p = sub.add_parser(
+        "resolve-kaizen-url",
+        help="Resolve a workroom's Kaizen ingress root (waits for ready).",
+    )
+    p.add_argument(
+        "--workroom-id",
+        required=True,
+        help="Workroom whose Kaizen instance to resolve.",
+    )
+    p.add_argument(
+        "--name",
+        default="kaizen",
+        help="Extension catalog/base name (default: kaizen).",
+    )
+    p.add_argument(
+        "--raw",
+        action="store_true",
+        help='Print only the bare URL (for URL="$(... --raw)").',
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=300.0,
+        help="Max seconds to wait for the ingress to resolve (default: 300).",
+    )
+    p.add_argument(
+        "--poll-interval",
+        type=float,
+        default=5.0,
+        help="Seconds between resolve attempts (default: 5).",
+    )
+    p.set_defaults(func=cmd_resolve_kaizen_url)
 
     # allow_abbrev=False so `--llm-api-key` can't be accepted as a prefix of
     # `--llm-api-key-env`, which would route a secret through argv.

--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -31,7 +31,7 @@ from ..schemas.models.external_endpoint import (
     AWSBedrockChatEndpoint,
     AWSTranscribeEndpoint,
 )
-from ..services.kaizen import wait_for_base_url
+from ..services.kaizen import AmbiguousExtensionError, wait_for_base_url
 from .client import build_client_from_env, scoped_client_for_workroom
 
 
@@ -166,7 +166,7 @@ def cmd_resolve_kaizen_url(args: argparse.Namespace, *, client) -> Optional[dict
             timeout_seconds=args.timeout,
             poll_interval_seconds=args.poll_interval,
         )
-    except TimeoutError as exc:
+    except (TimeoutError, AmbiguousExtensionError) as exc:
         raise SystemExit(str(exc))
     if args.raw:
         print(url)

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -13,7 +13,6 @@ platform honors this header. A workroom-scoped token is the durable fix
 (tracked for the nightly-seeding work).
 """
 
-import re
 import time
 from typing import Any, Dict, List, Optional, Union
 
@@ -65,12 +64,14 @@ def _endpoint_from_extension(extension, *, public: bool) -> Optional[str]:
 def _find_workroom_extension(client, extension_name: str, workroom_id):
     """Find a workroom's extension by base name (the operator suffixes CR names).
 
-    A per-workroom extension's CR is named ``<extension_name>-<hash>`` and carries
-    its ``workroom_id``, so we match on BOTH: the exact ``workroom_id`` (so we
-    never pick another workroom's instance) and the base name + operator hash
-    suffix (so a same-prefix sibling like ``kaizen-admin-<hash>`` can't be
-    mistaken for ``kaizen``). Requires the client to be scoped into the workroom
-    — the platform only lists a workroom's extensions to a caller scoped into it.
+    The operator names a per-workroom CR ``<extension_name>-<hash>`` and stamps it
+    with its ``workroom_id``, so we match on both: the exact ``workroom_id`` (never
+    another workroom's instance) and the ``<extension_name>-`` prefix (the kaizen,
+    not milvus/omniparse). ``workroom_id`` is the strong discriminator; the
+    ambiguity guard below is the backstop if more than one ever matches — so the
+    prefix check doesn't need to over-anchor on the hash shape. Requires the client
+    to be scoped into the workroom — the platform only lists a workroom's
+    extensions to a caller scoped into it.
 
     Raises:
         ValueError: when no instance is visible yet (still provisioning) —
@@ -78,15 +79,12 @@ def _find_workroom_extension(client, extension_name: str, workroom_id):
         AmbiguousExtensionError: when more than one matches (a workroom should
             hold one) — deterministic, callers must not retry.
     """
-    # The operator suffixes the CR with a single hex hash segment (e.g.
-    # ``kaizen-4f8b3ae1``). Anchoring on that shape avoids matching a longer
-    # sibling name that merely shares the base prefix.
-    suffix_re = re.compile(rf"^{re.escape(extension_name)}-[0-9a-f]+$")
+    prefix = f"{extension_name}-"
     matches = [
         ext
         for ext in client.extensions.list_extensions()
         if str(getattr(ext, "workroom_id", "")) == str(workroom_id)
-        and (ext.name == extension_name or suffix_re.match(ext.name))
+        and ext.name.startswith(prefix)
     ]
     if not matches:
         raise ValueError(

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -13,16 +13,26 @@ platform honors this header. A workroom-scoped token is the durable fix
 (tracked for the nightly-seeding work).
 """
 
+import re
 import time
 from typing import Any, Dict, List, Optional, Union
 
-from ..exceptions import NotFoundError
+from ..exceptions import KamiwazaError, NotFoundError
 from ..schemas.kaizen import Agent, Conversation, LLMConfig
 from .base_service import BaseService
 
 # Kaizen route prefixes, relative to the extension's ingress root.
 _AGENTS_PATH = "api/agents/"
 _CONVERSATIONS_PATH = "api/conversations/"
+
+
+class AmbiguousExtensionError(KamiwazaError):
+    """More than one extension matched a workroom + base-name lookup.
+
+    A deterministic failure (a workroom should hold one instance of a given
+    extension), so callers must NOT retry it — unlike the transient "not visible
+    yet" / "no endpoint yet" states that resolve on a later poll.
+    """
 
 
 def _workroom_headers(workroom_id: Optional[Union[str, object]]) -> Dict[str, str]:
@@ -57,21 +67,26 @@ def _find_workroom_extension(client, extension_name: str, workroom_id):
 
     A per-workroom extension's CR is named ``<extension_name>-<hash>`` and carries
     its ``workroom_id``, so we match on BOTH: the exact ``workroom_id`` (so we
-    never pick another workroom's instance) and the base name (so we don't pick a
-    different extension in the same workroom). Requires the client to be scoped
-    into the workroom — the platform only lists a workroom's extensions to a
-    caller scoped into it.
+    never pick another workroom's instance) and the base name + operator hash
+    suffix (so a same-prefix sibling like ``kaizen-admin-<hash>`` can't be
+    mistaken for ``kaizen``). Requires the client to be scoped into the workroom
+    — the platform only lists a workroom's extensions to a caller scoped into it.
 
     Raises:
-        ValueError: when no instance is visible yet (still provisioning) or when
-            more than one matches (anomalous — a workroom should have one Kaizen).
+        ValueError: when no instance is visible yet (still provisioning) —
+            transient, callers may retry.
+        AmbiguousExtensionError: when more than one matches (a workroom should
+            hold one) — deterministic, callers must not retry.
     """
-    prefix = f"{extension_name}-"
+    # The operator suffixes the CR with a single hex hash segment (e.g.
+    # ``kaizen-4f8b3ae1``). Anchoring on that shape avoids matching a longer
+    # sibling name that merely shares the base prefix.
+    suffix_re = re.compile(rf"^{re.escape(extension_name)}-[0-9a-f]+$")
     matches = [
         ext
         for ext in client.extensions.list_extensions()
         if str(getattr(ext, "workroom_id", "")) == str(workroom_id)
-        and (ext.name == extension_name or ext.name.startswith(prefix))
+        and (ext.name == extension_name or suffix_re.match(ext.name))
     ]
     if not matches:
         raise ValueError(
@@ -80,7 +95,7 @@ def _find_workroom_extension(client, extension_name: str, workroom_id):
         )
     if len(matches) > 1:
         names = ", ".join(sorted(m.name for m in matches))
-        raise ValueError(
+        raise AmbiguousExtensionError(
             f"Multiple '{extension_name}' extensions in workroom '{workroom_id}' "
             f"({names}); cannot pick one unambiguously."
         )
@@ -132,7 +147,9 @@ def wait_for_base_url(
     visible yet (``NotFoundError`` / no workroom match) and/or its endpoints
     aren't published (``ValueError``). Both are transient, so retry until one
     resolves or ``timeout_seconds`` elapses. Mirrors
-    ``serving.wait_deployment_ready``'s wait contract.
+    ``serving.wait_deployment_ready``'s wait contract. A deterministic
+    ``AmbiguousExtensionError`` is NOT retried — it propagates immediately rather
+    than burning the full timeout on something that will never resolve.
 
     Args:
         client: An authenticated client (workroom-scoped if the extension is).
@@ -159,12 +176,15 @@ def wait_for_base_url(
             )
         except (ValueError, NotFoundError) as exc:
             last_err = exc
-        if time.monotonic() >= deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             raise TimeoutError(
                 f"Extension '{extension_name}' ingress not resolvable after "
                 f"{timeout_seconds:g}s ({attempts} attempts): {last_err}"
             )
-        time.sleep(poll_interval_seconds)
+        # Cap the sleep at the remaining budget so the wait stays bounded even
+        # when poll_interval_seconds exceeds the time left.
+        time.sleep(min(poll_interval_seconds, remaining))
 
 
 class AgentService(BaseService):

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -13,8 +13,10 @@ platform honors this header. A workroom-scoped token is the durable fix
 (tracked for the nightly-seeding work).
 """
 
+import time
 from typing import Any, Dict, List, Optional, Union
 
+from ..exceptions import NotFoundError
 from ..schemas.kaizen import Agent, Conversation, LLMConfig
 from .base_service import BaseService
 
@@ -30,37 +32,139 @@ def _workroom_headers(workroom_id: Optional[Union[str, object]]) -> Dict[str, st
     return {"X-Workroom-Id": str(workroom_id)}
 
 
-def resolve_base_url(
-    client, extension_name: str = "kaizen", *, public: bool = False
-) -> str:
-    """Best-effort lookup of a Kaizen instance's ingress root from the platform.
-
-    Reads the extension's resolved endpoints. Raises ValueError when no endpoint
-    is published yet (extension still provisioning) — callers that already know
-    the URL should pass ``base_url`` directly instead.
-    """
-    extension = client.extensions.get_extension(extension_name)
+def _endpoint_from_extension(extension, *, public: bool) -> Optional[str]:
+    """Pull the ingress (or public) URL off an extension's endpoints, or None."""
     endpoints = getattr(extension, "endpoints", None)
-    candidates = []
-    if endpoints is not None:
-        # ``external`` is the ingress-reachable URL; some deployments instead
-        # surface ``public_api_url`` / ``api_url`` (extra fields). Prefer the
-        # public-facing field when ``public`` is set, else the ingress URL.
-        order = (
-            ("public_api_url", "api_url", "external")
-            if public
-            else ("external", "api_url", "public_api_url")
-        )
-        for attr in order:
-            value = getattr(endpoints, attr, None)
-            if value:
-                candidates.append(value)
-    if not candidates:
+    if endpoints is None:
+        return None
+    # ``external`` is the ingress-reachable URL; some deployments instead surface
+    # ``public_api_url`` / ``api_url`` (extra fields). Prefer the public-facing
+    # field when ``public`` is set, else the ingress URL.
+    order = (
+        ("public_api_url", "api_url", "external")
+        if public
+        else ("external", "api_url", "public_api_url")
+    )
+    for attr in order:
+        value = getattr(endpoints, attr, None)
+        if value:
+            return str(value).rstrip("/")
+    return None
+
+
+def _find_workroom_extension(client, extension_name: str, workroom_id):
+    """Find a workroom's extension by base name (the operator suffixes CR names).
+
+    A per-workroom extension's CR is named ``<extension_name>-<hash>`` and carries
+    its ``workroom_id``, so we match on BOTH: the exact ``workroom_id`` (so we
+    never pick another workroom's instance) and the base name (so we don't pick a
+    different extension in the same workroom). Requires the client to be scoped
+    into the workroom — the platform only lists a workroom's extensions to a
+    caller scoped into it.
+
+    Raises:
+        ValueError: when no instance is visible yet (still provisioning) or when
+            more than one matches (anomalous — a workroom should have one Kaizen).
+    """
+    prefix = f"{extension_name}-"
+    matches = [
+        ext
+        for ext in client.extensions.list_extensions()
+        if str(getattr(ext, "workroom_id", "")) == str(workroom_id)
+        and (ext.name == extension_name or ext.name.startswith(prefix))
+    ]
+    if not matches:
         raise ValueError(
-            f"Extension '{extension_name}' has no published endpoint yet; "
+            f"No '{extension_name}' extension found in workroom '{workroom_id}' yet; "
             "wait for it to become ready or pass base_url explicitly."
         )
-    return str(candidates[0]).rstrip("/")
+    if len(matches) > 1:
+        names = ", ".join(sorted(m.name for m in matches))
+        raise ValueError(
+            f"Multiple '{extension_name}' extensions in workroom '{workroom_id}' "
+            f"({names}); cannot pick one unambiguously."
+        )
+    return matches[0]
+
+
+def resolve_base_url(
+    client,
+    extension_name: str = "kaizen",
+    *,
+    workroom_id: Optional[Union[str, object]] = None,
+    public: bool = False,
+) -> str:
+    """Look up an extension's ingress root from the platform.
+
+    With ``workroom_id``, resolves a per-workroom extension by base name +
+    workroom (the operator suffixes the CR name, so an exact lookup misses it).
+    Without it, does an exact ``get_extension`` lookup (cluster-scoped
+    extensions). Raises ValueError when no endpoint is published yet (extension
+    still provisioning) — callers that already know the URL should pass
+    ``base_url`` directly instead.
+    """
+    if workroom_id is not None:
+        extension = _find_workroom_extension(client, extension_name, workroom_id)
+    else:
+        extension = client.extensions.get_extension(extension_name)
+    url = _endpoint_from_extension(extension, public=public)
+    if url is None:
+        raise ValueError(
+            f"Extension '{getattr(extension, 'name', extension_name)}' has no "
+            "published endpoint yet; wait for it to become ready or pass "
+            "base_url explicitly."
+        )
+    return url
+
+
+def wait_for_base_url(
+    client,
+    extension_name: str = "kaizen",
+    *,
+    workroom_id: Optional[Union[str, object]] = None,
+    public: bool = False,
+    timeout_seconds: float = 300.0,
+    poll_interval_seconds: float = 5.0,
+) -> str:
+    """Poll :func:`resolve_base_url` until the extension publishes its ingress.
+
+    Right after an install the ingress isn't resolvable yet: the extension isn't
+    visible yet (``NotFoundError`` / no workroom match) and/or its endpoints
+    aren't published (``ValueError``). Both are transient, so retry until one
+    resolves or ``timeout_seconds`` elapses. Mirrors
+    ``serving.wait_deployment_ready``'s wait contract.
+
+    Args:
+        client: An authenticated client (workroom-scoped if the extension is).
+        extension_name: Catalog/base name of the extension (e.g. "kaizen").
+        workroom_id: When set, resolve the per-workroom instance by base name +
+            workroom (see :func:`resolve_base_url`).
+        public: Prefer the public-facing endpoint over the ingress URL.
+        timeout_seconds: Max time to wait before giving up.
+        poll_interval_seconds: Delay between attempts.
+
+    Returns:
+        The resolved ingress root (no trailing slash).
+
+    Raises:
+        TimeoutError: If no endpoint resolves within ``timeout_seconds``.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    attempts = 0
+    while True:
+        attempts += 1
+        try:
+            return resolve_base_url(
+                client, extension_name, workroom_id=workroom_id, public=public
+            )
+        except (ValueError, NotFoundError) as exc:
+            last_err = exc
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"Extension '{extension_name}' ingress not resolvable after "
+                f"{timeout_seconds:g}s ({attempts} attempts): {last_err}"
+            )
+        time.sleep(poll_interval_seconds)
 
 
 class AgentService(BaseService):

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -190,7 +190,7 @@ def test_wait_for_base_url_workroom_retries_until_listed(monkeypatch):
 
     monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
 
-    # Round 1: workroom has no Kaizen yet. Round 2: it's listed and ready.
+    # First poll: workroom has no Kaizen yet. Second poll: it's listed and ready.
     rounds = [[], [_ext("kaizen-4f8b3ae1", "wr-A")]]
 
     def list_extensions():

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -4,11 +4,13 @@ from types import SimpleNamespace
 
 import pytest
 
+from kamiwaza_sdk.exceptions import NotFoundError
 from kamiwaza_sdk.schemas.kaizen import LLMConfig
 from kamiwaza_sdk.services.kaizen import (
     AgentService,
     ConversationService,
     resolve_base_url,
+    wait_for_base_url,
 )
 
 pytestmark = pytest.mark.unit
@@ -137,6 +139,122 @@ def test_resolve_base_url_raises_when_no_endpoint():
 
     with pytest.raises(ValueError, match="no published endpoint"):
         resolve_base_url(client, "kaizen")
+
+
+def _ext(name, workroom_id, *, external=KAIZEN_URL):
+    return SimpleNamespace(
+        name=name,
+        workroom_id=workroom_id,
+        endpoints=SimpleNamespace(external=external, public_api_url=None),
+    )
+
+
+def _client_listing(extensions):
+    return SimpleNamespace(
+        extensions=SimpleNamespace(list_extensions=lambda: list(extensions))
+    )
+
+
+def test_resolve_base_url_matches_workroom_by_base_name_and_id():
+    # The operator suffixes the CR name; match on base name + the exact workroom,
+    # and ignore other extensions (milvus) and other workrooms' Kaizen.
+    client = _client_listing(
+        [
+            _ext("kaizen-4f8b3ae1", "wr-A"),
+            _ext("kaizen-99999999", "wr-B"),  # another workroom's Kaizen
+            _ext("service-milvus-xyz", "wr-A", external="https://x/milvus"),
+        ]
+    )
+
+    assert resolve_base_url(client, "kaizen", workroom_id="wr-A") == KAIZEN_URL
+
+
+def test_resolve_base_url_workroom_no_match_raises():
+    # Kaizen exists, but only in a different workroom — must not be picked.
+    client = _client_listing([_ext("kaizen-99999999", "wr-B")])
+
+    with pytest.raises(ValueError, match="No 'kaizen' extension found"):
+        resolve_base_url(client, "kaizen", workroom_id="wr-A")
+
+
+def test_resolve_base_url_workroom_ambiguous_raises():
+    # Two Kaizen in the SAME workroom is anomalous — fail loudly, don't guess.
+    client = _client_listing([_ext("kaizen-aaaa", "wr-A"), _ext("kaizen-bbbb", "wr-A")])
+
+    with pytest.raises(ValueError, match="Multiple 'kaizen' extensions"):
+        resolve_base_url(client, "kaizen", workroom_id="wr-A")
+
+
+def test_wait_for_base_url_workroom_retries_until_listed(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+
+    # Round 1: workroom has no Kaizen yet. Round 2: it's listed and ready.
+    rounds = [[], [_ext("kaizen-4f8b3ae1", "wr-A")]]
+
+    def list_extensions():
+        return rounds.pop(0)
+
+    client = SimpleNamespace(
+        extensions=SimpleNamespace(list_extensions=list_extensions)
+    )
+
+    url = wait_for_base_url(
+        client, "kaizen", workroom_id="wr-A", poll_interval_seconds=0
+    )
+    assert url == KAIZEN_URL
+    assert rounds == []
+
+
+def test_wait_for_base_url_returns_when_ready():
+    extension = SimpleNamespace(
+        endpoints=SimpleNamespace(external=KAIZEN_URL, public_api_url=None)
+    )
+    client = SimpleNamespace(
+        extensions=SimpleNamespace(get_extension=lambda name: extension)
+    )
+
+    assert wait_for_base_url(client, "kaizen-4f8b3ae1") == KAIZEN_URL
+
+
+def test_wait_for_base_url_retries_past_transient_states(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+
+    ready = SimpleNamespace(
+        endpoints=SimpleNamespace(external=KAIZEN_URL, public_api_url=None)
+    )
+    unpublished = SimpleNamespace(
+        endpoints=SimpleNamespace(external=None, public_api_url=None)
+    )
+    # CR not visible yet (404), then present but no endpoint, then ready.
+    outcomes = [NotFoundError("nf"), unpublished, ready]
+
+    def get_extension(_name):
+        item = outcomes.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    client = SimpleNamespace(extensions=SimpleNamespace(get_extension=get_extension))
+
+    assert wait_for_base_url(client, "kaizen", poll_interval_seconds=0) == KAIZEN_URL
+    assert outcomes == []
+
+
+def test_wait_for_base_url_times_out():
+    unpublished = SimpleNamespace(
+        endpoints=SimpleNamespace(external=None, public_api_url=None)
+    )
+    client = SimpleNamespace(
+        extensions=SimpleNamespace(get_extension=lambda name: unpublished)
+    )
+
+    # timeout 0: the deadline is already past after the first failed attempt.
+    with pytest.raises(TimeoutError, match="not resolvable"):
+        wait_for_base_url(client, "kaizen", timeout_seconds=0)
 
 
 def test_agent_list_unwraps_agents_envelope():

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -187,13 +187,14 @@ def test_resolve_base_url_workroom_ambiguous_raises():
         resolve_base_url(client, "kaizen", workroom_id="wr-A")
 
 
-def test_resolve_base_url_workroom_excludes_same_prefix_sibling():
-    # A sibling that merely shares the base prefix (kaizen-admin-<hash>) must NOT
-    # be mistaken for kaizen — only the base + operator hash suffix matches.
+def test_resolve_base_url_workroom_ignores_unsuffixed_exact_name():
+    # A per-workroom instance is always the operator's suffixed CR (kaizen-<hash>),
+    # so a bare exact-name extension is not matched — a stray one can't shadow the
+    # real instance or trip a false ambiguity.
     client = _client_listing(
         [
+            _ext("kaizen", "wr-A", external="https://x/bare"),
             _ext("kaizen-4f8b3ae1", "wr-A"),
-            _ext("kaizen-admin-99999999", "wr-A", external="https://x/admin"),
         ]
     )
 

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -8,6 +8,7 @@ from kamiwaza_sdk.exceptions import NotFoundError
 from kamiwaza_sdk.schemas.kaizen import LLMConfig
 from kamiwaza_sdk.services.kaizen import (
     AgentService,
+    AmbiguousExtensionError,
     ConversationService,
     resolve_base_url,
     wait_for_base_url,
@@ -179,10 +180,60 @@ def test_resolve_base_url_workroom_no_match_raises():
 
 def test_resolve_base_url_workroom_ambiguous_raises():
     # Two Kaizen in the SAME workroom is anomalous — fail loudly, don't guess.
+    # AmbiguousExtensionError (not ValueError) so the wait loop won't retry it.
     client = _client_listing([_ext("kaizen-aaaa", "wr-A"), _ext("kaizen-bbbb", "wr-A")])
 
-    with pytest.raises(ValueError, match="Multiple 'kaizen' extensions"):
+    with pytest.raises(AmbiguousExtensionError, match="Multiple 'kaizen' extensions"):
         resolve_base_url(client, "kaizen", workroom_id="wr-A")
+
+
+def test_resolve_base_url_workroom_excludes_same_prefix_sibling():
+    # A sibling that merely shares the base prefix (kaizen-admin-<hash>) must NOT
+    # be mistaken for kaizen — only the base + operator hash suffix matches.
+    client = _client_listing(
+        [
+            _ext("kaizen-4f8b3ae1", "wr-A"),
+            _ext("kaizen-admin-99999999", "wr-A", external="https://x/admin"),
+        ]
+    )
+
+    assert resolve_base_url(client, "kaizen", workroom_id="wr-A") == KAIZEN_URL
+
+
+def test_wait_for_base_url_does_not_retry_ambiguity(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    slept: list = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    client = _client_listing([_ext("kaizen-aaaa", "wr-A"), _ext("kaizen-bbbb", "wr-A")])
+
+    # Ambiguity is deterministic — it must propagate immediately, never poll.
+    with pytest.raises(AmbiguousExtensionError):
+        wait_for_base_url(client, "kaizen", workroom_id="wr-A", poll_interval_seconds=0)
+    assert slept == []
+
+
+def test_wait_for_base_url_caps_sleep_to_remaining(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    # monotonic calls: deadline (0.0 -> deadline 1.0), attempt-1 remaining (0.0),
+    # attempt-2 remaining (1.0 -> deadline reached).
+    times = iter([0.0, 0.0, 1.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    slept: list = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    client = _client_listing([])  # nothing yet -> retryable ValueError
+
+    with pytest.raises(TimeoutError):
+        wait_for_base_url(
+            client,
+            "kaizen",
+            workroom_id="wr-A",
+            timeout_seconds=1,
+            poll_interval_seconds=60,
+        )
+    # Sleep capped to the 1s remaining, not the 60s poll interval.
+    assert slept == [1.0]
 
 
 def test_wait_for_base_url_workroom_retries_until_listed(monkeypatch):

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -222,6 +222,58 @@ def test_install_extension_passes_workroom_and_sync(capsys, monkeypatch):
     }
 
 
+def test_resolve_kaizen_url_scopes_and_matches_workroom(capsys, monkeypatch):
+    client = FakeClient()
+    scoped_calls: list = []
+    monkeypatch.setattr(
+        cli,
+        "scoped_client_for_workroom",
+        lambda c, wid: scoped_calls.append(wid) or c,
+    )
+    # Capture how resolution is invoked: the wait must be told BOTH the base name
+    # and the workroom id, so it matches the right workroom's Kaizen — not any.
+    seen: dict = {}
+
+    def fake_wait(_client, name, *, workroom_id, **_kw):
+        seen.update(name=name, workroom_id=workroom_id)
+        return "https://k/kaizen"
+
+    monkeypatch.setattr(cli, "wait_for_base_url", fake_wait)
+
+    _run(["resolve-kaizen-url", "--workroom-id", "wr-9"], client)
+
+    assert scoped_calls == ["wr-9"]
+    assert seen == {"name": "kaizen", "workroom_id": "wr-9"}
+    assert json.loads(capsys.readouterr().out) == {
+        "kaizen_base_url": "https://k/kaizen"
+    }
+
+
+def test_resolve_kaizen_url_raw_prints_bare_url(capsys, monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+    monkeypatch.setattr(cli, "wait_for_base_url", lambda *a, **k: "https://k/kaizen")
+
+    _run(["resolve-kaizen-url", "--workroom-id", "wr-9", "--raw"], client)
+
+    # --raw emits just the URL for $(...) capture — no JSON envelope.
+    assert capsys.readouterr().out.strip() == "https://k/kaizen"
+
+
+def test_resolve_kaizen_url_timeout_exits_nonzero(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    def time_out(*_a, **_k):
+        raise TimeoutError("ingress not resolvable")
+
+    monkeypatch.setattr(cli, "wait_for_base_url", time_out)
+
+    # A readiness timeout surfaces as a non-zero exit with the wait's message.
+    with pytest.raises(SystemExit):
+        _run(["resolve-kaizen-url", "--workroom-id", "wr-9"], client)
+
+
 def test_create_agent_uses_kaizen_base_url(capsys, monkeypatch):
     client = FakeClient()
     monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -274,6 +274,20 @@ def test_resolve_kaizen_url_timeout_exits_nonzero(monkeypatch):
         _run(["resolve-kaizen-url", "--workroom-id", "wr-9"], client)
 
 
+def test_resolve_kaizen_url_ambiguous_exits_nonzero(monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    def ambiguous(*_a, **_k):
+        raise cli.AmbiguousExtensionError("Multiple 'kaizen' extensions in workroom")
+
+    monkeypatch.setattr(cli, "wait_for_base_url", ambiguous)
+
+    # Ambiguity is a clean non-zero exit (the message), not an uncaught traceback.
+    with pytest.raises(SystemExit):
+        _run(["resolve-kaizen-url", "--workroom-id", "wr-9"], client)
+
+
 def test_create_agent_uses_kaizen_base_url(capsys, monkeypatch):
     client = FakeClient()
     monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)


### PR DESCRIPTION
## What this ships

A `kamiwaza-seed resolve-kaizen-url` subcommand so on-box nightly seeding (ENG-6932) can discover a workroom's Kaizen ingress and create a workroom-bound agent without a hardcoded URL. Backed by a workroom-aware resolver in the SDK (`services/kaizen.py`).

## Contract

```
kamiwaza-seed resolve-kaizen-url --workroom-id <wid> [--name kaizen] [--raw] [--timeout 300] [--poll-interval 5]
```
- Enters the workroom (only then is its Kaizen listed), then resolves the ingress root.
- `--raw` prints the bare URL for `URL="$(… --raw)"`; otherwise JSON `{"kaizen_base_url": …}`.
- Exits non-zero with a clear message on timeout or ambiguity.

Kaizen is a per-workroom extension; the operator names its CR `<base>-<hash>` and stamps it with `workroom_id`. The resolver matches on **`workroom_id` (the strong discriminator) + the `<name>-` prefix**, requiring exactly one — so it never picks another workroom's Kaizen. More than one match raises a non-retryable `AmbiguousExtensionError`. `wait_for_base_url` polls only transient states (`ValueError`/`NotFoundError`), caps each sleep to the remaining budget, and raises `TimeoutError` on the deadline — mirroring `serving.wait_deployment_ready`.

Backward compatible: `resolve_base_url`'s new params are keyword-only; `workroom_id=None` keeps the prior exact `get_extension` lookup for cluster-scoped extensions.

## Verification

42 unit tests (resolve match / no-match / ambiguity / unsuffixed-shadow / retry / capped-sleep / timeout + all three CLI paths); ruff + mypy clean. Live-exercised on a k0s-lima cluster: resolves the correct workroom's Kaizen, refuses to resolve from a workroom that has none, and times out cleanly. See the PR Evidence block for details.

Acceptance #2 (the ENG-6932 `seed-uat-profile.sh` agent step) is handed off to ENG-6932, which owns that file. #3 (seeder image) rides ENG-7020 automatically.

<!-- pr-evidence-start -->
<details>
<summary>📋 <b>pr-evidence</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-06-15T19:56:59.899Z
manifest_hash: sha256:51a9675efa9f6fcebed789ca377a1e59f850f830aeed3a29ce7c5a0236b14206
phase_a_complete: true
phase_b_complete: true
repos:
  - name: kamiwaza-sdk
    path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-ENG-7048
    branch: feature/ENG-7048
    head_sha: d7c48da959f6527992f21d18b97c0784e472e212
    head_sha_short: d7c48da95
    dirty_files: 0
    ahead: 0
    behind: 0
    upstream: origin/feature/ENG-7048
    delivery:
      mode: not-applicable
      verified: true
      note: SDK/CLI change. The kamiwaza-seed CLI is run directly (or baked into the seeder image per
        ENG-7020); it is not bind-mounted into a running pod, so there is no source-mount delivery
        to verify.
clusters: []
```

</details>

# PR Evidence — generated 2026-06-15T19:56:59.899Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| kamiwaza-sdk | feature/ENG-7048 | `d7c48da95` | clean | not-applicable ✓ |

## Cross-references

- Linear: `ENG-7048`


## Testing

**Unit:** 42 tests pass (`tests/unit/test_seeding_cli.py`, `tests/unit/test_kaizen_service.py`) — happy path, no-match (transient), ambiguity (deterministic, non-retried), unsuffixed-name shadow, retry-until-listed, sleep-capped-to-remaining, timeout, and all three CLI paths (JSON / `--raw` / non-zero exit). ruff + mypy clean on changed files.

**Live (k0s-lima laptop cluster, API-level CLI verification — not a pod preflight):** ran the built `kamiwaza-seed` CLI directly (`uv run`) against `https://localhost/api`:
- `resolve-kaizen-url --workroom-id <uat-e2e>` → resolved the correct instance `https://kamiwaza.test/runtime/apps/kaizen-4f8b3ae1` (JSON + `--raw`, rc=0).
- Created a throwaway empty workroom and resolved against it → correctly **refused** to return another workroom's Kaizen (`No 'kaizen' extension found in workroom '<id>'`, rc=1); workroom deleted afterward.
- Timeout path → rc=1 with a clear message.

No source-mount/pod delivery to verify (SDK/CLI; baked into the seeder image per ENG-7020). No cluster pod-identity preflight performed — verification was at the CLI/API level described above.

<!-- pr-evidence-end -->