### PR TITLE
ENG-7048: scope resolve-kaizen-url's extension listing with X-Workroom-Id

### DIFF
--- a/kamiwaza_sdk/services/extensions.py
+++ b/kamiwaza_sdk/services/extensions.py
@@ -3,7 +3,7 @@
 """Service for managing K8s-native extensions via the platform API."""
 
 import logging
-from typing import List
+from typing import List, Optional, Union
 
 from ..exceptions import APIError, NotFoundError
 from ..schemas.extensions import (
@@ -22,13 +22,25 @@ class ExtensionService(BaseService):
         super().__init__(client)
         self.logger = logging.getLogger(__name__)
 
-    def list_extensions(self) -> List[Extension]:
+    def list_extensions(
+        self, workroom_id: Optional[Union[str, object]] = None
+    ) -> List[Extension]:
         """List extensions visible to the current user.
+
+        Args:
+            workroom_id: When set, scope the listing to a workroom via the
+                ``X-Workroom-Id`` header. The platform only lists a workroom's
+                per-workroom extensions to a caller that sends this header, so a
+                global PAT must pass it explicitly — a workroom-claim token alone
+                does not drive this endpoint's scoping.
 
         Returns:
             List of Extension objects.
         """
-        response = self.client.get("/extensions")
+        kwargs = {}
+        if workroom_id is not None:
+            kwargs["headers"] = {"X-Workroom-Id": str(workroom_id)}
+        response = self.client.get("/extensions", **kwargs)
         return [Extension.model_validate(item) for item in response]
 
     def get_extension(self, name: str) -> Extension:

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -82,7 +82,7 @@ def _find_workroom_extension(client, extension_name: str, workroom_id):
     prefix = f"{extension_name}-"
     matches = [
         ext
-        for ext in client.extensions.list_extensions()
+        for ext in client.extensions.list_extensions(workroom_id=workroom_id)
         if str(getattr(ext, "workroom_id", "")) == str(workroom_id)
         and ext.name.startswith(prefix)
     ]

--- a/tests/unit/test_extension_service.py
+++ b/tests/unit/test_extension_service.py
@@ -14,7 +14,6 @@ from kamiwaza_sdk.schemas.extensions import (
     ImagePatch,
     PatchExtension,
     PatchServiceSpec,
-    ServiceStatusDetail,
 )
 from kamiwaza_sdk.services.extensions import ExtensionService
 
@@ -69,6 +68,28 @@ def test_list_extensions():
     assert all(isinstance(e, Extension) for e in result)
     assert result[0].name == "ext-a"
     assert result[1].type == "tool"
+
+
+def test_list_extensions_scopes_to_workroom_with_header():
+    # The fix: workroom_id is translated into the X-Workroom-Id header on the
+    # GET, because the platform scopes the listing by that header. Without it the
+    # resolver only ever sees global extensions (the ENG-7048 bug).
+    client = DummyClient({("GET", "/extensions"): []})
+    service = ExtensionService(client)
+
+    service.list_extensions(workroom_id="wr-A")
+
+    assert client.calls[-1][2]["headers"] == {"X-Workroom-Id": "wr-A"}
+
+
+def test_list_extensions_without_workroom_sends_no_header():
+    # Backward compatible: existing no-arg callers must not send the header.
+    client = DummyClient({("GET", "/extensions"): []})
+    service = ExtensionService(client)
+
+    service.list_extensions()
+
+    assert "headers" not in client.calls[-1][2]
 
 
 def test_list_extensions_empty():

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -151,9 +151,17 @@ def _ext(name, workroom_id, *, external=KAIZEN_URL):
 
 
 def _client_listing(extensions):
-    return SimpleNamespace(
-        extensions=SimpleNamespace(list_extensions=lambda: list(extensions))
-    )
+    # Record the workroom_id the resolver scopes the listing with. The platform
+    # only lists a workroom's extensions to a caller that sends X-Workroom-Id, so
+    # a resolver that drops the scope (the bug this guards) must fail loudly.
+    client = SimpleNamespace(seen_workroom_ids=[])
+
+    def list_extensions(workroom_id=None):
+        client.seen_workroom_ids.append(workroom_id)
+        return list(extensions)
+
+    client.extensions = SimpleNamespace(list_extensions=list_extensions)
+    return client
 
 
 def test_resolve_base_url_matches_workroom_by_base_name_and_id():
@@ -168,6 +176,9 @@ def test_resolve_base_url_matches_workroom_by_base_name_and_id():
     )
 
     assert resolve_base_url(client, "kaizen", workroom_id="wr-A") == KAIZEN_URL
+    # The listing MUST be scoped to the workroom (X-Workroom-Id); without it the
+    # platform returns only global extensions and the match silently misses.
+    assert client.seen_workroom_ids == ["wr-A"]
 
 
 def test_resolve_base_url_workroom_no_match_raises():
@@ -245,7 +256,7 @@ def test_wait_for_base_url_workroom_retries_until_listed(monkeypatch):
     # First poll: workroom has no Kaizen yet. Second poll: it's listed and ready.
     rounds = [[], [_ext("kaizen-4f8b3ae1", "wr-A")]]
 
-    def list_extensions():
+    def list_extensions(workroom_id=None):
         return rounds.pop(0)
 
     client = SimpleNamespace(


### PR DESCRIPTION
Follow-up fix to ENG-7048 (#175): `resolve-kaizen-url` could never resolve a workroom’s Kaizen ingress in practice.

## Problem

The platform scopes `GET /extensions` by the **`X-Workroom-Id` header**. The resolver’s `_find_workroom_extension` called `list_extensions()` **without** that header, relying on a workroom-scoped token from `workrooms.enter()` — but `enter()` does not (always) re-mint such a token, so the listing returned only global (`ffff…`) extensions. The workroom’s `kaizen-<hash>` CR was never matched → `No 'kaizen' extension found in workroom` until timeout, even with Kaizen fully Running/Ready.

Reproduced live on a k0s-lima cluster: `/extensions` with no header → 3 global extensions; with `X-Workroom-Id` → 7, including the workroom’s `kaizen-<hash>` + its ingress URL.

## Fix

- `ExtensionsService.list_extensions(workroom_id=None)` sends `X-Workroom-Id` when a workroom is given.
- The resolver passes its `workroom_id` through.

Works with a plain global PAT; no dependence on `enter()` reminting.

## Verification

- **Live:** `kamiwaza-seed resolve-kaizen-url --workroom-id <wid> --raw` now returns the workroom’s Kaizen ingress URL (rc=0).
- **Unit:** the resolver tests now assert the listing is scoped to the workroom (`X-Workroom-Id` forwarded), so the regression can’t silently return. `tests/unit/test_kaizen_service.py` + `test_extension_service.py` green; ruff clean.

Unblocks the deferred agent-creation step in the nightly UAT seeding profile (ENG-6932).