### PR TITLE
ENG-7076: add deploy-model subcommand to the seeder CLI

### DIFF
--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -148,6 +148,49 @@ def cmd_install_extension(args: argparse.Namespace, *, client) -> dict:
     return {"deployment_id": str(deployment.id), "name": deployment.name}
 
 
+def _resolve_model_id(client, model_id: Optional[str], name: Optional[str]) -> str:
+    """Return the model id to deploy — given directly, or resolved by name."""
+    if model_id:
+        return model_id
+    for model in client.models.list_models():
+        if (getattr(model, "name", None) or "") == name:
+            return str(model.id)
+    raise SystemExit(f"No registered model named '{name}'.")
+
+
+def _deployment_endpoint(client, deployment_id) -> Optional[str]:
+    """The OpenAI-compatible endpoint of a deployment, or None if not listed."""
+    for deployment in client.serving.list_active_deployments():
+        if str(getattr(deployment, "id", "")) == str(deployment_id):
+            return getattr(deployment, "endpoint", None)
+    return None
+
+
+def cmd_deploy_model(args: argparse.Namespace, *, client) -> dict:
+    """Deploy a registered model so it's callable.
+
+    External models (Bedrock/Transcribe) are only callable once deployed, so an
+    agent can't bind to one until this runs. Returns the deployment id and its
+    OpenAI-compatible endpoint (``…/runtime/models/<dep>/v1``) for the caller to
+    pass to ``create-agent --llm-base-url``.
+    """
+    model_id = _resolve_model_id(client, args.model_id, args.name)
+    deployment_id = client.serving.deploy_model(
+        model_id=model_id,
+        engine_name=args.engine_name,
+        wait=not args.no_wait,
+        timeout_seconds=args.timeout,
+        poll_interval_seconds=args.poll_interval,
+    )
+    if not deployment_id:
+        raise SystemExit(f"Deploy request for model {model_id} was refused by the server.")
+    result = {"deployment_id": str(deployment_id)}
+    endpoint = _deployment_endpoint(client, deployment_id)
+    if endpoint:
+        result["endpoint"] = endpoint
+    return result
+
+
 def cmd_resolve_kaizen_url(args: argparse.Namespace, *, client) -> Optional[dict]:
     """Resolve a workroom's Kaizen ingress root, waiting for it to come up.
 
@@ -304,6 +347,27 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-sync", action="store_true", help="Don't import the catalog if missing."
     )
     p.set_defaults(func=cmd_install_extension)
+
+    p = sub.add_parser(
+        "deploy-model",
+        help="Deploy a registered model so it's callable (external models need this before an agent can bind).",
+    )
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("--model-id", default=None, help="ID of a registered model to deploy.")
+    g.add_argument("--name", default=None, help="Name of a registered model to resolve, then deploy.")
+    p.add_argument(
+        "--engine-name",
+        default="external_chat",
+        help="Serving engine (default external_chat; external_transcribe for Transcribe).",
+    )
+    p.add_argument(
+        "--no-wait",
+        action="store_true",
+        help="Return the deployment id immediately instead of waiting for DEPLOYED.",
+    )
+    p.add_argument("--timeout", type=int, default=600, help="Max seconds to wait for DEPLOYED.")
+    p.add_argument("--poll-interval", type=float, default=5.0, help="Seconds between readiness polls.")
+    p.set_defaults(func=cmd_deploy_model)
 
     p = sub.add_parser(
         "resolve-kaizen-url",

--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -26,6 +26,7 @@ import os
 from pathlib import Path
 from typing import Callable, Dict, Optional, Union
 
+from ..exceptions import DeploymentFailedError
 from ..schemas.kaizen import LLMConfig
 from ..schemas.models.external_endpoint import (
     AWSBedrockChatEndpoint,
@@ -152,14 +153,26 @@ def _resolve_model_id(client, model_id: Optional[str], name: Optional[str]) -> s
     """Return the model id to deploy — given directly, or resolved by name."""
     if model_id:
         return model_id
-    for model in client.models.list_models():
-        if (getattr(model, "name", None) or "") == name:
-            return str(model.id)
-    raise SystemExit(f"No registered model named '{name}'.")
+    matches = [
+        m for m in client.models.list_models() if (getattr(m, "name", None) or "") == name
+    ]
+    if not matches:
+        raise SystemExit(f"No registered model named '{name}'.")
+    if len(matches) > 1:
+        # Deterministic: don't silently deploy an arbitrary one of a name collision.
+        raise SystemExit(
+            f"Multiple registered models named '{name}'; pass --model-id to disambiguate."
+        )
+    return str(matches[0].id)
 
 
 def _deployment_endpoint(client, deployment_id) -> Optional[str]:
-    """The OpenAI-compatible endpoint of a deployment, or None if not listed."""
+    """The OpenAI-compatible endpoint of a deployment, or None if not listed.
+
+    Lists all active deployments to find the one we just created: only
+    ``list_active_deployments`` computes the ``endpoint`` string (``get_deployment``
+    does not), so don't "optimize" this into a by-id fetch.
+    """
     for deployment in client.serving.list_active_deployments():
         if str(getattr(deployment, "id", "")) == str(deployment_id):
             return getattr(deployment, "endpoint", None)
@@ -175,13 +188,19 @@ def cmd_deploy_model(args: argparse.Namespace, *, client) -> dict:
     pass to ``create-agent --llm-base-url``.
     """
     model_id = _resolve_model_id(client, args.model_id, args.name)
-    deployment_id = client.serving.deploy_model(
-        model_id=model_id,
-        engine_name=args.engine_name,
-        wait=not args.no_wait,
-        timeout_seconds=args.timeout,
-        poll_interval_seconds=args.poll_interval,
-    )
+    try:
+        deployment_id = client.serving.deploy_model(
+            model_id=model_id,
+            engine_name=args.engine_name,
+            wait=not args.no_wait,
+            timeout_seconds=args.timeout,
+            poll_interval_seconds=args.poll_interval,
+        )
+    except (DeploymentFailedError, TimeoutError) as exc:
+        # Convert the documented wait=True failure modes to a clean message
+        # (mirrors cmd_resolve_kaizen_url) — a traceback is poor diagnostics for
+        # the nightly profile.
+        raise SystemExit(str(exc))
     if not deployment_id:
         raise SystemExit(f"Deploy request for model {model_id} was refused by the server.")
     result = {"deployment_id": str(deployment_id)}
@@ -363,7 +382,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--no-wait",
         action="store_true",
-        help="Return the deployment id immediately instead of waiting for DEPLOYED.",
+        help=(
+            "Return the deployment id immediately instead of waiting for DEPLOYED. "
+            "The endpoint is omitted from the output until the deployment is DEPLOYED."
+        ),
     )
     p.add_argument("--timeout", type=int, default=600, help="Max seconds to wait for DEPLOYED.")
     p.add_argument("--poll-interval", type=float, default=5.0, help="Seconds between readiness polls.")

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -5,9 +5,17 @@ from types import SimpleNamespace
 
 import pytest
 
+from kamiwaza_sdk.exceptions import DeploymentFailedError
 from kamiwaza_sdk.seeding import cli
 
 pytestmark = pytest.mark.unit
+
+
+def _raiser(exc):
+    def _f(*_args, **_kwargs):
+        raise exc
+
+    return _f
 
 
 class RecordingService:
@@ -463,3 +471,45 @@ def test_deploy_model_requires_model_id_or_name():
     # --model-id / --name are a required mutually-exclusive group.
     with pytest.raises(SystemExit):
         _run(["deploy-model"], FakeClient())
+
+
+def test_deploy_model_converts_wait_failure_to_systemexit():
+    # The documented wait=True failure modes must surface as a clean SystemExit,
+    # not a raw traceback (matches cmd_resolve_kaizen_url).
+    for exc in (DeploymentFailedError("deploy failed"), TimeoutError("deploy timed out")):
+        client = FakeClient()
+        client.serving.deploy_model = _raiser(exc)
+        with pytest.raises(SystemExit):
+            _run(["deploy-model", "--model-id", "m1"], client)
+
+
+def test_deploy_model_server_refused_exits():
+    # A falsy deployment id means the server refused the deploy -> clean exit.
+    client = FakeClient()
+    client.serving.deploy_model = RecordingService(None)
+    with pytest.raises(SystemExit):
+        _run(["deploy-model", "--model-id", "m1"], client)
+
+
+def test_deploy_model_omits_endpoint_when_not_yet_listed(capsys):
+    # --no-wait can return before DEPLOYED; list_active_deployments only returns
+    # DEPLOYED ones, so the endpoint is omitted rather than wrong.
+    client = FakeClient()
+    client.serving.deploy_model = RecordingService("pending-dep")  # not in the listing
+    _run(["deploy-model", "--model-id", "m1", "--no-wait"], client)
+
+    out = json.loads(capsys.readouterr().out)
+    assert out == {"deployment_id": "pending-dep"}
+    assert "endpoint" not in out
+
+
+def test_deploy_model_duplicate_name_exits():
+    # Ambiguous name resolution must fail loudly, not pick one arbitrarily.
+    client = FakeClient()
+    client.models.list_models = RecordingService(
+        [SimpleNamespace(id="m1", name="dup"), SimpleNamespace(id="m2", name="dup")]
+    )
+    with pytest.raises(SystemExit):
+        _run(["deploy-model", "--name", "dup"], client)
+
+    assert client.serving.deploy_model.calls == []

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -33,7 +33,21 @@ class FakeClient:
             create=RecordingService(SimpleNamespace(id="wr-1"))
         )
         self.models = SimpleNamespace(
-            register_external_model=RecordingService(SimpleNamespace(id="model-1"))
+            register_external_model=RecordingService(SimpleNamespace(id="model-1")),
+            list_models=RecordingService(
+                [SimpleNamespace(id="model-1", name="bedrock-uat")]
+            ),
+        )
+        self.serving = SimpleNamespace(
+            deploy_model=RecordingService("dep-xyz"),
+            list_active_deployments=RecordingService(
+                [
+                    SimpleNamespace(
+                        id="dep-xyz",
+                        endpoint="https://host/runtime/models/dep-xyz/v1",
+                    )
+                ]
+            ),
         )
         self.apps = SimpleNamespace(
             install_by_name=RecordingService(SimpleNamespace(id="dep-1", name="kaizen"))
@@ -395,3 +409,57 @@ def test_no_subcommand_errors():
 def test_parse_env_rejects_bad_pair():
     with pytest.raises(SystemExit):
         cli._parse_env(["NOTAVALIDPAIR"])
+
+
+def test_deploy_model_by_id_emits_deployment_and_endpoint(capsys):
+    client = FakeClient()
+
+    _run(["deploy-model", "--model-id", "model-1"], client)
+
+    call = client.serving.deploy_model.calls[0]["kwargs"]
+    assert call["model_id"] == "model-1"
+    assert call["engine_name"] == "external_chat"  # default
+    assert call["wait"] is True
+    # Output threads the endpoint create-agent needs for --llm-base-url.
+    assert json.loads(capsys.readouterr().out) == {
+        "deployment_id": "dep-xyz",
+        "endpoint": "https://host/runtime/models/dep-xyz/v1",
+    }
+
+
+def test_deploy_model_resolves_name_to_id(capsys):
+    client = FakeClient()
+
+    _run(["deploy-model", "--name", "bedrock-uat"], client)
+
+    # The name is resolved against the registered models, then deployed by id.
+    assert client.models.list_models.calls  # lookup happened
+    assert client.serving.deploy_model.calls[0]["kwargs"]["model_id"] == "model-1"
+
+
+def test_deploy_model_unknown_name_exits():
+    client = FakeClient()
+
+    with pytest.raises(SystemExit):
+        _run(["deploy-model", "--name", "does-not-exist"], client)
+
+    assert client.serving.deploy_model.calls == []
+
+
+def test_deploy_model_engine_name_and_no_wait_pass_through():
+    client = FakeClient()
+
+    _run(
+        ["deploy-model", "--model-id", "m2", "--engine-name", "external_transcribe", "--no-wait"],
+        client,
+    )
+
+    call = client.serving.deploy_model.calls[0]["kwargs"]
+    assert call["engine_name"] == "external_transcribe"
+    assert call["wait"] is False
+
+
+def test_deploy_model_requires_model_id_or_name():
+    # --model-id / --name are a required mutually-exclusive group.
+    with pytest.raises(SystemExit):
+        _run(["deploy-model"], FakeClient())


### PR DESCRIPTION
Adds `kamiwaza-seed deploy-model`, the last missing seeder surface for the nightly auto-agent (ENG-6932).

## Why

External models (Bedrock/Transcribe) are only callable once **deployed** (`engine_name=external_chat`), so a Kaizen agent cannot bind to one until then. The SDK *library* already has `serving.deploy_model`, but the `kamiwaza-seed` CLI had no way to invoke it — leaving the profile to either raw-curl the API or `--entrypoint python` the image. This exposes it cleanly so the profile stays all-`kamiwaza-seed`.

## What

```
kamiwaza-seed deploy-model (--model-id ID | --name NAME) \
  [--engine-name external_chat] [--no-wait] [--timeout] [--poll-interval]
```

- Wraps `serving.deploy_model`; prints `{deployment_id, endpoint}` where `endpoint` is the OpenAI-compatible `…/runtime/models/<dep>/v1` — exactly what `create-agent --llm-base-url` consumes.
- `--model-id` / `--name` are a required mutually-exclusive group; `--name` resolves against the registered models.
- `--engine-name` defaults to `external_chat` (`external_transcribe` for Transcribe).

## Verification

- 5 new unit tests (by-id + endpoint output, name→id resolution, unknown-name exit, engine-name/`--no-wait` pass-through, required group); full `test_seeding_cli.py` green (26), ruff clean, mypy clean on `cli.py`.
- **Live-verified** on a local k0s-lima cluster: registered a fresh Bedrock model → `deploy-model --name …` resolved + deployed to `DEPLOYED` and returned the endpoint → torn down. Earlier in the same effort the resulting endpoint was confirmed to bind a working Kaizen agent.

## Sequencing

Independent of #177 (resolve-kaizen-url fix) — `serving.deploy_model` already exists on `develop`. Completes the seeder chain `register-external-model → deploy-model → resolve-kaizen-url → create-agent` and unblocks the deferred agent-bound-to-Bedrock step in the ENG-6932 nightly profile.