### PR TITLE
ENG-7084: Default non-HTTP extension service ports to tcp-* port names

### DIFF
--- a/kamiwaza_extensions/compose_ports.py
+++ b/kamiwaza_extensions/compose_ports.py
@@ -20,6 +20,13 @@ from typing import Any, Optional
 # ``tcp*`` → raw TCP passthrough). Naming a non-HTTP backend port ``http`` makes
 # the sidecar apply HTTP parsing to a binary wire protocol — e.g. it answers a
 # postgres SSL handshake with an HTTP error, CrashLooping the client.
+#
+# This must stay in sync with the platform's compose→CR translation, which
+# carries the same maps and heuristic (the App-Garden install path). Canonical
+# source: ``kamiwaza/serving/garden/apps/k8s_adapter.py`` (``_HTTP_DEFAULT_PORTS``
+# / ``_KNOWN_TCP_PORT_NAMES`` / ``_service_port_name``). Keep both in lockstep
+# when adding a backend, or the two deploy paths will name the same port
+# differently.
 _HTTP_DEFAULT_PORTS = {80, 443, 3000, 5000, 8000, 8080, 8443, 9090}
 _KNOWN_TCP_PORT_NAMES = {
     5432: "tcp-postgres",

--- a/kamiwaza_extensions/compose_ports.py
+++ b/kamiwaza_extensions/compose_ports.py
@@ -15,6 +15,44 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+# Well-known port → Istio port-name prefix. Istio's port-name-prefix convention
+# determines the L7 protocol applied by the sidecar (``http*`` → HTTP/1.1 codec,
+# ``tcp*`` → raw TCP passthrough). Naming a non-HTTP backend port ``http`` makes
+# the sidecar apply HTTP parsing to a binary wire protocol — e.g. it answers a
+# postgres SSL handshake with an HTTP error, CrashLooping the client.
+_HTTP_DEFAULT_PORTS = {80, 443, 3000, 5000, 8000, 8080, 8443, 9090}
+_KNOWN_TCP_PORT_NAMES = {
+    5432: "tcp-postgres",
+    3306: "tcp-mysql",
+    6379: "tcp-redis",
+    27017: "tcp-mongo",
+    9200: "tcp-elastic",
+    5672: "tcp-amqp",
+    9092: "tcp-kafka",
+    2379: "tcp-etcd",
+    2380: "tcp-etcd-peer",
+    19530: "tcp-milvus",  # Milvus gRPC (HTTP/2); never the HTTP/1.1 codec
+}
+
+
+def default_service_port_name(port: int, is_primary: bool) -> str:
+    """Fallback Istio port name for a port the compose author didn't name.
+
+    Used only when a compose port is bare short-form (no ``name`` /
+    ``app_protocol``) or a long-form entry without an explicit ``name``; a
+    declared name always takes precedence. Returns ``"http"`` for known HTTP
+    ports and for unknown *primary* ports (preserves the historical app
+    frontend/backend behavior), ``"tcp-<service>"`` for known TCP backends like
+    postgres/redis, and ``"tcp-port-<n>"`` for unknown non-primary ports.
+    """
+    if port in _KNOWN_TCP_PORT_NAMES:
+        return _KNOWN_TCP_PORT_NAMES[port]
+    if port in _HTTP_DEFAULT_PORTS:
+        return "http"
+    if is_primary:
+        return "http"
+    return f"tcp-port-{port}"
+
 
 def extract_container_port(port_spec: Any) -> Optional[int]:
     """Return the container port from a compose port entry, or ``None``

--- a/kamiwaza_extensions/compose_ports.py
+++ b/kamiwaza_extensions/compose_ports.py
@@ -27,13 +27,16 @@ from typing import Any, Optional
 # / ``_KNOWN_TCP_PORT_NAMES`` / ``_service_port_name``). Keep both in lockstep
 # when adding a backend, or the two deploy paths will name the same port
 # differently.
-_HTTP_DEFAULT_PORTS = {80, 443, 3000, 5000, 8000, 8080, 8443, 9090}
+# 9200 is the Elasticsearch/OpenSearch HTTP REST port (the binary transport
+# protocol is 9300), so it belongs here, not in the TCP map.
+# TODO(ENG-7092): platform core's k8s_adapter still maps 9200 → tcp-elastic;
+# realign it there so the two compose→CR paths stay in lockstep.
+_HTTP_DEFAULT_PORTS = {80, 443, 3000, 5000, 8000, 8080, 8443, 9090, 9200}
 _KNOWN_TCP_PORT_NAMES = {
     5432: "tcp-postgres",
     3306: "tcp-mysql",
     6379: "tcp-redis",
     27017: "tcp-mongo",
-    9200: "tcp-elastic",
     5672: "tcp-amqp",
     9092: "tcp-kafka",
     2379: "tcp-etcd",

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -9,7 +9,10 @@ import socket
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
-from kamiwaza_extensions.compose_ports import extract_container_port
+from kamiwaza_extensions.compose_ports import (
+    default_service_port_name,
+    extract_container_port,
+)
 from kamiwaza_sdk.schemas.extensions import (
     CreateExtension,
     ExtensionPort,
@@ -448,15 +451,20 @@ class PayloadBuilder:
 
         Accepts both short-form (``"19530"``, ``"19530/udp"``) and long-form
         compose-spec port entries (``{target, protocol, name, app_protocol}``).
-        For short-form the port name defaults to ``"http"`` — matches the
-        long-standing app/tool extension behavior. Long-form entries pass
-        ``name`` and ``app_protocol`` through to the K8s Service, which
-        istio reads for L7 protocol selection (ENG-5954).
+        Ports without a declared name get a protocol-aware default via
+        ``default_service_port_name`` — known non-HTTP backends (postgres,
+        redis, ...) become ``tcp-*`` so istio treats them as opaque TCP rather
+        than applying the HTTP codec. The first port is treated as primary and
+        keeps the historical ``"http"`` default when its number is unknown.
+        Long-form entries pass ``name`` and ``app_protocol`` through to the K8s
+        Service, which istio reads for L7 protocol selection.
         """
-        result = []
+        result: List[ExtensionPort] = []
         for p in ports:
+            # The first successfully-parsed port is the primary (app) port.
+            is_primary = not result
             if isinstance(p, dict):
-                parsed = PayloadBuilder._parse_port_dict(p)
+                parsed = PayloadBuilder._parse_port_dict(p, is_primary=is_primary)
                 if parsed is not None:
                     result.append(parsed)
                 continue
@@ -470,15 +478,22 @@ class PayloadBuilder:
                     proto_str.upper() if proto_str.upper() in ("TCP", "UDP") else "TCP"
                 )
             try:
-                result.append(
-                    ExtensionPort(container_port=int(s), protocol=proto, name="http")
-                )
+                port_int = int(s)
             except (ValueError, TypeError):
                 continue
+            result.append(
+                ExtensionPort(
+                    container_port=port_int,
+                    protocol=proto,
+                    name=default_service_port_name(port_int, is_primary),
+                )
+            )
         return result
 
     @staticmethod
-    def _parse_port_dict(port: Dict[str, Any]) -> Optional[ExtensionPort]:
+    def _parse_port_dict(
+        port: Dict[str, Any], is_primary: bool = False
+    ) -> Optional[ExtensionPort]:
         """Translate one compose-spec long-form port entry."""
         # Compose-spec long-form: ``target`` is the container port.
         # ``published`` (host port) is stripped upstream by the transformer's
@@ -490,14 +505,21 @@ class PayloadBuilder:
         if target is None:
             return None
 
+        try:
+            container_port = int(target)
+        except (ValueError, TypeError):
+            return None
+
         proto_raw = str(port.get("protocol", "tcp")).upper()
         proto = proto_raw if proto_raw in ("TCP", "UDP") else "TCP"
 
-        # Long-form ports without an explicit name still default to "http"
-        # so existing extensions that adopt long-form syntax for unrelated
-        # reasons (e.g. adding ``protocol: tcp``) don't silently lose the
-        # historical port name.
-        name = port.get("name") or "http"
+        # Long-form ports without an explicit name fall back to the same
+        # protocol-aware default as short-form, so a non-HTTP backend that
+        # adopts long-form syntax for unrelated reasons (e.g. adding
+        # ``protocol: tcp``) isn't mislabeled ``http`` and broken on istio.
+        name = port.get("name") or default_service_port_name(
+            container_port, is_primary
+        )
 
         # Prefer the compose-spec ``app_protocol`` key; fall back to the
         # k8s-shaped ``appProtocol`` only when the spec key is absent.
@@ -511,7 +533,7 @@ class PayloadBuilder:
 
         try:
             return ExtensionPort(
-                container_port=int(target),
+                container_port=container_port,
                 protocol=proto,
                 name=name,
                 app_protocol=app_protocol,

--- a/tests/unit/extensions/test_compose_ports.py
+++ b/tests/unit/extensions/test_compose_ports.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from kamiwaza_extensions.compose_ports import extract_container_port
+from kamiwaza_extensions.compose_ports import (
+    default_service_port_name,
+    extract_container_port,
+)
 
 
 @pytest.mark.unit
@@ -38,3 +41,44 @@ class TestExtractContainerPort:
 
     def test_mapped_range_returns_container_lower_bound(self):
         assert extract_container_port("9090-9091:3000-3001") == 3000
+
+
+@pytest.mark.unit
+class TestDefaultServicePortName:
+    """The Istio port-name heuristic shared with platform core."""
+
+    @pytest.mark.parametrize(
+        "port,expected",
+        [
+            (5432, "tcp-postgres"),
+            (3306, "tcp-mysql"),
+            (6379, "tcp-redis"),
+            (27017, "tcp-mongo"),
+            (9200, "tcp-elastic"),
+            (5672, "tcp-amqp"),
+            (9092, "tcp-kafka"),
+            (2379, "tcp-etcd"),
+            (2380, "tcp-etcd-peer"),
+            (19530, "tcp-milvus"),
+        ],
+    )
+    def test_known_tcp_backends_win_over_primary(self, port, expected):
+        # Known non-HTTP backends must map to their tcp-* name even when they
+        # are the primary (first) port — the case that broke postgres/milvus on
+        # istio. is_primary must not promote them to "http".
+        assert default_service_port_name(port, is_primary=True) == expected
+        assert default_service_port_name(port, is_primary=False) == expected
+
+    @pytest.mark.parametrize("port", [80, 443, 3000, 5000, 8000, 8080, 8443, 9090])
+    def test_known_http_ports_are_http(self, port):
+        assert default_service_port_name(port, is_primary=False) == "http"
+
+    def test_unknown_primary_defaults_to_http(self):
+        assert default_service_port_name(7000, is_primary=True) == "http"
+
+    def test_unknown_non_primary_is_opaque_tcp(self):
+        assert default_service_port_name(7000, is_primary=False) == "tcp-port-7000"
+
+    def test_generated_name_within_k8s_15_char_limit(self):
+        # K8s Service port names are capped at 15 chars; tcp-port-<max> = 14.
+        assert len(default_service_port_name(65535, is_primary=False)) <= 15

--- a/tests/unit/extensions/test_compose_ports.py
+++ b/tests/unit/extensions/test_compose_ports.py
@@ -54,7 +54,6 @@ class TestDefaultServicePortName:
             (3306, "tcp-mysql"),
             (6379, "tcp-redis"),
             (27017, "tcp-mongo"),
-            (9200, "tcp-elastic"),
             (5672, "tcp-amqp"),
             (9092, "tcp-kafka"),
             (2379, "tcp-etcd"),
@@ -69,8 +68,12 @@ class TestDefaultServicePortName:
         assert default_service_port_name(port, is_primary=True) == expected
         assert default_service_port_name(port, is_primary=False) == expected
 
-    @pytest.mark.parametrize("port", [80, 443, 3000, 5000, 8000, 8080, 8443, 9090])
+    @pytest.mark.parametrize(
+        "port", [80, 443, 3000, 5000, 8000, 8080, 8443, 9090, 9200]
+    )
     def test_known_http_ports_are_http(self, port):
+        # 9200 is Elasticsearch/OpenSearch's HTTP REST port — it must stay HTTP
+        # so istio keeps applying the HTTP codec (the binary transport is 9300).
         assert default_service_port_name(port, is_primary=False) == "http"
 
     def test_unknown_primary_defaults_to_http(self):

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -281,8 +281,10 @@ class TestParsePorts:
 
     def test_known_tcp_backends_never_named_http(self):
         # Acceptance regression: no well-known non-HTTP backend port may be
-        # translated to the "http" name, regardless of position.
-        for port in (5432, 3306, 6379, 27017, 9200, 5672, 9092):
+        # translated to the "http" name, regardless of position — including
+        # milvus/etcd, where each port here is the sole (primary) port, so this
+        # also pins that a known-TCP backend wins over the primary→http default.
+        for port in (5432, 3306, 6379, 27017, 9200, 5672, 9092, 19530, 2379, 2380):
             parsed = PayloadBuilder._parse_ports([str(port)])
             assert len(parsed) == 1
             assert parsed[0].name != "http"

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -253,6 +253,48 @@ class TestParsePorts:
         ports = PayloadBuilder._parse_ports([{"target": "not-a-number"}])
         assert ports == []
 
+    def test_short_form_postgres_not_named_http(self):
+        # Unnamed short-form postgres must not inherit "http": istio reads the
+        # Service port name to pick the L7 codec, and an "http" name makes the
+        # sidecar answer the postgres SSL handshake with an HTTP response,
+        # CrashLooping the client backend.
+        ports = PayloadBuilder._parse_ports(["5432"])
+        assert len(ports) == 1
+        assert ports[0].container_port == 5432
+        assert ports[0].name == "tcp-postgres"
+        assert ports[0].name != "http"
+
+    def test_short_form_non_primary_unknown_gets_tcp_port_name(self):
+        # First port keeps the historical "http" default (app frontends/backends
+        # speak HTTP); a secondary unknown port falls back to opaque TCP.
+        ports = PayloadBuilder._parse_ports(["8000", "5555"])
+        assert len(ports) == 2
+        assert ports[0].name == "http"
+        assert ports[1].container_port == 5555
+        assert ports[1].name == "tcp-port-5555"
+
+    def test_long_form_postgres_without_name_not_http(self):
+        ports = PayloadBuilder._parse_ports([{"target": 5432, "protocol": "tcp"}])
+        assert len(ports) == 1
+        assert ports[0].name == "tcp-postgres"
+        assert ports[0].name != "http"
+
+    def test_known_tcp_backends_never_named_http(self):
+        # Acceptance regression: no well-known non-HTTP backend port may be
+        # translated to the "http" name, regardless of position.
+        for port in (5432, 3306, 6379, 27017, 9200, 5672, 9092):
+            parsed = PayloadBuilder._parse_ports([str(port)])
+            assert len(parsed) == 1
+            assert parsed[0].name != "http"
+            assert parsed[0].name.startswith("tcp-")
+
+    def test_primary_unknown_port_still_http(self):
+        # An unknown primary port preserves the long-standing "http" default so
+        # app frontends/backends on non-standard ports keep working.
+        ports = PayloadBuilder._parse_ports(["7000"])
+        assert len(ports) == 1
+        assert ports[0].name == "http"
+
 
 class TestAnnotations:
     """ENG-3887 / §4.2.9 — DeployedImageAnnotation on the CRD payload."""

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -284,7 +284,7 @@ class TestParsePorts:
         # translated to the "http" name, regardless of position — including
         # milvus/etcd, where each port here is the sole (primary) port, so this
         # also pins that a known-TCP backend wins over the primary→http default.
-        for port in (5432, 3306, 6379, 27017, 9200, 5672, 9092, 19530, 2379, 2380):
+        for port in (5432, 3306, 6379, 27017, 5672, 9092, 19530, 2379, 2380):
             parsed = PayloadBuilder._parse_ports([str(port)])
             assert len(parsed) == 1
             assert parsed[0].name != "http"
@@ -296,6 +296,15 @@ class TestParsePorts:
         ports = PayloadBuilder._parse_ports(["7000"])
         assert len(ports) == 1
         assert ports[0].name == "http"
+
+    def test_elasticsearch_rest_port_stays_http(self):
+        # 9200 is the ES/OpenSearch HTTP REST port (binary transport is 9300);
+        # it must keep the HTTP codec rather than being treated as opaque TCP,
+        # even as a non-primary port.
+        ports = PayloadBuilder._parse_ports(["8000", "9200"])
+        assert len(ports) == 2
+        assert ports[1].container_port == 9200
+        assert ports[1].name == "http"
 
 
 class TestAnnotations:


### PR DESCRIPTION
### Verification

Ran the real `kamiwaza-extensions-kaizen/docker-compose.yml` through the
actual `ComposeTransformer.transform()` → `PayloadBuilder.build()` pipeline.
Resulting CR service-port names:

| service | port | name |
|---|---|---|
| postgres | 5432 | `tcp-postgres` (was `http`) |
| sandbox-controller | 8085 | `http` |
| backend | 8000 | `http` |
| frontend | 3000 | `http` |

No non-HTTP port is named `http`. On an istio mesh this gives postgres opaque
TCP passthrough, which the ticket confirmed (manually renaming 5432 to
`tcp-postgres` made the backend connect and the extension reach `Running`).

### Scope-to-confirm answer

The catalog / App-Garden install path is **not** affected: it translates ports
through `kamiwaza`'s `serving/garden/apps/k8s_adapter._service_port_name`, which
already carries this protocol-aware heuristic. Only the `kz-ext` / SDK path
(`payload_builder`) still hardcoded `http`; this PR closes that gap so both
paths agree. No `kamiwaza-extensions-kaizen` workaround is needed once this
lands.


## Summary

The `kz-ext` / SDK compose → `KamiwazaExtension` CR translation
(`payload_builder._parse_ports` / `_parse_port_dict`) hardcoded every unnamed
port to `name: "http"`. Istio infers the L7 protocol from the Service port
name, so a postgres port named `http` gets the HTTP/1.1 codec — the sidecar
answers the postgres SSL handshake with an HTTP response and the client
backend CrashLoops (`received invalid response to SSL negotiation: H`).

This mirrors the platform core's protocol-aware heuristic into the SDK via a
shared `compose_ports.default_service_port_name` helper:

- known non-HTTP backends (postgres, mysql, redis, mongo, amqp,
  kafka, etcd, milvus) → `tcp-<service>`
- unknown non-primary ports → `tcp-port-<n>`
- primary / known-HTTP ports → `http` (unchanged behavior)

Applied to both short- and long-form unnamed ports, so the App-Garden core
path (already fixed) and the `kz-ext` path now agree.

## Test plan

- New regression tests in `tests/unit/extensions/test_payload_builder.py`
  (`TestParsePorts`): postgres 5432 → `tcp-postgres`, non-primary unknown →
  `tcp-port-N`, no well-known non-HTTP backend ever named `http`, primary
  unknown still `http`.
- Full extensions unit suite green (1605 passed).
- End-to-end: ran the real `kamiwaza-extensions-kaizen/docker-compose.yml`
  through `ComposeTransformer.transform()` → `PayloadBuilder.build()`; the
  resulting CR names postgres `tcp-postgres` while the HTTP services stay
  `http`.

Refs ENG-7084

