### PR TITLE
fix(extensions): rewrite AGENT_SERVER_IMAGE env-default for kz-ext dev (ENG-7110)

### DIFF
--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -680,6 +680,15 @@ def run_dev_remote(
     # ``image-only`` agent resolves to the ``{registry}/{ext}-agent`` fallback
     # path). Applied to both the K8s payload (bare refs, post-resolve) and
     # the catalog overlay compose (``${VAR:-default}`` form).
+    #
+    # Caveat: env_ref_map spans ALL build-context services, so under
+    # ``--service X`` or ``--no-build`` this can rewrite AGENT_SERVER_IMAGE to
+    # the agent ref even though the invocation builds/pushes only a subset.
+    # That's the same accepted partial-deploy sharp edge as the service
+    # ``image:`` fields (a ``--service backend`` run already deploys
+    # un-rebuilt siblings); a full run — or a prior run whose agent push the
+    # registry still holds (see the --no-build branch below) — is what makes
+    # the ref resolve.
     env_ref_map = build_image_ref_map(
         info.compose_data.get("services") or {},
         canonical_refs,

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -777,6 +777,16 @@ def run_dev_remote(
         # Collect expected image refs for push from the canonical map so
         # --no-build pushes hit the same registry path the deployment
         # payload will reference.
+        #
+        # ENG-7110: profiled ``image-only`` services (the agent, referenced
+        # via AGENT_SERVER_IMAGE — see the env rewrite above) are excluded
+        # from canonical_refs and so are intentionally NOT in this push list.
+        # A full run builds+pushes them via ImageBuilder (which iterates all
+        # build-context services); under --no-build they rely on a prior
+        # run's registry push (resume adopts that revision tag, so the agent
+        # ref the env rewrite points at already exists). Re-pushing them here
+        # would tag from the local engine store, which a resumed run may no
+        # longer hold — regressing the path that works.
         if service:
             image_refs = [canonical_refs[service]] if service in canonical_refs else []
         else:

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -378,6 +378,10 @@ def run_dev_remote(
         compute_canonical_refs,
     )
     from kamiwaza_extensions.connections import ConnectionManager
+    from kamiwaza_extensions.dev_env_image_refs import (
+        build_image_ref_map,
+        rewrite_env_image_refs,
+    )
     from kamiwaza_extensions.deployment_poller import (
         DeploymentFailedError,
         DeploymentPoller,
@@ -663,6 +667,29 @@ def run_dev_remote(
         revision_tag=rev_tag,
         image_basename=info.image_basename,
     )
+
+    # ENG-7110: image refs embedded in env values are a parallel surface the
+    # compose transform doesn't rewrite. Kaizen's backend spawns agent
+    # sandbox pods dynamically from ``AGENT_SERVER_IMAGE``, whose compose
+    # default is the *released* agent tag this dev build never pushed —
+    # ImagePullBackOff, chat 500. Rewrite that ref (and the sandbox
+    # ``SANDBOX_ALLOWED_IMAGE_PREFIXES`` allowlist, in lockstep) to the
+    # dev-built agent ref — the dev analog of ENG-5260's publish-side fix.
+    # ``build_image_ref_map`` mirrors ImageBuilder's per-service ref choice,
+    # so the env ref equals exactly what was built and pushed (the profiled
+    # ``image-only`` agent resolves to the ``{registry}/{ext}-agent`` fallback
+    # path). Applied to both the K8s payload (bare refs, post-resolve) and
+    # the catalog overlay compose (``${VAR:-default}`` form).
+    env_ref_map = build_image_ref_map(
+        info.compose_data.get("services") or {},
+        canonical_refs,
+        registry=registry,
+        extension_name=info.name,
+        revision_tag=rev_tag,
+        image_basename=info.image_basename,
+    )
+    transformed = rewrite_env_image_refs(transformed, env_ref_map)
+    catalog_compose = rewrite_env_image_refs(catalog_compose, env_ref_map)
 
     # 5b. Resolve SDK override for build
     build_overrides = None

--- a/kamiwaza_extensions/dev_env_image_refs.py
+++ b/kamiwaza_extensions/dev_env_image_refs.py
@@ -1,0 +1,187 @@
+"""Rewrite image refs embedded in compose env values for ``kz-ext dev``.
+
+The dev compose transform rewrites service ``image:`` fields to the
+dev-built ref, but image refs that live *inside* env values are a
+parallel surface it doesn't touch. Kaizen's backend spawns agent
+sandbox pods dynamically from ``AGENT_SERVER_IMAGE`` (and the sandbox
+controller gates them against ``SANDBOX_ALLOWED_IMAGE_PREFIXES``); the
+compose defaults point at the *released* agent tag, which ``kz-ext dev``
+never builds or pushes, so the sandbox pod ImagePullBackOffs (ENG-7110).
+
+This is the dev analog of ENG-5260's publish-side
+``registry_builder._apply_env_image_rewrites``. Two differences from the
+publish path:
+
+1. Dev rewrites to the **built ref** (where ``ImageBuilder`` actually
+   pushed the image), not a digest-pin — the dev tag is unique per build.
+2. It must align the ``SANDBOX_ALLOWED_IMAGE_PREFIXES`` allowlist in
+   lockstep, because a profiled ``image-only`` agent is built at the
+   legacy ``{registry}/{ext}-agent:{tag}`` fallback path, outside the
+   source whitelist. The platform's ``image_rewrite.py`` encodes the
+   same env-name coupling (``IMAGE_ENV_NAMES`` / ``IMAGE_PREFIX_ENV_NAMES``)
+   for the offline-relocation install type; this is the dev-tooling
+   equivalent for normal (non-relocation) dev clusters.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any, Dict, List, Optional
+
+from kamiwaza_extensions.compose_transformer import (
+    _fallback_image_basename,
+    _repo_part,
+)
+
+# Env vars whose value is a single container image reference (possibly
+# wrapped in a ``${NAME:-default}`` shell default). Mirrors the platform's
+# kamiwaza.serving.garden.extensions.image_rewrite.IMAGE_ENV_NAMES.
+IMAGE_ENV_NAMES = frozenset({"AGENT_SERVER_IMAGE"})
+# Env vars whose value is a comma-separated list of image *prefixes* (not
+# full refs) — the sandbox controller's allowlist. Must be aligned in
+# lockstep with AGENT_SERVER_IMAGE or the controller rejects the agent.
+IMAGE_PREFIX_ENV_NAMES = frozenset({"SANDBOX_ALLOWED_IMAGE_PREFIXES"})
+
+# A value that is exactly one ``${VAR:-default}`` / ``${VAR-default}``
+# substitution. Group 1 = ``${VAR:-`` / ``${VAR-``, group 2 = default,
+# group 3 = ``}``. ``[^}]+`` keeps a digest's ``@sha256:...`` inside the
+# default. Mirrors registry_builder._ENV_DEFAULT_SUB_RE.
+_DEFAULT_SUB_RE = re.compile(r"\A(\$\{[A-Za-z_][A-Za-z0-9_]*:?-)([^}]+)(\})\Z")
+
+
+def build_image_ref_map(
+    source_services: Optional[Dict[str, Any]],
+    canonical_refs: Dict[str, str],
+    *,
+    registry: str,
+    extension_name: str,
+    revision_tag: str,
+    image_basename: Optional[str] = None,
+) -> Dict[str, str]:
+    """Map each build-context service's declared image repo to its built ref.
+
+    Keyed by ``registry/repository`` (tag/digest stripped) so an env ref
+    that pins a *different* tag than the source ``image:`` field (e.g.
+    ``AGENT_SERVER_IMAGE`` defaulting to the released ``:2.0.2`` while the
+    service declares the same repo) still matches.
+
+    The built ref is selected exactly as ``ImageBuilder.build`` does
+    (``image_builder.py``): ``canonical_refs[name]`` when present, else the
+    legacy ``{registry}/{basename}-{name}:{tag}`` fallback. A profiled
+    ``image-only`` service (the agent) is absent from ``canonical_refs``,
+    so it resolves to the fallback path — which is where it actually lives
+    in the registry. Keeping this in step with the builder is the whole
+    point: the env ref must equal what was pushed.
+    """
+    basename = _fallback_image_basename(
+        extension_name, fallback_image_basename=image_basename
+    )
+    out: Dict[str, str] = {}
+    for name, svc in (source_services or {}).items():
+        if not isinstance(svc, dict) or "build" not in svc:
+            continue
+        declared = svc.get("image")
+        if not isinstance(declared, str) or not declared.strip():
+            continue
+        built = canonical_refs.get(name) or (
+            f"{registry}/{basename}-{name}:{revision_tag}"
+        )
+        out[_repo_part(declared.strip())] = built
+    return out
+
+
+def rewrite_env_image_refs(
+    compose: Dict[str, Any],
+    ref_map: Dict[str, str],
+) -> Dict[str, Any]:
+    """Return a copy of *compose* with image-bearing env values rewritten.
+
+    Walks every service's ``environment`` (dict and ``KEY=value`` list
+    shapes) and, keyed on env name:
+
+    - ``AGENT_SERVER_IMAGE`` (an image ref, bare or ``${VAR:-default}``):
+      rewrite the ref to its built ref when its repo is in *ref_map*.
+    - ``SANDBOX_ALLOWED_IMAGE_PREFIXES`` (a CSV of repo prefixes): append
+      the built repo prefix for each entry that names a built repo,
+      preserving the originals.
+
+    A no-op when *ref_map* is empty. The caller's dict is not mutated.
+    """
+    out = copy.deepcopy(compose)
+    if not ref_map:
+        return out
+    for svc in (out.get("services") or {}).values():
+        if not isinstance(svc, dict):
+            continue
+        env = svc.get("environment")
+        if isinstance(env, dict):
+            for key, val in list(env.items()):
+                if isinstance(val, str):
+                    env[key] = _rewrite_env_value(key, val, ref_map)
+        elif isinstance(env, list):
+            for i, entry in enumerate(env):
+                if not isinstance(entry, str) or "=" not in entry:
+                    continue
+                key, val = entry.split("=", 1)
+                new_val = _rewrite_env_value(key.strip(), val, ref_map)
+                if new_val != val:
+                    env[i] = f"{key}={new_val}"
+    return out
+
+
+def _rewrite_env_value(name: str, value: str, ref_map: Dict[str, str]) -> str:
+    """Dispatch an env value to the rewriter for its env name."""
+    if name in IMAGE_ENV_NAMES:
+        return _rewrite_image_ref_value(value, ref_map)
+    if name in IMAGE_PREFIX_ENV_NAMES:
+        return _rewrite_prefix_csv_value(value, ref_map)
+    return value
+
+
+def _rewrite_image_ref_value(value: str, ref_map: Dict[str, str]) -> str:
+    """Rewrite a single image-ref env value (bare or ``${VAR:-default}``).
+
+    The ``${VAR:-default}`` form is preserved so a runtime override still
+    wins; only the literal default is rewritten.
+    """
+    match = _DEFAULT_SUB_RE.match(value.strip())
+    if match:
+        prefix, default, brace = match.group(1), match.group(2), match.group(3)
+        new_ref = _rewrite_ref(default.strip(), ref_map)
+        if new_ref == default.strip():
+            return value
+        return f"{prefix}{new_ref}{brace}"
+    return _rewrite_ref(value.strip(), ref_map)
+
+
+def _rewrite_ref(ref: str, ref_map: Dict[str, str]) -> str:
+    """Return the built ref for *ref*'s repo, or *ref* unchanged."""
+    if not ref:
+        return ref
+    return ref_map.get(_repo_part(ref), ref)
+
+
+def _rewrite_prefix_csv_value(value: str, ref_map: Dict[str, str]) -> str:
+    """Append built repo prefixes to an allowlist CSV, in lockstep.
+
+    Each entry that exactly names a built repo gets that repo's built
+    prefix appended (the built ref with its tag stripped). Originals are
+    preserved verbatim — some flows may still reference the source path,
+    and an over-broad replace could drop a still-valid prefix. Bare
+    namespace prefixes (``ghcr.io/openhands/``) name no built repo and
+    pass through, matching the platform's full-repo-only relocation rule.
+    """
+    entries = [part.strip() for part in value.split(",")]
+    existing = set(entries)
+    additions: List[str] = []
+    for entry in entries:
+        built = ref_map.get(entry)
+        if built is None:
+            continue
+        built_prefix = _repo_part(built)
+        if built_prefix not in existing and built_prefix not in additions:
+            additions.append(built_prefix)
+    if not additions:
+        return value
+    return ",".join(entries + additions)

--- a/kamiwaza_extensions/dev_env_image_refs.py
+++ b/kamiwaza_extensions/dev_env_image_refs.py
@@ -84,8 +84,12 @@ def build_image_ref_map(
         declared = svc.get("image")
         if not isinstance(declared, str) or not declared.strip():
             continue
-        built = canonical_refs.get(name) or (
-            f"{registry}/{basename}-{name}:{revision_tag}"
+        # Presence, not truthiness — the exact mirror of ImageBuilder.build's
+        # ``svc_name in image_refs`` check.
+        built = (
+            canonical_refs[name]
+            if name in canonical_refs
+            else f"{registry}/{basename}-{name}:{revision_tag}"
         )
         out[_repo_part(declared.strip())] = built
     return out
@@ -165,14 +169,36 @@ def _rewrite_ref(ref: str, ref_map: Dict[str, str]) -> str:
 def _rewrite_prefix_csv_value(value: str, ref_map: Dict[str, str]) -> str:
     """Append built repo prefixes to an allowlist CSV, in lockstep.
 
-    Each entry that exactly names a built repo gets that repo's built
-    prefix appended (the built ref with its tag stripped). Originals are
-    preserved verbatim — some flows may still reference the source path,
-    and an over-broad replace could drop a still-valid prefix. Bare
-    namespace prefixes (``ghcr.io/openhands/``) name no built repo and
-    pass through, matching the platform's full-repo-only relocation rule.
+    Handles both the bare CSV (K8s payload, post ``resolve_env_placeholders``)
+    and the ``${VAR:-csv}`` form (catalog overlay, placeholders preserved) —
+    the same two shapes :func:`_rewrite_image_ref_value` handles. Without the
+    ``${VAR:-default}`` unwrap, a templated allowlist would be CSV-split with
+    the ``${…:-`` prefix / trailing ``}`` still attached, no entry would match
+    *ref_map*, and the lockstep append would silently drop — while
+    ``AGENT_SERVER_IMAGE`` (which IS unwrapped) still gets rewritten, defeating
+    the lockstep invariant for any extension that templates the allowlist.
     """
-    entries = [part.strip() for part in value.split(",")]
+    match = _DEFAULT_SUB_RE.match(value.strip())
+    if match:
+        prefix, default, brace = match.group(1), match.group(2), match.group(3)
+        new_csv = _append_built_prefixes(default, ref_map)
+        if new_csv == default:
+            return value
+        return f"{prefix}{new_csv}{brace}"
+    return _append_built_prefixes(value, ref_map)
+
+
+def _append_built_prefixes(csv: str, ref_map: Dict[str, str]) -> str:
+    """Append built repo prefixes to a bare allowlist CSV.
+
+    Each entry that exactly names a built repo gets that repo's built prefix
+    appended (the built ref with its tag stripped). Originals are preserved
+    verbatim — some flows may still reference the source path, and an
+    over-broad replace could drop a still-valid prefix. Bare namespace
+    prefixes (``ghcr.io/openhands/``) name no built repo and pass through,
+    matching the platform's full-repo-only relocation rule.
+    """
+    entries = [part.strip() for part in csv.split(",")]
     existing = set(entries)
     additions: List[str] = []
     for entry in entries:
@@ -183,5 +209,5 @@ def _rewrite_prefix_csv_value(value: str, ref_map: Dict[str, str]) -> str:
         if built_prefix not in existing and built_prefix not in additions:
             additions.append(built_prefix)
     if not additions:
-        return value
+        return csv
     return ",".join(entries + additions)

--- a/tests/unit/extensions/test_dev_env_image_refs.py
+++ b/tests/unit/extensions/test_dev_env_image_refs.py
@@ -1,0 +1,328 @@
+"""``kz-ext dev`` must rewrite image refs embedded in env values (ENG-7110).
+
+The dev compose transform rewrites service ``image:`` fields to the
+dev-built ref, but leaves image refs that live *inside* env values
+untouched. Kaizen's backend spawns agent sandbox pods dynamically from
+``AGENT_SERVER_IMAGE``; its compose default
+(``${AGENT_SERVER_IMAGE:-ghcr.io/.../images/kaizen-agent:2.0.2}``) is the
+*released* tag, which ``kz-ext dev`` never builds or pushes. So the
+sandbox pod ImagePullBackOffs on a ref that doesn't exist and chat 500s.
+
+This is the dev analog of ENG-5260 (publish-side env-image rewriting in
+``registry_builder._apply_env_image_rewrites``). It additionally aligns
+``SANDBOX_ALLOWED_IMAGE_PREFIXES`` in lockstep — the agent (a profiled
+``image-only`` build-context service) is built at the legacy fallback
+``{registry}/{ext}-agent:{tag}`` path, which is *outside* the original
+whitelist, so the sandbox controller would reject the very image the
+backend asks it to run.
+"""
+
+from __future__ import annotations
+
+import copy
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+
+from kamiwaza_extensions.compose_transformer import (
+    ComposeTransformer,
+    compute_canonical_refs,
+)
+from kamiwaza_extensions.connections import ConnectionInfo
+from kamiwaza_extensions.dev_env_image_refs import (
+    build_image_ref_map,
+    rewrite_env_image_refs,
+)
+from kamiwaza_extensions.extension_detector import ExtensionInfo
+from kamiwaza_extensions.image_builder import ImageBuildError
+
+pytestmark = [pytest.mark.unit, pytest.mark.extension_regression]
+
+_REGISTRY = "host.docker.internal:5001"
+_EXT = "kaizen"
+_REV = "2.0.2-dev-f46cd1fc.1781636703"
+
+_AGENT_GHCR = (
+    "ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images/kaizen-agent"
+)
+_BACKEND_GHCR = (
+    "ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images/kaizen-backend"
+)
+_CONTROLLER_GHCR = (
+    "ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images/kaizen-controller"
+)
+# What ImageBuilder.build actually tags the agent at: the profiled service
+# is excluded from canonical_refs, so the builder falls back to
+# ``{registry}/{ext}-{svc}:{tag}``.
+_AGENT_BUILT = f"{_REGISTRY}/{_EXT}-agent:{_REV}"
+
+
+def _kaizen_compose() -> dict:
+    """Minimal Kaizen-shaped compose: a profiled (image-only) agent build
+    service, a backend that references the agent via ``AGENT_SERVER_IMAGE``,
+    and a sandbox-controller carrying the image whitelist."""
+    return {
+        "services": {
+            "agent": {
+                "profiles": ["image-only"],
+                "build": {"context": ".", "dockerfile": "backend/Dockerfile.agent"},
+                "image": f"{_AGENT_GHCR}:2.0.2",
+            },
+            "backend": {
+                "build": {"context": "."},
+                "image": f"{_BACKEND_GHCR}:2.0.2",
+                "environment": {
+                    "AGENT_SERVER_IMAGE": f"${{AGENT_SERVER_IMAGE:-{_AGENT_GHCR}:2.0.2}}",
+                    "DEFAULT_AGENTS_CONFIG": "${DEFAULT_AGENTS_CONFIG:-default_agents.yaml}",
+                },
+            },
+            "sandbox-controller": {
+                "build": {"context": "."},
+                "image": f"{_CONTROLLER_GHCR}:2.0.2",
+                "environment": {
+                    "SANDBOX_ALLOWED_IMAGE_PREFIXES": (
+                        f"ghcr.io/openhands/,{_AGENT_GHCR}"
+                    ),
+                },
+            },
+            "postgres": {
+                "image": "ghcr.io/kamiwaza-internal/containers/images/postgres:v18.4",
+            },
+        },
+    }
+
+
+def _ref_map(source_services: dict) -> dict:
+    canonical = compute_canonical_refs(
+        source_services,
+        registry=_REGISTRY,
+        extension_name=_EXT,
+        revision_tag=_REV,
+    )
+    return build_image_ref_map(
+        source_services,
+        canonical,
+        registry=_REGISTRY,
+        extension_name=_EXT,
+        revision_tag=_REV,
+    )
+
+
+class TestBuildImageRefMap:
+    """``build_image_ref_map`` mirrors ImageBuilder.build's per-service ref
+    selection so the env rewrite targets the exact ref the agent is built and
+    pushed at."""
+
+    def test_profiled_agent_maps_to_legacy_fallback_ref(self):
+        ref_map = _ref_map(_kaizen_compose()["services"])
+        # The profiled agent is excluded from canonical_refs, so ImageBuilder
+        # tags it at {registry}/{ext}-agent:{tag} — that's where it lives.
+        assert ref_map[_AGENT_GHCR] == _AGENT_BUILT
+
+    def test_normal_service_keeps_declared_namespace(self):
+        ref_map = _ref_map(_kaizen_compose()["services"])
+        # Non-profiled services keep their declared namespace (canonical).
+        assert ref_map[_BACKEND_GHCR] == f"{_BACKEND_GHCR}:{_REV}"
+
+    def test_external_image_excluded(self):
+        ref_map = _ref_map(_kaizen_compose()["services"])
+        # postgres has no build context — not a built image, must not appear.
+        assert all("postgres" not in repo for repo in ref_map)
+
+
+class TestRewriteEnvImageRefs:
+    """The K8s payload surface: env values are bare (post
+    ``resolve_env_placeholders``) literal refs."""
+
+    def _transformed(self) -> dict:
+        compose = _kaizen_compose()
+        transformer = ComposeTransformer()
+        transformed = transformer.transform(
+            compose, extension_name=_EXT, revision_tag=_REV, registry=_REGISTRY
+        )
+        return transformer.resolve_env_placeholders(transformed)
+
+    def test_agent_server_image_rewritten_to_built_ref(self):
+        compose = _kaizen_compose()
+        transformed = self._transformed()
+        ref_map = _ref_map(compose["services"])
+
+        result = rewrite_env_image_refs(transformed, ref_map)
+
+        env = result["services"]["backend"]["environment"]
+        assert env["AGENT_SERVER_IMAGE"] == _AGENT_BUILT
+
+    def test_whitelist_aligned_in_lockstep(self):
+        compose = _kaizen_compose()
+        transformed = self._transformed()
+        ref_map = _ref_map(compose["services"])
+
+        result = rewrite_env_image_refs(transformed, ref_map)
+
+        env = result["services"]["sandbox-controller"]["environment"]
+        prefixes = env["SANDBOX_ALLOWED_IMAGE_PREFIXES"].split(",")
+        # The built agent prefix is appended; the originals are preserved
+        # (some flows may still reference the ghcr path).
+        assert f"{_REGISTRY}/{_EXT}-agent" in prefixes
+        assert "ghcr.io/openhands/" in prefixes
+        assert _AGENT_GHCR in prefixes
+
+    def test_non_image_env_untouched(self):
+        compose = _kaizen_compose()
+        transformed = self._transformed()
+        ref_map = _ref_map(compose["services"])
+
+        result = rewrite_env_image_refs(transformed, ref_map)
+
+        env = result["services"]["backend"]["environment"]
+        assert env["DEFAULT_AGENTS_CONFIG"] == "default_agents.yaml"
+
+    def test_does_not_mutate_input(self):
+        compose = _kaizen_compose()
+        transformed = self._transformed()
+        ref_map = _ref_map(compose["services"])
+        before = copy.deepcopy(transformed)
+
+        rewrite_env_image_refs(transformed, ref_map)
+
+        assert transformed == before
+
+
+class TestRewriteEnvImageRefsCatalogSurface:
+    """The catalog-overlay surface keeps ``${VAR:-default}`` placeholders
+    (the platform performs install-time substitution), so the rewrite must
+    rewrite the default *inside* the substitution form."""
+
+    def test_substitution_default_rewritten(self):
+        compose = _kaizen_compose()
+        ref_map = _ref_map(compose["services"])
+        # catalog_compose is transformed but NOT resolve_env_placeholders'd.
+        catalog = ComposeTransformer().transform(
+            compose, extension_name=_EXT, revision_tag=_REV, registry=_REGISTRY
+        )
+
+        result = rewrite_env_image_refs(catalog, ref_map)
+
+        env = result["services"]["backend"]["environment"]
+        # The ${VAR:-default} form is preserved; only the default is rewritten
+        # so a runtime override still wins.
+        assert env["AGENT_SERVER_IMAGE"] == (
+            f"${{AGENT_SERVER_IMAGE:-{_AGENT_BUILT}}}"
+        )
+
+
+class TestRewriteEnvImageRefsListForm:
+    """Robustness: env may be a list of ``KEY=value`` strings, not a dict."""
+
+    def test_list_form_agent_server_image(self):
+        ref_map = _ref_map(_kaizen_compose()["services"])
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": [
+                        f"AGENT_SERVER_IMAGE={_AGENT_GHCR}:2.0.2",
+                        "FOO=bar",
+                    ],
+                },
+            },
+        }
+        result = rewrite_env_image_refs(compose, ref_map)
+        env = result["services"]["backend"]["environment"]
+        assert f"AGENT_SERVER_IMAGE={_AGENT_BUILT}" in env
+        assert "FOO=bar" in env
+
+
+class TestDevRemoteWiresEnvRewrite:
+    """``run_dev_remote`` must actually apply the env rewrite — guards against
+    the helper being correct but never called (the 2-line wiring in dev.py).
+    """
+
+    def test_run_dev_remote_invokes_env_rewrite_for_both_surfaces(self, tmp_path):
+        from kamiwaza_extensions.commands import dev as dev_cmd
+        from kamiwaza_extensions.dev_env_image_refs import (
+            rewrite_env_image_refs as real_rewrite,
+        )
+
+        info = ExtensionInfo(
+            path=tmp_path,
+            name=_EXT,
+            version="2.0.2",
+            metadata={"name": _EXT, "type": "app"},
+            compose_path=tmp_path / "docker-compose.yml",
+            compose_data=_kaizen_compose(),
+        )
+
+        calls: list = []
+
+        def _spy(compose, ref_map):
+            calls.append((compose, ref_map))
+            return real_rewrite(compose, ref_map)
+
+        # Stop the pipeline right after the rewrite step (which runs before
+        # the build) by raising from ImageBuilder.build.
+        builder = MagicMock()
+        builder.build.side_effect = ImageBuildError("stop-after-capture")
+
+        conn_mgr = MagicMock()
+        conn_mgr.get_active_connection.return_value = ConnectionInfo(
+            name="dev",
+            url="https://kamiwaza.test/api",
+            active=True,
+            created_at=0.0,
+            verify_ssl=False,
+        )
+        conn_mgr.get_token.return_value = MagicMock(access_token="tok-abc")
+        detector = MagicMock()
+        detector.detect.return_value = info
+        tagger = MagicMock()
+        tagger.generate_tag.return_value = _REV
+        tagger.get_git_info.return_value = ("f46cd1fc", False)
+
+        with (
+            patch(
+                "kamiwaza_extensions.extension_detector.ExtensionDetector",
+                return_value=detector,
+            ),
+            patch(
+                "kamiwaza_extensions.connections.ConnectionManager",
+                return_value=conn_mgr,
+            ),
+            patch(
+                "kamiwaza_extensions.revision_tagger.RevisionTagger",
+                return_value=tagger,
+            ),
+            patch(
+                "kamiwaza_extensions.image_builder.ImageBuilder",
+                return_value=builder,
+            ),
+            patch(
+                "kamiwaza_extensions.dev_env_image_refs.rewrite_env_image_refs",
+                side_effect=_spy,
+            ),
+            patch.object(dev_cmd, "_detect_kind_registry", return_value=None),
+            patch(
+                "kamiwaza_extensions.registry_resolution.detect_core_config_registry",
+                return_value=None,
+            ),
+            patch("kamiwaza_extensions.dev_state.read_state", return_value=None),
+            patch("kamiwaza_extensions.dev_state.resume_message", return_value=None),
+            pytest.raises(click.exceptions.Exit),
+        ):
+            dev_cmd.run_dev_remote(no_push=True)
+
+        # Called for both the K8s payload and the catalog overlay compose.
+        assert len(calls) == 2, "env rewrite must run on transformed AND catalog"
+        # The ref_map must map the agent's declared repo to a dev-built
+        # kaizen-agent ref (the profiled image-only fallback path), and at
+        # least one surface must carry AGENT_SERVER_IMAGE.
+        ref_map = calls[0][1]
+        assert _AGENT_GHCR in ref_map
+        assert ref_map[_AGENT_GHCR].split("/")[-1] == f"{_EXT}-agent:{_REV}"
+        carried = any(
+            "AGENT_SERVER_IMAGE" in (svc.get("environment") or {})
+            for compose, _ in calls
+            for svc in (compose.get("services") or {}).values()
+            if isinstance(svc.get("environment"), dict)
+        )
+        assert carried, "AGENT_SERVER_IMAGE must reach the rewrite step"

--- a/tests/unit/extensions/test_dev_env_image_refs.py
+++ b/tests/unit/extensions/test_dev_env_image_refs.py
@@ -211,6 +211,38 @@ class TestRewriteEnvImageRefsCatalogSurface:
             f"${{AGENT_SERVER_IMAGE:-{_AGENT_BUILT}}}"
         )
 
+    def test_templated_allowlist_appended_in_lockstep(self):
+        """Regression (cron re-review High #1): a *templated*
+        ``${SANDBOX_ALLOWED_IMAGE_PREFIXES:-csv}`` must get the built prefix
+        appended inside the substitution form — same ``${VAR:-default}``
+        unwrap AGENT_SERVER_IMAGE gets. Before the fix, the CSV was split with
+        the ``${…:-``/``}`` still attached, no entry matched, and the lockstep
+        append silently dropped while AGENT_SERVER_IMAGE was still rewritten.
+        """
+        ref_map = _ref_map(_kaizen_compose()["services"])
+        compose = {
+            "services": {
+                "sandbox-controller": {
+                    "environment": {
+                        "SANDBOX_ALLOWED_IMAGE_PREFIXES": (
+                            f"${{SANDBOX_ALLOWED_IMAGE_PREFIXES:-ghcr.io/openhands/,{_AGENT_GHCR}}}"
+                        ),
+                    },
+                },
+            },
+        }
+
+        result = rewrite_env_image_refs(compose, ref_map)
+        wl = result["services"]["sandbox-controller"]["environment"][
+            "SANDBOX_ALLOWED_IMAGE_PREFIXES"
+        ]
+
+        # Substitution form preserved, built prefix appended inside it.
+        assert wl == (
+            f"${{SANDBOX_ALLOWED_IMAGE_PREFIXES:-ghcr.io/openhands/,"
+            f"{_AGENT_GHCR},{_REGISTRY}/{_EXT}-agent}}"
+        )
+
 
 class TestRewriteEnvImageRefsListForm:
     """Robustness: env may be a list of ``KEY=value`` strings, not a dict."""


### PR DESCRIPTION
## Summary

On a `kz-ext dev`-deployed Kaizen, starting a chat 500s: the agent sandbox pod `ImagePullBackOff`s pulling `ghcr.io/.../images/kaizen-agent:2.0.2` (the **released** tag, never built/pushed), so `create_sandbox` ReadTimeouts and `POST /api/conversations/` 500s.

**Root cause:** `kz-ext dev` rewrites service `image:` fields to the dev tag, but `resolve_env_placeholders` only **collapses `${AGENT_SERVER_IMAGE:-...:2.0.2}` to its literal released-tag default** — it never rewrites the image ref *embedded in the env value*. The backend spawns sandbox pods dynamically from `AGENT_SERVER_IMAGE`, so that stale ref is what fails.

This is the **dev analog of ENG-5260** (which fixed env-image rewriting for `kz-ext publish` only, in `registry_builder._apply_env_image_rewrites`). The platform's equivalent rewriter (`image_rewrite.py`) is gated on offline relocation and **dormant on normal dev clusters** (`KAMIWAZA_EXTENSION_IMAGE_RELOCATE_REGISTRY` empty), so the fix belongs in the SDK dev path.

The agent carries `profiles: [image-only]` → dropped from the deployed compose and excluded from `compute_canonical_refs`, so `ImageBuilder` builds it at the legacy `{registry}/{ext}-agent:{tag}` fallback path — **outside** the `SANDBOX_ALLOWED_IMAGE_PREFIXES` whitelist. So the allowlist is aligned in lockstep (mirrors core `image_rewrite`'s `IMAGE_ENV_NAMES` / `IMAGE_PREFIX_ENV_NAMES` coupling).

## Changes

- **new `kamiwaza_extensions/dev_env_image_refs.py`**
  - `build_image_ref_map` — maps each build-context service's declared repo → its built ref, mirroring `ImageBuilder.build`'s per-service choice (canonical else `{registry}/{ext}-{svc}:{tag}` fallback) so the env ref equals exactly what was built and pushed.
  - `rewrite_env_image_refs` — rewrites `AGENT_SERVER_IMAGE` (bare and `${VAR:-default}` forms) to the built ref and appends the built whitelist prefix in lockstep.
- **wired into `commands/dev.py`** after `canonical_refs`, applied to both the K8s payload (`transformed`) and the catalog overlay compose (`catalog_compose`).
- **tests** `tests/unit/extensions/test_dev_env_image_refs.py` (11), RED-first against the exact production symptom, incl. a wiring guard that fails if the dev.py application is removed.

## Acceptance

- `AGENT_SERVER_IMAGE` on a `kz-ext dev` deploy points at the dev-built, node-pullable, whitelisted agent image.
- Starting a chat spawns an agent sandbox that reaches Ready; `POST /api/conversations/` returns 2xx. *(Requires a `kz-ext dev` redeploy on kamiwaza.test to verify end-to-end.)*

## Notes

- Registry-path flattening for the agent is ENG-7051 territory; this fix reuses `ImageBuilder`'s resolution so it tracks whatever ENG-7051 produces.
- Linear: ENG-7110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-06-16T23:00:59.698Z
pr:
  repo: kamiwaza-ai/kamiwaza-sdk
  number: 180
linear_issues:
  - ENG-7110
  - ENG-5260
  - ENG-7051
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: 8/8 GitHub checks green at author time (Build Package, Build seeder
      image, Coverage, Cyclomatic Complexity, Mypy, Ruff, Unit Tests,
      check-linear-issue). Gate re-verifies live.
  - kind: pr-evidence
    required: false
    status: skipped
    detail: SDK client-CLI change (kz-ext dev tooling); no in-cluster service pod of
      its own to smoke. Deploy effect is covered by the manual steps.
  - kind: linear-issue-present
    required: true
    status: pass
    detail: ENG-7110 present in PR title, head branch, and body (ENG-5260, ENG-7051
      referenced).
  - kind: no-debug-statements
    required: true
    status: pass
    detail: Diff scanned; no pdb/breakpoint/print/console.log/debugger added.
      (console.print is the CLI's normal Rich output, not a debug statement.)
manual_steps:
  - id: ms-1
    description: Run this branch's kz-ext dev transform pipeline against the real
      Kaizen extension (docker-compose.yml + kamiwaza.json); read the backend
      env AGENT_SERVER_IMAGE it produces.
    observation: "Ran the pipeline (ComposeTransformer.transform ->
      resolve_env_placeholders -> build_image_ref_map -> rewrite_env_image_refs)
      with registry=host.docker.internal:5001,
      rev=2.0.2-dev-f46cd1fc.1781636703. backend AGENT_SERVER_IMAGE resolved to
      'host.docker.internal:5001/kaizen-agent:2.0.2-dev-f46cd1fc.1781636703'
      (pre-fix it was
      'ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images/kaizen-agent\
      :2.0.2', the unpublished released tag). Confirmed that exact tag is
      present and pullable in the registry (GET
      http://localhost:5001/v2/kaizen-agent/tags/list -> tag present: True)."
    status: pass
  - id: ms-2
    description: From the same pipeline run, read the sandbox-controller env
      SANDBOX_ALLOWED_IMAGE_PREFIXES.
    observation: "Output:
      'ghcr.io/openhands/,ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/\
      images/kaizen-agent,host.docker.internal:5001/kaizen-agent'. The built
      dev-agent prefix host.docker.internal:5001/kaizen-agent was appended in
      lockstep and the original two prefixes preserved. Byte-identical to the
      live workaround-patched (working) instance kaizen-o49s6s00."
    status: pass
  - id: ms-3
    description: Confirm a deployment carrying these exact AGENT_SERVER_IMAGE +
      whitelist values runs healthy on kamiwaza.test.
    observation: "kubectl --context Default get pods -n kamiwaza-extensions:
      kaizen-o49s6s00-aeb3817c backend (2/2), frontend (2/2), postgres (2/2),
      sandbox-controller (2/2) all Running, 0 restarts. This instance carries
      AGENT_SERVER_IMAGE=host.docker.internal:5001/kaizen-agent:2.0.2-dev-f46cd\
      1fc.1781636703 and the lockstep whitelist — the exact values this branch
      produces."
    status: pass
  - id: ms-4
    description: "Exercise the full end-to-end: deploy this branch via kz-ext dev,
      start a chat (POST /api/conversations/), and observe a freshly-spawned
      agent sandbox reach Ready with a 2xx response."
    observation: Not exercised autonomously. A fresh kz-ext dev of this branch
      requires adding host.docker.internal:5001 to Docker insecure-registries
      (currently only :30010 is set) plus a Docker daemon restart, which was not
      performed. No agent sandbox pod is currently present in the cluster to
      observe (sandboxes are ephemeral/per-conversation). The live
      2xx-on-POST-/api/conversations with a newly-spawned sandbox was therefore
      not observed; corroborated only indirectly via ms-1/ms-3.
    status: fail
verdict:
  decision: hold
  rationale: "failing manual steps: ms-4"
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
linear:
  - id: ENG-7110
    url: https://linear.app/kamiwaza/issue/ENG-7110
    cached_description: |
      ## Summary

      On a `kz-ext dev`-deployed Kaizen, **starting a chat 500s**. The backend's `POST /api/conversations/` calls the sandbox-controller `create_sandbox`, which **ReadTimeouts (~300s)** because the agent sandbox pod never becomes ready: it's stuck in `ImagePullBackOff` trying to pull `ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images/kaizen-agent:2.0.2` → `not found`.

      ## Root cause (two compounding gaps in the `kz-ext dev` path)

      1. `AGENT_SERVER_IMAGE` env-default isn't rewritten for dev. Kaizen's `docker-compose.yml` sets `AGENT_SERVER_IMAGE: ${AGENT_SERVER_IMAGE:-ghcr.io/.../kaizen-agent:2.0.2}` — the released tag, which was never published. `kz-ext dev` builds the agent (an `extra_docker_images` entry) at a dev tag but never rewrites this env-var default. This is the `kz-ext dev` analog of ENG-5260 (which fixed image refs in env-var defaults for `kz-ext publish` only).
      2. Agent extra_docker_image lands at a registry path the sandbox can't use. `kz-ext dev` pushes the agent to `host.docker.internal:5001/kaizen-agent:<dev-tag>` (top-level repo), but the sandbox image whitelist (`spec.sandbox.imageWhitelist` → controller `SANDBOX_ALLOWED_IMAGE_PREFIXES`) only allows `ghcr.io/openhands/` and `ghcr.io/.../images/kaizen-agent`. So even pointing at the local image is rejected by `_validate_image`. (Registry-resolution split is ENG-7051 territory.)

      ## Evidence (local kamiwaza.test, 2026-06-16)

      Failed to pull image kaizen-agent:2.0.2: not found → ImagePullBackOff. Controller: Sandbox pod did not become ready, cleaning up. Backend: create_sandbox -> ReadTimeout -> POST /api/conversations/ 500. Dev agent image does exist and is node-pullable at host.docker.internal:5001/kaizen-agent:2.0.2-dev-dirty.<n> (verified: a test pod pulled it, 1.45 GB, in 25s). The released :2.0.2 tag is simply not published.

      ## Fix candidates

      1. SDK (correct, dev analog of ENG-5260): in the `kz-ext dev` compose transform, rewrite image refs embedded in `environment` values (e.g. `AGENT_SERVER_IMAGE`) to the dev-built tag, the same way service `image:` fields are rewritten.
      2. Whitelist alignment: ensure the dev-built agent image's registry/path is included in the sandbox image whitelist (or push the agent extra_docker_image to the same `ghcr.io/.../images/kaizen-agent` path the services use, which is already whitelisted and node-pullable).

      ## Acceptance

      * `AGENT_SERVER_IMAGE` on a `kz-ext dev` deploy points at the dev-built, node-pullable, whitelisted agent image.
      * Starting a chat spawns an agent sandbox that reaches Ready (no ImagePullBackOff), `POST /api/conversations/` returns 2xx.

      ## Workaround applied locally

      Patched the live CR: backend `AGENT_SERVER_IMAGE` → `host.docker.internal:5001/kaizen-agent:<dev-tag>` and sandbox-controller `SANDBOX_ALLOWED_IMAGE_PREFIXES` += `host.docker.internal:5001/kaizen-agent`. Reverts on next `kz-ext dev`.

      ## Context

      Fifth `kz-ext dev` gap found in sequence while bringing up Kaizen's agent flow locally (after RBAC ENG-6890, istio port naming ENG-7084, east-west api_url ENG-7108, and a SANDBOX_BACKEND→SANDBOX_RUNTIME env-name drift). Suggests the `kz-ext dev` agent/sandbox path needs an end-to-end pass.
    cached_at: 2026-06-16T22:47:36Z
  - id: ENG-5260
    url: https://linear.app/kamiwaza/issue/ENG-5260
    cached_description: >
      ## Problem


      `kz-ext publish` rewrites image tags only on compose service `image:`
      fields. Image refs embedded as defaults in `services.*.environment` values
      (e.g. `${AGENT_SERVER_IMAGE:-<registry>/agent:1.8.13}`) pass through
      verbatim — no stage suffix, no digest pin — even when the same image
      elsewhere in the catalog is fully resolved. For Kaizen, the published
      `compose_yml`'s `AGENT_SERVER_IMAGE` env default disagrees with the
      catalog's `extra_docker_images` entry for the same image. Kaizen's backend
      reads `AGENT_SERVER_IMAGE` to spawn per-conversation sandbox pods; on a
      `-dev` publish, `agent:1.8.13` is not a tag the shared workflow pushed, so
      the published catalog ships a backend that can't start sandboxes.


      ## Recommendation


      Option A: Extend `ComposeTransformer` to walk `services.*.environment`
      after the existing service-image rewrite, matching
      `${VAR:-<registry>/<repo>:<tag>}` defaults and bare
      `<registry>/<repo>:<tag>` values, applying the same stage-suffix rewrite.
      Digest-pin env defaults when `digest_map` has a match. Refs outside the
      configured registry pass through.


      ## Acceptance


      * `ComposeTransformer` walks `services.*.environment` values and rewrites
      image refs under the configured registry with the stage-derived tag
      suffix.

      * When `digest_map` has a matching post-suffix ref, the env default is
      rewritten to `:tag@sha256:…` form.

      * Refs outside registry and already-pinned refs pass through.

      * Unit test in `test_compose_transformer.py` covers `${VAR:-...}` and bare
      env-value patterns.

      * Integration test in `test_publish_cmd.py` asserts compose env defaults
      match `extra_docker_images` for the kaizen-shaped input.


      Status: Done. Shipped in kamiwaza-sdk PR #110 (`_apply_env_image_rewrites`
      in registry_builder.py). ENG-7110 is the dev-path analog of this
      publish-path fix.
    cached_at: 2026-06-16T22:47:36Z
  - id: ENG-7051
    url: https://linear.app/kamiwaza/issue/ENG-7051
    cached_description: >
      ## Summary


      On a local k0s/lima dev cluster, `kz-ext dev` builds and pushes extension
      images to the in-cluster model registry (`127.0.0.1:30010`) and embeds
      that address as the image reference in the Kubernetes Deployment. The k0s
      node cannot pull from `127.0.0.1:30010`, so every dev extension deploy
      lands in `ImagePullBackOff`. Extension images are supposed to live in the
      host-side local registry at `host.docker.internal:5001`, which the k0s
      node is provisioned to pull from. The SDK never targets it.


      ## Root cause


      The k0s/lima installer provisions the node to pull extension images from
      `host.docker.internal:5001`, but never advertises that registry to the
      `kz-ext` SDK. With no extension-registry value to read, the SDK falls
      through to the model registry's external host and ships extension images
      there, which is not node-routable.


      ## Fix (implemented — two repos)


      deploy: advertise the extension registry via `scheduler.extensionRegistry`
      → `KAMIWAZA_EXTENSION_REGISTRY` (PR deploy#418). kamiwaza-sdk:
      `registry_resolution.py` `detect_extension_registry()` reads
      `KAMIWAZA_EXTENSION_REGISTRY`; `resolve_image_registry()` prefers it.
      Purely additive (PR kamiwaza-sdk#174). The advertised value is the
      node-routable VM alias `host.docker.internal:5001`, which is both embedded
      in the deployment AND the push target.


      ## Validation


      SDK unit suite 1599 passed, ruff clean. End-to-end against a live cluster:
      `kz-ext dev` resolves `host.docker.internal:5001`, pushes, deploys; pods
      reach 1/1 Running. Status: Needs Validation. ENG-7110 notes the
      registry-resolution split (agent landing at
      `host.docker.internal:5001/kaizen-agent` top-level) is ENG-7051 territory.
    cached_at: 2026-06-16T22:47:36Z
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->