### PR TITLE
fix(kaizen): wait for Kaizen to be serving in resolve-kaizen-url (ENG-7111)

### DIFF
--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -210,7 +210,19 @@ def wait_for_base_url(
             url = resolve_base_url(
                 client, extension_name, workroom_id=workroom_id, public=public
             )
-            if _is_serving(client, url, workroom_id=workroom_id):
+            # The readiness probe rides the credentialed platform client, which
+            # refuses off-host URLs (it won't leak the bearer). The public URL
+            # may be off-host (browser-facing), so probe the same-host ingress
+            # endpoint — the route the backend actually serves on — and return
+            # whichever URL the caller asked for.
+            probe_url = (
+                url
+                if not public
+                else resolve_base_url(
+                    client, extension_name, workroom_id=workroom_id, public=False
+                )
+            )
+            if _is_serving(client, probe_url, workroom_id=workroom_id):
                 return url
             last_err = "ingress published but backend not serving yet (503)"
         except (ValueError, NotFoundError) as exc:

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -16,7 +16,7 @@ platform honors this header. A workroom-scoped token is the durable fix
 import time
 from typing import Any, Dict, List, Optional, Union
 
-from ..exceptions import KamiwazaError, NotFoundError
+from ..exceptions import APIError, KamiwazaError, NotFoundError
 from ..schemas.kaizen import Agent, Conversation, LLMConfig
 from .base_service import BaseService
 
@@ -130,6 +130,36 @@ def resolve_base_url(
     return url
 
 
+def _is_serving(client, base_url: str, *, workroom_id) -> bool:
+    """Probe the extension backend to confirm it answers, not just that it routes.
+
+    A published ingress only means envoy has a route — right after install the
+    backend pod can still be starting, so the proxy returns ``503 no healthy
+    upstream`` (or refuses the connection outright), and a real call against the
+    URL would 503 too (ENG-7111). Treat 503 and transport errors (no response at
+    all) as "not ready yet"; any other outcome — a 2xx, or even a structured 4xx
+    — proves the backend is up and answering, which is all a caller needs before
+    using the URL.
+
+    In this client a 503 and a connection failure both surface as ``APIError``
+    (503 carries ``status_code=503``; a transport error carries
+    ``status_code=None``). Other ``KamiwazaError`` subclasses (auth/validation)
+    mean the backend returned a structured response, i.e. it is serving.
+    """
+    try:
+        client._request(
+            "GET",
+            _AGENTS_PATH,
+            base_url=base_url,
+            headers=_workroom_headers(workroom_id),
+        )
+    except APIError as exc:
+        return getattr(exc, "status_code", None) not in (503, None)
+    except KamiwazaError:
+        return True
+    return True
+
+
 def wait_for_base_url(
     client,
     extension_name: str = "kaizen",
@@ -139,13 +169,20 @@ def wait_for_base_url(
     timeout_seconds: float = 300.0,
     poll_interval_seconds: float = 5.0,
 ) -> str:
-    """Poll :func:`resolve_base_url` until the extension publishes its ingress.
+    """Poll until the extension is resolvable AND actually serving requests.
 
-    Right after an install the ingress isn't resolvable yet: the extension isn't
-    visible yet (``NotFoundError`` / no workroom match) and/or its endpoints
-    aren't published (``ValueError``). Both are transient, so retry until one
-    resolves or ``timeout_seconds`` elapses. Mirrors
-    ``serving.wait_deployment_ready``'s wait contract. A deterministic
+    Two startup stages have to clear before the URL is usable, and both are
+    transient — retry until one resolves or ``timeout_seconds`` elapses:
+
+    1. **Ingress resolves.** Right after an install the extension isn't visible
+       yet (``NotFoundError`` / no workroom match) and/or its endpoints aren't
+       published (``ValueError``).
+    2. **Backend serves.** Once the ingress is published, envoy has a route but
+       the backend pod may still be starting — a call would get ``503 no healthy
+       upstream`` (ENG-7111). :func:`_is_serving` probes the backend and we keep
+       polling until it answers, so the returned URL is immediately usable.
+
+    Mirrors ``serving.wait_deployment_ready``'s wait contract. A deterministic
     ``AmbiguousExtensionError`` is NOT retried — it propagates immediately rather
     than burning the full timeout on something that will never resolve.
 
@@ -159,25 +196,29 @@ def wait_for_base_url(
         poll_interval_seconds: Delay between attempts.
 
     Returns:
-        The resolved ingress root (no trailing slash).
+        The resolved ingress root (no trailing slash), confirmed serving.
 
     Raises:
-        TimeoutError: If no endpoint resolves within ``timeout_seconds``.
+        TimeoutError: If the extension isn't serving within ``timeout_seconds``.
     """
     deadline = time.monotonic() + timeout_seconds
     attempts = 0
+    last_err: object = "not resolvable yet"
     while True:
         attempts += 1
         try:
-            return resolve_base_url(
+            url = resolve_base_url(
                 client, extension_name, workroom_id=workroom_id, public=public
             )
+            if _is_serving(client, url, workroom_id=workroom_id):
+                return url
+            last_err = "ingress published but backend not serving yet (503)"
         except (ValueError, NotFoundError) as exc:
             last_err = exc
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise TimeoutError(
-                f"Extension '{extension_name}' ingress not resolvable after "
+                f"Extension '{extension_name}' not serving after "
                 f"{timeout_seconds:g}s ({attempts} attempts): {last_err}"
             )
         # Cap the sleep at the remaining budget so the wait stays bounded even

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -134,15 +134,15 @@ def _is_serving(client, base_url: str, *, workroom_id) -> bool:
     """Probe the extension backend to confirm it answers, not just that it routes.
 
     A published ingress only means envoy has a route — right after install the
-    backend pod can still be starting, so the proxy returns ``503 no healthy
-    upstream`` (or refuses the connection outright), and a real call against the
-    URL would 503 too (ENG-7111). Treat 503 and transport errors (no response at
-    all) as "not ready yet"; any other outcome — a 2xx, or even a structured 4xx
-    — proves the backend is up and answering, which is all a caller needs before
-    using the URL.
+    backend pod can still be starting, so the gateway returns a 5xx (``503 no
+    healthy upstream``, or a ``502``/``504`` while the upstream is coming up) or
+    refuses the connection outright, and a real call against the URL would fail
+    too (ENG-7111). Treat any 5xx and transport errors (no response at all) as
+    "not ready yet"; a 2xx — or even a 4xx — means the backend answered at the
+    app layer, which is all a caller needs before using the URL.
 
-    In this client a 503 and a connection failure both surface as ``APIError``
-    (503 carries ``status_code=503``; a transport error carries
+    In this client a 5xx and a connection failure both surface as ``APIError``
+    (the 5xx carries its ``status_code``; a transport error carries
     ``status_code=None``). Other ``KamiwazaError`` subclasses (auth/validation)
     mean the backend returned a structured response, i.e. it is serving.
     """
@@ -154,7 +154,11 @@ def _is_serving(client, base_url: str, *, workroom_id) -> bool:
             headers=_workroom_headers(workroom_id),
         )
     except APIError as exc:
-        return getattr(exc, "status_code", None) not in (503, None)
+        status = getattr(exc, "status_code", None)
+        # No status = transport error before any response; any 5xx = the gateway
+        # or backend isn't ready yet. Both are transient startup states — keep
+        # polling. A 4xx means the backend answered, i.e. it is serving.
+        return status is not None and not 500 <= status <= 599
     except KamiwazaError:
         return True
     return True

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -419,6 +419,31 @@ def test_wait_for_base_url_polls_past_503_until_serving(monkeypatch):
     assert outcomes == []
 
 
+def test_wait_for_base_url_public_probes_ingress_not_offhost_url():
+    # public=True returns the (possibly off-host) public URL, but the readiness
+    # probe must ride the same-host ingress URL — the credentialed client refuses
+    # off-host base_urls, so probing the public URL would never resolve.
+    ingress = "https://kamiwaza.test/runtime/apps/kaizen-4f8b3ae1"
+    public = "https://public.example/kaizen"
+    extension = SimpleNamespace(
+        endpoints=SimpleNamespace(external=ingress, public_api_url=public)
+    )
+    probed: list = []
+
+    def record(method, path, **kwargs):
+        probed.append(kwargs.get("base_url"))
+        return {"agents": []}
+
+    client = SimpleNamespace(
+        extensions=SimpleNamespace(get_extension=lambda name: extension),
+        _request=record,
+    )
+
+    assert wait_for_base_url(client, "kaizen-4f8b3ae1", public=True) == public
+    # Probe hit the ingress endpoint, never the off-host public URL.
+    assert probed == [ingress]
+
+
 def test_wait_for_base_url_times_out_when_published_but_never_serving(monkeypatch):
     import kamiwaza_sdk.services.kaizen as kaizen_mod
 

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -359,11 +359,14 @@ def test_is_serving_true_on_success():
     assert kwargs["headers"] == {"X-Workroom-Id": "wr-A"}
 
 
-def test_is_serving_false_on_503():
-    def unhealthy(*a, **k):
-        raise APIError("no healthy upstream", status_code=503)
+@pytest.mark.parametrize("status", [500, 502, 503, 504])
+def test_is_serving_false_on_5xx(status):
+    # Any 5xx means the gateway/backend isn't ready (no healthy upstream during
+    # pod startup is 503, but envoy can also emit 502/504 mid-startup).
+    def server_error(*a, **k):
+        raise APIError("server error", status_code=status)
 
-    client = SimpleNamespace(_request=unhealthy)
+    client = SimpleNamespace(_request=server_error)
     assert _is_serving(client, KAIZEN_URL, workroom_id=None) is False
 
 

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -4,12 +4,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from kamiwaza_sdk.exceptions import NotFoundError
+from kamiwaza_sdk.exceptions import APIError, AuthenticationError, NotFoundError
 from kamiwaza_sdk.schemas.kaizen import LLMConfig
 from kamiwaza_sdk.services.kaizen import (
     AgentService,
     AmbiguousExtensionError,
     ConversationService,
+    _is_serving,
     resolve_base_url,
     wait_for_base_url,
 )
@@ -161,6 +162,9 @@ def _client_listing(extensions):
         return list(extensions)
 
     client.extensions = SimpleNamespace(list_extensions=list_extensions)
+    # Backend probe (_is_serving) succeeds by default; tests that exercise the
+    # not-serving path supply their own _request.
+    client._request = lambda *a, **k: {}
     return client
 
 
@@ -260,7 +264,8 @@ def test_wait_for_base_url_workroom_retries_until_listed(monkeypatch):
         return rounds.pop(0)
 
     client = SimpleNamespace(
-        extensions=SimpleNamespace(list_extensions=list_extensions)
+        extensions=SimpleNamespace(list_extensions=list_extensions),
+        _request=lambda *a, **k: {},  # backend serves once listed
     )
 
     url = wait_for_base_url(
@@ -275,7 +280,8 @@ def test_wait_for_base_url_returns_when_ready():
         endpoints=SimpleNamespace(external=KAIZEN_URL, public_api_url=None)
     )
     client = SimpleNamespace(
-        extensions=SimpleNamespace(get_extension=lambda name: extension)
+        extensions=SimpleNamespace(get_extension=lambda name: extension),
+        _request=lambda *a, **k: {},  # backend serves
     )
 
     assert wait_for_base_url(client, "kaizen-4f8b3ae1") == KAIZEN_URL
@@ -301,7 +307,10 @@ def test_wait_for_base_url_retries_past_transient_states(monkeypatch):
             raise item
         return item
 
-    client = SimpleNamespace(extensions=SimpleNamespace(get_extension=get_extension))
+    client = SimpleNamespace(
+        extensions=SimpleNamespace(get_extension=get_extension),
+        _request=lambda *a, **k: {},  # backend serves once published
+    )
 
     assert wait_for_base_url(client, "kaizen", poll_interval_seconds=0) == KAIZEN_URL
     assert outcomes == []
@@ -316,7 +325,112 @@ def test_wait_for_base_url_times_out():
     )
 
     # timeout 0: the deadline is already past after the first failed attempt.
-    with pytest.raises(TimeoutError, match="not resolvable"):
+    with pytest.raises(TimeoutError, match="not serving"):
+        wait_for_base_url(client, "kaizen", timeout_seconds=0)
+
+
+# --- backend-serving probe -------------------------------------------------
+
+
+def _serving_client(get_request):
+    """A client whose _request delegates to get_request (probe behavior)."""
+    extension = SimpleNamespace(
+        endpoints=SimpleNamespace(external=KAIZEN_URL, public_api_url=None)
+    )
+    return SimpleNamespace(
+        extensions=SimpleNamespace(get_extension=lambda name: extension),
+        _request=get_request,
+    )
+
+
+def test_is_serving_true_on_success():
+    calls: list = []
+
+    def ok(method, path, **kwargs):
+        calls.append((method, path, kwargs))
+        return {"agents": []}
+
+    client = SimpleNamespace(_request=ok)
+    assert _is_serving(client, KAIZEN_URL, workroom_id="wr-A") is True
+    # Probes the agents endpoint against the resolved base_url, workroom-scoped.
+    method, path, kwargs = calls[0]
+    assert (method, path) == ("GET", "api/agents/")
+    assert kwargs["base_url"] == KAIZEN_URL
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-A"}
+
+
+def test_is_serving_false_on_503():
+    def unhealthy(*a, **k):
+        raise APIError("no healthy upstream", status_code=503)
+
+    client = SimpleNamespace(_request=unhealthy)
+    assert _is_serving(client, KAIZEN_URL, workroom_id=None) is False
+
+
+def test_is_serving_false_on_connection_error():
+    # A transport failure surfaces as APIError with no status_code — the route
+    # exists but nothing is answering yet, so keep polling.
+    def refused(*a, **k):
+        raise APIError("An error occurred while making the request: refused")
+
+    client = SimpleNamespace(_request=refused)
+    assert _is_serving(client, KAIZEN_URL, workroom_id=None) is False
+
+
+def test_is_serving_true_on_4xx():
+    # A 4xx means the backend answered — it's up, just rejecting this probe.
+    def not_found(*a, **k):
+        raise APIError("not found", status_code=404)
+
+    client = SimpleNamespace(_request=not_found)
+    assert _is_serving(client, KAIZEN_URL, workroom_id=None) is True
+
+
+def test_is_serving_true_on_structured_error():
+    # Non-APIError KamiwazaError subclasses (auth/validation) prove a response.
+    def unauthorized(*a, **k):
+        raise AuthenticationError("nope")
+
+    client = SimpleNamespace(_request=unauthorized)
+    assert _is_serving(client, KAIZEN_URL, workroom_id=None) is True
+
+
+def test_wait_for_base_url_polls_past_503_until_serving(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+
+    # Ingress is published immediately, but the backend 503s twice (pod still
+    # starting) before it serves. wait must not return the URL until it serves.
+    outcomes = [
+        APIError("no healthy upstream", status_code=503),
+        APIError("no healthy upstream", status_code=503),
+        {"agents": []},
+    ]
+
+    def probe(*a, **k):
+        item = outcomes.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    client = _serving_client(probe)
+    assert wait_for_base_url(client, "kaizen", poll_interval_seconds=0) == KAIZEN_URL
+    assert outcomes == []
+
+
+def test_wait_for_base_url_times_out_when_published_but_never_serving(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+
+    # Ingress resolves but the backend 503s forever — the timeout message must
+    # reflect "not serving", not "not resolvable".
+    def always_503(*a, **k):
+        raise APIError("no healthy upstream", status_code=503)
+
+    client = _serving_client(always_503)
+    with pytest.raises(TimeoutError, match="not serving yet"):
         wait_for_base_url(client, "kaizen", timeout_seconds=0)
 
 


### PR DESCRIPTION
## What this ships

`wait_for_base_url` (→ `kamiwaza-seed resolve-kaizen-url`) returned as soon as the Kaizen ingress was *published*, but the backend pod could still be starting — envoy has the route, no healthy upstream — so the next `create-agent` got `503 no healthy upstream`. It now probes the backend (`GET api/agents/`) after resolving the URL and keeps polling until it actually answers, within the existing `--timeout`/`--poll-interval`. Unblocks the ENG-6932 nightly's `create-agent` step on a cold workroom.

## Contract

| Probe outcome | Meaning | Action |
|---------------|---------|--------|
| 5xx (incl. 503 no-healthy-upstream) or transport error | gateway/backend not ready | keep polling |
| 2xx / 4xx | backend answered at the app layer | serving → return URL |

`public=True` returns the public URL but probes the same-host ingress (the credentialed client won't talk off-host).

## Verification

- Unit: 32 kaizen-service tests (5xx/4xx/transport/poll-past-503/public-probe-ingress); full suite 2549 pass.
- Live (k0s-lima): reproduced the cold-workroom race — scaled the Kaizen backend to 0, envoy returned `no healthy upstream`, probe gated for ~13s, flipped to serving once the pod recovered. Evidence block below.

<!-- pr-evidence-start -->
<details>
<summary>📋 <b>pr-evidence</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-06-17T07:11:02.029Z
manifest_hash: sha256:5326cc0ded0a536e7eff33f2651009847ab448a08194c1d8ea90ef1d327891cc
phase_a_complete: true
phase_b_complete: true
repos:
  - name: kamiwaza-sdk
    path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-ENG-7111
    branch: feature/ENG-7111
    head_sha: 0e80e76fd033aaab4a64b1ebfe25909505225add
    head_sha_short: 0e80e76fd
    dirty_files: 0
    ahead: 3
    behind: 0
    upstream: origin/develop
    delivery:
      mode: not-applicable
      verified: true
clusters: []
```

</details>

# PR Evidence — generated 2026-06-17T07:11:02.029Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| kamiwaza-sdk | feature/ENG-7111 | `0e80e76fd` | +3 | not-applicable ✓ |

## Cross-references

- Linear: `ENG-7111`


## Testing summary

- **Unit**: `tests/unit/test_kaizen_service.py` — 32 passed (probe True/False on
  success / 5xx (500/502/503/504) / connection-error / 4xx / structured-error;
  poll-past-503-until-serving; timeout-when-never-serving; public=True probes
  the same-host ingress, not the off-host URL). Full SDK unit/contract suite:
  2549 passed. ruff clean; mypy clean on `kaizen.py`.
- **Live (earlier this session, running k0s-lima)**: reproduced the cold-workroom
  race against the real Kaizen + envoy + workroom-scoped auth — scaled the Kaizen
  backend to 0 → envoy `no healthy upstream` (503) → `_is_serving` returned False
  for ~13s → operator restored the pod → flipped to True. Confirmed the probe
  gates on the exact "route published, no healthy upstream" condition the ticket
  describes. Happy-path: `wait_for_base_url` returned in 0.05s on a healthy backend.
- **No fresh cluster preflight at PR time**: the Lima VM went offline after the
  live repro, so `clusters: []`. The post-repro refinements (5xx broadening,
  same-host probe URL) are unit-covered and don't alter the core 503-gating
  mechanism that was live-verified (503 ⊂ 5xx).

<!-- pr-evidence-end -->