### PR TITLE
ENG-7209: register external models into config so they're deployable (match FE)

### DIFF
--- a/kamiwaza_sdk/services/models/base.py
+++ b/kamiwaza_sdk/services/models/base.py
@@ -18,7 +18,19 @@ from .compatibility import CompatibilityMixin
 from ...model_selector import ModelAutoSelector
 
 
-class ModelService(BaseService, 
+# Maps an external-endpoint ``protocol`` discriminator to the canonical engine
+# name the platform routes external models through. Mirrors the frontend's
+# external-endpoint wizard (AwsBedrockForm / AwsTranscribeForm), which persists
+# the engine name in the config so the Deploy path can find it. ``aws_bedrock``
+# is the legacy protocol slug; the platform canonicalizes it to ``external_chat``
+# at registration, so the canonical value is sent directly.
+_ENGINE_NAME_BY_PROTOCOL: Dict[str, str] = {
+    "aws_bedrock": "external_chat",
+    "aws_transcribe": "external_transcribe",
+}
+
+
+class ModelService(BaseService,
                   ModelSearchMixin,
                   ModelDownloadMixin, 
                   ModelFileMixin, 
@@ -97,9 +109,12 @@ class ModelService(BaseService,
 
         Wraps the platform's external-endpoint registration: the ``endpoint``
         blob plus an inline ``credential_secret`` (the plaintext credential,
-        serialized to JSON) is submitted under ``default_config.system_config``.
-        The platform validates it, stores the credential as an encrypted Catalog
-        secret, strips the plaintext, and persists only the resolved URN.
+        serialized to JSON) is submitted, JSON-stringified, under
+        ``default_config.config.external_endpoint`` alongside the canonical
+        ``engine_name`` — matching how the frontend wizard registers external
+        endpoints so the deploy path can resolve the engine. The platform
+        validates it, stores the credential as an encrypted Catalog secret,
+        strips the plaintext, and persists only the resolved URN.
 
         Args:
             name: Model name shown in the platform.
@@ -121,15 +136,35 @@ class ModelService(BaseService,
         blob: Dict[str, Any] = endpoint.model_dump(exclude_none=True)
         blob["credential_secret"] = self._serialize_credential(credential)
 
-        # The blob lives in ``system_config`` (not ``config``): the platform
-        # JSON-stringifies system_config values before persisting them, whereas
-        # config values are stored raw and a nested dict fails to adapt at the
-        # DB layer. This also matches where the platform normalizes credentials.
+        protocol = blob.get("protocol")
+        engine_name = (
+            _ENGINE_NAME_BY_PROTOCOL.get(protocol)
+            if isinstance(protocol, str)
+            else None
+        )
+        if engine_name is None:
+            raise ValueError(
+                f"Unsupported external endpoint protocol: {protocol!r}"
+            )
+
+        # Mirror the frontend's external-endpoint registration (AwsBedrockForm /
+        # AwsTranscribeForm): ``engine_name`` and the JSON-stringified
+        # ``external_endpoint`` blob live under ``config``, not ``system_config``.
+        # The platform deploy path (and the UI Deploy button) reads
+        # ``engine_name`` out of ``config`` to route external models; leaving it
+        # in ``system_config`` makes the model undeployable without an explicit
+        # engine_name. Stringifying the blob sidesteps the nested-dict
+        # DB-adaptation problem that originally pushed it into system_config; the
+        # platform credential normalizer locates the blob in either container, so
+        # the inline credential is still encrypted to a URN.
         default_config: Dict[str, Any] = {
             "default": True,
             "name": config_name or f"{name} External Endpoint",
-            "config": {},
-            "system_config": {"external_endpoint": blob},
+            "config": {
+                "engine_name": engine_name,
+                "external_endpoint": json.dumps(blob),
+            },
+            "system_config": {},
         }
         model = CreateModel(
             name=name,

--- a/tests/unit/test_model_service.py
+++ b/tests/unit/test_model_service.py
@@ -205,7 +205,13 @@ def test_register_external_model_bedrock_builds_endpoint_blob():
     # No rotation requested -> no query param sent.
     assert kwargs.get("params") is None
 
-    blob = kwargs["json"]["default_config"]["system_config"]["external_endpoint"]
+    # Mirrors the frontend wizard: engine_name + JSON-stringified external_endpoint
+    # live under ``config`` (so the deploy path can resolve the engine), and
+    # ``system_config`` is empty. aws_bedrock canonicalizes to external_chat.
+    cfg = kwargs["json"]["default_config"]["config"]
+    assert cfg["engine_name"] == "external_chat"
+    assert kwargs["json"]["default_config"]["system_config"] == {}
+    blob = json.loads(cfg["external_endpoint"])
     assert blob["protocol"] == "aws_bedrock"
     assert blob["region"] == "us-east-1"
     assert blob["model_id"] == "anthropic.claude-3-sonnet-20240229-v1:0"
@@ -237,11 +243,30 @@ def test_register_external_model_transcribe_force_replace_passes_query_param():
 
     _, _, kwargs = client.calls[0]
     assert kwargs["params"] == {"force_replace_credentials": True}
-    blob = kwargs["json"]["default_config"]["system_config"]["external_endpoint"]
+    cfg = kwargs["json"]["default_config"]["config"]
+    assert cfg["engine_name"] == "external_transcribe"
+    assert kwargs["json"]["default_config"]["system_config"] == {}
+    blob = json.loads(cfg["external_endpoint"])
     assert blob["protocol"] == "aws_transcribe"
     assert blob["s3_bucket"] == "my-bucket"
     # Defaults are mirrored from the platform schema.
     assert blob["s3_prefix"] == "transcribe-jobs/"
+
+
+def test_register_external_model_unknown_protocol_raises():
+    from types import SimpleNamespace
+
+    service = ModelService(DummyClient({}))
+    # An endpoint whose blob carries a protocol with no engine mapping (only
+    # reachable via an untyped/extra-allowed endpoint) must fail fast, not
+    # silently register an undeployable model.
+    endpoint = SimpleNamespace(
+        model_dump=lambda exclude_none=True: {"protocol": "bogus", "region": "x"}
+    )
+    with pytest.raises(ValueError, match="Unsupported external endpoint protocol"):
+        service.register_external_model(
+            name="x", endpoint=endpoint, credential={"k": "v"}
+        )
 
 
 def test_register_external_model_accepts_raw_credential_forms():


### PR DESCRIPTION
## What this ships

`models.register_external_model` now registers AWS Bedrock / Transcribe endpoints the way the frontend wizard does: the canonical `engine_name` (mapped from the endpoint protocol) and the **JSON-stringified** `external_endpoint` blob go under `default_config.config`, with `system_config` empty.

Previously the blob lived in `system_config`, so the deploy path / UI Deploy button — which reads `config.engine_name` to route external models — couldn't find it. Deploying an SDK-registered external model with no explicit `engine_name` auto-selected a weights engine (`whisper_cpp`/`llamacpp`) and 500'd with *"Model weights file could not be determined."*

## Contract

| protocol | engine_name (canonical) |
|----------|-------------------------|
| `aws_bedrock` | `external_chat` |
| `aws_transcribe` | `external_transcribe` |

Unknown protocol → `ValueError` (fail fast). Credential handling unchanged: the inline credential is still encrypted server-side to a Catalog URN — the platform normalizer locates the endpoint blob in `config` or `system_config`, so no plaintext-leak path is introduced.

## Verification

Unit: full SDK suite green (2553 passed); `register_external_model` tests assert the new `config` shape (both protocols + unsupported-protocol error path). Live (UAT box): the exact patched-SDK registration payload registers with `config.engine_name=external_transcribe` + credential normalized to a URN (no plaintext), and an FE-faithful deploy (read `config.engine_name`, send it) returns a deployment id — no 500. Details in the PR-evidence block below.

Out of scope (deliberate): the backend deriving `engine_name` from the model's `external_endpoint` at deploy so no client needs to send it — a separate cleanup; FE↔SDK consistency is sufficient here.

<!-- pr-evidence-start -->
<details>
<summary>📋 <b>pr-evidence</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-06-17T18:43:57.017Z
manifest_hash: sha256:72d387a9001cc9a6a2489cd0e7d92cfbdae7437dd04c71c52e9f97d5e2070ef2
phase_a_complete: true
phase_b_complete: true
repos:
  - name: kamiwaza-sdk
    path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-ENG-7209
    branch: feature/ENG-7209
    head_sha: bedee72b03b3f38939fd499118ce8c7d1fb0527a
    head_sha_short: bedee72b0
    dirty_files: 0
    ahead: 1
    behind: 0
    upstream: origin/develop
    delivery:
      mode: not-applicable
      verified: true
      note: kamiwaza-sdk is a client library (consumed as a wheel / the seeder image), not source-mounted
        into a running pod. Verified by unit tests plus exercising the exact patched-SDK
        registration payload against the live UAT box API; no source-mount-into-cluster delivery and
        no `kw switch` were performed.
clusters: []
```

</details>

# PR Evidence — generated 2026-06-17T18:43:57.017Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| kamiwaza-sdk | feature/ENG-7209 | `bedee72b0` | +1 | not-applicable ✓ |

## Cross-references

- Linear: `ENG-7209`

## Testing summary (honest)

**Unit:** `uv run pytest` — full SDK unit/contract suite green: **2553 passed, 1 skipped** (unrelated BSD-sed skip). `register_external_model` tests updated to assert the new `config` shape; ruff + mypy clean on the changed file.

**Live (UAT box `test.kamiwaza.dev`, via the box's local ingress):** generated the *exact* `POST /models/` body the patched SDK emits (`register_external_model` for an AWS Transcribe endpoint) and exercised it end-to-end against the running platform:
- Registration → stored `default_config.config.engine_name = external_transcribe`; the inline credential normalized to a Catalog URN with **no plaintext** in the persisted blob (the platform's credential normalizer locates the endpoint blob in `config`, confirming no leak path).
- FE-faithful deploy (read `config.engine_name`, send it — exactly what the UI Deploy button does) → returned a deployment id, **no 500** (vs. the pre-fix `DeploymentException: Model weights file could not be determined`).
- All test models/deployments deleted afterward; the box's seeded `transcribe-uat`/`bedrock-uat` were left untouched.

**Not done:** no source-mount-into-cluster delivery and no `kw switch` (the SDK is a client library, not pod-mounted source). A raw deploy with no `engine_name` still 500s — that's the backend-derive gap deliberately left out of scope.


<!-- pr-evidence-end -->