### PR TITLE
feat(seeding): add `chat` to exercise an agent end to end (ENG-7204)

### DIFF
--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -40,6 +40,17 @@ from ..services.kaizen import (
 from .client import build_client_from_env, scoped_client_for_workroom
 
 
+def _non_negative_float(value: str) -> float:
+    """argparse type for a seconds value that must be zero or positive."""
+    try:
+        parsed = float(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"invalid float value: '{value}'")
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be zero or a positive number of seconds")
+    return parsed
+
+
 def _parse_env(pairs: Optional[list[str]]) -> Optional[Dict[str, str]]:
     """Parse repeated ``KEY=VALUE`` args into an env dict."""
     if not pairs:
@@ -526,7 +537,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--timeout",
-        type=float,
+        type=_non_negative_float,
         default=60.0,
         help="Max seconds to wait for the reply (0 = fire-and-forget, don't wait).",
     )

--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -32,7 +32,11 @@ from ..schemas.models.external_endpoint import (
     AWSBedrockChatEndpoint,
     AWSTranscribeEndpoint,
 )
-from ..services.kaizen import AmbiguousExtensionError, wait_for_base_url
+from ..services.kaizen import (
+    AmbiguousExtensionError,
+    ConversationError,
+    wait_for_base_url,
+)
 from .client import build_client_from_env, scoped_client_for_workroom
 
 
@@ -270,6 +274,44 @@ def cmd_create_conversation(args: argparse.Namespace, *, client) -> dict:
     return {"conversation_id": conversation.id}
 
 
+def cmd_chat(args: argparse.Namespace, *, client) -> Optional[dict]:
+    """Send a prompt to an agent and return its reply (exercises it end to end).
+
+    Opens a fresh conversation against ``--agent-id``, sends ``--message``, and
+    (with a positive ``--timeout``) waits for the agent's reply — proving the
+    agent can actually respond, not just that it was created. ``--raw`` prints
+    only the reply text. Exits non-zero on an agent error, an empty reply, or a
+    wait timeout (mirrors cmd_deploy_model / cmd_resolve_kaizen_url).
+    """
+    client = _client_for_workroom(client, args.workroom_id)
+    conversation = client.conversations.create(
+        base_url=args.kaizen_base_url,
+        agent_id=args.agent_id,
+        title=args.title,
+        workroom_id=args.workroom_id,
+    )
+    try:
+        reply = client.conversations.chat(
+            conversation.id,
+            args.message,
+            base_url=args.kaizen_base_url,
+            workroom_id=args.workroom_id,
+            timeout_seconds=args.timeout,
+            poll_interval_seconds=args.poll_interval,
+        )
+    except (TimeoutError, ConversationError) as exc:
+        raise SystemExit(str(exc))
+    # timeout=0 is fire-and-forget (no reply to assert); only fault an empty
+    # reply when a wait was requested.
+    if args.timeout and not reply:
+        raise SystemExit(f"Agent '{args.agent_id}' returned an empty reply.")
+    if args.raw:
+        if reply:
+            print(reply)
+        return None
+    return {"conversation_id": conversation.id, "reply": reply}
+
+
 def cmd_configure_m365(args: argparse.Namespace, *, client) -> dict:
     conn = client.connectors.create_m365(
         tenant_id=args.tenant_id,
@@ -463,6 +505,38 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--ephemeral", action="store_true")
     p.add_argument("--workroom-id", default=None)
     p.set_defaults(func=cmd_create_conversation)
+
+    p = sub.add_parser(
+        "chat",
+        help="Send a prompt to an agent and return its reply (exercises the agent end to end).",
+    )
+    p.add_argument(
+        "--kaizen-base-url",
+        required=True,
+        help="Kaizen instance API root (per-workroom).",
+    )
+    p.add_argument("--agent-id", required=True)
+    p.add_argument("--message", required=True, help="Prompt to send to the agent.")
+    p.add_argument("--workroom-id", default=None)
+    p.add_argument("--title", default=None, help="Conversation title (optional).")
+    p.add_argument(
+        "--raw",
+        action="store_true",
+        help='Print only the bare reply text (for REPLY="$(... --raw)").',
+    )
+    p.add_argument(
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="Max seconds to wait for the reply (0 = fire-and-forget, don't wait).",
+    )
+    p.add_argument(
+        "--poll-interval",
+        type=float,
+        default=3.0,
+        help="Seconds between event polls while waiting (default: 3).",
+    )
+    p.set_defaults(func=cmd_chat)
 
     p = sub.add_parser("import-skill", help="Import a skill package (.zip).")
     p.add_argument("--file", required=True)

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -34,6 +34,15 @@ class AmbiguousExtensionError(KamiwazaError):
     """
 
 
+class ConversationError(KamiwazaError):
+    """The agent surfaced an error event while processing a chat message.
+
+    A terminal failure for that turn (the agent reported it can't proceed), so
+    callers must NOT keep polling for a reply — distinct from the transient
+    "no reply yet" state that resolves on a later poll.
+    """
+
+
 def _workroom_headers(workroom_id: Optional[Union[str, object]]) -> Dict[str, str]:
     """Build the X-Workroom-Id header that scopes a Kaizen call to a workroom."""
     if workroom_id is None:
@@ -353,6 +362,71 @@ class AgentService(BaseService):
         return Agent.model_validate(response)
 
 
+def _agent_error_from_events(events: List[Dict[str, Any]]) -> Optional[str]:
+    """Return an agent error message from a list of event payloads, or None.
+
+    Kaizen serializes a failed turn as an ``AgentErrorEvent`` (``kind`` field)
+    carrying a user-facing ``error`` string — a terminal signal that the agent
+    can't answer, so :meth:`ConversationService.chat` stops waiting on it.
+    """
+    for event in events:
+        if event.get("kind") == "AgentErrorEvent":
+            return str(event.get("error") or "agent error")
+    return None
+
+
+def _has_finish_action(events: List[Dict[str, Any]]) -> bool:
+    """True if the agent emitted its terminal ``finish`` action this turn.
+
+    The run is done once a ``FinishAction`` lands, so its presence with no usable
+    reply text means the agent finished empty — a terminal state, not "not yet".
+    """
+    return any(
+        event.get("kind") == "ActionEvent"
+        and (event.get("action") or {}).get("kind") == "FinishAction"
+        for event in events
+    )
+
+
+def _reply_from_events(events: List[Dict[str, Any]]) -> Optional[str]:
+    """Return the latest non-empty agent reply text, or None.
+
+    The agent signals "done" two ways, and we accept either (latest wins):
+
+    * **The ``finish`` tool** — an ``ActionEvent`` whose ``action.kind`` is
+      ``FinishAction``, carrying the final answer in ``action.message``. This is
+      the canonical completion signal for the agent runtime, so it's the usual
+      source of the reply.
+    * **A plain assistant turn** — a ``MessageEvent`` whose ``llm_message.role``
+      is ``assistant``; its text is the concatenation of the message's ``text``
+      content blocks (image blocks ignored). Kept as a fallback for replies that
+      don't route through ``finish``.
+    """
+    reply: Optional[str] = None
+    for event in events:
+        kind = event.get("kind")
+        if kind == "ActionEvent":
+            action = event.get("action") or {}
+            if action.get("kind") == "FinishAction":
+                message = action.get("message")
+                if isinstance(message, str) and message.strip():
+                    reply = message.strip()
+            continue
+        if kind != "MessageEvent":
+            continue
+        message_obj = event.get("llm_message") or {}
+        if message_obj.get("role") != "assistant":
+            continue
+        text = "".join(
+            block.get("text", "")
+            for block in (message_obj.get("content") or [])
+            if isinstance(block, dict) and block.get("type") == "text"
+        ).strip()
+        if text:
+            reply = text
+    return reply
+
+
 class ConversationService(BaseService):
     """Create Kaizen conversations (auto-starts the agent sandbox)."""
 
@@ -463,3 +537,86 @@ class ConversationService(BaseService):
             params={"offset": offset, "limit": limit},
             headers=_workroom_headers(workroom_id),
         )
+
+    def chat(
+        self,
+        conversation_id: str,
+        message: str,
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+        timeout_seconds: float = 60.0,
+        poll_interval_seconds: float = 3.0,
+    ) -> Optional[str]:
+        """Send a message, run the agent, and return its reply.
+
+        Wraps :meth:`send_message` + :meth:`run`, then polls :meth:`get_events`
+        until the agent's reply lands. Used to exercise an agent end to end
+        (e.g. proving a freshly seeded agent actually responds).
+
+        ``timeout_seconds`` is the wait budget: a positive value (the default)
+        waits up to that long and returns the reply text; pass ``0`` for
+        fire-and-forget — the message is sent and the run triggered, but the
+        method returns ``None`` immediately without waiting. Only this turn's
+        events are considered (the pre-run event count is the read offset), so
+        prior history in a reused conversation is ignored.
+
+        Args:
+            conversation_id: The conversation to post to.
+            message: The prompt to send.
+            base_url: The Kaizen instance API root.
+            workroom_id: Workroom scope (X-Workroom-Id header).
+            timeout_seconds: Max seconds to wait for the reply; ``0`` = don't wait.
+            poll_interval_seconds: Delay between event polls.
+
+        Returns:
+            The assistant's reply text; ``None`` when ``timeout_seconds`` is 0
+            (fire-and-forget) or the agent finished without any reply text.
+
+        Raises:
+            ConversationError: The agent emitted an error event for this turn.
+            TimeoutError: No reply arrived within ``timeout_seconds``.
+        """
+        self.send_message(
+            conversation_id, message, base_url=base_url, workroom_id=workroom_id
+        )
+        if not timeout_seconds:
+            self.run(conversation_id, base_url=base_url, workroom_id=workroom_id)
+            return None
+
+        # Read this turn's output only: events appended from here on. Captured
+        # after send (the just-queued user message is excluded) and before run.
+        baseline = self.get_events(
+            conversation_id, base_url=base_url, workroom_id=workroom_id, limit=1
+        ).get("total", 0)
+        self.run(conversation_id, base_url=base_url, workroom_id=workroom_id)
+
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            new_events = self.get_events(
+                conversation_id,
+                base_url=base_url,
+                workroom_id=workroom_id,
+                offset=baseline,
+            ).get("events", [])
+            error = _agent_error_from_events(new_events)
+            if error is not None:
+                raise ConversationError(
+                    f"Agent errored on conversation {conversation_id}: {error}"
+                )
+            reply = _reply_from_events(new_events)
+            if reply:
+                return reply
+            if _has_finish_action(new_events):
+                # Agent finished with no usable text — terminal, so don't burn
+                # the rest of the timeout waiting for a reply that won't come.
+                return None
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"No agent reply on conversation {conversation_id} after "
+                    f"{timeout_seconds:g}s."
+                )
+            # max(0, …) so a non-positive poll interval degrades to a busy-wait
+            # bounded by the timeout rather than raising from time.sleep().
+            time.sleep(max(0.0, min(poll_interval_seconds, remaining)))

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -362,16 +362,23 @@ class AgentService(BaseService):
         return Agent.model_validate(response)
 
 
+# Event ``kind`` values that mark a failed turn. The Kaizen backend serializes
+# the agent error as ``AgentErrorEvent``; ``ConversationErrorEvent`` is accepted
+# defensively so a backend that names it differently still surfaces a clear
+# error instead of degrading to a generic timeout.
+_ERROR_EVENT_KINDS = frozenset({"AgentErrorEvent", "ConversationErrorEvent"})
+
+
 def _agent_error_from_events(events: List[Dict[str, Any]]) -> Optional[str]:
     """Return an agent error message from a list of event payloads, or None.
 
-    Kaizen serializes a failed turn as an ``AgentErrorEvent`` (``kind`` field)
-    carrying a user-facing ``error`` string — a terminal signal that the agent
-    can't answer, so :meth:`ConversationService.chat` stops waiting on it.
+    A failed turn is a terminal signal that the agent can't answer, so
+    :meth:`ConversationService.chat` stops waiting on it. The message is read
+    from the event's ``error`` or ``message`` field.
     """
     for event in events:
-        if event.get("kind") == "AgentErrorEvent":
-            return str(event.get("error") or "agent error")
+        if event.get("kind") in _ERROR_EVENT_KINDS:
+            return str(event.get("error") or event.get("message") or "agent error")
     return None
 
 
@@ -528,7 +535,8 @@ class ConversationService(BaseService):
 
         Returns the raw events envelope ``{events, total, offset, limit}``.
         Event ``kind`` values include ``MessageEvent`` (the ``llm_message`` with
-        role/content), ``ConversationErrorEvent``, tool events, etc.
+        role/content), ``ActionEvent`` (incl. the terminal ``FinishAction``),
+        ``AgentErrorEvent``, tool events, etc.
         """
         return self.client._request(
             "GET",
@@ -555,11 +563,15 @@ class ConversationService(BaseService):
         (e.g. proving a freshly seeded agent actually responds).
 
         ``timeout_seconds`` is the wait budget: a positive value (the default)
-        waits up to that long and returns the reply text; pass ``0`` for
-        fire-and-forget — the message is sent and the run triggered, but the
-        method returns ``None`` immediately without waiting. Only this turn's
-        events are considered (the pre-run event count is the read offset), so
-        prior history in a reused conversation is ignored.
+        waits up to that long and returns the reply text; ``0`` is fire-and-forget
+        — the message is sent and the run triggered, but the method returns
+        ``None`` immediately without waiting. The reply is taken only once the
+        agent's run is terminal (a ``finish`` action or an error event), so an
+        interim assistant narration before the final answer is never mistaken
+        for the reply. Only this turn's events are considered (the pre-run event
+        count is the read offset), and only the first page of them
+        (``get_events`` default ``limit``); a verification turn is a handful of
+        events, so this is not paginated.
 
         Args:
             conversation_id: The conversation to post to.
@@ -570,13 +582,18 @@ class ConversationService(BaseService):
             poll_interval_seconds: Delay between event polls.
 
         Returns:
-            The assistant's reply text; ``None`` when ``timeout_seconds`` is 0
+            The agent's reply text; ``None`` when ``timeout_seconds`` is 0
             (fire-and-forget) or the agent finished without any reply text.
 
         Raises:
+            ValueError: ``timeout_seconds`` is negative.
             ConversationError: The agent emitted an error event for this turn.
-            TimeoutError: No reply arrived within ``timeout_seconds``.
+            TimeoutError: The agent did not finish within ``timeout_seconds``.
         """
+        if timeout_seconds < 0:
+            raise ValueError(
+                "timeout_seconds must be zero or a positive number of seconds."
+            )
         self.send_message(
             conversation_id, message, base_url=base_url, workroom_id=workroom_id
         )
@@ -604,13 +621,11 @@ class ConversationService(BaseService):
                 raise ConversationError(
                     f"Agent errored on conversation {conversation_id}: {error}"
                 )
-            reply = _reply_from_events(new_events)
-            if reply:
-                return reply
             if _has_finish_action(new_events):
-                # Agent finished with no usable text — terminal, so don't burn
-                # the rest of the timeout waiting for a reply that won't come.
-                return None
+                # The run is terminal — take the reply now (the finish message,
+                # or the last assistant text if finish carried none, or None).
+                # Don't accept interim assistant narration before this point.
+                return _reply_from_events(new_events)
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise TimeoutError(

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -632,6 +632,11 @@ def test_agent_error_from_events_returns_message_or_none():
     assert _agent_error_from_events([_error_event("boom")]) == "boom"
     assert _agent_error_from_events([{"kind": "AgentErrorEvent"}]) == "agent error"
     assert _agent_error_from_events([_message_event("ok")]) is None
+    # Defensively accept the alternate error-event kind + its `message` field.
+    assert (
+        _agent_error_from_events([{"kind": "ConversationErrorEvent", "message": "nope"}])
+        == "nope"
+    )
 
 
 def test_chat_sends_message_runs_and_returns_reply(monkeypatch):
@@ -659,8 +664,8 @@ def test_chat_polls_until_reply_appears(monkeypatch):
 
     slept: list = []
     monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
-    # First poll: nothing yet. Second poll: the reply has landed.
-    client = ChatClient(polls=[[], [_message_event("done")]])
+    # First poll: nothing yet. Second poll: the agent finished with the reply.
+    client = ChatClient(polls=[[], [_finish_event("done")]])
     service = ConversationService(client)
 
     reply = service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0)
@@ -702,6 +707,24 @@ def test_chat_non_positive_poll_interval_does_not_raise(monkeypatch):
 
     assert service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=-5) == "done"
     assert slept == [0.0]
+
+
+def test_chat_ignores_interim_assistant_text_before_finish(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # First poll: only interim assistant narration, no finish yet — must NOT be
+    # returned. Second poll: the terminal finish carries the real answer.
+    client = ChatClient(polls=[[_message_event("Let me think…")], [_finish_event("real answer")]])
+    service = ConversationService(client)
+
+    assert service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0) == "real answer"
+
+
+def test_chat_negative_timeout_raises():
+    service = ConversationService(ChatClient(polls=[[_finish_event("x")]]))
+    with pytest.raises(ValueError, match="zero or a positive"):
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=-1)
 
 
 def test_chat_raises_conversation_error_on_agent_error(monkeypatch):

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -9,8 +9,12 @@ from kamiwaza_sdk.schemas.kaizen import LLMConfig
 from kamiwaza_sdk.services.kaizen import (
     AgentService,
     AmbiguousExtensionError,
+    ConversationError,
     ConversationService,
+    _agent_error_from_events,
+    _has_finish_action,
     _is_serving,
+    _reply_from_events,
     resolve_base_url,
     wait_for_base_url,
 )
@@ -529,3 +533,210 @@ def test_conversation_get_events_passes_pagination():
     assert (method, path) == ("GET", "api/conversations/conv-1/events")
     assert kwargs["params"] == {"offset": 5, "limit": 50}
     assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}
+
+
+# --- chat() + event helpers ------------------------------------------------
+
+
+def _message_event(text, role="assistant"):
+    return {
+        "kind": "MessageEvent",
+        "llm_message": {"role": role, "content": [{"type": "text", "text": text}]},
+    }
+
+
+def _error_event(message):
+    return {"kind": "AgentErrorEvent", "error": message}
+
+
+def _finish_event(text):
+    # The agent's canonical "done" signal: the `finish` tool, with the reply in
+    # action.message (the shape a live Kaizen run emits).
+    return {
+        "kind": "ActionEvent",
+        "tool_name": "finish",
+        "action": {"kind": "FinishAction", "message": text},
+    }
+
+
+class ChatClient:
+    """Scripts send/run/poll for ConversationService.chat tests.
+
+    The limit=1 baseline read returns ``baseline_total``; subsequent polling
+    reads pop from ``polls`` (the last entry repeats once exhausted, so a
+    never-answers run keeps returning the same empty list).
+    """
+
+    def __init__(self, polls, baseline_total=0):
+        self.polls = list(polls)
+        self.baseline_total = baseline_total
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def _request(self, method, path, **kwargs):
+        self.calls.append((method, path, kwargs))
+        if path.endswith("/events"):
+            if kwargs.get("params", {}).get("limit") == 1:
+                return {"total": self.baseline_total, "events": []}
+            events = self.polls.pop(0) if len(self.polls) > 1 else self.polls[0]
+            return {"events": events}
+        return None  # messages / run -> 204
+
+
+def test_reply_from_events_reads_finish_action_message():
+    # The common happy path: the reply arrives via the `finish` tool with no
+    # assistant MessageEvent, so a MessageEvent-only reader would miss it.
+    events = [
+        {"kind": "SystemPromptEvent"},
+        _message_event("hi", role="user"),
+        _finish_event("Hello! I'm Kaizen."),
+    ]
+    assert _reply_from_events(events) == "Hello! I'm Kaizen."
+
+
+def test_reply_from_events_returns_latest_assistant_text():
+    events = [
+        _message_event("hi", role="user"),
+        {"kind": "ActionEvent", "tool_name": "bash"},
+        _message_event("partial"),
+        _message_event("final answer"),
+    ]
+    assert _reply_from_events(events) == "final answer"
+
+
+def test_reply_from_events_joins_text_blocks_and_ignores_images():
+    events = [
+        {
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "a"},
+                    {"type": "image_url", "image_url": {"url": "x"}},
+                    {"type": "text", "text": "b"},
+                ],
+            },
+        }
+    ]
+    assert _reply_from_events(events) == "ab"
+
+
+def test_reply_from_events_none_for_empty_user_only_or_blank():
+    assert _reply_from_events([]) is None
+    assert _reply_from_events([_message_event("hi", role="user")]) is None
+    assert _reply_from_events([_message_event("   ")]) is None
+    # A non-finish action (e.g. a tool call) is not a reply on its own.
+    assert _reply_from_events([{"kind": "ActionEvent", "tool_name": "bash"}]) is None
+
+
+def test_agent_error_from_events_returns_message_or_none():
+    assert _agent_error_from_events([_error_event("boom")]) == "boom"
+    assert _agent_error_from_events([{"kind": "AgentErrorEvent"}]) == "agent error"
+    assert _agent_error_from_events([_message_event("ok")]) is None
+
+
+def test_chat_sends_message_runs_and_returns_reply(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # Reply arrives via the finish tool, as it does on a live cluster.
+    client = ChatClient(polls=[[_finish_event("Hi, I'm Kaizen.")]])
+    service = ConversationService(client)
+
+    reply = service.chat("conv-1", "hello", base_url=KAIZEN_URL, workroom_id="wr-1")
+
+    assert reply == "Hi, I'm Kaizen."
+    paths = [(m, p) for m, p, _ in client.calls]
+    send_i = paths.index(("POST", "api/conversations/conv-1/messages"))
+    run_i = paths.index(("POST", "api/conversations/conv-1/run"))
+    # Order: send the message, then run, then read events for the reply.
+    assert send_i < run_i < len(paths) - 1
+    # Workroom scope rides the header on every leg.
+    assert client.calls[send_i][2]["headers"] == {"X-Workroom-Id": "wr-1"}
+
+
+def test_chat_polls_until_reply_appears(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    slept: list = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    # First poll: nothing yet. Second poll: the reply has landed.
+    client = ChatClient(polls=[[], [_message_event("done")]])
+    service = ConversationService(client)
+
+    reply = service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0)
+
+    assert reply == "done"
+    assert slept == [0]  # slept once between the two polls
+
+
+def test_has_finish_action_detects_terminal_finish():
+    assert _has_finish_action([_finish_event("done")]) is True
+    assert _has_finish_action([_finish_event("")]) is True  # empty but terminal
+    assert _has_finish_action([{"kind": "ActionEvent", "tool_name": "bash"}]) is False
+    assert _has_finish_action([_message_event("hi")]) is False
+
+
+def test_chat_returns_none_when_agent_finishes_empty(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    slept: list = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    # Agent finishes with an empty message: terminal, so return immediately
+    # rather than burning the timeout. cmd_chat faults the empty reply.
+    client = ChatClient(polls=[[_finish_event("")]])
+    service = ConversationService(client)
+
+    assert service.chat("conv-1", "hi", base_url=KAIZEN_URL) is None
+    assert slept == []  # returned on the first poll, never waited
+
+
+def test_chat_non_positive_poll_interval_does_not_raise(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    slept: list = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    # First poll empty, second has the reply; a negative interval must clamp to
+    # 0 at the sleep rather than raising ValueError out of the wait loop.
+    client = ChatClient(polls=[[], [_finish_event("done")]])
+    service = ConversationService(client)
+
+    assert service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=-5) == "done"
+    assert slept == [0.0]
+
+
+def test_chat_raises_conversation_error_on_agent_error(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    client = ChatClient(polls=[[_error_event("model unreachable")]])
+    service = ConversationService(client)
+
+    with pytest.raises(ConversationError, match="model unreachable"):
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL)
+
+
+def test_chat_fire_and_forget_returns_none_without_reading_events():
+    client = ChatClient(polls=[[_message_event("ignored")]])
+    service = ConversationService(client)
+
+    assert service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=0) is None
+
+    paths = [(m, p) for m, p, _ in client.calls]
+    assert ("POST", "api/conversations/conv-1/messages") in paths
+    assert ("POST", "api/conversations/conv-1/run") in paths
+    # No events are read at all when not waiting.
+    assert not any(p.endswith("/events") for _, p, _ in client.calls)
+
+
+def test_chat_times_out_when_no_reply(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    # deadline (0.0 -> 1.0), first remaining (0.0), second remaining (5.0 -> past).
+    times = iter([0.0, 0.0, 5.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    client = ChatClient(polls=[[]])  # never any reply
+    service = ConversationService(client)
+
+    with pytest.raises(TimeoutError, match="No agent reply"):
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=1)

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -608,6 +608,16 @@ def test_chat_agent_error_exits_nonzero(monkeypatch):
         )
 
 
+def test_chat_negative_timeout_rejected_by_parser():
+    # argparse rejects a negative --timeout before any client call.
+    with pytest.raises(SystemExit):
+        _run(
+            ["chat", "--kaizen-base-url", "u", "--agent-id", "a", "--message", "m",
+             "--timeout", "-5"],
+            FakeClient(),
+        )
+
+
 def test_chat_timeout_exits_nonzero(monkeypatch):
     client = FakeClient()
     client.conversations.chat = _raiser(TimeoutError("no reply in time"))

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -64,7 +64,8 @@ class FakeClient:
             create=RecordingService(SimpleNamespace(id="agent-1"))
         )
         self.conversations = SimpleNamespace(
-            create=RecordingService(SimpleNamespace(id="conv-1"))
+            create=RecordingService(SimpleNamespace(id="conv-1")),
+            chat=RecordingService("Hello! I am claude."),
         )
         self.skills = SimpleNamespace(
             import_skill_package=RecordingService(SimpleNamespace(id="skill-1"))
@@ -513,3 +514,107 @@ def test_deploy_model_duplicate_name_exits():
         _run(["deploy-model", "--name", "dup"], client)
 
     assert client.serving.deploy_model.calls == []
+
+
+def test_chat_creates_conversation_and_returns_reply(capsys, monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    _run(
+        [
+            "chat",
+            "--kaizen-base-url",
+            "https://kamiwaza.test/kaizen",
+            "--agent-id",
+            "agent-1",
+            "--message",
+            "hello there",
+            "--workroom-id",
+            "wr-1",
+        ],
+        client,
+    )
+
+    create = client.conversations.create.calls[0]["kwargs"]
+    assert create["agent_id"] == "agent-1"
+    assert create["base_url"] == "https://kamiwaza.test/kaizen"
+    chat = client.conversations.chat.calls[0]
+    assert chat["args"] == ("conv-1", "hello there")
+    assert chat["kwargs"]["workroom_id"] == "wr-1"
+    assert json.loads(capsys.readouterr().out) == {
+        "conversation_id": "conv-1",
+        "reply": "Hello! I am claude.",
+    }
+
+
+def test_chat_raw_prints_bare_reply(capsys, monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    _run(
+        ["chat", "--kaizen-base-url", "u", "--agent-id", "a", "--message", "m", "--raw"],
+        client,
+    )
+
+    assert capsys.readouterr().out.strip() == "Hello! I am claude."
+
+
+def test_chat_empty_reply_exits_nonzero(monkeypatch):
+    client = FakeClient()
+    client.conversations.chat = RecordingService("")  # waited, but got nothing back
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    with pytest.raises(SystemExit):
+        _run(
+            ["chat", "--kaizen-base-url", "u", "--agent-id", "a", "--message", "m"],
+            client,
+        )
+
+
+def test_chat_fire_and_forget_allows_empty_reply(capsys, monkeypatch):
+    client = FakeClient()
+    client.conversations.chat = RecordingService(None)
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    _run(
+        [
+            "chat",
+            "--kaizen-base-url", "u",
+            "--agent-id", "a",
+            "--message", "m",
+            "--timeout", "0",
+        ],
+        client,
+    )
+
+    assert client.conversations.chat.calls[0]["kwargs"]["timeout_seconds"] == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "conversation_id": "conv-1",
+        "reply": None,
+    }
+
+
+def test_chat_agent_error_exits_nonzero(monkeypatch):
+    from kamiwaza_sdk.services.kaizen import ConversationError
+
+    client = FakeClient()
+    client.conversations.chat = _raiser(ConversationError("agent boom"))
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    with pytest.raises(SystemExit, match="agent boom"):
+        _run(
+            ["chat", "--kaizen-base-url", "u", "--agent-id", "a", "--message", "m"],
+            client,
+        )
+
+
+def test_chat_timeout_exits_nonzero(monkeypatch):
+    client = FakeClient()
+    client.conversations.chat = _raiser(TimeoutError("no reply in time"))
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    with pytest.raises(SystemExit, match="no reply in time"):
+        _run(
+            ["chat", "--kaizen-base-url", "u", "--agent-id", "a", "--message", "m"],
+            client,
+        )


### PR DESCRIPTION
## What this ships

`ConversationService.chat()` + a `kamiwaza-seed chat` CLI verb that sends a prompt to a Kaizen agent, runs it, and returns the reply — so the nightly UAT seed can prove a created agent actually responds (today it stops at `create-agent` and a dead agent passes silently). ENG-7204.

## Contract

- `chat(conversation_id, message, *, base_url, workroom_id=None, timeout_seconds=60, poll_interval_seconds=3) -> Optional[str]` — `send_message` + `run`, then polls `/events` for the reply. `timeout_seconds=0` = fire-and-forget. Reply read from the agent's `finish` tool (`FinishAction.message`), assistant `MessageEvent` as fallback; `AgentErrorEvent` → `ConversationError`; no reply in time → `TimeoutError`; agent finishes empty → `None`.
- CLI: `kamiwaza-seed chat --kaizen-base-url … --agent-id … --message … [--workroom-id …] [--raw] [--timeout 60]`. Prints the bare reply (`--raw`) or `{conversation_id, reply}`; non-zero exit on agent error / empty reply / timeout.

## Verification

Live-verified on k0s-lima against a real Bedrock-backed agent (reply returned, exit 0; `--raw` and JSON). The reply arrives via the agent's `finish` tool, not an assistant message — caught and fixed during live testing. 81 unit tests; ruff + mypy clean.

<!-- pr-evidence-start -->
<details>
<summary>📋 <b>pr-evidence</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-06-17T21:46:39.274Z
manifest_hash: sha256:46f7df266fba2c710f362e93e863892fd3aa9a418533106f4ae191bbc1263b11
phase_a_complete: true
phase_b_complete: true
repos:
  - name: kamiwaza-sdk
    path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-ENG-7204
    branch: feature/ENG-7204
    head_sha: d7d0219bbcc456b287f214ad55b59b79e4600206
    head_sha_short: d7d0219bb
    dirty_files: 0
    ahead: 1
    behind: 1
    upstream: origin/develop
    delivery:
      mode: not-applicable
      verified: true
      note: kamiwaza-sdk is a client library / CLI, not deployed into the cluster as code. Verified by
        running the worktree CLI against a live cluster.
clusters:
  - name: Default
    kubectl_context: Default
    identity:
      k8s_distribution: k0s
      k8s_version: v1.35.2+k0s
      container_runtime: containerd-cri
      host_vm_layer: macos-lima
      network_mode: kube-router
    health:
      pods_total: 67
      pods_by_phase:
        Running: 62
        Succeeded: 5
      non_running: []
      api_plane:
        url: https://kamiwaza.test/api/cluster/capabilities
        http_code: 401
        expected_code: 401
        match: true
```

</details>

# PR Evidence — generated 2026-06-17T21:46:39.274Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| kamiwaza-sdk | feature/ENG-7204 | `d7d0219bb` | +1, -1 | not-applicable ✓ |

## Cluster identity

| Cluster | k8s distro | Runtime | Host/VM | Network | k8s version |
|---------|-----------|---------|---------|---------|-------------|
| Default | k0s | containerd-cri | macos-lima | kube-router | v1.35.2+k0s |

## Cluster health

| Cluster | Total pods | By phase | Non-Running | API plane |
|---------|-----------|----------|-------------|-----------|
| Default | 67 | 62 Running, 5 Succeeded | 0 | 401 (✓) |

## Cross-references

- Linear: `ENG-7204`


## Testing summary

- **Live (k0s-lima)**: ran `kamiwaza-seed chat` from this worktree against the running cluster (admin token from the `kamiwaza-user-admin` secret) targeting a real Bedrock-backed Kaizen agent — agent replied, exit 0, in both `--raw` and JSON modes. The first run surfaced (and the fix addressed) that the reply arrives via the agent's `finish` tool, not an assistant message.
- **Unit**: 81 tests in `tests/unit/test_kaizen_service.py` + `tests/unit/test_seeding_cli.py` (reply extraction incl. finish/empty-finish, fallback, poll/timeout/clamp, CLI exit paths). Full SDK suite: 2569 passed.
- **Gates**: `ruff` clean; `mypy` clean on changed files.
- **Not done**: end-to-end run of the kajiya nightly profile (covered by the kajiya PR; requires the new CLI verb to ship in the seeder image first).

<!-- pr-evidence-end -->