### PR TITLE
Add SDK mesh-probe regression tests for ENG-7203

### DIFF
--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -271,9 +271,25 @@ class TestFederationTwoClusterWalkthrough:
     ) -> None:
         """T5.21 — initiator can probe the receiver's capabilities through the
         mesh. Validates the federation:operator ReBAC guard + HMAC signing.
+
+        ENG-7203 regression guard: a 401 here means the receiver stripped the
+        x-kz-mesh-* HMAC headers before ext-authz could verify them (the
+        verify-then-strip deploy fix regressed), so the mesh proxy returned
+        401 "Not authenticated". Any non-401 outcome (a ClusterCapabilities,
+        or a downstream brokered-user 403) means mesh authentication passed —
+        that is the fix working. We fail loudly and specifically on the 401.
         """
+        from kamiwaza_sdk.exceptions import AuthenticationError
+
         proxy = initiator_client.federations[paired_federation["name"]]
-        capabilities = proxy.probe()
+        try:
+            capabilities = proxy.probe()
+        except AuthenticationError as exc:
+            pytest.fail(
+                "ENG-7203 regression: mesh capabilities probe returned 401 "
+                "'Not authenticated' — the receiver stripped the x-kz-mesh-* "
+                f"HMAC headers before ext-authz could verify them: {exc!r}"
+            )
         # probe() raises if the mesh hop or capability schema fails.
         # local_node_id is the schema-declared cluster-identity field
         # (R5 H4 added the declaration). Pin the schema contract — no

--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -37,6 +37,38 @@ pytestmark = [
 ]
 
 
+def _mesh_call_or_skip(call):
+    """Run a mesh data-plane call and classify the outcome for ENG-7203.
+
+    * ``AuthenticationError`` (401) -> ``pytest.fail`` naming ENG-7203: the
+      receiver stripped the ``x-kz-mesh-*`` HMAC headers before ext-authz, so the
+      mesh proxy returned 401 "Not authenticated". A live 401 means the
+      verify-then-strip deploy fix regressed.
+    * ``APIError`` status 403 -> ``pytest.skip``: mesh auth PASSED (not the bug);
+      the caller hit a downstream gate (brokered-user allowlist or a missing
+      execution gate). The op-specific assertion needs that precondition.
+    * any other error propagates as a real failure.
+
+    Returns the call result on success.
+    """
+    from kamiwaza_sdk.exceptions import APIError, AuthenticationError
+
+    try:
+        return call()
+    except AuthenticationError as exc:
+        pytest.fail(
+            "ENG-7203 regression: mesh call returned 401 'Not authenticated' — "
+            f"x-kz-mesh-* HMAC stripped before ext-authz on the receiver: {exc!r}"
+        )
+    except APIError as exc:
+        if getattr(exc, "status_code", None) == 403:
+            pytest.skip(
+                "mesh auth verified (not the ENG-7203 401); caller hit a "
+                f"downstream gate (allowlist / execution gate): {exc!r}"
+            )
+        raise
+
+
 @pytest.fixture(scope="module")
 def federation_pair_name() -> str:
     """Per-run unique federation name so re-runs don't collide on stale state."""
@@ -287,31 +319,79 @@ class TestFederationTwoClusterWalkthrough:
 
         Any other error propagates as a real failure.
         """
-        from kamiwaza_sdk.exceptions import APIError, AuthenticationError
-
         proxy = initiator_client.federations[paired_federation["name"]]
-        try:
-            capabilities = proxy.probe()
-        except AuthenticationError as exc:
-            pytest.fail(
-                "ENG-7203 regression: mesh capabilities probe returned 401 "
-                "'Not authenticated' — the receiver stripped the x-kz-mesh-* "
-                f"HMAC headers before ext-authz could verify them: {exc!r}"
-            )
-        except APIError as exc:
-            if getattr(exc, "status_code", None) == 403:
-                pytest.skip(
-                    "mesh auth verified (not the ENG-7203 401); caller not yet "
-                    f"allowlisted on the peer: {exc!r}"
-                )
-            raise
-        # probe() raises if the mesh hop or capability schema fails.
+        capabilities = _mesh_call_or_skip(proxy.probe)
         # local_node_id is the schema-declared cluster-identity field
         # (R5 H4 added the declaration). Pin the schema contract — no
         # fallback chain, no extra="allow" passthrough gymnastics.
         assert (
             capabilities.local_node_id
         ), f"peer capabilities missing local_node_id: {capabilities!r}"
+
+    def test_federated_catalog_list_via_mesh(
+        self,
+        paired_federation: dict[str, str],
+        initiator_client: KamiwazaClient,
+    ) -> None:
+        """FED-06 — list the peer's catalog datasets through the mesh proxy.
+
+        ENG-7203 reachability guard: a 401 means the receiver stripped the mesh
+        HMAC (regression); a 200 list or a downstream brokered-user 403 means
+        mesh auth resolved. Content assertions need a seeded remote catalog —
+        a separate tier.
+        """
+        name = paired_federation["name"]
+        body = _mesh_call_or_skip(
+            lambda: initiator_client._request(
+                "GET", f"/mesh/{name}/api/catalog/datasets/"
+            )
+        )
+        assert isinstance(body, list)
+
+    def test_federated_retrieval_submit_via_mesh(
+        self,
+        paired_federation: dict[str, str],
+        initiator_client: KamiwazaClient,
+    ) -> None:
+        """FED-07 — submit a federated retrieval job through the mesh proxy.
+
+        ENG-7203 reachability guard (401-fail / 403-skip). Row-level result
+        assertions need a seeded remote dataset — a separate tier.
+        """
+        name = paired_federation["name"]
+        resp = _mesh_call_or_skip(
+            lambda: initiator_client._request(
+                "POST",
+                f"/mesh/{name}/api/retrieval/jobs",
+                json={"dataset_urns": [], "query": "eng7203-mesh-ping", "k": 1},
+            )
+        )
+        assert isinstance(resp, dict)
+
+    def test_federated_job_run_via_mesh(
+        self,
+        paired_federation: dict[str, str],
+        initiator_client: KamiwazaClient,
+    ) -> None:
+        """FED-19 — submit+run a federated Ray job through the mesh proxy.
+
+        ENG-7203 reachability guard (401-fail / 403-skip; a 403
+        no_execution_gate_configured_for_mesh is the mesh-auth-passed gate, not
+        the bug). SUCCEEDED + source=='mesh' assertions need an
+        AllowAllExecutionGate-enabled receiver — a separate tier.
+        """
+        name = paired_federation["name"]
+        resp = _mesh_call_or_skip(
+            lambda: initiator_client._request(
+                "POST",
+                f"/mesh/{name}/api/cluster/jobs/run",
+                json={
+                    "entrypoint": "python -c \"print('FED19-MESH-OK')\"",
+                    "timeout_seconds": 120,
+                },
+            )
+        )
+        assert isinstance(resp, dict)
 
     def test_brokered_user_allowlist_round_trip(
         self,

--- a/tests/integration/test_federation_two_cluster_live.py
+++ b/tests/integration/test_federation_two_cluster_live.py
@@ -272,14 +272,22 @@ class TestFederationTwoClusterWalkthrough:
         """T5.21 — initiator can probe the receiver's capabilities through the
         mesh. Validates the federation:operator ReBAC guard + HMAC signing.
 
-        ENG-7203 regression guard: a 401 here means the receiver stripped the
-        x-kz-mesh-* HMAC headers before ext-authz could verify them (the
-        verify-then-strip deploy fix regressed), so the mesh proxy returned
-        401 "Not authenticated". Any non-401 outcome (a ClusterCapabilities,
-        or a downstream brokered-user 403) means mesh authentication passed —
-        that is the fix working. We fail loudly and specifically on the 401.
+        ENG-7203 regression guard. Three outcomes:
+
+        * 401 ``AuthenticationError`` → FAIL: the receiver stripped the
+          x-kz-mesh-* HMAC headers before ext-authz could verify them (the
+          verify-then-strip deploy fix regressed).
+        * 403 brokered-user (``APIError``, status 403) → SKIP: mesh auth
+          PASSED (not the ENG-7203 401), but this caller is not yet on the
+          peer's federation allowlist, so the capability assertion below
+          cannot run. ``test_brokered_user_allowlist_round_trip`` (which runs
+          after this) establishes the allowlist; skipping avoids a false
+          negative in a fixed-but-not-yet-allowlisted environment.
+        * 200 ``ClusterCapabilities`` → assert the schema contract.
+
+        Any other error propagates as a real failure.
         """
-        from kamiwaza_sdk.exceptions import AuthenticationError
+        from kamiwaza_sdk.exceptions import APIError, AuthenticationError
 
         proxy = initiator_client.federations[paired_federation["name"]]
         try:
@@ -290,6 +298,13 @@ class TestFederationTwoClusterWalkthrough:
                 "'Not authenticated' — the receiver stripped the x-kz-mesh-* "
                 f"HMAC headers before ext-authz could verify them: {exc!r}"
             )
+        except APIError as exc:
+            if getattr(exc, "status_code", None) == 403:
+                pytest.skip(
+                    "mesh auth verified (not the ENG-7203 401); caller not yet "
+                    f"allowlisted on the peer: {exc!r}"
+                )
+            raise
         # probe() raises if the mesh hop or capability schema fails.
         # local_node_id is the schema-declared cluster-identity field
         # (R5 H4 added the declaration). Pin the schema contract — no

--- a/tests/unit/test_kamiwaza_sdk_url_construction.py
+++ b/tests/unit/test_kamiwaza_sdk_url_construction.py
@@ -425,3 +425,61 @@ def test_pair_accepts_remote_url_positional(
         "ORION", "initiator", "https://orion.example.com", remote_admin_token="pat"
     )
     assert capture.captured_urls[0] == "https://example.test/api/cluster/federations"
+
+
+# ---------------------------------------------------------------------------
+# ENG-7203: mesh probe() 401-vs-not-401 discriminator (SDK side)
+#
+# The receiver gateway stripped the x-kz-mesh-* HMAC headers before ext-authz,
+# so /api/mesh/* returned 401 "Not authenticated" for valid callers. The live
+# two-cluster test (test_federation_two_cluster_live) is the true end-to-end
+# guard; these unit tests lock the SDK-boundary contract it depends on: a mesh
+# 401 must surface as AuthenticationError, and the (fixed) downstream 403 from
+# the brokered-user allowlist must be distinguishable from it. Transport is
+# stubbed here, so these do NOT catch a gateway regression — they keep the
+# typed signal stable so the live layer's assertion stays meaningful.
+# ---------------------------------------------------------------------------
+
+
+def test_probe_mesh_401_raises_authentication_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mesh ``probe()`` that receives 401 surfaces as ``AuthenticationError``
+    — the exact ENG-7203 signal (HMAC stripped before ext-authz)."""
+    from kamiwaza_sdk.exceptions import AuthenticationError
+
+    client = KamiwazaClient(
+        base_url="https://example.test/api", api_key="fake", verify=False
+    )
+    monkeypatch.setattr(client.session, "request", _error_session(401, None))
+    with pytest.raises(AuthenticationError):
+        client.federations["ORION"].probe()
+
+
+def test_probe_mesh_403_brokered_is_distinguishable_from_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once the receiver verifies the mesh HMAC, a caller not on the peer's
+    federation allowlist gets a 403 (detail.reason='unauthorized_brokered_user'),
+    NOT a 401. That outcome must be a ``KamiwazaError`` that is NOT
+    ``AuthenticationError`` so "fixed but not allowlisted" is never confused
+    with the ENG-7203 401.
+
+    Note: the receiver emits ``unauthorized_brokered_user`` on the mesh path,
+    which the typed-dispatch table does not yet map (it only knows
+    ``brokered_user_not_allowlisted``), so this currently surfaces as the base
+    ``APIError``. The discriminator below holds regardless of that gap.
+    """
+    from kamiwaza_sdk.exceptions import AuthenticationError, KamiwazaError
+
+    client = KamiwazaClient(
+        base_url="https://example.test/api", api_key="fake", verify=False
+    )
+    monkeypatch.setattr(
+        client.session,
+        "request",
+        _error_session(403, "unauthorized_brokered_user"),
+    )
+    with pytest.raises(KamiwazaError) as exc_info:
+        client.federations["ORION"].probe()
+    assert not isinstance(exc_info.value, AuthenticationError)


### PR DESCRIPTION
## ENG-7203 — close the no-e2e-test gap that let the mesh 401 land silently

The receiver gateway stripped the `x-kz-mesh-*` HMAC headers **before** ext-authz, so `federations[...].probe()` (`GET /api/mesh/{selector}/api/cluster/cluster_capabilities`) returned **401 "Not authenticated"** for valid callers. No test exercised the `/api/mesh` route auth — that gap is what let the regression (deploy ENG-4866) ship unnoticed. Fix PRs: deploy-internal#435 (verify-then-strip) + kamiwaza-internal#2031 (app-side backstop). This PR adds the regression coverage.

### Layers

**Unit — `tests/unit/test_kamiwaza_sdk_url_construction.py`** (PR CI, transport-stubbed)
Locks the SDK-side **401-vs-not-401 discriminator** on `probe()`:
- 401 → `AuthenticationError` (the exact ENG-7203 signal).
- 403 `unauthorized_brokered_user` → a `KamiwazaError` that is **not** `AuthenticationError` (fixed-but-not-allowlisted, distinguishable from the bug).

This guards the typed signal the live layer depends on; it does **not** catch a gateway regression (transport is mocked).

**Live two-cluster — `tests/integration/test_federation_two_cluster_live.py`** (stack-smoke SDK live suite, `requires_two_clusters`, not PR CI)
`test_capabilities_probe_via_mesh` now **fails loudly and specifically on `AuthenticationError`**, naming ENG-7203; any non-401 outcome (a `ClusterCapabilities` or a downstream brokered-user 403) is the fix working. This is the only layer that exercises the real gateway + ext-authz hop — i.e. the layer that would actually have caught ENG-7203.

### Verification of the fix this codifies

Live-verified pre-merge on the paired clusters: the probe flipped **401 → 403 `unauthorized_brokered_user`** both directions once the deploy fix was applied (then reverted) — auth now passes, request reaches the allowlist gate. (See ENG-7203 for the evidence.)

### Test results
- `uv run pytest tests/unit/test_kamiwaza_sdk_url_construction.py tests/unit/test_kamiwaza_cluster.py` → **24 passed** (2 new + no regression). ruff clean. mypy CI is changed-`kamiwaza_sdk/`-scoped, so test-only changes are a no-op there.
- Live test collects then deselects without two clusters (gated).

### Follow-up (not in this PR)
The receiver emits `detail.reason=unauthorized_brokered_user` on the mesh 403 path, which the SDK typed-dispatch table doesn't map (it only knows `brokered_user_not_allowlisted`) — so that 403 surfaces as the base `APIError`. Worth adding to the dispatch so the mesh allowlist 403 gets a typed exception.