### PR TITLE
[ENG-7184] Pass Postgres credential in SDK live retrieval test

### DIFF
--- a/tests/integration/test_catalog_multi_source.py
+++ b/tests/integration/test_catalog_multi_source.py
@@ -465,6 +465,7 @@ def test_catalog_postgres_ingestion_metadata(live_kamiwaza_client, catalog_stack
                 "dataset_urn": orders,
                 "transport": "inline",
                 "format_hint": "parquet",
+                "credential_override": json.dumps({"password": pg["password"]}),
             },
         )
         assert job["transport"] == "inline"


### PR DESCRIPTION
Linear: ENG-7184

## Summary

- Pass the Postgres fixture password through retrieval `credential_override` in the live catalog test.

## Root Cause

Postgres ingestion receives a password, but retrieval materialization does not read raw passwords from catalog dataset properties. When the ingestion-created secret reference is unavailable or not resolved in the live topology, retrieval reaches `host.docker.internal:15432` but fails with `fe_sendauth: no password supplied`.

## Validation

- `KAMIWAZA_ROOT=/home/ec2-user/kamiwaza-stack timeout 20m uv run pytest tests/integration/test_catalog_multi_source.py::test_catalog_postgres_ingestion_metadata -m live -vv --tb=long -ra`
- Focused SDK live final run with deploy CoreDNS fix: `8 passed, 1 skipped, 2 xfailed in 108.97s`.

## Notes

- Initial run in a fresh worktree skipped because generated catalog fixture data was root-owned locally; after correcting local fixture ownership, the targeted test passed.
