### PR TITLE
ENG-7300: Accept plain assistant Kaizen chat replies

### DIFF
--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -302,6 +302,13 @@ def cmd_chat(args: argparse.Namespace, *, client) -> Optional[dict]:
         workroom_id=args.workroom_id,
     )
     try:
+        client.conversations.wait_until_ready(
+            conversation.id,
+            base_url=args.kaizen_base_url,
+            workroom_id=args.workroom_id,
+            timeout_seconds=args.sandbox_timeout,
+            poll_interval_seconds=args.poll_interval,
+        )
         reply = client.conversations.chat(
             conversation.id,
             args.message,
@@ -540,6 +547,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=_non_negative_float,
         default=60.0,
         help="Max seconds to wait for the reply (0 = fire-and-forget, don't wait).",
+    )
+    p.add_argument(
+        "--sandbox-timeout",
+        type=_non_negative_float,
+        default=120.0,
+        help="Max seconds to wait for the agent sandbox before sending the message.",
     )
     p.add_argument(
         "--poll-interval",

--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -302,13 +302,14 @@ def cmd_chat(args: argparse.Namespace, *, client) -> Optional[dict]:
         workroom_id=args.workroom_id,
     )
     try:
-        client.conversations.wait_until_ready(
-            conversation.id,
-            base_url=args.kaizen_base_url,
-            workroom_id=args.workroom_id,
-            timeout_seconds=args.sandbox_timeout,
-            poll_interval_seconds=args.poll_interval,
-        )
+        if args.timeout:
+            client.conversations.wait_until_ready(
+                conversation.id,
+                base_url=args.kaizen_base_url,
+                workroom_id=args.workroom_id,
+                timeout_seconds=args.sandbox_timeout,
+                poll_interval_seconds=args.poll_interval,
+            )
         reply = client.conversations.chat(
             conversation.id,
             args.message,

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -448,6 +448,8 @@ def _reply_from_events(events: List[Dict[str, Any]]) -> Optional[str]:
         message_obj = event.get("llm_message") or {}
         if message_obj.get("role") != "assistant":
             continue
+        if message_obj.get("tool_calls") or event.get("tool_calls"):
+            continue
         text = _assistant_text(message_obj)
         if text:
             reply = text
@@ -646,12 +648,11 @@ class ConversationService(BaseService):
         — the message is sent and the run triggered, but the method returns
         ``None`` immediately without waiting. The reply is taken only once the
         agent's run is terminal (a ``finish`` action, an error event, or a
-        completed conversation status with a reply present), so an interim
-        assistant narration before the final answer is never mistaken for the
-        reply. Only this turn's events are considered (the pre-run event count
-        is the read offset), and only the first page of them (``get_events``
-        default ``limit``); a verification turn is a handful of events, so this
-        is not paginated.
+        completed conversation status), so an interim assistant narration before
+        the final answer is never mistaken for the reply. Only this turn's
+        events are considered (the pre-run event count is the read offset), and
+        only the first page of them (``get_events`` default ``limit``); a
+        verification turn is a handful of events, so this is not paginated.
 
         Args:
             conversation_id: The conversation to post to.
@@ -717,7 +718,7 @@ class ConversationService(BaseService):
                 # Don't accept interim assistant narration before this point.
                 return _reply_from_events(new_events)
             reply = _reply_from_events(new_events)
-            if execution_status in _DONE_EXECUTION_STATUSES and reply:
+            if execution_status in _DONE_EXECUTION_STATUSES:
                 return reply
             remaining = deadline - time.monotonic()
             if remaining <= 0:

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -367,6 +367,20 @@ class AgentService(BaseService):
 # defensively so a backend that names it differently still surfaces a clear
 # error instead of degrading to a generic timeout.
 _ERROR_EVENT_KINDS = frozenset({"AgentErrorEvent", "ConversationErrorEvent"})
+_DONE_EXECUTION_STATUSES = frozenset({"finished", "completed", "done"})
+_ERROR_EXECUTION_STATUSES = frozenset({"error", "failed"})
+_READY_CONTAINER_STATUS = "active"
+_TERMINAL_CONTAINER_STATUSES = frozenset(
+    {"deleted", "error", "failed", "stopped", "suspended"}
+)
+
+
+def _normalized_status(value: Optional[str]) -> Optional[str]:
+    """Normalize a Kaizen status value for case-insensitive comparisons."""
+    if value is None:
+        return None
+    status = str(value).strip().lower()
+    return status or None
 
 
 def _agent_error_from_events(events: List[Dict[str, Any]]) -> Optional[str]:
@@ -393,6 +407,16 @@ def _has_finish_action(events: List[Dict[str, Any]]) -> bool:
         and (event.get("action") or {}).get("kind") == "FinishAction"
         for event in events
     )
+
+
+def _assistant_text(message_obj: Dict[str, Any]) -> Optional[str]:
+    """Return the joined text blocks from an assistant message, or None."""
+    text = "".join(
+        block.get("text", "")
+        for block in (message_obj.get("content") or [])
+        if isinstance(block, dict) and block.get("type") == "text"
+    ).strip()
+    return text or None
 
 
 def _reply_from_events(events: List[Dict[str, Any]]) -> Optional[str]:
@@ -424,11 +448,7 @@ def _reply_from_events(events: List[Dict[str, Any]]) -> Optional[str]:
         message_obj = event.get("llm_message") or {}
         if message_obj.get("role") != "assistant":
             continue
-        text = "".join(
-            block.get("text", "")
-            for block in (message_obj.get("content") or [])
-            if isinstance(block, dict) and block.get("type") == "text"
-        ).strip()
+        text = _assistant_text(message_obj)
         if text:
             reply = text
     return reply
@@ -480,6 +500,65 @@ class ConversationService(BaseService):
             headers=_workroom_headers(workroom_id),
         )
         return Conversation.model_validate(response)
+
+    def get(
+        self,
+        conversation_id: str,
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+    ) -> Conversation:
+        """Fetch a conversation, including execution/container status."""
+        response = self.client._request(
+            "GET",
+            f"api/conversations/{conversation_id}",
+            base_url=base_url,
+            headers=_workroom_headers(workroom_id),
+        )
+        return Conversation.model_validate(response)
+
+    def wait_until_ready(
+        self,
+        conversation_id: str,
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+        timeout_seconds: float = 120.0,
+        poll_interval_seconds: float = 3.0,
+    ) -> Conversation:
+        """Wait until the conversation sandbox is active before messaging it.
+
+        Conversation creation can return while a cold sandbox is still coming
+        up. Poll the conversation's ``container_status`` and fail before sending
+        a message if the sandbox reaches a terminal non-serving state.
+        """
+        if timeout_seconds < 0:
+            raise ValueError(
+                "timeout_seconds must be zero or a positive number of seconds."
+            )
+
+        deadline = time.monotonic() + timeout_seconds
+        last_status: Optional[str] = None
+        while True:
+            conversation = self.get(
+                conversation_id, base_url=base_url, workroom_id=workroom_id
+            )
+            last_status = _normalized_status(conversation.container_status)
+            if last_status == _READY_CONTAINER_STATUS:
+                return conversation
+            if last_status in _TERMINAL_CONTAINER_STATUSES:
+                raise ConversationError(
+                    f"Conversation {conversation_id} sandbox is not ready "
+                    f"(container_status={last_status})."
+                )
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Conversation {conversation_id} sandbox not ready after "
+                    f"{timeout_seconds:g}s (container_status={last_status or 'unknown'})."
+                )
+            time.sleep(max(0.0, min(poll_interval_seconds, remaining)))
 
     def send_message(
         self,
@@ -566,12 +645,13 @@ class ConversationService(BaseService):
         waits up to that long and returns the reply text; ``0`` is fire-and-forget
         — the message is sent and the run triggered, but the method returns
         ``None`` immediately without waiting. The reply is taken only once the
-        agent's run is terminal (a ``finish`` action or an error event), so an
-        interim assistant narration before the final answer is never mistaken
-        for the reply. Only this turn's events are considered (the pre-run event
-        count is the read offset), and only the first page of them
-        (``get_events`` default ``limit``); a verification turn is a handful of
-        events, so this is not paginated.
+        agent's run is terminal (a ``finish`` action, an error event, or a
+        completed conversation status with a reply present), so an interim
+        assistant narration before the final answer is never mistaken for the
+        reply. Only this turn's events are considered (the pre-run event count
+        is the read offset), and only the first page of them (``get_events``
+        default ``limit``); a verification turn is a handful of events, so this
+        is not paginated.
 
         Args:
             conversation_id: The conversation to post to.
@@ -610,6 +690,16 @@ class ConversationService(BaseService):
 
         deadline = time.monotonic() + timeout_seconds
         while True:
+            conversation = self.get(
+                conversation_id, base_url=base_url, workroom_id=workroom_id
+            )
+            execution_status = _normalized_status(conversation.execution_status)
+            if execution_status in _ERROR_EXECUTION_STATUSES:
+                raise ConversationError(
+                    f"Agent errored on conversation {conversation_id} "
+                    f"(execution_status={execution_status})."
+                )
+
             new_events = self.get_events(
                 conversation_id,
                 base_url=base_url,
@@ -626,6 +716,9 @@ class ConversationService(BaseService):
                 # or the last assistant text if finish carried none, or None).
                 # Don't accept interim assistant narration before this point.
                 return _reply_from_events(new_events)
+            reply = _reply_from_events(new_events)
+            if execution_status in _DONE_EXECUTION_STATUSES and reply:
+                return reply
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise TimeoutError(

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -369,7 +369,18 @@ class AgentService(BaseService):
 _ERROR_EVENT_KINDS = frozenset({"AgentErrorEvent", "ConversationErrorEvent"})
 _DONE_EXECUTION_STATUSES = frozenset({"finished", "completed", "done"})
 _ERROR_EXECUTION_STATUSES = frozenset({"error", "failed"})
-_READY_CONTAINER_STATUS = "active"
+_READY_CONTAINER_STATUSES = frozenset({"active", "ready", "running", "serving"})
+_PENDING_CONTAINER_STATUSES = frozenset(
+    {
+        "creating",
+        "initializing",
+        "pending",
+        "provisioning",
+        "pulling",
+        "starting",
+        "waiting",
+    }
+)
 _TERMINAL_CONTAINER_STATUSES = frozenset(
     {"deleted", "error", "failed", "stopped", "suspended"}
 )
@@ -532,7 +543,9 @@ class ConversationService(BaseService):
 
         Conversation creation can return while a cold sandbox is still coming
         up. Poll the conversation's ``container_status`` and fail before sending
-        a message if the sandbox reaches a terminal non-serving state.
+        a message if the sandbox reaches a known terminal non-serving state.
+        Older Kaizen builds may omit this optional field; in that case, proceed
+        optimistically to preserve the pre-readiness-check behavior.
         """
         if timeout_seconds < 0:
             raise ValueError(
@@ -546,13 +559,15 @@ class ConversationService(BaseService):
                 conversation_id, base_url=base_url, workroom_id=workroom_id
             )
             last_status = _normalized_status(conversation.container_status)
-            if last_status == _READY_CONTAINER_STATUS:
+            if last_status in _READY_CONTAINER_STATUSES:
                 return conversation
             if last_status in _TERMINAL_CONTAINER_STATUSES:
                 raise ConversationError(
                     f"Conversation {conversation_id} sandbox is not ready "
                     f"(container_status={last_status})."
                 )
+            if last_status is None or last_status not in _PENDING_CONTAINER_STATUSES:
+                return conversation
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -720,6 +735,18 @@ class ConversationService(BaseService):
             reply = _reply_from_events(new_events)
             if execution_status in _DONE_EXECUTION_STATUSES:
                 return reply
+            if reply:
+                conversation = self.get(
+                    conversation_id, base_url=base_url, workroom_id=workroom_id
+                )
+                execution_status = _normalized_status(conversation.execution_status)
+                if execution_status in _ERROR_EXECUTION_STATUSES:
+                    raise ConversationError(
+                        f"Agent errored on conversation {conversation_id} "
+                        f"(execution_status={execution_status})."
+                    )
+                if execution_status in _DONE_EXECUTION_STATUSES:
+                    return reply
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise TimeoutError(

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -836,6 +836,40 @@ def test_chat_returns_none_when_finished_without_final_reply(monkeypatch):
     )
 
 
+def test_chat_rechecks_status_when_plain_reply_seen_near_deadline(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 2.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    plain_reply = [
+        {
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "assistant",
+                "tool_calls": None,
+                "content": [{"type": "text", "text": "late plain reply"}],
+            },
+        }
+    ]
+    client = ChatClient(
+        polls=[plain_reply],
+        execution_statuses=["running", "finished"],
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+        == "late plain reply"
+    )
+
+
 def test_chat_ignores_plain_assistant_reply_while_execution_running(monkeypatch):
     import kamiwaza_sdk.services.kaizen as kaizen_mod
 
@@ -898,6 +932,38 @@ def test_wait_until_ready_polls_until_container_active(monkeypatch):
 
     assert conversation.container_status == "active"
     assert slept == [2, 2]
+
+
+def test_wait_until_ready_proceeds_when_container_status_missing(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    slept: list[float] = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    client = ChatClient(polls=[[]], container_statuses=[None])
+    service = ConversationService(client)
+
+    conversation = service.wait_until_ready(
+        "conv-1", base_url=KAIZEN_URL, timeout_seconds=0, poll_interval_seconds=0
+    )
+
+    assert conversation.container_status is None
+    assert slept == []
+
+
+def test_wait_until_ready_accepts_ready_status_synonym(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    slept: list[float] = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    client = ChatClient(polls=[[]], container_statuses=["ready"])
+    service = ConversationService(client)
+
+    conversation = service.wait_until_ready(
+        "conv-1", base_url=KAIZEN_URL, timeout_seconds=0, poll_interval_seconds=0
+    )
+
+    assert conversation.container_status == "ready"
+    assert slept == []
 
 
 def test_wait_until_ready_raises_on_terminal_container_status(monkeypatch):

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -535,6 +535,28 @@ def test_conversation_get_events_passes_pagination():
     assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}
 
 
+def test_conversation_get_returns_status():
+    responses = {
+        ("GET", "api/conversations/conv-1"): {
+            "id": "conv-1",
+            "agent_id": "agent-1",
+            "execution_status": "running",
+            "container_status": "active",
+        }
+    }
+    client = DummyClient(responses)
+    service = ConversationService(client)
+
+    conversation = service.get("conv-1", base_url=KAIZEN_URL, workroom_id="wr-1")
+
+    assert conversation.id == "conv-1"
+    assert conversation.execution_status == "running"
+    assert conversation.container_status == "active"
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("GET", "api/conversations/conv-1")
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}
+
+
 # --- chat() + event helpers ------------------------------------------------
 
 
@@ -567,9 +589,17 @@ class ChatClient:
     never-answers run keeps returning the same empty list).
     """
 
-    def __init__(self, polls, baseline_total=0):
+    def __init__(
+        self,
+        polls,
+        baseline_total=0,
+        execution_statuses=None,
+        container_statuses=None,
+    ):
         self.polls = list(polls)
         self.baseline_total = baseline_total
+        self.execution_statuses = list(execution_statuses or ["running"])
+        self.container_statuses = list(container_statuses or ["active"])
         self.calls: list[tuple[str, str, dict]] = []
 
     def _request(self, method, path, **kwargs):
@@ -579,6 +609,23 @@ class ChatClient:
                 return {"total": self.baseline_total, "events": []}
             events = self.polls.pop(0) if len(self.polls) > 1 else self.polls[0]
             return {"events": events}
+        if method == "GET" and path.startswith("api/conversations/"):
+            execution_status = (
+                self.execution_statuses.pop(0)
+                if len(self.execution_statuses) > 1
+                else self.execution_statuses[0]
+            )
+            container_status = (
+                self.container_statuses.pop(0)
+                if len(self.container_statuses) > 1
+                else self.container_statuses[0]
+            )
+            return {
+                "id": "conv-1",
+                "agent_id": "agent-1",
+                "execution_status": execution_status,
+                "container_status": container_status,
+            }
         return None  # messages / run -> 204
 
 
@@ -719,6 +766,115 @@ def test_chat_ignores_interim_assistant_text_before_finish(monkeypatch):
     service = ConversationService(client)
 
     assert service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0) == "real answer"
+
+
+def test_chat_returns_plain_assistant_reply_when_execution_finished(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    # Current broken behavior times out after seeing the reply because no
+    # FinishAction is present. The fixed path returns before checking remaining
+    # time once Kaizen marks the execution finished.
+    times = iter([0.0, 2.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    plain_reply = [
+        {
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "assistant",
+                "tool_calls": None,
+                "content": [{"type": "text", "text": "Hello! I'm Kaizen."}],
+            },
+        }
+    ]
+    client = ChatClient(polls=[plain_reply], execution_statuses=["finished"])
+    service = ConversationService(client)
+
+    assert (
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+        == "Hello! I'm Kaizen."
+    )
+
+
+def test_chat_ignores_plain_assistant_reply_while_execution_running(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 0.0, 2.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    plain_reply = [
+        {
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "assistant",
+                "tool_calls": None,
+                "content": [{"type": "text", "text": "Let me think..."}],
+            },
+        }
+    ]
+    client = ChatClient(
+        polls=[plain_reply, plain_reply, plain_reply],
+        execution_statuses=["running", "running", "running"],
+    )
+    service = ConversationService(client)
+
+    with pytest.raises(TimeoutError, match="No agent reply"):
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+
+def test_chat_raises_conversation_error_on_execution_error_status(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 2.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    client = ChatClient(polls=[[]], execution_statuses=["error"])
+    service = ConversationService(client)
+
+    with pytest.raises(ConversationError, match="execution_status=error"):
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=1)
+
+
+def test_wait_until_ready_polls_until_container_active(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    slept: list[float] = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    client = ChatClient(
+        polls=[[]],
+        container_statuses=["provisioning", "initializing", "active"],
+    )
+    service = ConversationService(client)
+
+    conversation = service.wait_until_ready(
+        "conv-1", base_url=KAIZEN_URL, timeout_seconds=10, poll_interval_seconds=2
+    )
+
+    assert conversation.container_status == "active"
+    assert slept == [2, 2]
+
+
+def test_wait_until_ready_raises_on_terminal_container_status(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    client = ChatClient(polls=[[]], container_statuses=["error"])
+    service = ConversationService(client)
+
+    with pytest.raises(ConversationError, match="container_status=error"):
+        service.wait_until_ready("conv-1", base_url=KAIZEN_URL)
 
 
 def test_chat_negative_timeout_raises():

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -650,6 +650,21 @@ def test_reply_from_events_returns_latest_assistant_text():
     assert _reply_from_events(events) == "final answer"
 
 
+def test_reply_from_events_ignores_assistant_tool_call_text():
+    events = [
+        {
+            "kind": "MessageEvent",
+            "tool_calls": [{"id": "call-1"}],
+            "llm_message": {
+                "role": "assistant",
+                "tool_calls": None,
+                "content": [{"type": "text", "text": "Let me search..."}],
+            },
+        }
+    ]
+    assert _reply_from_events(events) is None
+
+
 def test_reply_from_events_joins_text_blocks_and_ignores_images():
     events = [
         {
@@ -799,6 +814,25 @@ def test_chat_returns_plain_assistant_reply_when_execution_finished(monkeypatch)
             poll_interval_seconds=0,
         )
         == "Hello! I'm Kaizen."
+    )
+
+
+def test_chat_returns_none_when_finished_without_final_reply(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    client = ChatClient(polls=[[]], execution_statuses=["finished"])
+    service = ConversationService(client)
+
+    assert (
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+        is None
     )
 
 

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -65,6 +65,7 @@ class FakeClient:
         )
         self.conversations = SimpleNamespace(
             create=RecordingService(SimpleNamespace(id="conv-1")),
+            wait_until_ready=RecordingService(SimpleNamespace(id="conv-1")),
             chat=RecordingService("Hello! I am claude."),
         )
         self.skills = SimpleNamespace(
@@ -541,10 +542,55 @@ def test_chat_creates_conversation_and_returns_reply(capsys, monkeypatch):
     chat = client.conversations.chat.calls[0]
     assert chat["args"] == ("conv-1", "hello there")
     assert chat["kwargs"]["workroom_id"] == "wr-1"
+    wait = client.conversations.wait_until_ready.calls[0]
+    assert wait["args"] == ("conv-1",)
+    assert wait["kwargs"]["base_url"] == "https://kamiwaza.test/kaizen"
+    assert wait["kwargs"]["workroom_id"] == "wr-1"
+    assert wait["kwargs"]["timeout_seconds"] == 120.0
     assert json.loads(capsys.readouterr().out) == {
         "conversation_id": "conv-1",
         "reply": "Hello! I am claude.",
     }
+
+
+def test_chat_sandbox_timeout_flag_controls_ready_wait(capsys, monkeypatch):
+    client = FakeClient()
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    _run(
+        [
+            "chat",
+            "--kaizen-base-url",
+            "u",
+            "--agent-id",
+            "a",
+            "--message",
+            "m",
+            "--sandbox-timeout",
+            "9",
+        ],
+        client,
+    )
+
+    assert client.conversations.wait_until_ready.calls[0]["kwargs"]["timeout_seconds"] == 9
+    assert json.loads(capsys.readouterr().out) == {
+        "conversation_id": "conv-1",
+        "reply": "Hello! I am claude.",
+    }
+
+
+def test_chat_sandbox_wait_timeout_exits_before_messaging(monkeypatch):
+    client = FakeClient()
+    client.conversations.wait_until_ready = _raiser(TimeoutError("sandbox not ready"))
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    with pytest.raises(SystemExit, match="sandbox not ready"):
+        _run(
+            ["chat", "--kaizen-base-url", "u", "--agent-id", "a", "--message", "m"],
+            client,
+        )
+
+    assert client.conversations.chat.calls == []
 
 
 def test_chat_raw_prints_bare_reply(capsys, monkeypatch):

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -633,6 +633,7 @@ def test_chat_fire_and_forget_allows_empty_reply(capsys, monkeypatch):
         client,
     )
 
+    assert client.conversations.wait_until_ready.calls == []
     assert client.conversations.chat.calls[0]["kwargs"]["timeout_seconds"] == 0
     assert json.loads(capsys.readouterr().out) == {
         "conversation_id": "conv-1",


### PR DESCRIPTION
## Summary
- Add `ConversationService.get()` and use Kaizen `execution_status` to distinguish completed replies from interim assistant narration.
- Treat plain assistant `MessageEvent` replies as valid only once the conversation execution is complete; preserve the existing `FinishAction` path and error-event handling.
- Add `ConversationService.wait_until_ready()` and make `kamiwaza-seed chat` wait for the sandbox `container_status=active` before sending the verification prompt.
- Add `--sandbox-timeout` for the seeder chat readiness wait.

Linear: ENG-7300

## Verification
- `uv run pytest tests/unit/test_kaizen_service.py -q`
- `uv run pytest tests/unit/test_seeding_cli.py -q`
- `uv run ruff check kamiwaza_sdk/services/kaizen.py kamiwaza_sdk/seeding/cli.py tests/unit/test_kaizen_service.py tests/unit/test_seeding_cli.py`
- `uv run mypy --follow-imports=silent kamiwaza_sdk/services/kaizen.py kamiwaza_sdk/seeding/cli.py tests/unit/test_kaizen_service.py tests/unit/test_seeding_cli.py`
- `git diff --check`
