### PR TITLE
ENG-7300: Harden Kaizen reused conversation chat status

### DIFF
--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -557,7 +557,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--poll-interval",
-        type=float,
+        type=_non_negative_float,
         default=3.0,
         help="Seconds between event polls while waiting (default: 3).",
     )

--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 from pathlib import Path
 from typing import Callable, Dict, Optional, Union
@@ -46,8 +47,10 @@ def _non_negative_float(value: str) -> float:
         parsed = float(value)
     except ValueError:
         raise argparse.ArgumentTypeError(f"invalid float value: '{value}'")
-    if parsed < 0:
-        raise argparse.ArgumentTypeError("must be zero or a positive number of seconds")
+    if not math.isfinite(parsed) or parsed < 0:
+        raise argparse.ArgumentTypeError(
+            "must be a finite zero or positive number of seconds"
+        )
     return parsed
 
 
@@ -449,7 +452,12 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument("--timeout", type=int, default=600, help="Max seconds to wait for DEPLOYED.")
-    p.add_argument("--poll-interval", type=float, default=5.0, help="Seconds between readiness polls.")
+    p.add_argument(
+        "--poll-interval",
+        type=_non_negative_float,
+        default=5.0,
+        help="Seconds between readiness polls.",
+    )
     p.set_defaults(func=cmd_deploy_model)
 
     p = sub.add_parser(
@@ -479,7 +487,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--poll-interval",
-        type=float,
+        type=_non_negative_float,
         default=5.0,
         help="Seconds between resolve attempts (default: 5).",
     )

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -13,6 +13,7 @@ platform honors this header. A workroom-scoped token is the durable fix
 (tracked for the nightly-seeding work).
 """
 
+import math
 import time
 from typing import Any, Dict, List, Optional, Union
 
@@ -685,13 +686,18 @@ class ConversationService(BaseService):
             (fire-and-forget) or the agent finished without any reply text.
 
         Raises:
-            ValueError: ``timeout_seconds`` is negative.
+            ValueError: ``timeout_seconds`` or ``poll_interval_seconds`` is invalid.
             ConversationError: The agent emitted an error event for this turn.
             TimeoutError: The agent did not finish within ``timeout_seconds``.
         """
         if timeout_seconds < 0:
             raise ValueError(
                 "timeout_seconds must be zero or a positive number of seconds."
+            )
+        if not math.isfinite(poll_interval_seconds) or poll_interval_seconds < 0:
+            raise ValueError(
+                "poll_interval_seconds must be a finite zero or positive number "
+                "of seconds."
             )
         self.send_message(
             conversation_id, message, base_url=base_url, workroom_id=workroom_id
@@ -722,6 +728,22 @@ class ConversationService(BaseService):
                 or execution_status not in terminal_statuses
             )
 
+        def current_terminal_outcome(
+            execution_status: Optional[str], reply: Optional[str]
+        ) -> tuple[bool, Optional[str]]:
+            if not status_applies_to_this_turn:
+                # Same-valued stale errors with no current-turn error event stay
+                # untrusted; otherwise a prior error could fail a new turn.
+                return False, None
+            if execution_status in _ERROR_EXECUTION_STATUSES:
+                raise ConversationError(
+                    f"Agent errored on conversation {conversation_id} "
+                    f"(execution_status={execution_status})."
+                )
+            if execution_status in _DONE_EXECUTION_STATUSES:
+                return True, reply
+            return False, None
+
         deadline = time.monotonic() + timeout_seconds
         saw_done_without_reply = False
         same_terminal_reply_seen: Optional[tuple[str, str]] = None
@@ -733,14 +755,6 @@ class ConversationService(BaseService):
             if status_marks_current_turn(execution_status):
                 status_applies_to_this_turn = True
                 same_terminal_reply_seen = None
-            if (
-                status_applies_to_this_turn
-                and execution_status in _ERROR_EXECUTION_STATUSES
-            ):
-                raise ConversationError(
-                    f"Agent errored on conversation {conversation_id} "
-                    f"(execution_status={execution_status})."
-                )
 
             new_events = self.get_events(
                 conversation_id,
@@ -759,12 +773,12 @@ class ConversationService(BaseService):
                 # Don't accept interim assistant narration before this point.
                 return _reply_from_events(new_events)
             reply = _reply_from_events(new_events)
-            if (
-                status_applies_to_this_turn
-                and execution_status in _DONE_EXECUTION_STATUSES
-            ):
-                if reply is not None:
-                    return reply
+            is_terminal, terminal_reply = current_terminal_outcome(
+                execution_status, reply
+            )
+            if is_terminal:
+                if terminal_reply is not None:
+                    return terminal_reply
                 if saw_done_without_reply:
                     return None
                 # Done can beat reply persistence; give Kaizen one immediate
@@ -780,19 +794,11 @@ class ConversationService(BaseService):
                 if status_marks_current_turn(execution_status):
                     status_applies_to_this_turn = True
                     same_terminal_reply_seen = None
-                if (
-                    status_applies_to_this_turn
-                    and execution_status in _ERROR_EXECUTION_STATUSES
-                ):
-                    raise ConversationError(
-                        f"Agent errored on conversation {conversation_id} "
-                        f"(execution_status={execution_status})."
-                    )
-                if (
-                    status_applies_to_this_turn
-                    and execution_status in _DONE_EXECUTION_STATUSES
-                ):
-                    return reply
+                is_terminal, terminal_reply = current_terminal_outcome(
+                    execution_status, reply
+                )
+                if is_terminal:
+                    return terminal_reply
                 if (
                     execution_status == pre_run_status
                     and execution_status in _DONE_EXECUTION_STATUSES
@@ -816,6 +822,6 @@ class ConversationService(BaseService):
                     f"No agent reply on conversation {conversation_id} after "
                     f"{timeout_seconds:g}s."
                 )
-            # max(0, …) so a non-positive poll interval degrades to a busy-wait
-            # bounded by the timeout rather than raising from time.sleep().
+            # max(0, …) keeps zero poll intervals bounded by the timeout rather
+            # than raising from time.sleep().
             time.sleep(max(0.0, min(poll_interval_seconds, remaining)))

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -702,15 +702,30 @@ class ConversationService(BaseService):
         baseline = self.get_events(
             conversation_id, base_url=base_url, workroom_id=workroom_id, limit=1
         ).get("total", 0)
+        pre_run_status = _normalized_status(
+            self.get(
+                conversation_id, base_url=base_url, workroom_id=workroom_id
+            ).execution_status
+        )
         self.run(conversation_id, base_url=base_url, workroom_id=workroom_id)
 
+        terminal_statuses = _DONE_EXECUTION_STATUSES | _ERROR_EXECUTION_STATUSES
+        status_applies_to_this_turn = pre_run_status not in terminal_statuses
         deadline = time.monotonic() + timeout_seconds
+        saw_done_without_reply = False
         while True:
             conversation = self.get(
                 conversation_id, base_url=base_url, workroom_id=workroom_id
             )
             execution_status = _normalized_status(conversation.execution_status)
-            if execution_status in _ERROR_EXECUTION_STATUSES:
+            if execution_status is not None and execution_status != pre_run_status:
+                status_applies_to_this_turn = True
+            if execution_status is not None and execution_status not in terminal_statuses:
+                status_applies_to_this_turn = True
+            if (
+                status_applies_to_this_turn
+                and execution_status in _ERROR_EXECUTION_STATUSES
+            ):
                 raise ConversationError(
                     f"Agent errored on conversation {conversation_id} "
                     f"(execution_status={execution_status})."
@@ -733,19 +748,41 @@ class ConversationService(BaseService):
                 # Don't accept interim assistant narration before this point.
                 return _reply_from_events(new_events)
             reply = _reply_from_events(new_events)
-            if execution_status in _DONE_EXECUTION_STATUSES:
-                return reply
+            if (
+                status_applies_to_this_turn
+                and execution_status in _DONE_EXECUTION_STATUSES
+            ):
+                if reply is not None:
+                    return reply
+                if saw_done_without_reply:
+                    return None
+                saw_done_without_reply = True
+                continue
+            saw_done_without_reply = False
             if reply:
                 conversation = self.get(
                     conversation_id, base_url=base_url, workroom_id=workroom_id
                 )
                 execution_status = _normalized_status(conversation.execution_status)
-                if execution_status in _ERROR_EXECUTION_STATUSES:
+                if execution_status is not None and execution_status != pre_run_status:
+                    status_applies_to_this_turn = True
+                if (
+                    execution_status is not None
+                    and execution_status not in terminal_statuses
+                ):
+                    status_applies_to_this_turn = True
+                if (
+                    status_applies_to_this_turn
+                    and execution_status in _ERROR_EXECUTION_STATUSES
+                ):
                     raise ConversationError(
                         f"Agent errored on conversation {conversation_id} "
                         f"(execution_status={execution_status})."
                     )
-                if execution_status in _DONE_EXECUTION_STATUSES:
+                if (
+                    status_applies_to_this_turn
+                    and execution_status in _DONE_EXECUTION_STATUSES
+                ):
                     return reply
             remaining = deadline - time.monotonic()
             if remaining <= 0:

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -804,7 +804,10 @@ class ConversationService(BaseService):
                     if same_terminal_reply_seen == same_terminal_reply:
                         return reply
                     same_terminal_reply_seen = same_terminal_reply
-                    continue
+                    # Fall through to the deadline/sleep below rather than
+                    # looping immediately: a reused conversation stuck terminal
+                    # with a *changing* reply would otherwise never match here,
+                    # busy-waiting forever and bypassing the timeout contract.
             else:
                 same_terminal_reply_seen = None
             remaining = deadline - time.monotonic()

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -711,17 +711,24 @@ class ConversationService(BaseService):
 
         terminal_statuses = _DONE_EXECUTION_STATUSES | _ERROR_EXECUTION_STATUSES
         status_applies_to_this_turn = pre_run_status not in terminal_statuses
+
+        def status_marks_current_turn(execution_status: Optional[str]) -> bool:
+            return execution_status is not None and (
+                execution_status != pre_run_status
+                or execution_status not in terminal_statuses
+            )
+
         deadline = time.monotonic() + timeout_seconds
         saw_done_without_reply = False
+        same_terminal_reply_seen: Optional[tuple[str, str]] = None
         while True:
             conversation = self.get(
                 conversation_id, base_url=base_url, workroom_id=workroom_id
             )
             execution_status = _normalized_status(conversation.execution_status)
-            if execution_status is not None and execution_status != pre_run_status:
+            if status_marks_current_turn(execution_status):
                 status_applies_to_this_turn = True
-            if execution_status is not None and execution_status not in terminal_statuses:
-                status_applies_to_this_turn = True
+                same_terminal_reply_seen = None
             if (
                 status_applies_to_this_turn
                 and execution_status in _ERROR_EXECUTION_STATUSES
@@ -764,13 +771,9 @@ class ConversationService(BaseService):
                     conversation_id, base_url=base_url, workroom_id=workroom_id
                 )
                 execution_status = _normalized_status(conversation.execution_status)
-                if execution_status is not None and execution_status != pre_run_status:
+                if status_marks_current_turn(execution_status):
                     status_applies_to_this_turn = True
-                if (
-                    execution_status is not None
-                    and execution_status not in terminal_statuses
-                ):
-                    status_applies_to_this_turn = True
+                    same_terminal_reply_seen = None
                 if (
                     status_applies_to_this_turn
                     and execution_status in _ERROR_EXECUTION_STATUSES
@@ -784,6 +787,17 @@ class ConversationService(BaseService):
                     and execution_status in _DONE_EXECUTION_STATUSES
                 ):
                     return reply
+                if (
+                    execution_status == pre_run_status
+                    and execution_status in _DONE_EXECUTION_STATUSES
+                ):
+                    same_terminal_reply = (execution_status, reply)
+                    if same_terminal_reply_seen == same_terminal_reply:
+                        return reply
+                    same_terminal_reply_seen = same_terminal_reply
+                    continue
+            else:
+                same_terminal_reply_seen = None
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise TimeoutError(

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -672,6 +672,8 @@ class ConversationService(BaseService):
         When reusing a conversation, a terminal status that existed before this
         run is treated as stale until the status changes, becomes non-terminal,
         or a same-terminal plain reply is confirmed across consecutive polls.
+        Error statuses from a previous turn are not trusted by repetition alone;
+        same-status failures need an error event or a real status transition.
 
         Args:
             conversation_id: The conversation to post to.
@@ -690,9 +692,10 @@ class ConversationService(BaseService):
             ConversationError: The agent emitted an error event for this turn.
             TimeoutError: The agent did not finish within ``timeout_seconds``.
         """
-        if timeout_seconds < 0:
+        if not math.isfinite(timeout_seconds) or timeout_seconds < 0:
             raise ValueError(
-                "timeout_seconds must be zero or a positive number of seconds."
+                "timeout_seconds must be a finite zero or positive number "
+                "of seconds."
             )
         if not math.isfinite(poll_interval_seconds) or poll_interval_seconds < 0:
             raise ValueError(
@@ -731,33 +734,15 @@ class ConversationService(BaseService):
         deadline = time.monotonic() + timeout_seconds
         saw_done_without_reply = False
         same_terminal_reply_seen: Optional[tuple[str, str]] = None
-        same_terminal_error_seen: Optional[str] = None
 
         def update_status_freshness(execution_status: Optional[str]) -> None:
             nonlocal status_applies_to_this_turn
-            nonlocal same_terminal_error_seen
             nonlocal same_terminal_reply_seen
 
             if status_marks_current_turn(execution_status):
                 status_applies_to_this_turn = True
-                same_terminal_error_seen = None
                 same_terminal_reply_seen = None
                 return
-
-            if (
-                execution_status == pre_run_status
-                and execution_status in _ERROR_EXECUTION_STATUSES
-            ):
-                # One unchanged terminal read can be stale from the previous
-                # turn. Seeing the same error again without a transition is the
-                # best signal Kaizen gives that this turn also failed.
-                if same_terminal_error_seen == execution_status:
-                    status_applies_to_this_turn = True
-                    same_terminal_reply_seen = None
-                same_terminal_error_seen = execution_status
-                return
-
-            same_terminal_error_seen = None
 
         def terminal_status_reply(
             execution_status: Optional[str], reply: Optional[str]

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -548,9 +548,10 @@ class ConversationService(BaseService):
         Older Kaizen builds may omit this optional field; in that case, proceed
         optimistically to preserve the pre-readiness-check behavior.
         """
-        if timeout_seconds < 0:
+        if not math.isfinite(timeout_seconds) or timeout_seconds < 0:
             raise ValueError(
-                "timeout_seconds must be zero or a positive number of seconds."
+                "timeout_seconds must be a finite zero or positive number "
+                "of seconds."
             )
 
         deadline = time.monotonic() + timeout_seconds

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -725,22 +725,53 @@ class ConversationService(BaseService):
         deadline = time.monotonic() + timeout_seconds
         saw_done_without_reply = False
         same_terminal_reply_seen: Optional[tuple[str, str]] = None
+        same_terminal_error_seen: Optional[str] = None
+
+        def update_status_freshness(execution_status: Optional[str]) -> None:
+            nonlocal status_applies_to_this_turn
+            nonlocal same_terminal_error_seen
+            nonlocal same_terminal_reply_seen
+
+            if status_marks_current_turn(execution_status):
+                status_applies_to_this_turn = True
+                same_terminal_error_seen = None
+                same_terminal_reply_seen = None
+                return
+
+            if (
+                execution_status == pre_run_status
+                and execution_status in _ERROR_EXECUTION_STATUSES
+            ):
+                # One unchanged terminal read can be stale from the previous
+                # turn. Seeing the same error again without a transition is the
+                # best signal Kaizen gives that this turn also failed.
+                if same_terminal_error_seen == execution_status:
+                    status_applies_to_this_turn = True
+                    same_terminal_reply_seen = None
+                same_terminal_error_seen = execution_status
+                return
+
+            same_terminal_error_seen = None
+
+        def terminal_status_reply(
+            execution_status: Optional[str], reply: Optional[str]
+        ) -> tuple[bool, Optional[str]]:
+            if not status_applies_to_this_turn:
+                return False, None
+            if execution_status in _ERROR_EXECUTION_STATUSES:
+                raise ConversationError(
+                    f"Agent errored on conversation {conversation_id} "
+                    f"(execution_status={execution_status})."
+                )
+            if execution_status in _DONE_EXECUTION_STATUSES:
+                return True, reply
+            return False, None
         while True:
             conversation = self.get(
                 conversation_id, base_url=base_url, workroom_id=workroom_id
             )
             execution_status = _normalized_status(conversation.execution_status)
-            if status_marks_current_turn(execution_status):
-                status_applies_to_this_turn = True
-                same_terminal_reply_seen = None
-            if (
-                status_applies_to_this_turn
-                and execution_status in _ERROR_EXECUTION_STATUSES
-            ):
-                raise ConversationError(
-                    f"Agent errored on conversation {conversation_id} "
-                    f"(execution_status={execution_status})."
-                )
+            update_status_freshness(execution_status)
 
             new_events = self.get_events(
                 conversation_id,
@@ -759,12 +790,12 @@ class ConversationService(BaseService):
                 # Don't accept interim assistant narration before this point.
                 return _reply_from_events(new_events)
             reply = _reply_from_events(new_events)
-            if (
-                status_applies_to_this_turn
-                and execution_status in _DONE_EXECUTION_STATUSES
-            ):
-                if reply is not None:
-                    return reply
+            is_terminal_status, terminal_reply = terminal_status_reply(
+                execution_status, reply
+            )
+            if is_terminal_status:
+                if terminal_reply is not None:
+                    return terminal_reply
                 if saw_done_without_reply:
                     return None
                 # Done can beat reply persistence; give Kaizen one immediate
@@ -777,22 +808,12 @@ class ConversationService(BaseService):
                     conversation_id, base_url=base_url, workroom_id=workroom_id
                 )
                 execution_status = _normalized_status(conversation.execution_status)
-                if status_marks_current_turn(execution_status):
-                    status_applies_to_this_turn = True
-                    same_terminal_reply_seen = None
-                if (
-                    status_applies_to_this_turn
-                    and execution_status in _ERROR_EXECUTION_STATUSES
-                ):
-                    raise ConversationError(
-                        f"Agent errored on conversation {conversation_id} "
-                        f"(execution_status={execution_status})."
-                    )
-                if (
-                    status_applies_to_this_turn
-                    and execution_status in _DONE_EXECUTION_STATUSES
-                ):
-                    return reply
+                update_status_freshness(execution_status)
+                is_terminal_status, terminal_reply = terminal_status_reply(
+                    execution_status, reply
+                )
+                if is_terminal_status:
+                    return terminal_reply
                 if (
                     execution_status == pre_run_status
                     and execution_status in _DONE_EXECUTION_STATUSES

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -668,6 +668,9 @@ class ConversationService(BaseService):
         events are considered (the pre-run event count is the read offset), and
         only the first page of them (``get_events`` default ``limit``); a
         verification turn is a handful of events, so this is not paginated.
+        When reusing a conversation, a terminal status that existed before this
+        run is treated as stale until the status changes, becomes non-terminal,
+        or a same-terminal plain reply is confirmed across consecutive polls.
 
         Args:
             conversation_id: The conversation to post to.
@@ -702,6 +705,7 @@ class ConversationService(BaseService):
         baseline = self.get_events(
             conversation_id, base_url=base_url, workroom_id=workroom_id, limit=1
         ).get("total", 0)
+        # This extra status read separates a stale terminal state from this run.
         pre_run_status = _normalized_status(
             self.get(
                 conversation_id, base_url=base_url, workroom_id=workroom_id
@@ -763,6 +767,8 @@ class ConversationService(BaseService):
                     return reply
                 if saw_done_without_reply:
                     return None
+                # Done can beat reply persistence; give Kaizen one immediate
+                # re-read before accepting "done with no reply" as terminal.
                 saw_done_without_reply = True
                 continue
             saw_done_without_reply = False
@@ -791,6 +797,9 @@ class ConversationService(BaseService):
                     execution_status == pre_run_status
                     and execution_status in _DONE_EXECUTION_STATUSES
                 ):
+                    # Fast reused runs may remain `finished` the whole time.
+                    # Require stability so a single stale/interim reply is not
+                    # accepted just because the previous turn was already done.
                     same_terminal_reply = (execution_status, reply)
                     if same_terminal_reply_seen == same_terminal_reply:
                         return reply

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -1283,6 +1283,21 @@ def test_wait_until_ready_raises_on_terminal_container_status(monkeypatch):
 
 
 @pytest.mark.parametrize("timeout", [-1.0, float("nan"), float("inf")])
+def test_wait_until_ready_invalid_timeout_raises_without_side_effects(timeout):
+    client = ChatClient(polls=[[]], container_statuses=["active"])
+    service = ConversationService(client)
+
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        service.wait_until_ready(
+            "conv-1",
+            base_url=KAIZEN_URL,
+            timeout_seconds=timeout,
+        )
+
+    assert client.calls == []
+
+
+@pytest.mark.parametrize("timeout", [-1.0, float("nan"), float("inf")])
 def test_chat_invalid_timeout_raises_without_side_effects(timeout):
     client = ChatClient(polls=[[_finish_event("x")]])
     service = ConversationService(client)
@@ -1291,6 +1306,7 @@ def test_chat_invalid_timeout_raises_without_side_effects(timeout):
         service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=timeout)
 
     assert client.calls == []
+
 
 def test_chat_raises_conversation_error_on_agent_error(monkeypatch):
     import kamiwaza_sdk.services.kaizen as kaizen_mod

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -1061,6 +1061,52 @@ def test_chat_ignores_stale_error_status_from_previous_turn(monkeypatch):
     )
 
 
+def test_chat_raises_on_repeated_same_error_status_without_error_event(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    client = ChatClient(
+        polls=[[], []],
+        execution_statuses=["error", "error", "error"],
+    )
+    service = ConversationService(client)
+
+    with pytest.raises(ConversationError, match="execution_status=error"):
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+
+def test_chat_times_out_when_same_terminal_reply_keeps_changing(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 2.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    first_reply = [_message_event("first")]
+    second_reply = [_message_event("second")]
+    client = ChatClient(
+        polls=[first_reply, second_reply],
+        execution_statuses=["finished", "finished", "finished", "finished"],
+    )
+    service = ConversationService(client)
+
+    with pytest.raises(TimeoutError, match="No agent reply"):
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+
 def test_wait_until_ready_polls_until_container_active(monkeypatch):
     import kamiwaza_sdk.services.kaizen as kaizen_mod
 

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -1123,7 +1123,58 @@ def test_chat_ignores_stale_error_status_from_previous_turn(monkeypatch):
     )
 
 
-def test_chat_raises_on_repeated_same_error_status_without_error_event(monkeypatch):
+def test_chat_ignores_lingering_stale_error_status_before_recovery(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 0.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    final_reply = [_message_event("recovered answer")]
+    client = ChatClient(
+        polls=[[], [], final_reply],
+        execution_statuses=["error", "error", "error", "running", "finished"],
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+        == "recovered answer"
+    )
+
+
+def test_chat_ignores_interim_reply_while_stale_error_status_lingers(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 0.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    interim_reply = [_message_event("still working")]
+    final_reply = [_message_event("recovered answer")]
+    client = ChatClient(
+        polls=[interim_reply, final_reply],
+        execution_statuses=["error", "error", "error", "running", "finished"],
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+        == "recovered answer"
+    )
+
+
+def test_chat_times_out_on_repeated_same_error_status_without_error_event(monkeypatch):
     import kamiwaza_sdk.services.kaizen as kaizen_mod
 
     times = iter([0.0, 0.0, 2.0])
@@ -1135,7 +1186,7 @@ def test_chat_raises_on_repeated_same_error_status_without_error_event(monkeypat
     )
     service = ConversationService(client)
 
-    with pytest.raises(ConversationError, match="execution_status=error"):
+    with pytest.raises(TimeoutError, match="No agent reply"):
         service.chat(
             "conv-1",
             "hi",
@@ -1231,11 +1282,15 @@ def test_wait_until_ready_raises_on_terminal_container_status(monkeypatch):
         service.wait_until_ready("conv-1", base_url=KAIZEN_URL)
 
 
-def test_chat_negative_timeout_raises():
-    service = ConversationService(ChatClient(polls=[[_finish_event("x")]]))
-    with pytest.raises(ValueError, match="zero or a positive"):
-        service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=-1)
+@pytest.mark.parametrize("timeout", [-1.0, float("nan"), float("inf")])
+def test_chat_invalid_timeout_raises_without_side_effects(timeout):
+    client = ChatClient(polls=[[_finish_event("x")]])
+    service = ConversationService(client)
 
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=timeout)
+
+    assert client.calls == []
 
 def test_chat_raises_conversation_error_on_agent_error(monkeypatch):
     import kamiwaza_sdk.services.kaizen as kaizen_mod

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -918,7 +918,7 @@ def test_chat_raises_conversation_error_on_execution_error_status(monkeypatch):
 def test_chat_ignores_stale_finished_status_from_previous_turn(monkeypatch):
     import kamiwaza_sdk.services.kaizen as kaizen_mod
 
-    times = iter([0.0, 0.0, 0.0])
+    times = iter([0.0, 0.0, 0.0, 2.0])
     monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
     monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
     final_reply = [
@@ -946,6 +946,40 @@ def test_chat_ignores_stale_finished_status_from_previous_turn(monkeypatch):
             poll_interval_seconds=0,
         )
         == "fresh answer"
+    )
+
+
+def test_chat_accepts_fast_plain_reply_when_status_stays_finished(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 0.0, 2.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    final_reply = [
+        {
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "assistant",
+                "tool_calls": None,
+                "content": [{"type": "text", "text": "fresh fast answer"}],
+            },
+        }
+    ]
+    client = ChatClient(
+        polls=[final_reply, final_reply],
+        execution_statuses=["finished", "finished", "finished", "finished"],
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+        == "fresh fast answer"
     )
 
 

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -757,18 +757,40 @@ def test_chat_returns_none_when_agent_finishes_empty(monkeypatch):
     assert slept == []  # returned on the first poll, never waited
 
 
-def test_chat_non_positive_poll_interval_does_not_raise(monkeypatch):
+def test_chat_zero_poll_interval_does_not_raise(monkeypatch):
     import kamiwaza_sdk.services.kaizen as kaizen_mod
 
     slept: list = []
     monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
-    # First poll empty, second has the reply; a negative interval must clamp to
-    # 0 at the sleep rather than raising ValueError out of the wait loop.
+    # First poll empty, second has the reply; zero is valid and sleeps without
+    # raising out of the wait loop.
     client = ChatClient(polls=[[], [_finish_event("done")]])
     service = ConversationService(client)
 
-    assert service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=-5) == "done"
+    assert (
+        service.chat(
+            "conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0
+        )
+        == "done"
+    )
     assert slept == [0.0]
+
+
+@pytest.mark.parametrize("poll_interval", [-1.0, float("nan"), float("inf")])
+def test_chat_rejects_invalid_poll_interval_without_side_effects(poll_interval):
+    client = ChatClient(polls=[[]])
+    service = ConversationService(client)
+
+    with pytest.raises(ValueError, match="poll_interval_seconds"):
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=0,
+            poll_interval_seconds=poll_interval,
+        )
+
+    assert client.calls == []
 
 
 def test_chat_ignores_interim_assistant_text_before_finish(monkeypatch):
@@ -981,6 +1003,46 @@ def test_chat_accepts_fast_plain_reply_when_status_stays_finished(monkeypatch):
         )
         == "fresh fast answer"
     )
+
+
+def test_chat_same_terminal_changing_reply_respects_timeout(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 2.0])
+    slept: list[float] = []
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+
+    class ChangingReplyClient(ChatClient):
+        def __init__(self):
+            super().__init__(polls=[[]], execution_statuses=["finished"])
+            self.reply_polls = 0
+
+        def _request(self, method, path, **kwargs):
+            if (
+                path.endswith("/events")
+                and kwargs.get("params", {}).get("limit") != 1
+            ):
+                self.reply_polls += 1
+                if self.reply_polls > 3:
+                    raise AssertionError("chat() did not enforce its timeout")
+                return {"events": [_message_event(f"draft {self.reply_polls}")]}
+            return super()._request(method, path, **kwargs)
+
+    client = ChangingReplyClient()
+    service = ConversationService(client)
+
+    with pytest.raises(TimeoutError, match="No agent reply"):
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+
+    assert client.reply_polls == 2
+    assert slept == [0.0]
 
 
 def test_chat_missing_status_does_not_make_stale_terminal_status_fresh(monkeypatch):

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -802,7 +802,7 @@ def test_chat_returns_plain_assistant_reply_when_execution_finished(monkeypatch)
             },
         }
     ]
-    client = ChatClient(polls=[plain_reply], execution_statuses=["finished"])
+    client = ChatClient(polls=[plain_reply], execution_statuses=["running", "finished"])
     service = ConversationService(client)
 
     assert (
@@ -821,7 +821,7 @@ def test_chat_returns_none_when_finished_without_final_reply(monkeypatch):
     import kamiwaza_sdk.services.kaizen as kaizen_mod
 
     monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
-    client = ChatClient(polls=[[]], execution_statuses=["finished"])
+    client = ChatClient(polls=[[]], execution_statuses=["running", "finished", "finished"])
     service = ConversationService(client)
 
     assert (
@@ -908,11 +908,123 @@ def test_chat_raises_conversation_error_on_execution_error_status(monkeypatch):
     times = iter([0.0, 2.0])
     monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
     monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
-    client = ChatClient(polls=[[]], execution_statuses=["error"])
+    client = ChatClient(polls=[[]], execution_statuses=["running", "error"])
     service = ConversationService(client)
 
     with pytest.raises(ConversationError, match="execution_status=error"):
         service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=1)
+
+
+def test_chat_ignores_stale_finished_status_from_previous_turn(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 0.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    final_reply = [
+        {
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "assistant",
+                "tool_calls": None,
+                "content": [{"type": "text", "text": "fresh answer"}],
+            },
+        }
+    ]
+    client = ChatClient(
+        polls=[[], final_reply, final_reply],
+        execution_statuses=["finished", "finished", "running", "finished"],
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+        == "fresh answer"
+    )
+
+
+def test_chat_missing_status_does_not_make_stale_terminal_status_fresh(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 0.0, 0.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    stale_interim = [
+        {
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "assistant",
+                "tool_calls": None,
+                "content": [{"type": "text", "text": "stale interim"}],
+            },
+        }
+    ]
+    final_reply = [
+        {
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "assistant",
+                "tool_calls": None,
+                "content": [{"type": "text", "text": "fresh answer"}],
+            },
+        }
+    ]
+    client = ChatClient(
+        polls=[[], stale_interim, [], final_reply],
+        execution_statuses=["finished", None, "finished", "running", "finished"],
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+        == "fresh answer"
+    )
+
+
+def test_chat_ignores_stale_error_status_from_previous_turn(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 0.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    final_reply = [
+        {
+            "kind": "MessageEvent",
+            "llm_message": {
+                "role": "assistant",
+                "tool_calls": None,
+                "content": [{"type": "text", "text": "recovered answer"}],
+            },
+        }
+    ]
+    client = ChatClient(
+        polls=[[], final_reply, final_reply],
+        execution_statuses=["error", "error", "running", "finished"],
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat(
+            "conv-1",
+            "hi",
+            base_url=KAIZEN_URL,
+            timeout_seconds=1,
+            poll_interval_seconds=0,
+        )
+        == "recovered answer"
+    )
 
 
 def test_wait_until_ready_polls_until_container_active(monkeypatch):

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -312,6 +312,17 @@ def test_resolve_kaizen_url_ambiguous_exits_nonzero(monkeypatch):
         _run(["resolve-kaizen-url", "--workroom-id", "wr-9"], client)
 
 
+def test_resolve_kaizen_url_negative_poll_interval_rejected_by_parser(monkeypatch):
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+    monkeypatch.setattr(cli, "wait_for_base_url", lambda *a, **k: "https://k/kaizen")
+
+    with pytest.raises(SystemExit):
+        _run(
+            ["resolve-kaizen-url", "--workroom-id", "wr-9", "--poll-interval", "-1"],
+            FakeClient(),
+        )
+
+
 def test_create_agent_uses_kaizen_base_url(capsys, monkeypatch):
     client = FakeClient()
     monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
@@ -473,6 +484,14 @@ def test_deploy_model_requires_model_id_or_name():
     # --model-id / --name are a required mutually-exclusive group.
     with pytest.raises(SystemExit):
         _run(["deploy-model"], FakeClient())
+
+
+def test_deploy_model_nan_poll_interval_rejected_by_parser():
+    with pytest.raises(SystemExit):
+        _run(
+            ["deploy-model", "--model-id", "m1", "--poll-interval", "nan"],
+            FakeClient(),
+        )
 
 
 def test_deploy_model_converts_wait_failure_to_systemexit():
@@ -678,6 +697,24 @@ def test_chat_negative_poll_interval_rejected_by_parser():
                 "m",
                 "--poll-interval",
                 "-1",
+            ],
+            FakeClient(),
+        )
+
+
+def test_chat_nan_poll_interval_rejected_by_parser():
+    with pytest.raises(SystemExit):
+        _run(
+            [
+                "chat",
+                "--kaizen-base-url",
+                "u",
+                "--agent-id",
+                "a",
+                "--message",
+                "m",
+                "--poll-interval",
+                "nan",
             ],
             FakeClient(),
         )

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -665,6 +665,24 @@ def test_chat_negative_timeout_rejected_by_parser():
         )
 
 
+def test_chat_negative_poll_interval_rejected_by_parser():
+    with pytest.raises(SystemExit):
+        _run(
+            [
+                "chat",
+                "--kaizen-base-url",
+                "u",
+                "--agent-id",
+                "a",
+                "--message",
+                "m",
+                "--poll-interval",
+                "-1",
+            ],
+            FakeClient(),
+        )
+
+
 def test_chat_timeout_exits_nonzero(monkeypatch):
     client = FakeClient()
     client.conversations.chat = _raiser(TimeoutError("no reply in time"))


### PR DESCRIPTION
Linear: ENG-7300

Follow-up to #187 after it was squash-merged.

## Summary
- Prevent stale terminal `execution_status` from a previous Kaizen turn from completing a newly submitted `chat()` call until the current turn is observed.
- Handle very fast reused-conversation runs where Kaizen stays at the same terminal status (`finished` -> `finished`) by requiring the same terminal status plus same plain reply to be observed twice before accepting it.
- Do not trust repeated same-status `error` from a previous turn by repetition alone; genuine current-turn failures still raise from `AgentErrorEvent` or a real error-status transition, while ambiguous stale-error repetition is bounded by timeout instead of fabricating `ConversationError`.
- Treat missing execution status as unknown rather than fresh terminal evidence.
- Reject invalid SDK `poll_interval_seconds`, `chat(timeout_seconds)`, and `wait_until_ready(timeout_seconds)` values before side effects.
- Reject negative/NaN/infinite seeding poll intervals at the parser boundary.
- Keep same-terminal changing replies bounded by the timeout instead of busy-waiting.

## Verification
- `uv run pytest tests/unit/test_kaizen_service.py::test_wait_until_ready_invalid_timeout_raises_without_side_effects -q` (`3 passed`; verified red first for `nan`/`inf`)
- `uv run pytest tests/unit/test_kaizen_service.py tests/unit/test_seeding_cli.py -q` (`118 passed`)
- `uv run ruff check kamiwaza_sdk/services/kaizen.py kamiwaza_sdk/seeding/cli.py tests/unit/test_kaizen_service.py tests/unit/test_seeding_cli.py`
- `uv run mypy --follow-imports=silent kamiwaza_sdk/services/kaizen.py kamiwaza_sdk/seeding/cli.py tests/unit/test_kaizen_service.py tests/unit/test_seeding_cli.py`
- `git diff --check`
- `uv run pytest tests/unit/ -q` (`2527 passed, 1 skipped`)
- GitHub CI on `d7a2861`: Unit Tests, Coverage, Mypy, Ruff, Build Package, Build seeder image, Extension contract, Complexity, and Linear issue check all passed.
