### PR TITLE
ENG-7300: fix seeder chat verification + wait for conversation sandbox

### DIFF
--- a/kamiwaza_sdk/seeding/cli.py
+++ b/kamiwaza_sdk/seeding/cli.py
@@ -169,7 +169,9 @@ def _resolve_model_id(client, model_id: Optional[str], name: Optional[str]) -> s
     if model_id:
         return model_id
     matches = [
-        m for m in client.models.list_models() if (getattr(m, "name", None) or "") == name
+        m
+        for m in client.models.list_models()
+        if (getattr(m, "name", None) or "") == name
     ]
     if not matches:
         raise SystemExit(f"No registered model named '{name}'.")
@@ -217,7 +219,9 @@ def cmd_deploy_model(args: argparse.Namespace, *, client) -> dict:
         # the nightly profile.
         raise SystemExit(str(exc))
     if not deployment_id:
-        raise SystemExit(f"Deploy request for model {model_id} was refused by the server.")
+        raise SystemExit(
+            f"Deploy request for model {model_id} was refused by the server."
+        )
     result = {"deployment_id": str(deployment_id)}
     endpoint = _deployment_endpoint(client, deployment_id)
     if endpoint:
@@ -288,11 +292,12 @@ def cmd_create_conversation(args: argparse.Namespace, *, client) -> dict:
 def cmd_chat(args: argparse.Namespace, *, client) -> Optional[dict]:
     """Send a prompt to an agent and return its reply (exercises it end to end).
 
-    Opens a fresh conversation against ``--agent-id``, sends ``--message``, and
-    (with a positive ``--timeout``) waits for the agent's reply — proving the
-    agent can actually respond, not just that it was created. ``--raw`` prints
-    only the reply text. Exits non-zero on an agent error, an empty reply, or a
-    wait timeout (mirrors cmd_deploy_model / cmd_resolve_kaizen_url).
+    Opens a fresh conversation against ``--agent-id``, waits for its sandbox
+    container to come up, sends ``--message``, and (with a positive ``--timeout``)
+    waits for the agent's reply — proving the agent can actually respond, not just
+    that it was created. ``--raw`` prints only the reply text. Exits non-zero on a
+    sandbox that never comes up, an agent error, an empty reply, or a wait timeout
+    (mirrors cmd_deploy_model / cmd_resolve_kaizen_url).
     """
     client = _client_for_workroom(client, args.workroom_id)
     conversation = client.conversations.create(
@@ -302,6 +307,16 @@ def cmd_chat(args: argparse.Namespace, *, client) -> Optional[dict]:
         workroom_id=args.workroom_id,
     )
     try:
+        # create() provisions the sandbox container but it may still be starting
+        # on a fresh box; wait for it to be active before messaging (a stalled
+        # sandbox would otherwise look like an empty/timed-out reply).
+        client.conversations.wait_until_ready(
+            conversation.id,
+            base_url=args.kaizen_base_url,
+            workroom_id=args.workroom_id,
+            timeout_seconds=args.sandbox_timeout,
+            poll_interval_seconds=args.poll_interval,
+        )
         reply = client.conversations.chat(
             conversation.id,
             args.message,
@@ -372,7 +387,7 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--raw",
         action="store_true",
-        help="Print only the bare token (for KAMIWAZA_API_KEY=\"$(... --raw)\").",
+        help='Print only the bare token (for KAMIWAZA_API_KEY="$(... --raw)").',
     )
     p.set_defaults(func=cmd_login)
 
@@ -425,8 +440,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Deploy a registered model so it's callable (external models need this before an agent can bind).",
     )
     g = p.add_mutually_exclusive_group(required=True)
-    g.add_argument("--model-id", default=None, help="ID of a registered model to deploy.")
-    g.add_argument("--name", default=None, help="Name of a registered model to resolve, then deploy.")
+    g.add_argument(
+        "--model-id", default=None, help="ID of a registered model to deploy."
+    )
+    g.add_argument(
+        "--name",
+        default=None,
+        help="Name of a registered model to resolve, then deploy.",
+    )
     p.add_argument(
         "--engine-name",
         default="external_chat",
@@ -440,8 +461,15 @@ def build_parser() -> argparse.ArgumentParser:
             "The endpoint is omitted from the output until the deployment is DEPLOYED."
         ),
     )
-    p.add_argument("--timeout", type=int, default=600, help="Max seconds to wait for DEPLOYED.")
-    p.add_argument("--poll-interval", type=float, default=5.0, help="Seconds between readiness polls.")
+    p.add_argument(
+        "--timeout", type=int, default=600, help="Max seconds to wait for DEPLOYED."
+    )
+    p.add_argument(
+        "--poll-interval",
+        type=float,
+        default=5.0,
+        help="Seconds between readiness polls.",
+    )
     p.set_defaults(func=cmd_deploy_model)
 
     p = sub.add_parser(
@@ -542,6 +570,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="Max seconds to wait for the reply (0 = fire-and-forget, don't wait).",
     )
     p.add_argument(
+        "--sandbox-timeout",
+        type=_non_negative_float,
+        default=120.0,
+        help="Max seconds to wait for the conversation sandbox to come up "
+        "before messaging (default: 120; a fresh box can be slow).",
+    )
+    p.add_argument(
         "--poll-interval",
         type=float,
         default=3.0,
@@ -557,10 +592,18 @@ def build_parser() -> argparse.ArgumentParser:
         "configure-m365",
         help="Register the cluster-wide M365 connector (tenant + client id).",
     )
-    p.add_argument("--tenant-id", required=True, help="Azure AD tenant ID (not secret).")
-    p.add_argument("--client-id", required=True, help="App-registration client ID (not secret).")
+    p.add_argument(
+        "--tenant-id", required=True, help="Azure AD tenant ID (not secret)."
+    )
+    p.add_argument(
+        "--client-id", required=True, help="App-registration client ID (not secret)."
+    )
     p.add_argument("--name", default="Microsoft 365")
-    p.add_argument("--scope", action="append", help="Graph scope (repeatable; defaults to the standard set).")
+    p.add_argument(
+        "--scope",
+        action="append",
+        help="Graph scope (repeatable; defaults to the standard set).",
+    )
     p.set_defaults(func=cmd_configure_m365)
 
     return parser

--- a/kamiwaza_sdk/services/kaizen.py
+++ b/kamiwaza_sdk/services/kaizen.py
@@ -368,6 +368,27 @@ class AgentService(BaseService):
 # error instead of degrading to a generic timeout.
 _ERROR_EVENT_KINDS = frozenset({"AgentErrorEvent", "ConversationErrorEvent"})
 
+# ``execution_status`` is the authoritative "turn has settled" signal. An agent
+# that replies with a plain assistant message and never calls the ``finish`` tool
+# emits no FinishAction, so events alone can't tell us the run is done — the
+# status can. Reading the reply only at a DONE status keeps interim narration
+# (emitted while ``running``) from being taken as the final answer.
+_RUN_DONE_STATUSES = frozenset({"finished", "completed", "done"})
+# ``stuck`` is Kaizen's stuck-loop-detection status: terminal but not a success,
+# so fail fast on it rather than polling out the whole timeout.
+_RUN_FAILED_STATUSES = frozenset({"error", "errored", "failed", "stuck"})
+
+# A conversation's sandbox container (``container_status``) must be ``active``
+# before the agent can process a message. On a fresh box that container can take
+# a while to provision (``initializing``/``pending``/``provisioning``), so
+# sending a message before it's up races the sandbox; :meth:`wait_until_ready`
+# polls until it's active. ``suspended``/``stopped``/``error``/``deleted`` mean
+# it won't come up — fail rather than wait out the timeout.
+_CONTAINER_READY_STATUS = "active"
+_CONTAINER_FAILED_STATUSES = frozenset(
+    {"error", "errored", "failed", "stopped", "suspended", "deleted", "terminated"}
+)
+
 
 def _agent_error_from_events(events: List[Dict[str, Any]]) -> Optional[str]:
     """Return an agent error message from a list of event payloads, or None.
@@ -546,6 +567,75 @@ class ConversationService(BaseService):
             headers=_workroom_headers(workroom_id),
         )
 
+    def get(
+        self,
+        conversation_id: str,
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+    ) -> Conversation:
+        """Fetch a conversation, including its ``execution_status``.
+
+        ``execution_status`` reports whether the agent's run is still working
+        (``running``) or has settled (``finished``/``error``); :meth:`chat` polls
+        it to know when a reply is ready.
+        """
+        response = self.client._request(
+            "GET",
+            f"api/conversations/{conversation_id}",
+            base_url=base_url,
+            headers=_workroom_headers(workroom_id),
+        )
+        return Conversation.model_validate(response)
+
+    def wait_until_ready(
+        self,
+        conversation_id: str,
+        *,
+        base_url: str,
+        workroom_id: Optional[Union[str, object]] = None,
+        timeout_seconds: float = 120.0,
+        poll_interval_seconds: float = 5.0,
+    ) -> Conversation:
+        """Poll until the conversation's sandbox container is ``active``.
+
+        :meth:`create` provisions a per-conversation sandbox container, but on a
+        fresh box that can take a while to come up; sending a message before it's
+        ready races the sandbox. This waits for ``container_status == "active"``
+        (mirrors :func:`wait_for_base_url` for the extension ingress). Returns the
+        ready :class:`Conversation`.
+
+        Raises:
+            ValueError: ``timeout_seconds`` is negative.
+            ConversationError: the container reached a terminal non-serving status
+                (``suspended``/``stopped``/``error``/…) — it won't become ready.
+            TimeoutError: the container was not ``active`` within the budget.
+        """
+        if timeout_seconds < 0:
+            raise ValueError(
+                "timeout_seconds must be zero or a positive number of seconds."
+            )
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            conversation = self.get(
+                conversation_id, base_url=base_url, workroom_id=workroom_id
+            )
+            status = (conversation.container_status or "").strip().lower()
+            if status == _CONTAINER_READY_STATUS:
+                return conversation
+            if status in _CONTAINER_FAILED_STATUSES:
+                raise ConversationError(
+                    f"Sandbox container for conversation {conversation_id} "
+                    f"reported status {status!r}; it will not become ready."
+                )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Sandbox container for conversation {conversation_id} not "
+                    f"ready after {timeout_seconds:g}s (last status {status!r})."
+                )
+            time.sleep(max(0.0, min(poll_interval_seconds, remaining)))
+
     def chat(
         self,
         conversation_id: str,
@@ -558,20 +648,29 @@ class ConversationService(BaseService):
     ) -> Optional[str]:
         """Send a message, run the agent, and return its reply.
 
-        Wraps :meth:`send_message` + :meth:`run`, then polls :meth:`get_events`
-        until the agent's reply lands. Used to exercise an agent end to end
-        (e.g. proving a freshly seeded agent actually responds).
+        Wraps :meth:`send_message` + :meth:`run`, then polls :meth:`get` (run
+        status) and :meth:`get_events` until the agent's reply lands. Used to
+        exercise an agent end to end (e.g. proving a freshly seeded agent
+        actually responds).
 
         ``timeout_seconds`` is the wait budget: a positive value (the default)
         waits up to that long and returns the reply text; ``0`` is fire-and-forget
         — the message is sent and the run triggered, but the method returns
-        ``None`` immediately without waiting. The reply is taken only once the
-        agent's run is terminal (a ``finish`` action or an error event), so an
-        interim assistant narration before the final answer is never mistaken
-        for the reply. Only this turn's events are considered (the pre-run event
-        count is the read offset), and only the first page of them
-        (``get_events`` default ``limit``); a verification turn is a handful of
-        events, so this is not paginated.
+        ``None`` immediately without waiting.
+
+        The reply is taken only once the run is **terminal**, established three
+        ways: the ``finish`` tool (``FinishAction``); an error (an error event or
+        an ``error``/``failed`` ``execution_status``) → raises; or the run
+        reaching a done ``execution_status`` (``finished``) with a reply present.
+        Gating on a done status means an interim assistant message emitted while
+        the run is still working — or a run that stalls (``waiting_for_confirmation``)
+        — is never mistaken for the final answer; a stalled run simply times out.
+        This matters for agents that answer with a plain assistant ``MessageEvent``
+        and never call ``finish`` (e.g. a Bedrock-backed agent), which would
+        otherwise wait forever for a FinishAction that never comes. Only this
+        turn's events are considered (the pre-run event count is the read offset),
+        and only the first page of them (``get_events`` default ``limit``); a
+        verification turn is a handful of events, so this is not paginated.
 
         Args:
             conversation_id: The conversation to post to.
@@ -601,31 +700,90 @@ class ConversationService(BaseService):
             self.run(conversation_id, base_url=base_url, workroom_id=workroom_id)
             return None
 
-        # Read this turn's output only: events appended from here on. Captured
-        # after send (the just-queued user message is excluded) and before run.
+        # run() only schedules the background run, so the first poll can still
+        # report the conversation's PRIOR state. Capture the pre-run status so a
+        # stale terminal status (a reused conversation's last turn, or this turn's
+        # initial 'finished') isn't read as this turn's outcome — it counts only
+        # once it has changed from this value (which still catches a real fresh
+        # failure: a new conversation's 'finished' → 'error' is a change).
+        pre_run_status = (
+            (
+                self.get(
+                    conversation_id, base_url=base_url, workroom_id=workroom_id
+                ).execution_status
+                or ""
+            )
+            .strip()
+            .lower()
+        )
+        # Event count before the run, so polling reads only this turn's events
+        # (the just-queued user message is excluded — it's counted here).
         baseline = self.get_events(
             conversation_id, base_url=base_url, workroom_id=workroom_id, limit=1
         ).get("total", 0)
         self.run(conversation_id, base_url=base_url, workroom_id=workroom_id)
 
         deadline = time.monotonic() + timeout_seconds
+        # True once the STATUS shows this turn's run is underway; gates both
+        # terminal branches so a stale status isn't read as this run's outcome.
+        saw_run_status = False
         while True:
+            # Read status before events: if the run reports done, the events
+            # fetched next already include the reply it settled with.
+            status = (
+                (
+                    self.get(
+                        conversation_id, base_url=base_url, workroom_id=workroom_id
+                    ).execution_status
+                    or ""
+                )
+                .strip()
+                .lower()
+            )
             new_events = self.get_events(
                 conversation_id,
                 base_url=base_url,
                 workroom_id=workroom_id,
                 offset=baseline,
             ).get("events", [])
+            # The run is underway — so a terminal status is THIS turn's — once the
+            # status goes non-terminal or differs from the pre-run value. NOT keyed
+            # on new_events: an interim assistant message is "events" but doesn't
+            # mean the run finished, so it must not unlock the terminal branches.
+            if status != pre_run_status or (
+                status
+                and status not in _RUN_DONE_STATUSES
+                and status not in _RUN_FAILED_STATUSES
+            ):
+                saw_run_status = True
             error = _agent_error_from_events(new_events)
             if error is not None:
                 raise ConversationError(
                     f"Agent errored on conversation {conversation_id}: {error}"
                 )
+            if saw_run_status and status in _RUN_FAILED_STATUSES:
+                raise ConversationError(
+                    f"Agent run on conversation {conversation_id} reported "
+                    f"status {status!r}."
+                )
             if _has_finish_action(new_events):
-                # The run is terminal — take the reply now (the finish message,
-                # or the last assistant text if finish carried none, or None).
-                # Don't accept interim assistant narration before this point.
+                # A FinishAction this turn is unambiguously terminal (it's a new
+                # event past the baseline), so take the reply now regardless of
+                # status — the finish message, the last assistant text if finish
+                # carried none, or None. Don't accept interim narration before it.
                 return _reply_from_events(new_events)
+            if saw_run_status and status in _RUN_DONE_STATUSES:
+                # Run settled without a finish tool (e.g. a plain assistant
+                # reply). Gated on saw_run_status so a stale 'finished' before
+                # the run starts can't return an interim message; return the
+                # reply once present (a genuinely empty run never produces one
+                # and times out). Trade-off: a run that starts AND finishes
+                # within one poll, never leaving 'finished', times out rather
+                # than returns — failing safe is preferred over false-passing a
+                # turn, and a real agent turn spans several polls.
+                reply = _reply_from_events(new_events)
+                if reply is not None:
+                    return reply
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise TimeoutError(

--- a/tests/unit/test_kaizen_service.py
+++ b/tests/unit/test_kaizen_service.py
@@ -125,7 +125,9 @@ def test_resolve_base_url_falls_back_to_api_url():
     # Deployment exposes only api_url (no external/public_api_url).
     extension = SimpleNamespace(
         endpoints=SimpleNamespace(
-            external=None, public_api_url=None, api_url="https://kamiwaza.test/kaizen-api/"
+            external=None,
+            public_api_url=None,
+            api_url="https://kamiwaza.test/kaizen-api/",
         )
     )
     client = SimpleNamespace(
@@ -498,7 +500,9 @@ def test_conversation_send_message_enqueues_without_json_response():
     client = DummyClient(responses)
     service = ConversationService(client)
 
-    result = service.send_message("conv-1", "hello", base_url=KAIZEN_URL, workroom_id="wr-1")
+    result = service.send_message(
+        "conv-1", "hello", base_url=KAIZEN_URL, workroom_id="wr-1"
+    )
 
     assert result is None
     method, path, kwargs = client.calls[0]
@@ -526,7 +530,9 @@ def test_conversation_get_events_passes_pagination():
     client = DummyClient(responses)
     service = ConversationService(client)
 
-    out = service.get_events("conv-1", base_url=KAIZEN_URL, workroom_id="wr-1", offset=5, limit=50)
+    out = service.get_events(
+        "conv-1", base_url=KAIZEN_URL, workroom_id="wr-1", offset=5, limit=50
+    )
 
     assert out == {"events": [], "total": 0}
     method, path, kwargs = client.calls[0]
@@ -562,23 +568,45 @@ def _finish_event(text):
 class ChatClient:
     """Scripts send/run/poll for ConversationService.chat tests.
 
-    The limit=1 baseline read returns ``baseline_total``; subsequent polling
-    reads pop from ``polls`` (the last entry repeats once exhausted, so a
-    never-answers run keeps returning the same empty list).
+    chat() reads the conversation's ``execution_status`` ONCE before the run
+    (the pre-run status, to tell a stale prior-turn status from this turn's),
+    then each wait iteration reads ``execution_status`` and this turn's events.
+    ``pre_status`` is that pre-run read (defaults to the first ``statuses``
+    entry). ``polls`` and ``statuses`` are parallel lists indexed by iteration
+    (the last entry repeats once exhausted). ``statuses`` defaults to ``running``
+    until the final poll, which is ``finished``. The limit=1 baseline read
+    returns ``baseline_total``.
     """
 
-    def __init__(self, polls, baseline_total=0):
+    def __init__(self, polls, statuses=None, pre_status=None, baseline_total=0):
         self.polls = list(polls)
+        if statuses is None:
+            statuses = ["running"] * (len(self.polls) - 1) + ["finished"]
+        self.statuses = list(statuses)
+        self.pre_status = pre_status if pre_status is not None else self.statuses[0]
         self.baseline_total = baseline_total
         self.calls: list[tuple[str, str, dict]] = []
+        self._i = 0  # wait-loop iteration index (events polls)
+        self._status_reads = 0  # GET execution_status reads (pre-run first)
 
     def _request(self, method, path, **kwargs):
         self.calls.append((method, path, kwargs))
         if path.endswith("/events"):
             if kwargs.get("params", {}).get("limit") == 1:
                 return {"total": self.baseline_total, "events": []}
-            events = self.polls.pop(0) if len(self.polls) > 1 else self.polls[0]
+            events = self.polls[min(self._i, len(self.polls) - 1)]
+            self._i += 1  # advance after consuming this iteration's events
             return {"events": events}
+        if method == "GET" and "/conversations/" in path:
+            # First status read is the pre-run capture; the rest are loop reads.
+            if self._status_reads == 0:
+                self._status_reads += 1
+                status = self.pre_status
+            else:
+                idx = self._status_reads - 1
+                self._status_reads += 1
+                status = self.statuses[min(idx, len(self.statuses) - 1)]
+            return {"id": "conv-1", "agent_id": "a", "execution_status": status}
         return None  # messages / run -> 204
 
 
@@ -634,7 +662,9 @@ def test_agent_error_from_events_returns_message_or_none():
     assert _agent_error_from_events([_message_event("ok")]) is None
     # Defensively accept the alternate error-event kind + its `message` field.
     assert (
-        _agent_error_from_events([{"kind": "ConversationErrorEvent", "message": "nope"}])
+        _agent_error_from_events(
+            [{"kind": "ConversationErrorEvent", "message": "nope"}]
+        )
         == "nope"
     )
 
@@ -705,7 +735,10 @@ def test_chat_non_positive_poll_interval_does_not_raise(monkeypatch):
     client = ChatClient(polls=[[], [_finish_event("done")]])
     service = ConversationService(client)
 
-    assert service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=-5) == "done"
+    assert (
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=-5)
+        == "done"
+    )
     assert slept == [0.0]
 
 
@@ -715,10 +748,15 @@ def test_chat_ignores_interim_assistant_text_before_finish(monkeypatch):
     monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
     # First poll: only interim assistant narration, no finish yet — must NOT be
     # returned. Second poll: the terminal finish carries the real answer.
-    client = ChatClient(polls=[[_message_event("Let me think…")], [_finish_event("real answer")]])
+    client = ChatClient(
+        polls=[[_message_event("Let me think…")], [_finish_event("real answer")]]
+    )
     service = ConversationService(client)
 
-    assert service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0) == "real answer"
+    assert (
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0)
+        == "real answer"
+    )
 
 
 def test_chat_negative_timeout_raises():
@@ -763,3 +801,245 @@ def test_chat_times_out_when_no_reply(monkeypatch):
 
     with pytest.raises(TimeoutError, match="No agent reply"):
         service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=1)
+
+
+def test_conversation_get_returns_execution_status():
+    responses = {
+        ("GET", "api/conversations/conv-1"): {
+            "id": "conv-1",
+            "agent_id": "a",
+            "execution_status": "running",
+        }
+    }
+    client = DummyClient(responses)
+    service = ConversationService(client)
+
+    convo = service.get("conv-1", base_url=KAIZEN_URL, workroom_id="wr-1")
+
+    assert convo.execution_status == "running"
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("GET", "api/conversations/conv-1")
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}
+
+
+def test_chat_returns_plain_assistant_reply_when_run_finished(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # The Bedrock-agent shape: the answer is a plain assistant MessageEvent with
+    # no `finish` tool. The real lifecycle is pre-run 'finished' → 'running' →
+    # 'finished'+reply; the reply is returned once the run is observed finished
+    # (after it left the pre-run status, so a stale 'finished' can't short-circuit).
+    client = ChatClient(
+        polls=[[], [_message_event("Hello! I'm Kaizen.")]],
+        statuses=["running", "finished"],
+        pre_status="finished",
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0)
+        == "Hello! I'm Kaizen."
+    )
+
+
+def test_chat_ignores_interim_message_under_stale_finished_status(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # Race guard: pre-run status is a stale 'finished', and the first poll still
+    # shows 'finished' while an INTERIM assistant message has landed before the
+    # run flips to 'running'. That interim text must NOT be returned; only the
+    # message present once the run is observed underway and finished is the reply.
+    client = ChatClient(
+        polls=[
+            [_message_event("thinking…")],
+            [_message_event("thinking…")],
+            [_message_event("thinking…"), _message_event("final answer")],
+        ],
+        statuses=["finished", "running", "finished"],
+        pre_status="finished",
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0)
+        == "final answer"
+    )
+
+
+def test_chat_ignores_assistant_text_while_run_still_running(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # An assistant message present while the run is still 'running' (interim
+    # narration / thinking) must NOT be taken as the answer; only the message
+    # present once the run reports 'finished' is the reply.
+    client = ChatClient(
+        polls=[[_message_event("working on it…")], [_message_event("final answer")]],
+        statuses=["running", "finished"],
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0)
+        == "final answer"
+    )
+
+
+def test_chat_raises_when_execution_status_failed(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # A run that fails after starting (e.g. the bound model isn't actually
+    # deployed) surfaces an error status once underway; chat() must fault, never
+    # report a false success.
+    client = ChatClient(polls=[[], []], statuses=["running", "error"])
+    service = ConversationService(client)
+
+    with pytest.raises(ConversationError, match="status 'error'"):
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL)
+
+
+def test_chat_raises_when_run_reports_stuck(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # Kaizen's stuck-loop detection is terminal-but-not-success: fail fast
+    # instead of polling out the whole timeout.
+    client = ChatClient(polls=[[], []], statuses=["running", "stuck"])
+    service = ConversationService(client)
+
+    with pytest.raises(ConversationError, match="status 'stuck'"):
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL)
+
+
+def test_chat_fast_fails_on_fresh_error_status(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # Fresh conversation: pre-run status is 'finished', and the run fails so fast
+    # the first poll already shows 'error' with no events yet. Because that
+    # differs from the pre-run status it's THIS turn's failure — raise promptly,
+    # don't poll out the whole timeout.
+    client = ChatClient(polls=[[]], statuses=["error"], pre_status="finished")
+    service = ConversationService(client)
+
+    with pytest.raises(ConversationError, match="status 'error'"):
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL)
+
+
+def test_chat_ignores_stale_terminal_status_until_run_starts(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # Reused conversation: the first poll still shows the PRIOR turn's terminal
+    # 'error' status before run() flips it to 'running'. chat() must not fault on
+    # that stale status — it should wait for this turn and return its reply.
+    client = ChatClient(
+        polls=[[], [_message_event("fresh answer")]],
+        statuses=["error", "finished"],
+    )
+    service = ConversationService(client)
+
+    assert (
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, poll_interval_seconds=0)
+        == "fresh answer"
+    )
+
+
+def test_chat_times_out_when_run_stuck_awaiting_confirmation(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 5.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    # A run stalled at waiting_for_confirmation is neither done nor failed: it
+    # must time out, not return the interim assistant message as the reply.
+    client = ChatClient(
+        polls=[[_message_event("Shall I proceed?")]],
+        statuses=["waiting_for_confirmation"],
+    )
+    service = ConversationService(client)
+
+    with pytest.raises(TimeoutError, match="No agent reply"):
+        service.chat("conv-1", "hi", base_url=KAIZEN_URL, timeout_seconds=1)
+
+
+# --- wait_until_ready (sandbox readiness) ----------------------------------
+
+
+class SandboxClient:
+    """Serves a scripted sequence of container_status values from the GET."""
+
+    def __init__(self, container_statuses):
+        self.container_statuses = list(container_statuses)
+        self.calls: list[tuple[str, str, dict]] = []
+        self._i = 0
+
+    def _request(self, method, path, **kwargs):
+        self.calls.append((method, path, kwargs))
+        status = self.container_statuses[min(self._i, len(self.container_statuses) - 1)]
+        self._i += 1
+        return {"id": "conv-1", "agent_id": "a", "container_status": status}
+
+
+def test_wait_until_ready_returns_when_active(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    slept: list = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    client = SandboxClient(["active"])
+    service = ConversationService(client)
+
+    convo = service.wait_until_ready("conv-1", base_url=KAIZEN_URL, workroom_id="wr-1")
+
+    assert convo.container_status == "active"
+    assert slept == []  # already active on the first read
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("GET", "api/conversations/conv-1")
+    assert kwargs["headers"] == {"X-Workroom-Id": "wr-1"}
+
+
+def test_wait_until_ready_polls_through_provisioning(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    slept: list = []
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda s: slept.append(s))
+    # A fresh box: the container starts provisioning and only later goes active.
+    client = SandboxClient(["initializing", "provisioning", "active"])
+    service = ConversationService(client)
+
+    service.wait_until_ready("conv-1", base_url=KAIZEN_URL, poll_interval_seconds=0)
+
+    assert slept == [0, 0]  # slept between the three reads
+
+
+def test_wait_until_ready_raises_on_terminal_container_status(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    client = SandboxClient(["suspended"])
+    service = ConversationService(client)
+
+    with pytest.raises(ConversationError, match="status 'suspended'"):
+        service.wait_until_ready("conv-1", base_url=KAIZEN_URL)
+
+
+def test_wait_until_ready_times_out(monkeypatch):
+    import kamiwaza_sdk.services.kaizen as kaizen_mod
+
+    times = iter([0.0, 0.0, 5.0])
+    monkeypatch.setattr(kaizen_mod.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(kaizen_mod.time, "sleep", lambda _s: None)
+    client = SandboxClient(["pending"])  # never goes active
+    service = ConversationService(client)
+
+    with pytest.raises(TimeoutError, match="not ready after"):
+        service.wait_until_ready("conv-1", base_url=KAIZEN_URL, timeout_seconds=1)
+
+
+def test_wait_until_ready_negative_timeout_raises():
+    service = ConversationService(SandboxClient(["active"]))
+    with pytest.raises(ValueError, match="zero or a positive"):
+        service.wait_until_ready("conv-1", base_url=KAIZEN_URL, timeout_seconds=-1)

--- a/tests/unit/test_seeding_cli.py
+++ b/tests/unit/test_seeding_cli.py
@@ -65,13 +65,18 @@ class FakeClient:
         )
         self.conversations = SimpleNamespace(
             create=RecordingService(SimpleNamespace(id="conv-1")),
+            wait_until_ready=RecordingService(
+                SimpleNamespace(id="conv-1", container_status="active")
+            ),
             chat=RecordingService("Hello! I am claude."),
         )
         self.skills = SimpleNamespace(
             import_skill_package=RecordingService(SimpleNamespace(id="skill-1"))
         )
         self.connectors = SimpleNamespace(
-            create_m365=RecordingService(SimpleNamespace(id="conn-1", name="Microsoft 365"))
+            create_m365=RecordingService(
+                SimpleNamespace(id="conn-1", name="Microsoft 365")
+            )
         )
 
 
@@ -144,13 +149,33 @@ def test_secret_env_flags_reject_abbreviation(monkeypatch):
 
     with pytest.raises(SystemExit):
         parser.parse_args(
-            ["register-external-model", "--protocol", "aws_bedrock", "--name", "n",
-             "--region", "r", "--model-id", "m", "--credential", "AWS_CRED"]
+            [
+                "register-external-model",
+                "--protocol",
+                "aws_bedrock",
+                "--name",
+                "n",
+                "--region",
+                "r",
+                "--model-id",
+                "m",
+                "--credential",
+                "AWS_CRED",
+            ]
         )
     with pytest.raises(SystemExit):
         parser.parse_args(
-            ["create-agent", "--kaizen-base-url", "u", "--name", "n", "--model", "m",
-             "--llm-api-key", "LLM_KEY"]
+            [
+                "create-agent",
+                "--kaizen-base-url",
+                "u",
+                "--name",
+                "n",
+                "--model",
+                "m",
+                "--llm-api-key",
+                "LLM_KEY",
+            ]
         )
 
 
@@ -350,10 +375,14 @@ def test_create_agent_missing_llm_api_key_env_exits(monkeypatch):
         _run(
             [
                 "create-agent",
-                "--kaizen-base-url", "https://kamiwaza.test/kaizen",
-                "--name", "a",
-                "--model", "m",
-                "--llm-api-key-env", "MISSING_KEY_VAR",
+                "--kaizen-base-url",
+                "https://kamiwaza.test/kaizen",
+                "--name",
+                "a",
+                "--model",
+                "m",
+                "--llm-api-key-env",
+                "MISSING_KEY_VAR",
             ],
             client,
         )
@@ -459,7 +488,14 @@ def test_deploy_model_engine_name_and_no_wait_pass_through():
     client = FakeClient()
 
     _run(
-        ["deploy-model", "--model-id", "m2", "--engine-name", "external_transcribe", "--no-wait"],
+        [
+            "deploy-model",
+            "--model-id",
+            "m2",
+            "--engine-name",
+            "external_transcribe",
+            "--no-wait",
+        ],
         client,
     )
 
@@ -477,7 +513,10 @@ def test_deploy_model_requires_model_id_or_name():
 def test_deploy_model_converts_wait_failure_to_systemexit():
     # The documented wait=True failure modes must surface as a clean SystemExit,
     # not a raw traceback (matches cmd_resolve_kaizen_url).
-    for exc in (DeploymentFailedError("deploy failed"), TimeoutError("deploy timed out")):
+    for exc in (
+        DeploymentFailedError("deploy failed"),
+        TimeoutError("deploy timed out"),
+    ):
         client = FakeClient()
         client.serving.deploy_model = _raiser(exc)
         with pytest.raises(SystemExit):
@@ -538,6 +577,10 @@ def test_chat_creates_conversation_and_returns_reply(capsys, monkeypatch):
     create = client.conversations.create.calls[0]["kwargs"]
     assert create["agent_id"] == "agent-1"
     assert create["base_url"] == "https://kamiwaza.test/kaizen"
+    # The sandbox must be waited on (between create and chat) before messaging.
+    wait = client.conversations.wait_until_ready.calls[0]
+    assert wait["args"] == ("conv-1",)
+    assert wait["kwargs"]["workroom_id"] == "wr-1"
     chat = client.conversations.chat.calls[0]
     assert chat["args"] == ("conv-1", "hello there")
     assert chat["kwargs"]["workroom_id"] == "wr-1"
@@ -552,7 +595,16 @@ def test_chat_raw_prints_bare_reply(capsys, monkeypatch):
     monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
 
     _run(
-        ["chat", "--kaizen-base-url", "u", "--agent-id", "a", "--message", "m", "--raw"],
+        [
+            "chat",
+            "--kaizen-base-url",
+            "u",
+            "--agent-id",
+            "a",
+            "--message",
+            "m",
+            "--raw",
+        ],
         client,
     )
 
@@ -579,10 +631,14 @@ def test_chat_fire_and_forget_allows_empty_reply(capsys, monkeypatch):
     _run(
         [
             "chat",
-            "--kaizen-base-url", "u",
-            "--agent-id", "a",
-            "--message", "m",
-            "--timeout", "0",
+            "--kaizen-base-url",
+            "u",
+            "--agent-id",
+            "a",
+            "--message",
+            "m",
+            "--timeout",
+            "0",
         ],
         client,
     )
@@ -608,12 +664,38 @@ def test_chat_agent_error_exits_nonzero(monkeypatch):
         )
 
 
+def test_chat_sandbox_never_ready_exits_without_messaging(monkeypatch):
+    client = FakeClient()
+    client.conversations.wait_until_ready = _raiser(
+        TimeoutError("Sandbox container for conversation conv-1 not ready after 120s")
+    )
+    monkeypatch.setattr(cli, "scoped_client_for_workroom", lambda c, wid: c)
+
+    with pytest.raises(SystemExit, match="not ready"):
+        _run(
+            ["chat", "--kaizen-base-url", "u", "--agent-id", "a", "--message", "m"],
+            client,
+        )
+
+    # A sandbox that never comes up must fail before any message is sent.
+    assert client.conversations.chat.calls == []
+
+
 def test_chat_negative_timeout_rejected_by_parser():
     # argparse rejects a negative --timeout before any client call.
     with pytest.raises(SystemExit):
         _run(
-            ["chat", "--kaizen-base-url", "u", "--agent-id", "a", "--message", "m",
-             "--timeout", "-5"],
+            [
+                "chat",
+                "--kaizen-base-url",
+                "u",
+                "--agent-id",
+                "a",
+                "--message",
+                "m",
+                "--timeout",
+                "-5",
+            ],
             FakeClient(),
         )
 


### PR DESCRIPTION
## What this ships

The nightly UAT seeder's agent chat-verification (`kamiwaza-seed chat`, ENG-7204) could never pass for an agent that answers with a plain assistant message instead of the `finish` tool (e.g. the Bedrock-backed UAT agent): `ConversationService.chat()` only returned a reply on a `FinishAction`, so the real reply was discarded and the run timed out at any budget. This reworks `chat()` to settle on the conversation's `execution_status`, and adds an explicit sandbox-readiness wait before messaging.

## Behavior

- `chat()` terminal detection: **error event or `error`/`failed`/`stuck` status → raise**; **`FinishAction` → return reply**; **`finished` status with a reply present → return** the plain assistant reply. Gated on `saw_run_status` (the status has shown *this* turn underway) so a stale pre-run status can't be read as this turn's outcome, and interim/thinking output (emitted while `running`) is never returned.
- New `ConversationService.get()` (exposes `execution_status`) and `wait_until_ready()` (polls `container_status` until `active`; raises on a terminal non-serving status).
- Seeder `cmd_chat` now does **create → wait_until_ready → chat**, with a new `--sandbox-timeout` (default 120s) for the cold-box sandbox spin-up.

Accepted trade-off (documented in-code): a run that both starts and finishes within a single poll without the status ever leaving `finished` times out rather than returns — failing safe over false-passing a verification.

## Verification

- **Unit**: full SDK unit suite **2504 passed** (+ new coverage for the status-gated terminal paths, `stuck`, stale-vs-fresh status, sandbox readiness, and the seeder wiring). ruff / black / isort / mypy clean.
- **Live (daily UAT box, `test.kamiwaza.dev`)**: ran the SDK from source against the real seeded `uat-bedrock-agent`. Pre-fix a fresh-conversation chat timed out at 60s **and** 300s; post-fix the real `kamiwaza-seed chat` path (create → wait_until_ready → chat) returns `rc=0` end-to-end in ~24s (sandbox ~16s, reply ~8s). Empirically `execution_status` goes `running` → `finished`; `create()` blocks until the sandbox is `active`.
- No local-cluster deploy preflight (SDK library change; verified by running source against the live box).

<!-- pr-evidence-start -->
<details>
<summary>PR Evidence (pr-evidence v0.3.2)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-06-19T00:36:41.156Z
manifest_hash: sha256:da30cd1b07752e8edb901bbd6c73ebc58ff8af7a530209eaaf4da579e36c863f
phase_a_complete: true
phase_b_complete: true
repos:
  - name: kamiwaza-sdk
    path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-ENG-7300
    branch: feature/ENG-7300
    head_sha: e2e42d7bbdec6a4b412228741536885e466df555
    head_sha_short: e2e42d7bb
    dirty_files: 0
    ahead: 0
    behind: 0
    upstream: origin/feature/ENG-7300
    delivery:
      mode: source-mount
      verified: false
      details:
        bind_mount:
          host_path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-ENG-7300
          container_path: /app/kamiwaza-sdk
          spot_check_file: kamiwaza_sdk/services/kaizen.py
          host_sha256: 0762b612cc0c1723a999512d927596983975d6664e107495c9ebd944a2282867
          container_verifications: []
clusters: []
```


# PR Evidence — generated 2026-06-19T00:36:41.156Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| kamiwaza-sdk | feature/ENG-7300 | `e2e42d7bb` | clean | source-mount ⚠ |

## Cross-references

- Linear: `ENG-7300`

</details>
<!-- pr-evidence-end -->
