### PR TITLE
ENG-7796: CodeScene PR-check pilot smoke (do not merge)

### DIFF
--- a/codescene_pilot_smoke.py
+++ b/codescene_pilot_smoke.py
@@ -33,3 +33,5 @@ def _smoke_classify(values, threshold, mode, flags):
     return result
 
 # touch to trigger pull_request.synchronize (ENG-7796)
+
+# live-repro 427cd87

--- a/codescene_pilot_smoke.py
+++ b/codescene_pilot_smoke.py
@@ -1,0 +1,33 @@
+"""Throwaway smoke test for the CodeScene PR-check pilot (ENG-7796).
+
+This file exists only to verify that CodeScene posts a Code Health delta
+check + review on a pull request. It is NOT meant to be merged — the PR is
+a draft and will be closed, and this file deleted.
+"""
+
+
+def _smoke_classify(values, threshold, mode, flags):
+    # Intentionally gnarly (deep nesting / branching) so the Clean Code
+    # Collective profile has something to flag in the PR review.
+    result = []
+    for v in values:
+        if v is not None:
+            if v > threshold:
+                if mode == "strict":
+                    if flags.get("double"):
+                        result.append(v * 2)
+                    else:
+                        result.append(v)
+                elif mode == "loose":
+                    if flags.get("negate"):
+                        result.append(-v)
+                    else:
+                        result.append(v + 1)
+                else:
+                    result.append(0)
+            else:
+                if mode == "strict":
+                    result.append(-1)
+                else:
+                    result.append(None)
+    return result

--- a/codescene_pilot_smoke.py
+++ b/codescene_pilot_smoke.py
@@ -35,3 +35,5 @@ def _smoke_classify(values, threshold, mode, flags):
 # touch to trigger pull_request.synchronize (ENG-7796)
 
 # live-repro 427cd87
+
+# retrigger after Contents:Read (ENG-7796)

--- a/codescene_pilot_smoke.py
+++ b/codescene_pilot_smoke.py
@@ -31,3 +31,5 @@ def _smoke_classify(values, threshold, mode, flags):
                 else:
                     result.append(None)
     return result
+
+# touch to trigger pull_request.synchronize (ENG-7796)


### PR DESCRIPTION
Draft smoke test for the CodeScene PR-check pilot (ENG-7796). Verifies the CodeScene GitHub App posts a Code Health delta check + review. **Do not merge** — will be closed and the throwaway file deleted once verified.