### PR TITLE
feat(connectors): connector server SPI (kamiwaza_sdk.connectors) [ENG-1538]

### DIFF
--- a/kamiwaza_sdk/connectors/__init__.py
+++ b/kamiwaza_sdk/connectors/__init__.py
@@ -1,0 +1,67 @@
+"""Kamiwaza connector server SPI.
+
+The contract a connector pod implements: subclass
+:class:`ConnectorProvider`, declare a :class:`ConfigSchema`, and serve it with
+:func:`create_connector_app`. ``provider.to_manifest()`` is the connector's full
+self-description (identity / auth / egress / deployment + the admin-form config
+JSON Schema) — the same document published to the catalog (``connectors.json``)
+and served at ``GET /manifest``.
+
+This is the server-side complement to the connector *client* surface
+(:mod:`kamiwaza_sdk.services.connectors`, :mod:`kamiwaza_sdk.schemas.connectors`).
+Connector repos depend on ``kamiwaza-sdk[connector]`` and import from here
+instead of vendoring the platform source.
+"""
+
+from __future__ import annotations
+
+from .config_schema import ConfigField, ConfigSchema, ConfigType
+from .connector_proxy import ConnectorProxyRequest, ConnectorProxyResponse
+from .connector_token import ConnectorMintRequest, ConnectorMintResponse
+from .exceptions import ConnectorException, InvalidConfigException
+from .provider import (
+    AuthModel,
+    ConnectorProvider,
+    ConnectorSpec,
+    ConstraintDescriptor,
+    DeploymentDescriptor,
+    OAuthDescriptor,
+    PerUserOAuth,
+    ServiceToken,
+    SurfaceDescriptor,
+    auth_model_from_kind,
+    validate_icon,
+)
+from .server_kit import (
+    ExecuteRequest,
+    OpResult,
+    VerifyRequest,
+    create_connector_app,
+)
+
+__all__ = [
+    "ConfigField",
+    "ConfigSchema",
+    "ConfigType",
+    "AuthModel",
+    "PerUserOAuth",
+    "ServiceToken",
+    "auth_model_from_kind",
+    "OAuthDescriptor",
+    "DeploymentDescriptor",
+    "ConstraintDescriptor",
+    "SurfaceDescriptor",
+    "ConnectorSpec",
+    "ConnectorProvider",
+    "validate_icon",
+    "create_connector_app",
+    "ExecuteRequest",
+    "VerifyRequest",
+    "OpResult",
+    "ConnectorProxyRequest",
+    "ConnectorProxyResponse",
+    "ConnectorMintRequest",
+    "ConnectorMintResponse",
+    "ConnectorException",
+    "InvalidConfigException",
+]

--- a/kamiwaza_sdk/connectors/config_schema.py
+++ b/kamiwaza_sdk/connectors/config_schema.py
@@ -95,10 +95,21 @@ class ConfigSchema:
         properties = schema.get("properties") or {}
         required = set(schema.get("required") or ())
         type_by_value = {t.value: t for t in ConfigType}
+
+        def _config_type(raw: Any) -> ConfigType:
+            # JSON Schema allows a nullable type as a list (["string","null"]);
+            # pick the first non-"null" entry. Non-str / unknown types fall back
+            # to string (matches the documented behavior).
+            if isinstance(raw, list):
+                raw = next((t for t in raw if t != "null"), "string")
+            if not isinstance(raw, str):
+                return ConfigType.STRING
+            return type_by_value.get(raw, ConfigType.STRING)
+
         fields = tuple(
             ConfigField(
                 name=name,
-                type=type_by_value.get((prop or {}).get("type", "string"), ConfigType.STRING),
+                type=_config_type((prop or {}).get("type", "string")),
                 required=name in required,
                 secret=bool((prop or {}).get("writeOnly")),
                 # A property listed in JSON Schema ``required`` must be supplied —

--- a/kamiwaza_sdk/connectors/config_schema.py
+++ b/kamiwaza_sdk/connectors/config_schema.py
@@ -101,7 +101,11 @@ class ConfigSchema:
                 type=type_by_value.get((prop or {}).get("type", "string"), ConfigType.STRING),
                 required=name in required,
                 secret=bool((prop or {}).get("writeOnly")),
-                default=(prop or {}).get("default"),
+                # A property listed in JSON Schema ``required`` must be supplied —
+                # ``required`` wins over a ``default``. Carrying the default would
+                # make ``must_supply`` false and let ``validate({})`` accept a
+                # missing required field from an externally-authored manifest.
+                default=None if name in required else (prop or {}).get("default"),
                 description=(prop or {}).get("description", ""),
             )
             for name, prop in properties.items()

--- a/kamiwaza_sdk/connectors/config_schema.py
+++ b/kamiwaza_sdk/connectors/config_schema.py
@@ -1,0 +1,133 @@
+"""Declarative connector config contract -- the framework's ConfigDef analog.
+
+A connector declares the admin configuration it needs as a :class:`ConfigSchema`
+(a set of :class:`ConfigField`). The framework derives BOTH validation and the
+admin-form JSON Schema from that one declaration, and marks secret fields so the
+UI and secret store can protect them. So a connector author writes the config once
+and gets validation + UI for free -- the Kafka Connect ``ConfigDef`` idea adapted
+to Kamiwaza connectors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from .exceptions import InvalidConfigException
+
+
+class ConfigType(str, Enum):
+    """The value type of a config field (kept small and JSON-Schema-mappable)."""
+
+    STRING = "string"
+    INTEGER = "integer"
+    BOOLEAN = "boolean"
+
+
+_PY_TYPES: dict[ConfigType, type] = {
+    ConfigType.STRING: str,
+    ConfigType.INTEGER: int,
+    ConfigType.BOOLEAN: bool,
+}
+
+
+@dataclass(frozen=True)
+class ConfigField:
+    """One admin-config field a connector declares.
+
+    ``required`` with no ``default`` means the admin must supply it. ``secret``
+    marks credential material (rendered write-only, routed to the secret store).
+    """
+
+    name: str
+    type: ConfigType = ConfigType.STRING
+    required: bool = True
+    secret: bool = False
+    default: Any = None
+    description: str = ""
+
+    @property
+    def must_supply(self) -> bool:
+        """Whether the admin must provide a value (required and no default)."""
+        return self.required and self.default is None
+
+
+@dataclass(frozen=True)
+class ConfigSchema:
+    """A connector's declarative admin-config contract (the ConfigDef analog)."""
+
+    fields: tuple[ConfigField, ...] = ()
+
+    def validate(self, config: dict[str, Any]) -> None:
+        """Validate admin config against the schema; raise with all problems.
+
+        Unknown keys are ignored (forward-compatible). Collects every error and
+        raises once, so the admin sees all problems at a time.
+        """
+        errors: list[str] = []
+        for field in self.fields:
+            value = config.get(field.name)
+            if value is None:
+                if field.must_supply:
+                    errors.append(f"missing required config: {field.name}")
+                continue
+            expected = _PY_TYPES[field.type]
+            # bool is a subclass of int -- never accept a bool for an integer field
+            if not isinstance(value, expected) or (
+                expected is int and isinstance(value, bool)
+            ):
+                errors.append(f"config {field.name} must be {field.type.value}")
+        if errors:
+            raise InvalidConfigException("; ".join(errors))
+
+    @classmethod
+    def from_json_schema(cls, schema: dict[str, Any]) -> "ConfigSchema":
+        """Rebuild a ConfigSchema from a JSON Schema (the inverse of to_json_schema).
+
+        A *remote* connector ships its config contract as JSON Schema in its manifest;
+        core must validate admin config against that, not the empty base schema, so a
+        missing required field (e.g. a confidential connector's client_secret) is
+        rejected. Reconstruction is validation-faithful: a field listed in ``required``
+        becomes must-supply; ``writeOnly`` marks secrets; an unknown type falls back to
+        string.
+        """
+        properties = schema.get("properties") or {}
+        required = set(schema.get("required") or ())
+        type_by_value = {t.value: t for t in ConfigType}
+        fields = tuple(
+            ConfigField(
+                name=name,
+                type=type_by_value.get((prop or {}).get("type", "string"), ConfigType.STRING),
+                required=name in required,
+                secret=bool((prop or {}).get("writeOnly")),
+                default=(prop or {}).get("default"),
+                description=(prop or {}).get("description", ""),
+            )
+            for name, prop in properties.items()
+        )
+        return cls(fields=fields)
+
+    def to_json_schema(self) -> dict[str, Any]:
+        """Render a JSON Schema the admin UI auto-renders the config form from."""
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+        for field in self.fields:
+            prop: dict[str, Any] = {"type": field.type.value}
+            if field.description:
+                prop["description"] = field.description
+            if field.default is not None:
+                prop["default"] = field.default
+            if field.secret:
+                prop["writeOnly"] = True
+            properties[field.name] = prop
+            if field.must_supply:
+                required.append(field.name)
+        schema: dict[str, Any] = {"type": "object", "properties": properties}
+        if required:
+            schema["required"] = required
+        return schema
+
+    def secret_fields(self) -> tuple[str, ...]:
+        """Names of fields holding secrets (for redaction / secret-store routing)."""
+        return tuple(field.name for field in self.fields if field.secret)

--- a/kamiwaza_sdk/connectors/connector_proxy.py
+++ b/kamiwaza_sdk/connectors/connector_proxy.py
@@ -46,7 +46,9 @@ class ConnectorProxyRequest(ConnectorMintRequest):
 class ConnectorProxyResponse(BaseModel):
     """The upstream response, returned to the connector."""
 
-    model_config = ConfigDict(from_attributes=True)
+    # extra="allow": retain fields a newer core adds (forward-compat), matching
+    # the SDK's other response schemas.
+    model_config = ConfigDict(from_attributes=True, extra="allow")
 
     status_code: int = Field(..., description="Upstream HTTP status code")
     body: Any = Field(None, description="Parsed JSON response body (v1 is JSON-only)")

--- a/kamiwaza_sdk/connectors/connector_proxy.py
+++ b/kamiwaza_sdk/connectors/connector_proxy.py
@@ -1,0 +1,52 @@
+"""Schemas for the connector raw-execute proxy (core-mediated egress).
+
+A subscribed connector builds a request against its data source and
+hands it to core to execute (the P1 / core-proxied posture): core authorizes the
+call, attaches the access token, enforces the connector's egress allowlist, calls
+the SaaS, and returns the response. The connector never holds a token and never
+egresses to the SaaS directly.
+
+The acting-subject (``subject_token``), ``scope_subset`` and ``lease_duration``
+fields are inherited from the mint request -- the same verified-subject trust
+boundary applies; the credential core mints to make the call is bound and scoped
+identically. See contracts/proxy-execute.md.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .connector_token import ConnectorMintRequest
+
+
+class ConnectorProxyRequest(ConnectorMintRequest):
+    """A connector's raw request for core to execute on its behalf.
+
+    ``Authorization`` is injected by core and never accepted from the caller.
+    """
+
+    method: Literal["GET", "POST"] = Field(
+        "GET", description="HTTP method (v1: GET or POST)"
+    )
+    url: str = Field(
+        ...,
+        description="Absolute URL; its host must be in the connector's egress allowlist",
+    )
+    params: dict[str, Any] | None = Field(None, description="Query parameters")
+    body: dict[str, Any] | None = Field(None, description="JSON body (POST)")
+    response_format: Literal["json", "binary"] = Field(
+        "json",
+        description="How core returns the upstream body: parsed JSON (default), or "
+        "base64-wrapped bytes for binary content such as file downloads",
+    )
+
+
+class ConnectorProxyResponse(BaseModel):
+    """The upstream response, returned to the connector."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    status_code: int = Field(..., description="Upstream HTTP status code")
+    body: Any = Field(None, description="Parsed JSON response body (v1 is JSON-only)")

--- a/kamiwaza_sdk/connectors/connector_token.py
+++ b/kamiwaza_sdk/connectors/connector_token.py
@@ -54,7 +54,9 @@ class ConnectorMintResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, extra="allow")
 
     access_token: str = Field(
-        ..., description="Provider access token (use directly against the provider API)"
+        ...,
+        repr=False,  # live bearer token — keep it out of repr()/logs/tracebacks
+        description="Provider access token (use directly against the provider API)",
     )
     lease_id: str = Field(..., description="Lease identifier for tracking / revocation")
     granted_scopes: list[str] = Field(

--- a/kamiwaza_sdk/connectors/connector_token.py
+++ b/kamiwaza_sdk/connectors/connector_token.py
@@ -1,0 +1,67 @@
+"""Schemas for connector-scoped ephemeral credential minting.
+
+The request a subscribed connector sends to mint a short-lived,
+scope-restricted credential for a subject it acts for, and the response carrying
+that credential. The connector authenticates as its own workload identity (see the
+route); the acting subject is named here.
+
+The acting subject is established from a *verified* token: the connector presents
+the acting user's ``subject_token`` and core's verification of it (its ``sub``) is
+authoritative. ``subject_id`` is a self-asserted fallback honored only under an
+explicit env gate; ``subject_type`` is an audit hint. Neither is a trust input. The
+credential source is chosen by the connector's admin-declared auth model
+(``PerUserOAuth`` vs ``ServiceToken``). See design.md "Principal-typed subjects".
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ConnectorMintRequest(BaseModel):
+    """Request to mint a credential for a connector's acting subject."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    subject_token: str | None = Field(
+        None,
+        repr=False,
+        description="Acting user's bearer token; its verified `sub` is authoritative",
+    )
+    subject_id: str | None = Field(
+        None,
+        description="Self-asserted subject; honored only under the env-gated PoC fallback",
+    )
+    subject_type: str | None = Field(
+        None,
+        description="Audit hint only (e.g. user / group / npe); NOT a trust input",
+    )
+    scope_subset: list[str] | None = Field(
+        None,
+        description="Optional subset of the subject's granted scopes (defaults to all)",
+    )
+    lease_duration: int = Field(
+        300,
+        ge=60,
+        le=900,
+        description="Broker lease TTL in seconds (1-15 min, default 5 min)",
+    )
+
+
+class ConnectorMintResponse(BaseModel):
+    """Response carrying a short-lived provider access token."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    access_token: str = Field(
+        ..., description="Provider access token (use directly against the provider API)"
+    )
+    lease_id: str = Field(..., description="Lease identifier for tracking / revocation")
+    granted_scopes: list[str] = Field(
+        ..., description="Scopes the minted token is restricted to"
+    )
+    expires_in: int = Field(
+        ..., description="Provider token expiry in seconds (refreshed in core)"
+    )
+    broker_lease_expires_in: int = Field(
+        ..., description="Broker lease expiry in seconds"
+    )
+    token_type: str = Field(default="Bearer", description="Token type")

--- a/kamiwaza_sdk/connectors/connector_token.py
+++ b/kamiwaza_sdk/connectors/connector_token.py
@@ -49,7 +49,9 @@ class ConnectorMintRequest(BaseModel):
 class ConnectorMintResponse(BaseModel):
     """Response carrying a short-lived provider access token."""
 
-    model_config = ConfigDict(from_attributes=True)
+    # extra="allow": retain fields a newer core adds so an older connector that
+    # round-trips (model_validate -> model_dump) this response doesn't drop them.
+    model_config = ConfigDict(from_attributes=True, extra="allow")
 
     access_token: str = Field(
         ..., description="Provider access token (use directly against the provider API)"

--- a/kamiwaza_sdk/connectors/exceptions.py
+++ b/kamiwaza_sdk/connectors/exceptions.py
@@ -1,0 +1,167 @@
+"""Custom exceptions for connectors service."""
+
+
+class ConnectorException(Exception):
+    """Base exception for connector service."""
+
+    pass
+
+
+class ConnectorNotFoundException(ConnectorException):
+    """Connector not found."""
+
+    pass
+
+
+class ConnectionNotFoundException(ConnectorException):
+    """User connection not found."""
+
+    pass
+
+
+class ConnectorDisabledException(ConnectorException):
+    """Connector is disabled."""
+
+    pass
+
+
+class ConnectorSurfaceUnavailableException(ConnectorException):
+    """A connector surface/op has no deployed implementation yet.
+
+    Raised when a surface (e.g. mail or calendar) is not served by the deployed
+    connector, instead of silently falling back to a now-deleted client.
+    """
+
+    pass
+
+
+class TokenEncryptionException(ConnectorException):
+    """Token encryption/decryption error."""
+
+    pass
+
+
+class DeviceCodeExpiredException(ConnectorException):
+    """Device code flow expired."""
+
+    pass
+
+
+class DeviceCodePendingException(ConnectorException):
+    """Device code flow still pending user authentication."""
+
+    pass
+
+
+class DeviceCodeErrorException(ConnectorException):
+    """Device code flow error."""
+
+    pass
+
+
+class ProviderAPIException(ConnectorException):
+    """External provider API error carrying an upstream HTTP status code."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class TokenRefreshException(ConnectorException):
+    """Token refresh failed."""
+
+    pass
+
+
+class TransientTokenRefreshException(TokenRefreshException):
+    """Token refresh failed transiently (network error / upstream 5xx /
+    eventually-consistent secret read).
+
+    The stored credentials are still valid — the caller should retry rather than
+    force the user to reconnect. Subclasses TokenRefreshException so existing
+    handlers still treat it as a refresh failure, while callers that care about
+    recoverability can catch it specifically.
+    """
+
+    pass
+
+
+class InvalidConfigException(ConnectorException):
+    """Invalid connector configuration."""
+
+    pass
+
+
+class RateLimitException(ConnectorException):
+    """Rate limit exceeded."""
+
+    def __init__(self, message: str, retry_after: int = 5):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+class ContentTooLargeException(ConnectorException):
+    """File content exceeds maximum download size."""
+
+    def __init__(self, message: str, file_size: int, max_size: int):
+        super().__init__(message)
+        self.file_size = file_size
+        self.max_size = max_size
+
+
+class OAuthException(ConnectorException):
+    """Base exception for OAuth flows."""
+
+    pass
+
+
+class OAuthConfigException(OAuthException):
+    """OAuth configuration error."""
+
+    def __init__(self, message: str, code: str | None = None):
+        super().__init__(message)
+        self.code = code
+
+
+class OAuthStateException(OAuthException):
+    """OAuth state validation error."""
+
+    pass
+
+
+class OAuthTokenExchangeException(OAuthException):
+    """OAuth token exchange failed."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class OAuthUserInfoException(OAuthException):
+    """OAuth userinfo retrieval failed."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class OAuthRequestException(OAuthException):
+    """OAuth request blocked or invalid."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class OAuthAccessDeniedException(OAuthException):
+    """OAuth access denied by user or provider policy."""
+
+    pass
+
+
+class RemoteConnectorException(ConnectorException):
+    """A call to a deployed connector failed (transport or non-2xx)."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code

--- a/kamiwaza_sdk/connectors/provider.py
+++ b/kamiwaza_sdk/connectors/provider.py
@@ -85,8 +85,10 @@ class OAuthDescriptor:
     as ordered pairs, so the descriptor stays frozen/hashable and JSON-stable.
     """
 
-    authorization_endpoint: str
     token_endpoint: str
+    # Optional: a device_code (RFC 8628) connector ships no authorization_endpoint
+    # (only token + device_authorization), so this is None for that flow.
+    authorization_endpoint: str | None = None
     revocation_endpoint: str | None = None
     # RFC 8628 device-authorization endpoint, for connectors that declare
     # ``flow="device_code"`` (public clients with no redirect, e.g. M365).
@@ -111,7 +113,8 @@ class OAuthDescriptor:
     def from_manifest(cls, data: dict[str, Any]) -> OAuthDescriptor:
         """Reconstruct a descriptor from a manifest produced by :meth:`to_manifest`."""
         return cls(
-            authorization_endpoint=data["authorization_endpoint"],
+            # Optional for device_code manifests (only token + device endpoints).
+            authorization_endpoint=data.get("authorization_endpoint"),
             token_endpoint=data["token_endpoint"],
             revocation_endpoint=data.get("revocation_endpoint"),
             device_authorization_endpoint=data.get("device_authorization_endpoint"),
@@ -143,7 +146,11 @@ class OAuthDescriptor:
 
         return replace(
             self,
-            authorization_endpoint=fill(self.authorization_endpoint),
+            authorization_endpoint=(
+                fill(self.authorization_endpoint)
+                if self.authorization_endpoint
+                else None
+            ),
             token_endpoint=fill(self.token_endpoint),
             revocation_endpoint=(
                 fill(self.revocation_endpoint) if self.revocation_endpoint else None

--- a/kamiwaza_sdk/connectors/provider.py
+++ b/kamiwaza_sdk/connectors/provider.py
@@ -1,0 +1,476 @@
+"""Connector provider SPI.
+
+The contract every connector provider satisfies, keyed by ``connector_type``.
+Subscribed connectors register a :class:`.providers.remote.RemoteConnectorProvider`
+in :mod:`.registry`; external connectors will later be loaded by classpath and
+validated with ``isinstance``, mirroring the gate-package plugin contract in
+``kamiwaza/services/authz/gates/protocol.py``.
+
+The contract grows one method at a time as cross-provider dispatch is migrated
+off ``connector_type ==`` string checks; today it carries identity and config
+validation.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, replace
+from typing import Any, ClassVar
+
+from .config_schema import ConfigSchema
+
+
+@dataclass(frozen=True)
+class AuthModel:
+    """How a connector authenticates — base of a closed discriminated union.
+
+    Variants are markers today, distinguished by ``kind``; per-variant manifest
+    detail (oauth flow, scopes, secret fields) is added when a consumer needs
+    it. ``kind`` is the stable discriminant rendered into the manifest.
+    """
+
+    kind: ClassVar[str]
+
+
+@dataclass(frozen=True)
+class PerUserOAuth(AuthModel):
+    """Each user authorizes their own account; tokens brokered per-user.
+
+    The model behind per-user connectors: core brokers and refreshes the user's
+    token generically from the manifest's OAuth descriptor (see
+    :mod:`kamiwaza.services.connectors.token_broker`), so the connector never holds it.
+    """
+
+    kind: ClassVar[str] = "per_user_oauth"
+
+
+@dataclass(frozen=True)
+class ServiceToken(AuthModel):
+    """A single shared credential configured once; no per-user OAuth.
+
+    The model behind service-token integrations (e.g. a bot's API key) that
+    have no per-user authorization step.
+    """
+
+    kind: ClassVar[str] = "service_token"
+
+
+_AUTH_MODELS: dict[str, type[AuthModel]] = {
+    PerUserOAuth.kind: PerUserOAuth,
+    ServiceToken.kind: ServiceToken,
+}
+
+
+def auth_model_from_kind(kind: str) -> AuthModel:
+    """Reconstruct an :class:`AuthModel` from its manifest ``kind`` discriminant.
+
+    Fails fast on an unknown kind rather than guessing a default — a malformed
+    manifest is a contract error, not a degradation to absorb silently.
+    """
+    try:
+        return _AUTH_MODELS[kind]()
+    except KeyError:
+        raise ValueError(f"Unknown auth model kind: {kind!r}") from None
+
+
+@dataclass(frozen=True)
+class OAuthDescriptor:
+    """A connector's OAuth endpoints + scopes, declared in its manifest.
+
+    Lets core run the OAuth authorization ceremony generically: the endpoints,
+    scopes, and flow type come from the connector, so no provider OAuth specifics
+    are hardcoded in core. The admin still supplies the client credentials via the
+    config schema -- those are never in the manifest. ``extra_auth_params`` carries
+    provider-specific authorization-URL params (e.g. an ``access_type=offline`` flag)
+    as ordered pairs, so the descriptor stays frozen/hashable and JSON-stable.
+    """
+
+    authorization_endpoint: str
+    token_endpoint: str
+    revocation_endpoint: str | None = None
+    # RFC 8628 device-authorization endpoint, for connectors that declare
+    # ``flow="device_code"`` (public clients with no redirect, e.g. M365).
+    device_authorization_endpoint: str | None = None
+    scopes: tuple[str, ...] = ()
+    flow: str = "authorization_code"
+    extra_auth_params: tuple[tuple[str, str], ...] = ()
+
+    def to_manifest(self) -> dict[str, Any]:
+        """Serialize to a plain-JSON object for the manifest envelope."""
+        return {
+            "authorization_endpoint": self.authorization_endpoint,
+            "token_endpoint": self.token_endpoint,
+            "revocation_endpoint": self.revocation_endpoint,
+            "device_authorization_endpoint": self.device_authorization_endpoint,
+            "scopes": list(self.scopes),
+            "flow": self.flow,
+            "extra_auth_params": dict(self.extra_auth_params),
+        }
+
+    @classmethod
+    def from_manifest(cls, data: dict[str, Any]) -> OAuthDescriptor:
+        """Reconstruct a descriptor from a manifest produced by :meth:`to_manifest`."""
+        return cls(
+            authorization_endpoint=data["authorization_endpoint"],
+            token_endpoint=data["token_endpoint"],
+            revocation_endpoint=data.get("revocation_endpoint"),
+            device_authorization_endpoint=data.get("device_authorization_endpoint"),
+            scopes=tuple(data.get("scopes") or ()),
+            flow=data.get("flow", "authorization_code"),
+            extra_auth_params=tuple(
+                (str(k), str(v))
+                for k, v in (data.get("extra_auth_params") or {}).items()
+            ),
+        )
+
+    def resolved(self, config: dict[str, Any]) -> OAuthDescriptor:
+        """Return a copy with ``{config_key}`` placeholders in the endpoints filled.
+
+        A connector may declare config-dependent endpoints (e.g. M365's
+        single-tenant authority ``.../{tenant_id}/oauth2/v2.0/token``). Resolving
+        on the descriptor means *every* consumer — the authorization ceremony, the
+        device-code poll, and the per-user refresh — is placeholder-safe by
+        construction, instead of each call site remembering to substitute (the gap
+        that left token refresh POSTing to a literal ``{tenant_id}`` URL). A no-op
+        for fixed endpoints (e.g. Google).
+        """
+
+        def fill(url: str) -> str:
+            for key, value in config.items():
+                if isinstance(value, str):
+                    url = url.replace("{" + key + "}", value)
+            return url
+
+        return replace(
+            self,
+            authorization_endpoint=fill(self.authorization_endpoint),
+            token_endpoint=fill(self.token_endpoint),
+            revocation_endpoint=(
+                fill(self.revocation_endpoint) if self.revocation_endpoint else None
+            ),
+            device_authorization_endpoint=(
+                fill(self.device_authorization_endpoint)
+                if self.device_authorization_endpoint
+                else None
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class DeploymentDescriptor:
+    """How core runs this connector as a deployed workload.
+
+    Required for every subscribed connector: a connector runs as a deployed
+    extension, so the manifest self-describes its deployable image (and an optional
+    serving port) and core deploys it as a ``type: connector`` KamiwazaExtension --
+    no public ingress, no external egress (it reaches its source only through core's
+    proxy). The image fields mirror the platform's ImageSpec shape
+    (registry / repository / tag).
+    """
+
+    image_repository: str
+    image_registry: str = "ghcr.io"
+    image_tag: str = "latest"
+    port: int | None = None
+    # Digest pin (``sha256:...``) for the deployed image. The connector's own
+    # spec leaves this None; the catalog publisher (kz-ext) resolves and pins
+    # the pushed image so a catalog-deployed connector is immutable.
+    image_digest: str | None = None
+
+    def to_manifest(self) -> dict[str, Any]:
+        """Serialize to a plain-JSON object for the manifest envelope."""
+        manifest: dict[str, Any] = {
+            "image_repository": self.image_repository,
+            "image_registry": self.image_registry,
+            "image_tag": self.image_tag,
+            "port": self.port,
+        }
+        # Omit unless pinned, so an unpinned connector's manifest is unchanged.
+        if self.image_digest:
+            manifest["image_digest"] = self.image_digest
+        return manifest
+
+    @classmethod
+    def from_manifest(cls, data: dict[str, Any]) -> DeploymentDescriptor:
+        """Reconstruct a descriptor from a manifest produced by :meth:`to_manifest`."""
+        return cls(
+            image_repository=data["image_repository"],
+            image_registry=data.get("image_registry", "ghcr.io"),
+            image_tag=data.get("image_tag", "latest"),
+            port=data.get("port"),
+            image_digest=data.get("image_digest"),
+        )
+
+
+@dataclass(frozen=True)
+class ConstraintDescriptor:
+    """A static, manifest-declared surface constraint (machine-readable).
+
+    The connector self-describes the constraints core used to hardcode per provider
+    (e.g. "search needs a drive scope", "folders import as files"). Dynamic,
+    user/workroom-dependent constraints (missing-scope reauth) are still computed by
+    core at catalog time -- these are the static ones the connector owns.
+    """
+
+    code: str
+    message: str
+    actions: tuple[str, ...] = ()
+    source_types: tuple[str, ...] = ()
+    metadata: tuple[tuple[str, Any], ...] = ()
+
+    def to_manifest(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "actions": list(self.actions),
+            "source_types": list(self.source_types),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_manifest(cls, data: dict[str, Any]) -> ConstraintDescriptor:
+        return cls(
+            code=data["code"],
+            message=data["message"],
+            actions=tuple(data.get("actions") or ()),
+            source_types=tuple(data.get("source_types") or ()),
+            metadata=tuple((data.get("metadata") or {}).items()),
+        )
+
+
+@dataclass(frozen=True)
+class SurfaceDescriptor:
+    """One browse/list/search surface a connector offers, fully self-described.
+
+    Replaces the per-provider capability blocks, op-name dicts, key-alias table, and
+    unsupported-import lists core used to hardcode in ``surfaces.py``. ``name`` and
+    ``resource_kinds`` are free strings, so a non-file connector (issues, messages,
+    tables) declares its own vocabulary with no core change -- core renders and routes
+    from this data and never branches on the connector type.
+
+    ``operations`` maps a logical action (``"list"``/``"search"``/``"content"``) to
+    the connector op name core calls for it (``("list", "drive.list_items")``), so the
+    op vocabulary lives in the manifest, not in core.
+    """
+
+    name: str
+    display_label: str
+    operations: tuple[tuple[str, str], ...] = ()
+    resource_kinds: tuple[str, ...] = ()
+    selection_modes: tuple[str, ...] = ()
+    search_supported: bool = False
+    freshness_supported: bool = False
+    constraints: tuple[ConstraintDescriptor, ...] = ()
+    unsupported_import_kinds: tuple[str, ...] = ()
+    credential_key_aliases: tuple[str, ...] = ()
+
+    def operation(self, action: str) -> str | None:
+        """The connector op name bound to *action*, or None if unsupported."""
+        for act, op in self.operations:
+            if act == action:
+                return op
+        return None
+
+    def to_manifest(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "display_label": self.display_label,
+            "operations": [[action, op] for action, op in self.operations],
+            "resource_kinds": list(self.resource_kinds),
+            "selection_modes": list(self.selection_modes),
+            "search_supported": self.search_supported,
+            "freshness_supported": self.freshness_supported,
+            "constraints": [c.to_manifest() for c in self.constraints],
+            "unsupported_import_kinds": list(self.unsupported_import_kinds),
+            "credential_key_aliases": list(self.credential_key_aliases),
+        }
+
+    @classmethod
+    def from_manifest(cls, data: dict[str, Any]) -> SurfaceDescriptor:
+        return cls(
+            name=data["name"],
+            display_label=data.get("display_label", data["name"]),
+            operations=tuple(
+                (str(pair[0]), str(pair[1])) for pair in (data.get("operations") or [])
+            ),
+            resource_kinds=tuple(data.get("resource_kinds") or ()),
+            selection_modes=tuple(data.get("selection_modes") or ()),
+            search_supported=bool(data.get("search_supported", False)),
+            freshness_supported=bool(data.get("freshness_supported", False)),
+            constraints=tuple(
+                ConstraintDescriptor.from_manifest(c)
+                for c in (data.get("constraints") or [])
+            ),
+            unsupported_import_kinds=tuple(data.get("unsupported_import_kinds") or ()),
+            credential_key_aliases=tuple(data.get("credential_key_aliases") or ()),
+        )
+
+
+@dataclass(frozen=True)
+class ConnectorSpec:
+    """A connector's self-description (the manifest the platform renders).
+
+    Identity, auth model, and the connector's declared ``surfaces`` (browse/list/
+    search capabilities, op names, resource kinds, and static constraints) -- so core
+    renders the catalog and routes operations entirely from this manifest, with no
+    per-provider code.
+
+    ``egress_allowlist`` is the set of external hostnames the connector may reach
+    (its SaaS endpoints, e.g. ``api.linear.app``). The platform records it as the
+    connector's declared egress intent and enforces it deny-by-default at core's
+    proxy (``connector_proxy_service._enforce_egress``): a connector reaches its
+    source only through core, whose deployment carries no external egress of its
+    own. Empty means no external egress.
+
+    ``icon`` is the connector's display logo, carried self-contained in the manifest
+    (e.g. a ``data:`` URI) so the connector ships its own branding and the platform
+    only renders it -- no core-hosted asset, no hardcoded per-type map, works
+    airgapped. ``None`` means the UI falls back to a generic icon.
+    """
+
+    connector_type: str
+    provider_id: str
+    provider_label: str
+    auth_model: AuthModel = PerUserOAuth()
+    egress_allowlist: tuple[str, ...] = ()
+    oauth: OAuthDescriptor | None = None
+    deployment: DeploymentDescriptor | None = None
+    icon: str | None = None
+    surfaces: tuple[SurfaceDescriptor, ...] = ()
+    constraints: tuple[ConstraintDescriptor, ...] = ()
+
+    def to_manifest(self) -> dict[str, Any]:
+        """Serialize to a plain-JSON manifest the platform stores and transmits.
+
+        ``auth_model`` nests under its own object so variants can grow fields
+        (scopes, secret fields) without changing the envelope.
+        """
+        return {
+            "connector_type": self.connector_type,
+            "provider_id": self.provider_id,
+            "provider_label": self.provider_label,
+            "icon": self.icon,
+            "auth_model": {"kind": self.auth_model.kind},
+            "egress_allowlist": list(self.egress_allowlist),
+            "oauth": self.oauth.to_manifest() if self.oauth else None,
+            "deployment": self.deployment.to_manifest() if self.deployment else None,
+            "surfaces": [surface.to_manifest() for surface in self.surfaces],
+            "constraints": [c.to_manifest() for c in self.constraints],
+        }
+
+    @classmethod
+    def from_manifest(cls, data: dict[str, Any]) -> ConnectorSpec:
+        """Reconstruct a spec from a manifest produced by :meth:`to_manifest`."""
+        return cls(
+            connector_type=data["connector_type"],
+            provider_id=data["provider_id"],
+            provider_label=data["provider_label"],
+            icon=data.get("icon"),
+            auth_model=auth_model_from_kind(data["auth_model"]["kind"]),
+            egress_allowlist=tuple(data.get("egress_allowlist") or ()),
+            oauth=OAuthDescriptor.from_manifest(data["oauth"])
+            if data.get("oauth")
+            else None,
+            deployment=DeploymentDescriptor.from_manifest(data["deployment"])
+            if data.get("deployment")
+            else None,
+            surfaces=tuple(
+                SurfaceDescriptor.from_manifest(s) for s in (data.get("surfaces") or [])
+            ),
+            constraints=tuple(
+                ConstraintDescriptor.from_manifest(c)
+                for c in (data.get("constraints") or [])
+            ),
+        )
+
+
+# A connector's icon travels self-contained in its manifest as a data: URI, so the
+# platform renders the connector's own branding with no core-hosted asset. The cap
+# bounds GET /connectors/types, which inlines every connector's icon.
+# It is a string-length cap, not decode-and-measure — catalog bloat is the only risk.
+_ICON_DATA_URI_PREFIXES = ("data:image/svg+xml", "data:image/png")
+_ICON_MAX_LEN = 256_000
+
+
+def validate_icon(icon: str | None) -> None:
+    """Validate a connector manifest's ``icon``; raise ``ValueError`` if unusable.
+
+    ``None`` is allowed (the UI falls back to a generic icon). A present icon must be
+    a self-contained ``data:`` SVG or PNG URI under :data:`_ICON_MAX_LEN`, so a
+    subscribed connector ships its own branding without a core-hosted asset and
+    cannot bloat the inlined catalog.
+    """
+    if icon is None:
+        return
+    if not icon.startswith(_ICON_DATA_URI_PREFIXES):
+        raise ValueError(
+            "connector icon must be a self-contained data:image/svg+xml "
+            "or data:image/png URI"
+        )
+    if len(icon) > _ICON_MAX_LEN:
+        raise ValueError(
+            f"connector icon exceeds {_ICON_MAX_LEN} bytes; ship a smaller logo"
+        )
+
+
+class ConnectorProvider(ABC):
+    """Provider-specific behavior for one connector type.
+
+    One instance represents one connector. Call sites resolve a provider from the
+    registry and delegate connector_type-specific work here instead of branching on
+    string equality.
+    """
+
+    @property
+    @abstractmethod
+    def connector_type(self) -> str:
+        """Stable identifier stored on ``Connector.connector_type``."""
+
+    def config_schema(self) -> ConfigSchema:
+        """Return this connector's declarative admin-config contract.
+
+        The framework derives both validation (the default :meth:`validate_config`)
+        and the admin-form JSON Schema (:meth:`ConfigSchema.to_json_schema`) from
+        this single declaration. Default: no fields (permissive).
+        """
+        return ConfigSchema()
+
+    def validate_config(self, config: dict[str, Any]) -> None:
+        """Validate admin-supplied connector config; raise on invalid.
+
+        Default: validate against :meth:`config_schema`, so a connector that
+        declares a schema gets validation for free. A provider whose validation the
+        schema cannot express may still override, raising
+        ``InvalidConfigException`` on failure.
+        """
+        self.config_schema().validate(config)
+
+    def missing_scopes(self, surface: str, scopes: set[str]) -> list[str]:
+        """Return the OAuth scopes the user lacks for *surface*, or [] if satisfied.
+
+        ``scopes`` is the user's current normalized scope set. The default has no
+        per-surface scope requirements — service-token / remote connectors grant
+        access by configuration, not per-surface OAuth scopes. Per-user OAuth
+        providers override with their own scope map.
+        """
+        _ = (surface, scopes)
+        return []
+
+    def spec(self) -> ConnectorSpec:
+        """Return this connector's self-description (identity defaults to connector_type)."""
+        return ConnectorSpec(
+            connector_type=self.connector_type,
+            provider_id=self.connector_type,
+            provider_label=self.connector_type,
+        )
+
+    def to_manifest(self) -> dict[str, Any]:
+        """Return the connector's full self-description for registration / the UI.
+
+        Combines the identity/auth/egress spec with the admin-form config JSON
+        Schema (and, later, operation descriptors) so one manifest carries
+        everything the platform needs to register and configure the connector.
+        """
+        manifest = self.spec().to_manifest()
+        manifest["config_schema"] = self.config_schema().to_json_schema()
+        return manifest

--- a/kamiwaza_sdk/connectors/server_kit.py
+++ b/kamiwaza_sdk/connectors/server_kit.py
@@ -109,11 +109,12 @@ def create_connector_app(
             yield
         finally:
             if own:
-                await app.state.dispatcher.aclose()
-                # Clear the closed dispatcher so a later lifespan pass (restart /
-                # repeated TestClient context) rebuilds instead of serving through
-                # a closed one.
+                # Null the ref BEFORE closing so a raising aclose() can't leave a
+                # closed dispatcher on app.state for a later lifespan pass (restart
+                # / repeated TestClient context) to serve through.
+                disp = app.state.dispatcher
                 app.state.dispatcher = None
+                await disp.aclose()
 
     app = FastAPI(title=title, lifespan=_lifespan)
     app.state.dispatcher = dispatcher

--- a/kamiwaza_sdk/connectors/server_kit.py
+++ b/kamiwaza_sdk/connectors/server_kit.py
@@ -1,0 +1,172 @@
+"""Shared HTTP server scaffold for connector workloads.
+
+Every deployed connector exposes the same contract to core:
+
+  GET  /healthz        liveness
+  GET  /manifest       the connector's self-describing manifest (self-registration)
+  POST /v1/execute     {op, subject_token, params} -> {body}
+  POST /v1/verify      {subject_token} -> capability probe
+
+Only three things vary per connector: its *provider* (for ``/manifest``), how it
+builds its *dispatcher* from the workload env, and how it maps its own error types
+to HTTP status codes. :func:`create_connector_app` owns everything else — so a
+connector's ``server.py`` is just those bindings, and new connectors inherit the
+whole contract (including self-registration) for free. This is the in-core form of
+the deferred ``kamiwaza-connector-sdk``.
+
+Import-light (fastapi + pydantic only) so connector images can import it without
+pulling the core service stack.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+# Builds the connector's dispatcher from the workload env (fail-closed).
+DispatcherFactory = Callable[[], Any]
+# Maps a connector error -> (http_status, error_kind, upstream_status | None).
+ErrorClassifier = Callable[[Exception], "tuple[int, str, int | None]"]
+
+
+class ExecuteRequest(BaseModel):
+    """A request to run one operation on behalf of an acting subject."""
+
+    op: str = Field(min_length=1)
+    subject_token: str | None = None
+    params: dict[str, Any] = Field(default_factory=dict)
+    # Reserved: an opaque resume position core replays so a state-aware connector
+    # continues where it left off (the request side of OpResult.state). Stateless
+    # connectors ignore it; it is forwarded to the dispatcher when a connector opts
+    # into state-aware ops.
+    state: str | None = None
+
+
+class VerifyRequest(BaseModel):
+    """A request to probe the connection's live capabilities."""
+
+    subject_token: str | None = None
+
+
+@dataclass
+class OpResult:
+    """An op result that carries framework-level continuation back to core.
+
+    An op returns this (instead of a plain body) when it has continuation to hand
+    back — so core can manage availability generically without parsing op bodies:
+
+    - ``state``: an opaque, **serializable** resume position core persists and
+      replays on the next call (the generalization of a page token). State lives in
+      core, so **any replica** can serve the continuation — restart-anywhere.
+    - ``session``: a reference to **live, non-serializable** state bound to this pod
+      (an open stream / scroll / cursor). Core routes follow-ups back to the holding
+      replica (sticky), and re-establishes if it dies.
+
+    Ops with neither just return a plain body (``state``/``session`` come back null).
+    """
+
+    body: Any
+    state: str | None = None
+    session: str | None = None
+
+
+def create_connector_app(
+    *,
+    title: str,
+    provider: Any,
+    build_dispatcher: DispatcherFactory,
+    error_type: type[Exception],
+    classify_error: ErrorClassifier,
+    dispatcher: Any | None = None,
+) -> FastAPI:
+    """Build a connector's ASGI app with the standard core-facing contract.
+
+    Args:
+        title: FastAPI app title (e.g. ``"kamiwaza-connector-google"``).
+        provider: the connector's provider; ``provider.to_manifest()`` (the full
+            self-description, incl. the config JSON Schema) is served at
+            ``GET /manifest`` for core self-registration — the same manifest the
+            published catalog entry carries.
+        build_dispatcher: builds the dispatcher from the workload env on startup
+            (fail-closed). Not called when *dispatcher* is injected (tests).
+        error_type: the connector's base error class to catch around dispatch.
+        classify_error: maps a caught error to (http_status, kind, upstream_status).
+        dispatcher: inject a dispatcher to bypass env-based construction (tests).
+    """
+
+    @asynccontextmanager
+    async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+        own = app.state.dispatcher is None
+        if own:
+            app.state.dispatcher = build_dispatcher()
+        try:
+            yield
+        finally:
+            if own:
+                await app.state.dispatcher.aclose()
+
+    app = FastAPI(title=title, lifespan=_lifespan)
+    app.state.dispatcher = dispatcher
+
+    def _error_response(exc: Exception) -> JSONResponse:
+        status, kind, upstream = classify_error(exc)
+        return JSONResponse(
+            status_code=status,
+            content={
+                "error": {"kind": kind, "message": str(exc), "upstream_status": upstream}
+            },
+        )
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/manifest")
+    async def manifest() -> Any:
+        """The connector's self-describing manifest (core self-registration).
+
+        Lets core learn this connector by asking it — ``core -> GET /manifest`` ->
+        subscribe — instead of the manifest being hand-supplied. Returns the full
+        manifest (identity/auth/egress/deployment + config_schema), identical to
+        the published catalog entry, so self-registered and catalog connectors
+        are the same.
+        """
+        return provider.to_manifest()
+
+    @app.post("/v1/execute")
+    async def execute(req: ExecuteRequest, request: Request) -> Any:
+        try:
+            result = await request.app.state.dispatcher.execute(
+                req.op, subject_token=req.subject_token, params=req.params
+            )
+        except error_type as exc:
+            return _error_response(exc)
+        # An op may return an OpResult to hand continuation (state/session) back to
+        # core; a plain return value is the body with no continuation. The
+        # continuation keys are only added when present, so a stateless op's response
+        # stays exactly {"body": ...}.
+        if isinstance(result, OpResult):
+            out: dict[str, Any] = {"body": result.body}
+            if result.state is not None:
+                out["state"] = result.state
+            if result.session is not None:
+                out["session"] = result.session
+            return out
+        return {"body": result}
+
+    @app.post("/v1/verify")
+    async def verify(req: VerifyRequest, request: Request) -> Any:
+        try:
+            return await request.app.state.dispatcher.verify(
+                subject_token=req.subject_token
+            )
+        except error_type as exc:
+            return _error_response(exc)
+
+    return app

--- a/kamiwaza_sdk/connectors/server_kit.py
+++ b/kamiwaza_sdk/connectors/server_kit.py
@@ -110,6 +110,10 @@ def create_connector_app(
         finally:
             if own:
                 await app.state.dispatcher.aclose()
+                # Clear the closed dispatcher so a later lifespan pass (restart /
+                # repeated TestClient context) rebuilds instead of serving through
+                # a closed one.
+                app.state.dispatcher = None
 
     app = FastAPI(title=title, lifespan=_lifespan)
     app.state.dispatcher = dispatcher

--- a/kamiwaza_sdk/connectors/server_kit.py
+++ b/kamiwaza_sdk/connectors/server_kit.py
@@ -41,10 +41,10 @@ class ExecuteRequest(BaseModel):
     op: str = Field(min_length=1)
     subject_token: str | None = None
     params: dict[str, Any] = Field(default_factory=dict)
-    # Reserved: an opaque resume position core replays so a state-aware connector
-    # continues where it left off (the request side of OpResult.state). Stateless
-    # connectors ignore it; it is forwarded to the dispatcher when a connector opts
-    # into state-aware ops.
+    # Reserved (not yet wired): an opaque resume position core would replay so a
+    # state-aware connector continues where it left off (the request side of
+    # OpResult.state). Accepted on the wire but not yet forwarded to the
+    # dispatcher; wiring it through dispatcher.execute is a follow-up.
     state: str | None = None
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ publish = [
 convert = [
     "anthropic>=0.30.0",
 ]
+# Install contract for connector repos building against kamiwaza_sdk.connectors.
+connector = [
+    "fastapi>=0.100.0",
+    "pydantic[email]>=2.11",
+]
 all = [
     "boto3>=1.28.0",
     "anthropic>=0.30.0",

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -19,8 +19,10 @@ from kamiwaza_sdk.connectors import (
     ConfigSchema,
     ConfigType,
     ConnectorMintRequest,
+    ConnectorMintResponse,
     ConnectorProvider,
     ConnectorProxyRequest,
+    ConnectorProxyResponse,
     ConnectorSpec,
     ConstraintDescriptor,
     DeploymentDescriptor,
@@ -333,3 +335,74 @@ def test_lifespan_rebuilds_after_owned_close() -> None:
             assert client.post("/v1/verify", json={}).json() == {"ok": True}
     assert len(built) == 2
     assert all(d.closed for d in built)
+
+
+def test_lifespan_clears_state_even_if_aclose_raises() -> None:
+    # If the owned dispatcher's aclose() raises during shutdown, app.state must
+    # still be nulled (the ref is cleared BEFORE close), so a later pass rebuilds.
+    class _RaisingClose(_StubDispatcher):
+        async def aclose(self) -> None:
+            raise RuntimeError("close failed")
+
+    disp = _RaisingClose(verify_result={"ok": True})
+    app = create_connector_app(
+        title="kamiwaza-connector-dummy",
+        provider=_DummyProvider(),
+        build_dispatcher=lambda: disp,
+        error_type=_BoomError,
+        classify_error=lambda exc: (500, "internal", None),
+        dispatcher=None,
+    )
+    try:
+        with TestClient(app) as client:
+            client.post("/v1/verify", json={})
+    except RuntimeError:
+        pass  # the raising aclose propagates out of shutdown
+    assert app.state.dispatcher is None
+
+
+# --- forward-compat / device-code edge cases ---------------------------------
+
+
+def test_oauth_device_code_manifest_loads_without_auth_endpoint() -> None:
+    # A device_code (RFC 8628) connector ships only token + device endpoints.
+    # from_manifest must not KeyError on the missing authorization_endpoint.
+    data = {
+        "token_endpoint": "https://login.test/token",
+        "device_authorization_endpoint": "https://login.test/devicecode",
+        "flow": "device_code",
+    }
+    d = OAuthDescriptor.from_manifest(data)
+    assert d.authorization_endpoint is None
+    assert d.flow == "device_code"
+    assert d.device_authorization_endpoint == "https://login.test/devicecode"
+    # resolved() must tolerate the None auth endpoint too.
+    assert d.resolved({"tenant_id": "x"}).authorization_endpoint is None
+    # and it round-trips inside a full ConnectorSpec.
+    spec = ConnectorSpec(
+        connector_type="m365",
+        provider_id="m365",
+        provider_label="Microsoft 365",
+        oauth=d,
+    )
+    assert ConnectorSpec.from_manifest(spec.to_manifest()) == spec
+
+
+def test_response_models_retain_extra_fields() -> None:
+    # extra="allow": a newer core's added fields survive validate -> dump on an
+    # older connector.
+    mint = ConnectorMintResponse.model_validate(
+        {
+            "access_token": "t",
+            "lease_id": "l",
+            "granted_scopes": [],
+            "expires_in": 1,
+            "broker_lease_expires_in": 1,
+            "new_core_field": "keep-me",
+        }
+    )
+    assert mint.model_dump()["new_core_field"] == "keep-me"
+    proxy = ConnectorProxyResponse.model_validate(
+        {"status_code": 200, "body": None, "new_core_field": "keep-me"}
+    )
+    assert proxy.model_dump()["new_core_field"] == "keep-me"

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -388,6 +388,33 @@ def test_oauth_device_code_manifest_loads_without_auth_endpoint() -> None:
     assert ConnectorSpec.from_manifest(spec.to_manifest()) == spec
 
 
+def test_from_json_schema_tolerates_nullable_type_array() -> None:
+    # JSON Schema nullable form expresses type as a list (["integer","null"]).
+    # from_json_schema must not crash (TypeError: unhashable list) — it picks the
+    # non-null type, and a non-string/unknown type falls back to string.
+    schema = {
+        "type": "object",
+        "properties": {
+            "port": {"type": ["integer", "null"]},
+            "weird": {"type": 123},
+        },
+    }
+    by_name = {f.name: f for f in ConfigSchema.from_json_schema(schema).fields}
+    assert by_name["port"].type is ConfigType.INTEGER
+    assert by_name["weird"].type is ConfigType.STRING
+
+
+def test_mint_response_access_token_not_in_repr() -> None:
+    resp = ConnectorMintResponse(
+        access_token="super-secret-token",
+        lease_id="lease-1",
+        granted_scopes=[],
+        expires_in=1,
+        broker_lease_expires_in=1,
+    )
+    assert "super-secret-token" not in repr(resp)
+
+
 def test_response_models_retain_extra_fields() -> None:
     # extra="allow": a newer core's added fields survive validate -> dump on an
     # older connector.

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -1,0 +1,66 @@
+"""The connector server SPI (``kamiwaza_sdk.connectors``).
+
+A connector pod subclasses :class:`ConnectorProvider`, declares a
+:class:`ConfigSchema`, and serves it with :func:`create_connector_app`. These
+assert the contract connector repos depend on (``kamiwaza-sdk[connector]``):
+``to_manifest()`` shape, config validation, and the served ``GET /manifest``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from kamiwaza_sdk.connectors import (
+    ConfigField,
+    ConfigSchema,
+    ConfigType,
+    ConnectorProvider,
+    InvalidConfigException,
+    create_connector_app,
+)
+
+
+class _DummyProvider(ConnectorProvider):
+    @property
+    def connector_type(self) -> str:
+        return "dummy"
+
+    def config_schema(self) -> ConfigSchema:
+        return ConfigSchema(
+            fields=(
+                ConfigField(name="client_id", type=ConfigType.STRING),
+                ConfigField(name="client_secret", type=ConfigType.STRING, secret=True),
+            )
+        )
+
+
+def test_to_manifest_carries_identity_and_config_schema() -> None:
+    manifest = _DummyProvider().to_manifest()
+    assert manifest["connector_type"] == "dummy"
+    cfg = manifest["config_schema"]
+    assert cfg["type"] == "object"
+    assert set(cfg["required"]) == {"client_id", "client_secret"}
+    assert cfg["properties"]["client_secret"]["writeOnly"] is True
+
+
+def test_validate_config_rejects_missing_required() -> None:
+    provider = _DummyProvider()
+    provider.validate_config({"client_id": "abc", "client_secret": "shh"})  # ok
+    with pytest.raises(InvalidConfigException):
+        provider.validate_config({"client_id": "abc"})
+
+
+def test_create_connector_app_serves_manifest() -> None:
+    app = create_connector_app(
+        title="kamiwaza-connector-dummy",
+        provider=_DummyProvider(),
+        build_dispatcher=lambda: None,
+        error_type=Exception,
+        classify_error=lambda exc: (500, "internal", None),
+        dispatcher=object(),  # injected so the lifespan skips env construction
+    )
+    with TestClient(app) as client:
+        resp = client.get("/manifest")
+    assert resp.status_code == 200
+    assert resp.json()["connector_type"] == "dummy"

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -270,3 +270,66 @@ def test_mint_request_lease_bounds() -> None:
     # the proxy request inherits the same bound
     with pytest.raises(ValidationError):
         ConnectorProxyRequest(url="https://api.acme.test/x", lease_duration=10)
+
+
+def test_from_json_schema_required_field_must_be_supplied() -> None:
+    # An externally-authored manifest: a property both `required` AND carrying a
+    # `default`. `required` wins — from_json_schema must reconstruct it as
+    # must-supply so validate({}) rejects the missing field.
+    schema = {
+        "type": "object",
+        "properties": {"client_secret": {"type": "string", "default": "x"}},
+        "required": ["client_secret"],
+    }
+    cfg = ConfigSchema.from_json_schema(schema)
+    with pytest.raises(InvalidConfigException):
+        cfg.validate({})
+    cfg.validate({"client_secret": "abc"})  # ok when supplied
+
+
+def test_oauth_descriptor_resolved_fills_placeholders() -> None:
+    d = OAuthDescriptor(
+        authorization_endpoint="https://login.test/{tenant_id}/authorize",
+        token_endpoint="https://login.test/{tenant_id}/token",
+        revocation_endpoint=None,
+    )
+    r = d.resolved({"tenant_id": "contoso"})
+    assert r.authorization_endpoint == "https://login.test/contoso/authorize"
+    assert r.token_endpoint == "https://login.test/contoso/token"
+    assert r.revocation_endpoint is None  # None stays None
+    # Fixed endpoints (no placeholders) are a no-op.
+    fixed = OAuthDescriptor(
+        authorization_endpoint="https://accounts.test/auth",
+        token_endpoint="https://accounts.test/token",
+    )
+    assert fixed.resolved({"tenant_id": "x"}) == fixed
+
+
+def test_missing_scopes_default_is_empty() -> None:
+    # The base provider grants access by configuration, not per-surface scopes.
+    assert _DummyProvider().missing_scopes("files", {"read"}) == []
+
+
+def test_lifespan_rebuilds_after_owned_close() -> None:
+    built: list[_StubDispatcher] = []
+
+    def build() -> _StubDispatcher:
+        disp = _StubDispatcher(verify_result={"ok": True})
+        built.append(disp)
+        return disp
+
+    app = create_connector_app(
+        title="kamiwaza-connector-dummy",
+        provider=_DummyProvider(),
+        build_dispatcher=build,
+        error_type=_BoomError,
+        classify_error=lambda exc: (500, "internal", None),
+        dispatcher=None,
+    )
+    # Two lifespan passes: each must build + close its OWN dispatcher, never serve
+    # through the previous (closed) one.
+    for _ in range(2):
+        with TestClient(app) as client:
+            assert client.post("/v1/verify", json={}).json() == {"ok": True}
+    assert len(built) == 2
+    assert all(d.closed for d in built)

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -2,22 +2,37 @@
 
 A connector pod subclasses :class:`ConnectorProvider`, declares a
 :class:`ConfigSchema`, and serves it with :func:`create_connector_app`. These
-assert the contract connector repos depend on (``kamiwaza-sdk[connector]``):
-``to_manifest()`` shape, config validation, and the served ``GET /manifest``.
+cover the contract connector repos depend on (``kamiwaza-sdk[connector]``): the
+served endpoints (manifest / execute / verify / lifespan), descriptor
+``to_manifest``/``from_manifest`` round-trips, config validation, and the
+proxy/token schema bounds.
 """
 
 from __future__ import annotations
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 
 from kamiwaza_sdk.connectors import (
     ConfigField,
     ConfigSchema,
     ConfigType,
+    ConnectorMintRequest,
     ConnectorProvider,
+    ConnectorProxyRequest,
+    ConnectorSpec,
+    ConstraintDescriptor,
+    DeploymentDescriptor,
     InvalidConfigException,
+    OAuthDescriptor,
+    OpResult,
+    PerUserOAuth,
+    ServiceToken,
+    SurfaceDescriptor,
+    auth_model_from_kind,
     create_connector_app,
+    validate_icon,
 )
 
 
@@ -33,6 +48,45 @@ class _DummyProvider(ConnectorProvider):
                 ConfigField(name="client_secret", type=ConfigType.STRING, secret=True),
             )
         )
+
+
+class _StubDispatcher:
+    """Async dispatcher stub: returns a canned execute/verify result or raises."""
+
+    def __init__(self, *, execute_result=None, execute_exc=None, verify_result=None):
+        self._execute_result = execute_result
+        self._execute_exc = execute_exc
+        self._verify_result = verify_result
+        self.closed = False
+
+    async def execute(self, op, *, subject_token, params):
+        if self._execute_exc is not None:
+            raise self._execute_exc
+        return self._execute_result
+
+    async def verify(self, *, subject_token):
+        return self._verify_result
+
+    async def aclose(self):
+        self.closed = True
+
+
+class _BoomError(Exception):
+    pass
+
+
+def _app(dispatcher, *, build=None):
+    return create_connector_app(
+        title="kamiwaza-connector-dummy",
+        provider=_DummyProvider(),
+        build_dispatcher=build or (lambda: dispatcher),
+        error_type=_BoomError,
+        classify_error=lambda exc: (429, "rate_limited", 503),
+        dispatcher=dispatcher,
+    )
+
+
+# --- manifest + config schema ------------------------------------------------
 
 
 def test_to_manifest_carries_identity_and_config_schema() -> None:
@@ -51,16 +105,168 @@ def test_validate_config_rejects_missing_required() -> None:
         provider.validate_config({"client_id": "abc"})
 
 
-def test_create_connector_app_serves_manifest() -> None:
-    app = create_connector_app(
-        title="kamiwaza-connector-dummy",
-        provider=_DummyProvider(),
-        build_dispatcher=lambda: None,
-        error_type=Exception,
-        classify_error=lambda exc: (500, "internal", None),
-        dispatcher=object(),  # injected so the lifespan skips env construction
+def test_config_schema_rejects_bool_for_int() -> None:
+    schema = ConfigSchema(fields=(ConfigField(name="n", type=ConfigType.INTEGER),))
+    schema.validate({"n": 5})  # ok
+    with pytest.raises(InvalidConfigException):
+        schema.validate({"n": True})  # bool is not an int here
+
+
+def test_config_schema_json_roundtrip_is_idempotent() -> None:
+    schema = ConfigSchema(
+        fields=(
+            ConfigField(name="client_id", type=ConfigType.STRING),
+            ConfigField(name="client_secret", type=ConfigType.STRING, secret=True),
+            ConfigField(name="port", type=ConfigType.INTEGER, required=False),
+        )
     )
-    with TestClient(app) as client:
+    once = schema.to_json_schema()
+    twice = ConfigSchema.from_json_schema(once).to_json_schema()
+    assert once == twice
+    assert ConfigSchema.from_json_schema(once).secret_fields() == ("client_secret",)
+
+
+# --- served endpoints --------------------------------------------------------
+
+
+def test_manifest_endpoint() -> None:
+    with TestClient(_app(_StubDispatcher())) as client:
         resp = client.get("/manifest")
     assert resp.status_code == 200
     assert resp.json()["connector_type"] == "dummy"
+
+
+def test_healthz() -> None:
+    with TestClient(_app(_StubDispatcher())) as client:
+        assert client.get("/healthz").json() == {"status": "ok"}
+
+
+def test_execute_plain_body() -> None:
+    with TestClient(_app(_StubDispatcher(execute_result={"items": [1, 2]}))) as client:
+        resp = client.post("/v1/execute", json={"op": "list", "params": {}})
+    assert resp.status_code == 200
+    assert resp.json() == {"body": {"items": [1, 2]}}
+
+
+def test_execute_opresult_carries_state_and_session() -> None:
+    result = OpResult(body={"items": []}, state="cursor-2", session="sess-9")
+    with TestClient(_app(_StubDispatcher(execute_result=result))) as client:
+        resp = client.post("/v1/execute", json={"op": "list"})
+    assert resp.json() == {
+        "body": {"items": []},
+        "state": "cursor-2",
+        "session": "sess-9",
+    }
+
+
+def test_execute_classifies_connector_error() -> None:
+    disp = _StubDispatcher(execute_exc=_BoomError("upstream throttled"))
+    with TestClient(_app(disp)) as client:
+        resp = client.post("/v1/execute", json={"op": "list"})
+    assert resp.status_code == 429
+    assert resp.json()["error"] == {
+        "kind": "rate_limited",
+        "message": "upstream throttled",
+        "upstream_status": 503,
+    }
+
+
+def test_verify() -> None:
+    with TestClient(_app(_StubDispatcher(verify_result={"ok": True}))) as client:
+        resp = client.post("/v1/verify", json={})
+    assert resp.json() == {"ok": True}
+
+
+def test_lifespan_builds_and_closes_owned_dispatcher() -> None:
+    built: list[_StubDispatcher] = []
+
+    def build() -> _StubDispatcher:
+        disp = _StubDispatcher(verify_result={"ok": True})
+        built.append(disp)
+        return disp
+
+    # dispatcher=None -> the app owns the one build() returns and must aclose it.
+    app = create_connector_app(
+        title="kamiwaza-connector-dummy",
+        provider=_DummyProvider(),
+        build_dispatcher=build,
+        error_type=_BoomError,
+        classify_error=lambda exc: (500, "internal", None),
+        dispatcher=None,
+    )
+    with TestClient(app) as client:
+        assert client.post("/v1/verify", json={}).json() == {"ok": True}
+    assert built and built[0].closed is True
+
+
+# --- descriptor round-trips --------------------------------------------------
+
+
+def test_connector_spec_manifest_roundtrip() -> None:
+    spec = ConnectorSpec(
+        connector_type="acme",
+        provider_id="acme",
+        provider_label="Acme",
+        auth_model=ServiceToken(),
+        egress_allowlist=("api.acme.test",),
+        oauth=OAuthDescriptor(
+            authorization_endpoint="https://acme.test/auth",
+            token_endpoint="https://acme.test/token",
+            scopes=("read", "write"),
+            extra_auth_params=(("access_type", "offline"),),
+        ),
+        deployment=DeploymentDescriptor(
+            image_repository="kamiwaza-internal/connectors/acme",
+            image_tag="develop",
+            port=8080,
+        ),
+        icon=None,
+        surfaces=(
+            SurfaceDescriptor(
+                name="tickets",
+                display_label="Tickets",
+                operations=(("list", "tickets.list"),),
+                resource_kinds=("ticket",),
+                search_supported=True,
+                constraints=(
+                    ConstraintDescriptor(
+                        code="no_search",
+                        message="search unsupported",
+                        actions=("search",),
+                    ),
+                ),
+            ),
+        ),
+        constraints=(ConstraintDescriptor(code="c1", message="m1"),),
+    )
+    assert ConnectorSpec.from_manifest(spec.to_manifest()) == spec
+
+
+def test_auth_model_from_kind() -> None:
+    assert isinstance(auth_model_from_kind("per_user_oauth"), PerUserOAuth)
+    assert isinstance(auth_model_from_kind("service_token"), ServiceToken)
+    with pytest.raises(ValueError):
+        auth_model_from_kind("nope")
+
+
+# --- validation guards -------------------------------------------------------
+
+
+def test_validate_icon() -> None:
+    validate_icon(None)  # allowed
+    validate_icon("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")  # allowed
+    with pytest.raises(ValueError):
+        validate_icon("https://example.test/logo.png")  # not a data: URI
+    with pytest.raises(ValueError):
+        validate_icon("data:image/png;base64," + "A" * 256_001)  # over cap
+
+
+def test_mint_request_lease_bounds() -> None:
+    ConnectorMintRequest(lease_duration=60)  # min
+    ConnectorMintRequest(lease_duration=900)  # max
+    for bad in (59, 901):
+        with pytest.raises(ValidationError):
+            ConnectorMintRequest(lease_duration=bad)
+    # the proxy request inherits the same bound
+    with pytest.raises(ValidationError):
+        ConnectorProxyRequest(url="https://api.acme.test/x", lease_duration=10)

--- a/uv.lock
+++ b/uv.lock
@@ -917,6 +917,10 @@ all = [
     { name = "anthropic" },
     { name = "boto3" },
 ]
+connector = [
+    { name = "fastapi" },
+    { name = "pydantic", extra = ["email"] },
+]
 convert = [
     { name = "anthropic" },
 ]
@@ -955,18 +959,20 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.28.0" },
     { name = "boto3", marker = "extra == 'publish'", specifier = ">=1.28.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
+    { name = "fastapi", marker = "extra == 'connector'", specifier = ">=0.100.0" },
     { name = "httpx" },
     { name = "huggingface-hub", specifier = ">=0.23" },
     { name = "kamiwaza-extensions-lib", editable = "kamiwaza_extensions_lib" },
     { name = "openai", specifier = ">=1.0" },
     { name = "packaging", specifier = ">=23.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.11" },
+    { name = "pydantic", extras = ["email"], marker = "extra == 'connector'", specifier = ">=2.11" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests" },
     { name = "rich", specifier = ">=13.0" },
     { name = "typer", specifier = ">=0.9.0" },
 ]
-provides-extras = ["publish", "convert", "all"]
+provides-extras = ["publish", "convert", "connector", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Refs ENG-1538 (Enhancement: SDK for building connectors).

## What

Adds the connector **server SPI** to the SDK as `kamiwaza_sdk.connectors` (behind a `[connector]` extra). This is the server-side complement to the connector **client** work already on `develop` (`kamiwaza_sdk/services/connectors.py`, `schemas/connectors.py`, `kamiwaza_extensions/connector_publisher.py`).

## Why

A connector pod subclasses `ConnectorProvider`, declares a `ConfigSchema`, and serves it via `create_connector_app`; `provider.to_manifest()` is the self-description published to `connectors.json` and served at `GET /manifest`. That SPI lived **only** in the private `kamiwaza` platform repo, so connector images had to vendor the platform source (`build.sh` stages it into the build context) — which forces push-only, token-gated CI (no PR builds/tests, since a PR build would hand PR-controlled code the private source).

Putting the SPI in the SDK lets connectors `pip install kamiwaza-sdk[connector]` and drop the vendoring — unblocking the org's standard extension build (and PR builds + tests).

## Contents

Lifted **verbatim** from the platform (`refactor/connectors-pluggable-spi`) so this can become the single source the platform re-exports from (no drift):

| Module | Surface |
|---|---|
| `config_schema.py` | `ConfigField`, `ConfigSchema` |
| `provider.py` | `ConnectorProvider` + descriptors (`Surface`/`Deployment`/`Constraint`/`OAuth`, `ConnectorSpec`, `AuthModel`) |
| `server_kit.py` | `create_connector_app` |
| `exceptions.py` | connector exception hierarchy |
| `connector_proxy.py` / `connector_token.py` | oauth-broker proxy schemas |

Self-contained: relative imports + stdlib/pydantic/fastapi only, no platform internals. fastapi + pydantic are already core SDK deps, so `[connector]` is just the explicit install contract.

## Verification

- `tests/unit/test_connectors_spi.py` — **15 tests** covering the served endpoints (manifest / execute plain-body + `OpResult(state/session)` + `classify_error` / verify / healthz / lifespan `aclose`), full `ConnectorSpec` `to_manifest`↔`from_manifest` round-trip, `ConfigSchema` JSON-schema idempotence + bool-as-int rejection, `auth_model_from_kind`, `validate_icon` bounds, and mint/proxy `lease_duration` bounds.
- **Drop-in proof:** `kamiwaza-connector-hubspot`'s full suite (75 tests) passes against this package with **no platform source on `PYTHONPATH`** (imports re-pointed `kamiwaza.services.connectors.*` → `kamiwaza_sdk.connectors.*`).
- `ruff` clean; `mypy` clean on the new package.

## Follow-ups (separate PRs)

1. **Connectors** — repoint imports off `kamiwaza.*`, depend on `kamiwaza-sdk[connector]`, drop `build.sh`'s source staging, build via the org reusable (unblocks PR builds + tests). Supersedes the interim per-connector CI PRs.
2. **Platform** — repoint `kamiwaza/services/connectors/{provider,config_schema,server_kit}` to re-export from here so there is one SPI source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
