### PR TITLE
feat(connectors): generalize the declarative config-form contract (ENG-7810)

### DIFF
--- a/kamiwaza_sdk/connectors/__init__.py
+++ b/kamiwaza_sdk/connectors/__init__.py
@@ -15,7 +15,15 @@ instead of vendoring the platform source.
 
 from __future__ import annotations
 
-from .config_schema import ConfigField, ConfigSchema, ConfigType
+from .config_schema import (
+    ConfigField,
+    ConfigOption,
+    ConfigOutput,
+    ConfigSchema,
+    ConfigType,
+    FieldWidth,
+    Importance,
+)
 from .connector_proxy import ConnectorProxyRequest, ConnectorProxyResponse
 from .connector_token import ConnectorMintRequest, ConnectorMintResponse
 from .exceptions import ConnectorException, InvalidConfigException
@@ -40,28 +48,32 @@ from .server_kit import (
 )
 
 __all__ = [
+    "AuthModel",
     "ConfigField",
+    "ConfigOption",
+    "ConfigOutput",
     "ConfigSchema",
     "ConfigType",
-    "AuthModel",
-    "PerUserOAuth",
-    "ServiceToken",
-    "auth_model_from_kind",
-    "OAuthDescriptor",
-    "DeploymentDescriptor",
-    "ConstraintDescriptor",
-    "SurfaceDescriptor",
-    "ConnectorSpec",
-    "ConnectorProvider",
-    "validate_icon",
-    "create_connector_app",
-    "ExecuteRequest",
-    "VerifyRequest",
-    "OpResult",
-    "ConnectorProxyRequest",
-    "ConnectorProxyResponse",
+    "ConnectorException",
     "ConnectorMintRequest",
     "ConnectorMintResponse",
-    "ConnectorException",
+    "ConnectorProvider",
+    "ConnectorProxyRequest",
+    "ConnectorProxyResponse",
+    "ConnectorSpec",
+    "ConstraintDescriptor",
+    "DeploymentDescriptor",
+    "ExecuteRequest",
+    "FieldWidth",
+    "Importance",
     "InvalidConfigException",
+    "OAuthDescriptor",
+    "OpResult",
+    "PerUserOAuth",
+    "ServiceToken",
+    "SurfaceDescriptor",
+    "VerifyRequest",
+    "auth_model_from_kind",
+    "create_connector_app",
+    "validate_icon",
 ]

--- a/kamiwaza_sdk/connectors/config_schema.py
+++ b/kamiwaza_sdk/connectors/config_schema.py
@@ -210,7 +210,14 @@ class ConfigField:
                 ),
                 default_template=data.get("default_template", ""),
                 depends_on=data.get("depends_on", ""),
-                visible_when=tuple(data.get("visible_when") or ()),
+                # A bare string is wrapped, not iterated -- a connector author writing
+                # ``visible_when="advanced"`` would otherwise char-splat into
+                # ``("a","d","v",...)``.
+                visible_when=(
+                    (data["visible_when"],)
+                    if isinstance(data.get("visible_when"), str)
+                    else tuple(data.get("visible_when") or ())
+                ),
                 out=_enum(ConfigOutput, data.get("out"), ConfigOutput.CONFIG),
             )
         except (KeyError, ValueError, TypeError) as exc:

--- a/kamiwaza_sdk/connectors/config_schema.py
+++ b/kamiwaza_sdk/connectors/config_schema.py
@@ -1,15 +1,33 @@
-"""Declarative connector config contract -- the framework's ConfigDef analog.
+"""Declarative connector config contract.
 
 A connector declares the admin configuration it needs as a :class:`ConfigSchema`
-(a set of :class:`ConfigField`). The framework derives BOTH validation and the
-admin-form JSON Schema from that one declaration, and marks secret fields so the
-UI and secret store can protect them. So a connector author writes the config once
-and gets validation + UI for free -- the Kafka Connect ``ConfigDef`` idea adapted
-to Kamiwaza connectors.
+(an ordered set of :class:`ConfigField`). The platform derives the whole admin form,
+its validation, and a JSON Schema from that one declaration -- so the config UI is
+written once, *in the connector*, and core renders it generically with no
+connector-specific UI code.
+
+Each :class:`ConfigField` carries enough metadata for a faithful form:
+
+- a value ``type`` (incl. multi-value ``LIST``) and a write-only ``secret`` flag;
+- a ``label`` + ``description`` (help text) and a ``placeholder``;
+- ``group`` + ``order`` for layout and ``importance`` for prominence;
+- optional validation: a regex ``pattern`` (+ ``pattern_error``) and ``required``;
+- recommended/allowed ``options`` -- each with its own label -- which render a
+  select (single value) or a multi-select (a ``LIST`` field);
+- a static ``default`` or a ``default_template`` resolved by the renderer
+  (e.g. ``"{origin}/api/connectors/public/{connector_type}/callback"``);
+- a simple visibility rule (``depends_on`` + ``visible_when``) so a field can show
+  only when another field has a given value.
+
+A field's value routes to the connector ``config`` by default, or to the OAuth
+``scopes`` set when ``out`` says so -- which is how a connector offers selectable
+permissions (the admin ticks capabilities; the ticked values become the requested
+scopes) without any of that living in core.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -18,26 +36,86 @@ from .exceptions import InvalidConfigException
 
 
 class ConfigType(str, Enum):
-    """The value type of a config field (kept small and JSON-Schema-mappable)."""
+    """The value type of a config field."""
 
     STRING = "string"
     INTEGER = "integer"
     BOOLEAN = "boolean"
+    LIST = "list"  # multi-value; rendered as a multi-select when ``options`` are given
+
+
+class Importance(str, Enum):
+    """How prominently the admin form should surface a field."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class FieldWidth(str, Enum):
+    """A hint for how wide the input should render."""
+
+    SHORT = "short"
+    MEDIUM = "medium"
+    LONG = "long"
+
+
+class ConfigOutput(str, Enum):
+    """Where a field's value goes when the admin saves the form."""
+
+    CONFIG = "config"  # -> the connector's stored config (the default)
+    SCOPES = "scopes"  # -> the OAuth scopes requested (selectable permissions)
 
 
 _PY_TYPES: dict[ConfigType, type] = {
     ConfigType.STRING: str,
     ConfigType.INTEGER: int,
     ConfigType.BOOLEAN: bool,
+    ConfigType.LIST: list,
 }
+
+
+def _humanize(name: str) -> str:
+    """A default display label from a field name (``client_id`` -> ``Client Id``)."""
+    return name.replace("_", " ").replace("-", " ").strip().title()
+
+
+@dataclass(frozen=True)
+class ConfigOption:
+    """One recommended/allowed value for a field (a select / multi-select choice)."""
+
+    value: str
+    label: str = ""
+    description: str = ""
+    default_selected: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "value": self.value,
+            "label": self.label or self.value,
+            "description": self.description,
+            "default_selected": self.default_selected,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ConfigOption:
+        return cls(
+            value=str(data["value"]),
+            label=data.get("label", ""),
+            description=data.get("description", ""),
+            default_selected=bool(data.get("default_selected", False)),
+        )
 
 
 @dataclass(frozen=True)
 class ConfigField:
-    """One admin-config field a connector declares.
+    """One admin-config field a connector declares, with its full rendering metadata.
 
-    ``required`` with no ``default`` means the admin must supply it. ``secret``
-    marks credential material (rendered write-only, routed to the secret store).
+    ``required`` with no ``default`` / ``default_template`` means the admin must
+    supply it. ``secret`` marks credential material (rendered write-only, routed to
+    the secret store). ``options`` make the field a select (or a multi-select when
+    ``type`` is ``LIST``). ``out`` routes a ``LIST`` field's selections to the OAuth
+    scope set instead of the config blob.
     """
 
     name: str
@@ -46,93 +124,191 @@ class ConfigField:
     secret: bool = False
     default: Any = None
     description: str = ""
+    display_name: str = ""
+    placeholder: str = ""
+    importance: Importance = Importance.MEDIUM
+    group: str = ""
+    order: int = 0
+    width: FieldWidth = FieldWidth.MEDIUM
+    pattern: str = ""
+    pattern_error: str = ""
+    options: tuple[ConfigOption, ...] = ()
+    default_template: str = ""
+    depends_on: str = ""
+    visible_when: tuple[str, ...] = ()
+    out: ConfigOutput = ConfigOutput.CONFIG
+
+    @property
+    def label(self) -> str:
+        """The display label (declared ``display_name`` or a humanized name)."""
+        return self.display_name or _humanize(self.name)
 
     @property
     def must_supply(self) -> bool:
-        """Whether the admin must provide a value (required and no default)."""
-        return self.required and self.default is None
+        """Whether the admin must provide a value (required, no default of any kind)."""
+        return self.required and self.default is None and not self.default_template
+
+    def _allowed(self) -> set[str]:
+        return {opt.value for opt in self.options}
+
+    def to_spec(self) -> dict[str, Any]:
+        """The rich, ordered spec the admin form renderer is generated from."""
+        return {
+            "name": self.name,
+            "type": self.type.value,
+            "required": self.required,
+            "secret": self.secret,
+            "default": self.default,
+            "default_template": self.default_template,
+            "description": self.description,
+            "label": self.label,
+            "placeholder": self.placeholder,
+            "importance": self.importance.value,
+            "group": self.group,
+            "order": self.order,
+            "width": self.width.value,
+            "pattern": self.pattern,
+            "pattern_error": self.pattern_error,
+            "options": [opt.to_dict() for opt in self.options],
+            "depends_on": self.depends_on,
+            "visible_when": list(self.visible_when),
+            "out": self.out.value,
+        }
+
+    @classmethod
+    def from_spec(cls, data: dict[str, Any]) -> ConfigField:
+        """Reconstruct a field from a spec produced by :meth:`to_spec`."""
+        return cls(
+            name=data["name"],
+            type=_enum(ConfigType, data.get("type"), ConfigType.STRING),
+            required=bool(data.get("required", True)),
+            secret=bool(data.get("secret", False)),
+            default=data.get("default"),
+            description=data.get("description", ""),
+            display_name=data.get("label", ""),
+            placeholder=data.get("placeholder", ""),
+            importance=_enum(Importance, data.get("importance"), Importance.MEDIUM),
+            group=data.get("group", ""),
+            order=int(data.get("order", 0)),
+            width=_enum(FieldWidth, data.get("width"), FieldWidth.MEDIUM),
+            pattern=data.get("pattern", ""),
+            pattern_error=data.get("pattern_error", ""),
+            options=tuple(
+                ConfigOption.from_dict(o) for o in (data.get("options") or [])
+            ),
+            default_template=data.get("default_template", ""),
+            depends_on=data.get("depends_on", ""),
+            visible_when=tuple(data.get("visible_when") or ()),
+            out=_enum(ConfigOutput, data.get("out"), ConfigOutput.CONFIG),
+        )
+
+
+def _enum(enum_cls: type, value: Any, fallback: Any) -> Any:
+    """Coerce a serialized value back to its enum member, falling back if unknown."""
+    try:
+        return enum_cls(value)
+    except ValueError:
+        return fallback
 
 
 @dataclass(frozen=True)
 class ConfigSchema:
-    """A connector's declarative admin-config contract (the ConfigDef analog)."""
+    """A connector's declarative admin-config contract (one ordered field set)."""
 
     fields: tuple[ConfigField, ...] = ()
 
-    def validate(self, config: dict[str, Any]) -> None:
-        """Validate admin config against the schema; raise with all problems.
+    def _config_fields(self) -> tuple[ConfigField, ...]:
+        """Fields whose value is stored as connector config (not OAuth scopes)."""
+        return tuple(f for f in self.fields if f.out is ConfigOutput.CONFIG)
 
-        Unknown keys are ignored (forward-compatible). Collects every error and
-        raises once, so the admin sees all problems at a time.
+    def scope_field_names(self) -> tuple[str, ...]:
+        """Names of fields whose selected values are OAuth scopes, not config."""
+        return tuple(f.name for f in self.fields if f.out is ConfigOutput.SCOPES)
+
+    def secret_fields(self) -> tuple[str, ...]:
+        """Names of fields holding secrets (for redaction / secret-store routing)."""
+        return tuple(f.name for f in self.fields if f.secret)
+
+    def validate(self, config: dict[str, Any]) -> None:
+        """Validate admin config against the schema; raise once with all problems.
+
+        Unknown keys are ignored (forward-compatible). Scope-routed fields are not
+        part of the config blob, so they are not validated here.
         """
         errors: list[str] = []
-        for field in self.fields:
+        for field in self._config_fields():
             value = config.get(field.name)
             if value is None:
                 if field.must_supply:
                     errors.append(f"missing required config: {field.name}")
                 continue
             expected = _PY_TYPES[field.type]
-            # bool is a subclass of int -- never accept a bool for an integer field
+            # bool is a subclass of int -- never accept a bool for an integer field.
             if not isinstance(value, expected) or (
                 expected is int and isinstance(value, bool)
             ):
                 errors.append(f"config {field.name} must be {field.type.value}")
+                continue
+            errors.extend(self._value_errors(field, value))
         if errors:
             raise InvalidConfigException("; ".join(errors))
 
-    @classmethod
-    def from_json_schema(cls, schema: dict[str, Any]) -> "ConfigSchema":
-        """Rebuild a ConfigSchema from a JSON Schema (the inverse of to_json_schema).
-
-        A *remote* connector ships its config contract as JSON Schema in its manifest;
-        core must validate admin config against that, not the empty base schema, so a
-        missing required field (e.g. a confidential connector's client_secret) is
-        rejected. Reconstruction is validation-faithful: a field listed in ``required``
-        becomes must-supply; ``writeOnly`` marks secrets; an unknown type falls back to
-        string.
-        """
-        properties = schema.get("properties") or {}
-        required = set(schema.get("required") or ())
-        type_by_value = {t.value: t for t in ConfigType}
-
-        def _config_type(raw: Any) -> ConfigType:
-            # JSON Schema allows a nullable type as a list (["string","null"]);
-            # pick the first non-"null" entry. Non-str / unknown types fall back
-            # to string (matches the documented behavior).
-            if isinstance(raw, list):
-                raw = next((t for t in raw if t != "null"), "string")
-            if not isinstance(raw, str):
-                return ConfigType.STRING
-            return type_by_value.get(raw, ConfigType.STRING)
-
-        fields = tuple(
-            ConfigField(
-                name=name,
-                type=_config_type((prop or {}).get("type", "string")),
-                required=name in required,
-                secret=bool((prop or {}).get("writeOnly")),
-                # A property listed in JSON Schema ``required`` must be supplied —
-                # ``required`` wins over a ``default``. Carrying the default would
-                # make ``must_supply`` false and let ``validate({})`` accept a
-                # missing required field from an externally-authored manifest.
-                default=None if name in required else (prop or {}).get("default"),
-                description=(prop or {}).get("description", ""),
+    @staticmethod
+    def _value_errors(field: ConfigField, value: Any) -> list[str]:
+        """Per-value checks (allowed options, regex pattern) once the type is right."""
+        errors: list[str] = []
+        if field.options:
+            allowed = field._allowed()
+            candidates = value if field.type is ConfigType.LIST else [value]
+            bad = [str(v) for v in candidates if str(v) not in allowed]
+            if bad:
+                errors.append(f"config {field.name} has invalid value(s): {bad}")
+        if (
+            field.pattern
+            and field.type is ConfigType.STRING
+            and not re.search(field.pattern, value)
+        ):
+            errors.append(
+                field.pattern_error
+                or f"config {field.name} does not match the required format"
             )
-            for name, prop in properties.items()
-        )
-        return cls(fields=fields)
+        return errors
+
+    def to_form_spec(self) -> list[dict[str, Any]]:
+        """The ordered rich field specs the admin form is rendered from."""
+        return [field.to_spec() for field in self.fields]
+
+    @classmethod
+    def from_form_spec(cls, specs: list[dict[str, Any]] | None) -> ConfigSchema:
+        """Reconstruct a schema from the rich field specs in a connector manifest."""
+        return cls(fields=tuple(ConfigField.from_spec(s) for s in (specs or ())))
 
     def to_json_schema(self) -> dict[str, Any]:
-        """Render a JSON Schema the admin UI auto-renders the config form from."""
+        """Render a JSON Schema (validation-faithful; scope fields excluded).
+
+        Standard keywords carry the validatable shape (type / required / enum /
+        pattern / default / writeOnly); the rich rendering metadata travels
+        separately as the form spec (:meth:`to_form_spec`).
+        """
         properties: dict[str, Any] = {}
         required: list[str] = []
-        for field in self.fields:
-            prop: dict[str, Any] = {"type": field.type.value}
+        for field in self._config_fields():
+            values = [opt.value for opt in field.options]
+            if field.type is ConfigType.LIST:
+                items: dict[str, Any] = {"type": "string"}
+                if values:
+                    items["enum"] = values
+                prop: dict[str, Any] = {"type": "array", "items": items}
+            else:
+                prop = {"type": field.type.value}
+                if values:
+                    prop["enum"] = values
             if field.description:
                 prop["description"] = field.description
             if field.default is not None:
                 prop["default"] = field.default
+            if field.pattern and field.type is ConfigType.STRING:
+                prop["pattern"] = field.pattern
             if field.secret:
                 prop["writeOnly"] = True
             properties[field.name] = prop
@@ -143,6 +319,29 @@ class ConfigSchema:
             schema["required"] = required
         return schema
 
-    def secret_fields(self) -> tuple[str, ...]:
-        """Names of fields holding secrets (for redaction / secret-store routing)."""
-        return tuple(field.name for field in self.fields if field.secret)
+    @classmethod
+    def from_json_schema(cls, schema: dict[str, Any]) -> ConfigSchema:
+        """Rebuild a (basic) ConfigSchema from a JSON Schema.
+
+        For a connector that ships only the legacy JSON Schema (no form spec), this
+        recovers enough to validate: required, type, secret, default, description.
+        Prefer :meth:`from_form_spec` when the manifest carries the rich field specs.
+        """
+        properties = schema.get("properties") or {}
+        required = set(schema.get("required") or ())
+        type_by_value = {t.value: t for t in ConfigType}
+        fields = tuple(
+            ConfigField(
+                name=name,
+                type=type_by_value.get(
+                    (prop or {}).get("type", "string"), ConfigType.STRING
+                ),
+                required=name in required,
+                secret=bool((prop or {}).get("writeOnly")),
+                default=(prop or {}).get("default"),
+                description=(prop or {}).get("description", ""),
+                pattern=(prop or {}).get("pattern", ""),
+            )
+            for name, prop in properties.items()
+        )
+        return cls(fields=fields)

--- a/kamiwaza_sdk/connectors/config_schema.py
+++ b/kamiwaza_sdk/connectors/config_schema.py
@@ -330,15 +330,25 @@ class ConfigSchema:
         properties = schema.get("properties") or {}
         required = set(schema.get("required") or ())
         type_by_value = {t.value: t for t in ConfigType}
+
+        def _resolve_type(raw: Any) -> ConfigType:
+            # Tolerate a nullable type array (e.g. ["integer", "null"]) and any
+            # non-string type node by falling back to STRING.
+            if isinstance(raw, list):
+                raw = next((t for t in raw if t != "null"), "string")
+            if not isinstance(raw, str):
+                return ConfigType.STRING
+            return type_by_value.get(raw, ConfigType.STRING)
+
         fields = tuple(
             ConfigField(
                 name=name,
-                type=type_by_value.get(
-                    (prop or {}).get("type", "string"), ConfigType.STRING
-                ),
+                type=_resolve_type((prop or {}).get("type", "string")),
                 required=name in required,
                 secret=bool((prop or {}).get("writeOnly")),
-                default=(prop or {}).get("default"),
+                # `required` wins over a declared default: a required field stays
+                # must-supply, so its default can't suppress the missing-field check.
+                default=None if name in required else (prop or {}).get("default"),
                 description=(prop or {}).get("description", ""),
                 pattern=(prop or {}).get("pattern", ""),
             )

--- a/kamiwaza_sdk/connectors/config_schema.py
+++ b/kamiwaza_sdk/connectors/config_schema.py
@@ -301,17 +301,29 @@ class ConfigSchema:
         if errors:
             raise InvalidConfigException("; ".join(errors))
 
-    @staticmethod
-    def _is_active(field: ConfigField, config: dict[str, Any]) -> bool:
+    def _is_active(self, field: ConfigField, config: dict[str, Any]) -> bool:
         """Whether a field is shown (and thus required/validated) given visibility.
 
         No ``depends_on`` -> always active. Otherwise active only when the controlling
         field's value is one of ``visible_when`` -- the same rule the form renderer
         applies, so validate() never requires a field the admin cannot see.
+
+        The controller value is compared as a string, so ``visible_when`` lists the
+        controlling values verbatim (e.g. ``("advanced",)``; a boolean controller uses
+        ``("True",)``). When the controller is absent from ``config`` its declared
+        ``default`` is used -- the value the form would have materialized -- so a field
+        gated by a *defaulted* controller is still validated (fail-closed).
         """
         if not field.depends_on:
             return True
-        return str(config.get(field.depends_on)) in field.visible_when
+        raw = config.get(field.depends_on)
+        if raw is None:
+            controller = next(
+                (f for f in self.fields if f.name == field.depends_on), None
+            )
+            if controller is not None:
+                raw = controller.default
+        return str(raw) in field.visible_when
 
     @staticmethod
     def _value_errors(field: ConfigField, value: Any) -> list[str]:

--- a/kamiwaza_sdk/connectors/config_schema.py
+++ b/kamiwaza_sdk/connectors/config_schema.py
@@ -145,7 +145,13 @@ class ConfigField:
 
     @property
     def must_supply(self) -> bool:
-        """Whether the admin must provide a value (required, no default of any kind)."""
+        """Whether the admin must provide a value (required, no default of any kind).
+
+        A directly-declared ``required=True`` field that *also* carries a ``default``
+        (or ``default_template``) is therefore NOT must-supply -- the default satisfies
+        it. JSON-Schema ``required`` is stronger intent, so :meth:`ConfigSchema.from_json_schema`
+        drops the default for a required field to keep it must-supply.
+        """
         return self.required and self.default is None and not self.default_template
 
     def _allowed(self) -> set[str]:
@@ -177,30 +183,38 @@ class ConfigField:
 
     @classmethod
     def from_spec(cls, data: dict[str, Any]) -> ConfigField:
-        """Reconstruct a field from a spec produced by :meth:`to_spec`."""
-        return cls(
-            name=data["name"],
-            type=_enum(ConfigType, data.get("type"), ConfigType.STRING),
-            required=bool(data.get("required", True)),
-            secret=bool(data.get("secret", False)),
-            default=data.get("default"),
-            description=data.get("description", ""),
-            display_name=data.get("label", ""),
-            placeholder=data.get("placeholder", ""),
-            importance=_enum(Importance, data.get("importance"), Importance.MEDIUM),
-            group=data.get("group", ""),
-            order=int(data.get("order", 0)),
-            width=_enum(FieldWidth, data.get("width"), FieldWidth.MEDIUM),
-            pattern=data.get("pattern", ""),
-            pattern_error=data.get("pattern_error", ""),
-            options=tuple(
-                ConfigOption.from_dict(o) for o in (data.get("options") or [])
-            ),
-            default_template=data.get("default_template", ""),
-            depends_on=data.get("depends_on", ""),
-            visible_when=tuple(data.get("visible_when") or ()),
-            out=_enum(ConfigOutput, data.get("out"), ConfigOutput.CONFIG),
-        )
+        """Reconstruct a field from a spec produced by :meth:`to_spec`.
+
+        Fails with :class:`InvalidConfigException` (not a raw KeyError/ValueError) on a
+        malformed spec -- a missing ``name``/option ``value`` or a non-numeric
+        ``order`` -- consistent with the forgiving enum handling.
+        """
+        try:
+            return cls(
+                name=data["name"],
+                type=_enum(ConfigType, data.get("type"), ConfigType.STRING),
+                required=bool(data.get("required", True)),
+                secret=bool(data.get("secret", False)),
+                default=data.get("default"),
+                description=data.get("description", ""),
+                display_name=data.get("label", ""),
+                placeholder=data.get("placeholder", ""),
+                importance=_enum(Importance, data.get("importance"), Importance.MEDIUM),
+                group=data.get("group", ""),
+                order=int(data.get("order", 0) or 0),
+                width=_enum(FieldWidth, data.get("width"), FieldWidth.MEDIUM),
+                pattern=data.get("pattern", ""),
+                pattern_error=data.get("pattern_error", ""),
+                options=tuple(
+                    ConfigOption.from_dict(o) for o in (data.get("options") or [])
+                ),
+                default_template=data.get("default_template", ""),
+                depends_on=data.get("depends_on", ""),
+                visible_when=tuple(data.get("visible_when") or ()),
+                out=_enum(ConfigOutput, data.get("out"), ConfigOutput.CONFIG),
+            )
+        except (KeyError, ValueError, TypeError) as exc:
+            raise InvalidConfigException(f"malformed config field spec: {exc}") from exc
 
 
 def _enum(enum_cls: type, value: Any, fallback: Any) -> Any:
@@ -209,6 +223,35 @@ def _enum(enum_cls: type, value: Any, fallback: Any) -> Any:
         return enum_cls(value)
     except ValueError:
         return fallback
+
+
+# Cap the input length a manifest-supplied regex runs against. The pattern comes from
+# the connector manifest and the value from admin input; bounding the length blunts
+# catastrophic-backtracking (ReDoS) blowup on a hostile/buggy pattern.
+# ponytail: length cap, not a regex timeout -- add a timeout if untrusted manifests
+# ever ship patterns.
+_MAX_PATTERN_INPUT = 1024
+
+
+def _pattern_errors(field: ConfigField, value: str) -> list[str]:
+    """Apply a field's regex, failing closed on a too-long input or bad pattern.
+
+    A malformed manifest pattern raises ``re.error``; surface it as a config error
+    rather than letting a raw ``re.error`` escape as an uncaught 500. ``re.search`` is
+    unanchored -- it matches a substring unless the pattern anchors with ``^``/``$``.
+    """
+    if len(value) > _MAX_PATTERN_INPUT:
+        return [f"config {field.name} is too long to validate (>{_MAX_PATTERN_INPUT})"]
+    try:
+        matched = re.search(field.pattern, value) is not None
+    except re.error:
+        return [f"config {field.name} has an invalid validation pattern"]
+    if not matched:
+        return [
+            field.pattern_error
+            or f"config {field.name} does not match the required format"
+        ]
+    return []
 
 
 @dataclass(frozen=True)
@@ -237,6 +280,11 @@ class ConfigSchema:
         """
         errors: list[str] = []
         for field in self._config_fields():
+            # A field gated by depends_on/visible_when is only required/validated when
+            # active, so a conditionally-required field hidden by its controller is not
+            # falsely required (matches what the form renderer shows).
+            if not self._is_active(field, config):
+                continue
             value = config.get(field.name)
             if value is None:
                 if field.must_supply:
@@ -254,24 +302,36 @@ class ConfigSchema:
             raise InvalidConfigException("; ".join(errors))
 
     @staticmethod
+    def _is_active(field: ConfigField, config: dict[str, Any]) -> bool:
+        """Whether a field is shown (and thus required/validated) given visibility.
+
+        No ``depends_on`` -> always active. Otherwise active only when the controlling
+        field's value is one of ``visible_when`` -- the same rule the form renderer
+        applies, so validate() never requires a field the admin cannot see.
+        """
+        if not field.depends_on:
+            return True
+        return str(config.get(field.depends_on)) in field.visible_when
+
+    @staticmethod
     def _value_errors(field: ConfigField, value: Any) -> list[str]:
-        """Per-value checks (allowed options, regex pattern) once the type is right."""
+        """Per-value checks (element types, allowed options, regex) once type is right."""
         errors: list[str] = []
+        candidates = value if field.type is ConfigType.LIST else [value]
+        # The emitted schema declares LIST items as strings; enforce that so a list
+        # value can't smuggle non-strings past validation.
+        if field.type is ConfigType.LIST and any(
+            not isinstance(v, str) for v in candidates
+        ):
+            return [f"config {field.name} must be a list of strings"]
         if field.options:
             allowed = field._allowed()
-            candidates = value if field.type is ConfigType.LIST else [value]
             bad = [str(v) for v in candidates if str(v) not in allowed]
             if bad:
-                errors.append(f"config {field.name} has invalid value(s): {bad}")
-        if (
-            field.pattern
-            and field.type is ConfigType.STRING
-            and not re.search(field.pattern, value)
-        ):
-            errors.append(
-                field.pattern_error
-                or f"config {field.name} does not match the required format"
-            )
+                # Bound the echo so a large/hostile input can't bloat the message.
+                errors.append(f"config {field.name} has invalid value(s): {bad[:5]}")
+        if field.pattern and field.type is ConfigType.STRING:
+            errors.extend(_pattern_errors(field, value))
         return errors
 
     def to_form_spec(self) -> list[dict[str, Any]]:
@@ -324,12 +384,17 @@ class ConfigSchema:
         """Rebuild a (basic) ConfigSchema from a JSON Schema.
 
         For a connector that ships only the legacy JSON Schema (no form spec), this
-        recovers enough to validate: required, type, secret, default, description.
-        Prefer :meth:`from_form_spec` when the manifest carries the rich field specs.
+        recovers enough to validate: required, type, secret, default, description,
+        pattern, and (from ``enum``) the allowed options. Prefer :meth:`from_form_spec`
+        when the manifest carries the rich field specs.
         """
         properties = schema.get("properties") or {}
         required = set(schema.get("required") or ())
+        # JSON Schema spells a LIST field "array"; map it back so a LIST round-trips
+        # (to_json_schema emits "array") instead of collapsing to STRING and then
+        # rejecting valid list values.
         type_by_value = {t.value: t for t in ConfigType}
+        type_by_value["array"] = ConfigType.LIST
 
         def _resolve_type(raw: Any) -> ConfigType:
             # Tolerate a nullable type array (e.g. ["integer", "null"]) and any
@@ -339,6 +404,11 @@ class ConfigSchema:
             if not isinstance(raw, str):
                 return ConfigType.STRING
             return type_by_value.get(raw, ConfigType.STRING)
+
+        def _options(prop: dict[str, Any]) -> tuple[ConfigOption, ...]:
+            # enum lives on the field for a scalar select, or on items for an array.
+            enum = prop.get("enum") or (prop.get("items") or {}).get("enum") or ()
+            return tuple(ConfigOption(str(v)) for v in enum)
 
         fields = tuple(
             ConfigField(
@@ -351,6 +421,7 @@ class ConfigSchema:
                 default=None if name in required else (prop or {}).get("default"),
                 description=(prop or {}).get("description", ""),
                 pattern=(prop or {}).get("pattern", ""),
+                options=_options(prop or {}),
             )
             for name, prop in properties.items()
         )

--- a/kamiwaza_sdk/connectors/provider.py
+++ b/kamiwaza_sdk/connectors/provider.py
@@ -375,12 +375,16 @@ class ConnectorSpec:
             icon=data.get("icon"),
             auth_model=auth_model_from_kind(data["auth_model"]["kind"]),
             egress_allowlist=tuple(data.get("egress_allowlist") or ()),
-            oauth=OAuthDescriptor.from_manifest(data["oauth"])
-            if data.get("oauth")
-            else None,
-            deployment=DeploymentDescriptor.from_manifest(data["deployment"])
-            if data.get("deployment")
-            else None,
+            oauth=(
+                OAuthDescriptor.from_manifest(data["oauth"])
+                if data.get("oauth")
+                else None
+            ),
+            deployment=(
+                DeploymentDescriptor.from_manifest(data["deployment"])
+                if data.get("deployment")
+                else None
+            ),
             surfaces=tuple(
                 SurfaceDescriptor.from_manifest(s) for s in (data.get("surfaces") or [])
             ),
@@ -474,10 +478,15 @@ class ConnectorProvider(ABC):
     def to_manifest(self) -> dict[str, Any]:
         """Return the connector's full self-description for registration / the UI.
 
-        Combines the identity/auth/egress spec with the admin-form config JSON
-        Schema (and, later, operation descriptors) so one manifest carries
-        everything the platform needs to register and configure the connector.
+        Combines the identity/auth/egress spec with the admin-config declaration so
+        one manifest carries everything the platform needs to register, validate, and
+        render the connector. ``config_schema`` is the validation-faithful JSON
+        Schema; ``config_fields`` is the ordered rich form spec the admin UI renders
+        the configuration form from (labels, groups, options, defaults, validation),
+        so the platform ships no connector-specific form.
         """
+        schema = self.config_schema()
         manifest = self.spec().to_manifest()
-        manifest["config_schema"] = self.config_schema().to_json_schema()
+        manifest["config_schema"] = schema.to_json_schema()
+        manifest["config_fields"] = schema.to_form_spec()
         return manifest

--- a/tests/unit/test_connectors_config_schema.py
+++ b/tests/unit/test_connectors_config_schema.py
@@ -398,3 +398,12 @@ def test_public_api_exports_the_form_types():
         FieldWidth,
         Importance,
     )
+
+
+def test_from_form_spec_wraps_a_bare_visible_when_string():
+    # A connector author writing visible_when="advanced" (a bare string, not a tuple)
+    # must not char-splat into ("a","d","v",...).
+    field = ConfigSchema.from_form_spec(
+        [{"name": "x", "depends_on": "mode", "visible_when": "advanced"}]
+    ).fields[0]
+    assert field.visible_when == ("advanced",)

--- a/tests/unit/test_connectors_config_schema.py
+++ b/tests/unit/test_connectors_config_schema.py
@@ -1,0 +1,227 @@
+"""Tests for the declarative connector config contract."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from kamiwaza_sdk.connectors.config_schema import (
+    ConfigField,
+    ConfigOption,
+    ConfigOutput,
+    ConfigSchema,
+    ConfigType,
+    Importance,
+)
+from kamiwaza_sdk.connectors.exceptions import InvalidConfigException
+
+pytestmark = pytest.mark.unit
+
+
+def _schema() -> ConfigSchema:
+    return ConfigSchema(
+        (
+            ConfigField("client_id", description="OAuth client id"),
+            ConfigField("client_secret", secret=True),
+            ConfigField("timeout", type=ConfigType.INTEGER, required=False, default=30),
+        )
+    )
+
+
+class TestValidate:
+    def test_accepts_valid_config(self):
+        _schema().validate({"client_id": "a", "client_secret": "b"})
+
+    def test_missing_required_raises(self):
+        with pytest.raises(InvalidConfigException):
+            _schema().validate({"client_id": "a"})
+
+    def test_optional_with_default_may_be_omitted(self):
+        _schema().validate({"client_id": "a", "client_secret": "b"})
+
+    def test_wrong_type_raises(self):
+        with pytest.raises(InvalidConfigException):
+            _schema().validate({"client_id": "a", "client_secret": "b", "timeout": "x"})
+
+    def test_bool_is_not_an_integer(self):
+        with pytest.raises(InvalidConfigException):
+            _schema().validate(
+                {"client_id": "a", "client_secret": "b", "timeout": True}
+            )
+
+    def test_collects_all_errors(self):
+        with pytest.raises(InvalidConfigException) as exc:
+            _schema().validate({"timeout": "x"})
+        msg = str(exc.value)
+        assert "client_id" in msg and "client_secret" in msg and "timeout" in msg
+
+    def test_extra_keys_ignored(self):
+        _schema().validate({"client_id": "a", "client_secret": "b", "extra": "x"})
+
+    def test_empty_schema_is_permissive(self):
+        ConfigSchema().validate({"anything": 1})
+
+
+class TestJsonSchema:
+    def test_shape_and_required(self):
+        js = _schema().to_json_schema()
+        assert js["type"] == "object"
+        assert set(js["required"]) == {"client_id", "client_secret"}
+        assert js["properties"]["timeout"]["type"] == "integer"
+        assert js["properties"]["timeout"]["default"] == 30
+
+    def test_secret_field_marked_write_only(self):
+        js = _schema().to_json_schema()
+        assert js["properties"]["client_secret"]["writeOnly"] is True
+        assert "writeOnly" not in js["properties"]["client_id"]
+
+    def test_json_safe(self):
+        js = _schema().to_json_schema()
+        assert json.loads(json.dumps(js)) == js
+
+
+def test_secret_fields():
+    assert _schema().secret_fields() == ("client_secret",)
+
+
+def test_label_defaults_to_humanized_name():
+    assert ConfigField("client_id").label == "Client Id"
+    assert ConfigField("client_id", display_name="Client ID").label == "Client ID"
+
+
+class TestValidation:
+    def test_pattern_enforced(self):
+        schema = ConfigSchema(
+            (
+                ConfigField(
+                    "client_id",
+                    pattern=r"\.example\.com$",
+                    pattern_error="must end with .example.com",
+                ),
+            )
+        )
+        schema.validate({"client_id": "app.example.com"})
+        with pytest.raises(InvalidConfigException) as exc:
+            schema.validate({"client_id": "nope"})
+        assert "must end with .example.com" in str(exc.value)
+
+    def test_select_value_must_be_an_option(self):
+        schema = ConfigSchema(
+            (
+                ConfigField(
+                    "region",
+                    required=False,
+                    options=(ConfigOption("us"), ConfigOption("eu")),
+                ),
+            )
+        )
+        schema.validate({"region": "us"})
+        with pytest.raises(InvalidConfigException):
+            schema.validate({"region": "mars"})
+
+    def test_list_multiselect_each_value_must_be_an_option(self):
+        schema = ConfigSchema(
+            (
+                ConfigField(
+                    "caps",
+                    type=ConfigType.LIST,
+                    required=False,
+                    options=(ConfigOption("a"), ConfigOption("b")),
+                ),
+            )
+        )
+        schema.validate({"caps": ["a", "b"]})
+        with pytest.raises(InvalidConfigException):
+            schema.validate({"caps": ["a", "z"]})
+
+    def test_default_template_satisfies_required(self):
+        schema = ConfigSchema(
+            (ConfigField("redirect_uri", default_template="{origin}/cb"),)
+        )
+        schema.validate({})
+
+
+class TestScopeFields:
+    def _schema(self) -> ConfigSchema:
+        return ConfigSchema(
+            (
+                ConfigField("client_id"),
+                ConfigField(
+                    "scopes",
+                    type=ConfigType.LIST,
+                    out=ConfigOutput.SCOPES,
+                    options=(ConfigOption("read", default_selected=True),),
+                ),
+            )
+        )
+
+    def test_scope_field_not_validated_as_config(self):
+        self._schema().validate({"client_id": "a"})
+
+    def test_scope_field_names(self):
+        assert self._schema().scope_field_names() == ("scopes",)
+
+    def test_scope_field_excluded_from_json_schema(self):
+        js = self._schema().to_json_schema()
+        assert "scopes" not in js["properties"]
+        assert "client_id" in js["properties"]
+
+
+class TestFormSpec:
+    def _rich(self) -> ConfigSchema:
+        return ConfigSchema(
+            (
+                ConfigField(
+                    "client_id",
+                    display_name="Client ID",
+                    description="from console",
+                    placeholder="x.apps",
+                    importance=Importance.HIGH,
+                    group="Credentials",
+                    order=1,
+                    pattern=r"\.apps$",
+                ),
+                ConfigField(
+                    "scopes",
+                    type=ConfigType.LIST,
+                    required=False,
+                    out=ConfigOutput.SCOPES,
+                    group="Permissions",
+                    order=2,
+                    options=(
+                        ConfigOption(
+                            "gmail",
+                            label="Gmail",
+                            description="read mail",
+                            default_selected=True,
+                        ),
+                        ConfigOption("drive", label="Drive"),
+                    ),
+                ),
+            )
+        )
+
+    def test_form_spec_carries_rich_metadata(self):
+        spec = self._rich().to_form_spec()
+        client_id, scopes = spec[0], spec[1]
+        assert client_id["label"] == "Client ID"
+        assert client_id["importance"] == "high"
+        assert client_id["group"] == "Credentials"
+        assert client_id["pattern"] == r"\.apps$"
+        assert scopes["type"] == "list"
+        assert scopes["out"] == "scopes"
+        assert scopes["options"][0] == {
+            "value": "gmail",
+            "label": "Gmail",
+            "description": "read mail",
+            "default_selected": True,
+        }
+
+    def test_form_spec_round_trips(self):
+        schema = self._rich()
+        rebuilt = ConfigSchema.from_form_spec(schema.to_form_spec())
+        assert rebuilt.to_form_spec() == schema.to_form_spec()
+
+    def test_form_spec_json_safe(self):
+        spec = self._rich().to_form_spec()
+        assert json.loads(json.dumps(spec)) == spec

--- a/tests/unit/test_connectors_config_schema.py
+++ b/tests/unit/test_connectors_config_schema.py
@@ -11,6 +11,7 @@ from kamiwaza_sdk.connectors.config_schema import (
     ConfigOutput,
     ConfigSchema,
     ConfigType,
+    FieldWidth,
     Importance,
 )
 from kamiwaza_sdk.connectors.exceptions import InvalidConfigException
@@ -267,3 +268,114 @@ def test_from_form_spec_tolerates_unknown_enum_values():
     assert field.type is ConfigType.STRING
     assert field.importance is Importance.MEDIUM
     assert field.out is ConfigOutput.CONFIG
+
+
+class TestJsonSchemaRoundTrip:
+    def test_list_field_round_trips_through_json_schema(self):
+        # H1: to_json_schema emits a LIST as {"type":"array"}; from_json_schema must
+        # map it back to LIST (not STRING) and rebuild options from the enum.
+        schema = ConfigSchema(
+            (
+                ConfigField(
+                    "regions",
+                    type=ConfigType.LIST,
+                    required=False,
+                    options=(ConfigOption("us"), ConfigOption("eu")),
+                ),
+            )
+        )
+        rebuilt = ConfigSchema.from_json_schema(schema.to_json_schema())
+        assert rebuilt.fields[0].type is ConfigType.LIST
+        rebuilt.validate({"regions": ["us"]})  # valid list no longer rejected
+        with pytest.raises(InvalidConfigException):
+            rebuilt.validate({"regions": ["mars"]})  # options recovered from enum
+
+
+class TestVisibility:
+    def _schema(self) -> ConfigSchema:
+        return ConfigSchema(
+            (
+                ConfigField("mode", required=False),
+                ConfigField(
+                    "advanced_token",
+                    required=True,
+                    depends_on="mode",
+                    visible_when=("advanced",),
+                ),
+            )
+        )
+
+    def test_hidden_required_field_is_not_required(self):
+        # H2: required field hidden by its controller must not be falsely required.
+        self._schema().validate({"mode": "basic"})
+
+    def test_visible_required_field_is_enforced(self):
+        with pytest.raises(InvalidConfigException):
+            self._schema().validate({"mode": "advanced"})
+        self._schema().validate({"mode": "advanced", "advanced_token": "t"})
+
+
+class TestPatternHardening:
+    def test_malformed_pattern_raises_typed_error_not_re_error(self):
+        # H3: a bad manifest pattern is a config error, not an uncaught re.error/500.
+        schema = ConfigSchema((ConfigField("x", pattern="(unclosed"),))
+        with pytest.raises(InvalidConfigException):
+            schema.validate({"x": "abc"})
+
+    def test_overlong_value_rejected_before_running_regex(self):
+        # H3: an over-length input is rejected up-front, so a ReDoS pattern never runs.
+        schema = ConfigSchema((ConfigField("x", pattern=r"(a+)+$"),))
+        with pytest.raises(InvalidConfigException):
+            schema.validate({"x": "a" * 5000})
+
+
+def test_list_rejects_non_string_elements():
+    # M1: LIST items are strings in the emitted schema; enforce it.
+    schema = ConfigSchema((ConfigField("tags", type=ConfigType.LIST, required=False),))
+    with pytest.raises(InvalidConfigException):
+        schema.validate({"tags": ["a", 1]})
+
+
+def test_from_spec_rejects_malformed_spec():
+    # M2: malformed spec -> typed error, not a raw KeyError/ValueError.
+    with pytest.raises(InvalidConfigException):
+        ConfigField.from_spec({})  # missing name
+    with pytest.raises(InvalidConfigException):
+        ConfigField.from_spec({"name": "x", "order": "nope"})  # non-int order
+
+
+def test_json_schema_and_form_spec_cover_the_same_fields():
+    # M3: config_schema (validation) and config_fields (form) must stay consistent --
+    # the form carries every field; the JSON Schema carries exactly the non-scope ones.
+    schema = ConfigSchema(
+        (
+            ConfigField("client_id"),
+            ConfigField(
+                "scopes",
+                type=ConfigType.LIST,
+                required=False,
+                out=ConfigOutput.SCOPES,
+                options=(ConfigOption("read"),),
+            ),
+        )
+    )
+    form_names = {f["name"] for f in schema.to_form_spec()}
+    js_props = set(schema.to_json_schema()["properties"])
+    scope_names = set(schema.scope_field_names())
+    assert form_names == {"client_id", "scopes"}
+    assert js_props == form_names - scope_names == {"client_id"}
+
+
+def test_public_api_exports_the_form_types():
+    # H4: connector authors must reach the form types from the package root.
+    from kamiwaza_sdk.connectors import ConfigOption as Opt
+    from kamiwaza_sdk.connectors import ConfigOutput as Out
+    from kamiwaza_sdk.connectors import FieldWidth as Width
+    from kamiwaza_sdk.connectors import Importance as Imp
+
+    assert (Opt, Out, Width, Imp) == (
+        ConfigOption,
+        ConfigOutput,
+        FieldWidth,
+        Importance,
+    )

--- a/tests/unit/test_connectors_config_schema.py
+++ b/tests/unit/test_connectors_config_schema.py
@@ -314,6 +314,25 @@ class TestVisibility:
             self._schema().validate({"mode": "advanced"})
         self._schema().validate({"mode": "advanced", "advanced_token": "t"})
 
+    def test_defaulted_controller_still_activates_a_gated_field(self):
+        # A controller omitted from config falls back to its declared default, so a
+        # field gated on that default is validated (fail-closed) even with no value
+        # supplied for the controller.
+        schema = ConfigSchema(
+            (
+                ConfigField("mode", required=False, default="advanced"),
+                ConfigField(
+                    "advanced_token",
+                    required=True,
+                    depends_on="mode",
+                    visible_when=("advanced",),
+                ),
+            )
+        )
+        with pytest.raises(InvalidConfigException):
+            schema.validate({})  # mode defaults to "advanced" -> token required
+        schema.validate({"advanced_token": "t"})
+
 
 class TestPatternHardening:
     def test_malformed_pattern_raises_typed_error_not_re_error(self):

--- a/tests/unit/test_connectors_config_schema.py
+++ b/tests/unit/test_connectors_config_schema.py
@@ -225,3 +225,45 @@ class TestFormSpec:
     def test_form_spec_json_safe(self):
         spec = self._rich().to_form_spec()
         assert json.loads(json.dumps(spec)) == spec
+
+
+class TestJsonSchemaFromConfigFields:
+    def test_list_config_field_becomes_array_with_enum(self):
+        schema = ConfigSchema(
+            (
+                ConfigField(
+                    "regions",
+                    type=ConfigType.LIST,
+                    required=False,
+                    options=(ConfigOption("us"), ConfigOption("eu")),
+                ),
+            )
+        )
+        prop = schema.to_json_schema()["properties"]["regions"]
+        assert prop["type"] == "array"
+        assert prop["items"]["enum"] == ["us", "eu"]
+
+    def test_select_carries_enum_and_string_pattern(self):
+        schema = ConfigSchema(
+            (
+                ConfigField(
+                    "tier",
+                    required=False,
+                    options=(ConfigOption("a"), ConfigOption("b")),
+                ),
+                ConfigField("host", pattern=r"\.example\.com$"),
+            )
+        )
+        props = schema.to_json_schema()["properties"]
+        assert props["tier"]["enum"] == ["a", "b"]
+        assert props["host"]["pattern"] == r"\.example\.com$"
+
+
+def test_from_form_spec_tolerates_unknown_enum_values():
+    # Unknown type/importance/out strings fall back to the default members.
+    field = ConfigSchema.from_form_spec(
+        [{"name": "x", "type": "bogus", "importance": "nope", "out": "huh"}]
+    ).fields[0]
+    assert field.type is ConfigType.STRING
+    assert field.importance is Importance.MEDIUM
+    assert field.out is ConfigOutput.CONFIG


### PR DESCRIPTION
Generalize the connector config-form contract so a connector declares its whole admin form in its manifest and the platform renders it generically — no per-connector form in core.

- Rich `ConfigField`/`ConfigSchema`: types (incl. multi-value lists), labels/help, group+order, importance, regex validation, labelled options for select/multi-select, static or templated defaults, visibility, and an `out` that routes a value to the connector config or the OAuth scopes.
- `provider.to_manifest()` emits `config_fields` (rich form spec) alongside `config_schema` (validation JSON Schema).
- 23 unit tests; ruff/black/isort clean.

Consumed by the google/m365/linear/hubspot connector PRs and the kamiwaza core renderer PR. **Merge this first.**