### PR TITLE
feat(connectors/server_kit): /v1/whoami route routed to dispatcher.whoami

### DIFF
--- a/kamiwaza_sdk/connectors/__init__.py
+++ b/kamiwaza_sdk/connectors/__init__.py
@@ -44,6 +44,7 @@ from .server_kit import (
     ExecuteRequest,
     OpResult,
     VerifyRequest,
+    WhoamiRequest,
     create_connector_app,
 )
 
@@ -73,6 +74,7 @@ __all__ = [
     "ServiceToken",
     "SurfaceDescriptor",
     "VerifyRequest",
+    "WhoamiRequest",
     "auth_model_from_kind",
     "create_connector_app",
     "validate_icon",

--- a/kamiwaza_sdk/connectors/server_kit.py
+++ b/kamiwaza_sdk/connectors/server_kit.py
@@ -78,7 +78,9 @@ class WhoamiRequest(BaseModel):
     provider call goes through the proxy.
     """
 
-    access_token: str = Field(min_length=1)
+    # Live bearer token — keep it out of repr()/logs/tracebacks (matches the
+    # connector_token bearer-field convention).
+    access_token: str = Field(min_length=1, repr=False)
 
 
 @dataclass
@@ -213,7 +215,9 @@ def create_connector_app(
         """
         dispatcher = request.app.state.dispatcher
         handler = getattr(dispatcher, "whoami", None)
-        if handler is None:
+        # Absent OR non-callable (a stray truthy attribute) both mean "no probe"
+        # -> the clean 404 contract, never a 500.
+        if not callable(handler):
             return JSONResponse(
                 status_code=404,
                 content={

--- a/kamiwaza_sdk/connectors/server_kit.py
+++ b/kamiwaza_sdk/connectors/server_kit.py
@@ -6,6 +6,7 @@ Every deployed connector exposes the same contract to core:
   GET  /manifest       the connector's self-describing manifest (self-registration)
   POST /v1/execute     {op, subject_token, params} -> {body}
   POST /v1/verify      {subject_token} -> capability probe
+  POST /v1/whoami      {access_token} -> {email?, name?, account_id?}   (optional)
 
 Only three things vary per connector: its *provider* (for ``/manifest``), how it
 builds its *dispatcher* from the workload env, and how it maps its own error types
@@ -13,6 +14,14 @@ to HTTP status codes. :func:`create_connector_app` owns everything else — so a
 connector's ``server.py`` is just those bindings, and new connectors inherit the
 whole contract (including self-registration) for free. This is the in-core form of
 the deferred ``kamiwaza-connector-sdk``.
+
+``/v1/whoami`` is the OAuth-2.0 (non-OIDC) identity fallback core invokes from
+its OAuth callback for connectors whose token response carries no ``id_token``.
+A dispatcher that implements ``async def whoami(access_token)`` gets the route
+mounted automatically; one that doesn't responds 404 and core falls back to the
+documented "Unknown account" UI label. The hook is optional and additive —
+OIDC connectors (Google, M365) don't need it because the id_token already
+carries the email.
 
 Import-light (fastapi + pydantic only) so connector images can import it without
 pulling the core service stack.
@@ -52,6 +61,24 @@ class VerifyRequest(BaseModel):
     """A request to probe the connection's live capabilities."""
 
     subject_token: str | None = None
+
+
+class WhoamiRequest(BaseModel):
+    """A request to resolve the connected account's identity from a fresh
+    provider access token.
+
+    Used by core's OAuth callback path for OAuth-2.0 (non-OIDC) providers that
+    don't return an ``id_token``. The connector receives the just-minted
+    access token and calls the provider's identity endpoint with it directly
+    (the provider host is on the connector's egress allowlist), returning a
+    standardized ``{email?, name?, account_id?}`` payload. The connector sees
+    the raw token only for this one identity call — the OAuth callback has no
+    user JWT, so core's proxy mint isn't available yet; after whoami the
+    token is sealed into core's credential store and every subsequent
+    provider call goes through the proxy.
+    """
+
+    access_token: str = Field(min_length=1)
 
 
 @dataclass
@@ -171,6 +198,34 @@ def create_connector_app(
             return await request.app.state.dispatcher.verify(
                 subject_token=req.subject_token
             )
+        except error_type as exc:
+            return _error_response(exc)
+
+    @app.post("/v1/whoami")
+    async def whoami(req: WhoamiRequest, request: Request) -> Any:
+        """Resolve the connected account's identity (optional per dispatcher).
+
+        Dispatchers without a ``whoami`` method respond 404 — core's connect
+        fallback treats that the same as a connector that returned an empty
+        payload (the UI keeps the documented "Unknown account" label until
+        the connector ships the probe). Adding a connector for an OIDC
+        provider does not require implementing this.
+        """
+        dispatcher = request.app.state.dispatcher
+        handler = getattr(dispatcher, "whoami", None)
+        if handler is None:
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "error": {
+                        "kind": "whoami_not_implemented",
+                        "message": "connector does not expose a whoami probe",
+                        "upstream_status": None,
+                    }
+                },
+            )
+        try:
+            return await handler(access_token=req.access_token)
         except error_type as exc:
             return _error_response(exc)
 

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -179,6 +179,70 @@ def test_verify() -> None:
     assert resp.json() == {"ok": True}
 
 
+# --- /v1/whoami: optional identity probe per dispatcher ---------------------
+
+
+class _WhoamiDispatcher(_StubDispatcher):
+    """Dispatcher that implements whoami; record the token it received."""
+
+    def __init__(self, identity: dict) -> None:
+        super().__init__(verify_result={"ok": True})
+        self._identity = identity
+        self.whoami_tokens: list[str] = []
+
+    async def whoami(self, *, access_token: str) -> dict:
+        self.whoami_tokens.append(access_token)
+        return self._identity
+
+
+def test_whoami_routes_to_dispatcher_when_implemented() -> None:
+    """A dispatcher with whoami gets the identity call routed through."""
+    dispatcher = _WhoamiDispatcher(
+        {"email": "user@example.com", "name": "User"}
+    )
+    with TestClient(_app(dispatcher)) as client:
+        resp = client.post("/v1/whoami", json={"access_token": "hs-at"})
+    assert resp.status_code == 200
+    assert resp.json() == {"email": "user@example.com", "name": "User"}
+    assert dispatcher.whoami_tokens == ["hs-at"]
+
+
+def test_whoami_returns_404_when_dispatcher_does_not_implement_it() -> None:
+    """An OIDC-only connector (or one shipped before whoami) responds 404.
+
+    Core's connect fallback treats this the same as an empty payload — the
+    UI keeps its documented "Unknown account" label until the connector
+    ships the probe.
+    """
+    with TestClient(_app(_StubDispatcher())) as client:
+        # Base _StubDispatcher has no whoami method.
+        resp = client.post("/v1/whoami", json={"access_token": "tok"})
+    assert resp.status_code == 404
+    assert resp.json()["error"]["kind"] == "whoami_not_implemented"
+
+
+def test_whoami_rejects_empty_access_token() -> None:
+    """Pydantic validation: empty access_token never reaches the dispatcher."""
+    dispatcher = _WhoamiDispatcher({})
+    with TestClient(_app(dispatcher)) as client:
+        resp = client.post("/v1/whoami", json={"access_token": ""})
+    assert resp.status_code == 422
+    assert dispatcher.whoami_tokens == []
+
+
+def test_whoami_classifies_connector_error() -> None:
+    """Connector errors raised inside whoami flow through the classifier."""
+
+    class _ExplodingWhoami(_StubDispatcher):
+        async def whoami(self, *, access_token: str) -> dict:
+            raise _BoomError("upstream blew up")
+
+    with TestClient(_app(_ExplodingWhoami())) as client:
+        resp = client.post("/v1/whoami", json={"access_token": "tok"})
+    assert resp.status_code == 429  # _app's classify_error maps _BoomError -> 429
+    assert resp.json()["error"]["kind"] == "rate_limited"
+
+
 def test_lifespan_builds_and_closes_owned_dispatcher() -> None:
     built: list[_StubDispatcher] = []
 

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -32,6 +32,7 @@ from kamiwaza_sdk.connectors import (
     PerUserOAuth,
     ServiceToken,
     SurfaceDescriptor,
+    WhoamiRequest,
     auth_model_from_kind,
     create_connector_app,
     validate_icon,
@@ -241,6 +242,24 @@ def test_whoami_classifies_connector_error() -> None:
         resp = client.post("/v1/whoami", json={"access_token": "tok"})
     assert resp.status_code == 429  # _app's classify_error maps _BoomError -> 429
     assert resp.json()["error"]["kind"] == "rate_limited"
+
+
+def test_whoami_returns_404_when_handler_not_callable() -> None:
+    """A non-callable ``whoami`` attribute folds into the 404 contract, not 500."""
+
+    class _NonCallableWhoami(_StubDispatcher):
+        whoami = "not a method"  # truthy but not callable
+
+    with TestClient(_app(_NonCallableWhoami())) as client:
+        resp = client.post("/v1/whoami", json={"access_token": "tok"})
+    assert resp.status_code == 404
+    assert resp.json()["error"]["kind"] == "whoami_not_implemented"
+
+
+def test_whoami_request_token_not_in_repr() -> None:
+    """The raw provider access token must not surface in repr()/logs/tracebacks."""
+    req = WhoamiRequest(access_token="super-secret-token")
+    assert "super-secret-token" not in repr(req)
 
 
 def test_lifespan_builds_and_closes_owned_dispatcher() -> None:


### PR DESCRIPTION
## Summary

Adds the optional `/v1/whoami` route to `kamiwaza_sdk.connectors.server_kit.create_connector_app`. A dispatcher that implements `async def whoami(access_token)` gets the route mounted automatically; a dispatcher that doesn't responds 404 (and core's connect fallback treats that the same as a connector that returned an empty payload — the UI keeps the documented "Unknown account" label until the connector ships the probe).

## Why

Pure OAuth 2.0 providers (HubSpot, Linear, …) don't return an OIDC `id_token`, so core's `_email_from_id_token` returns `None` and `UserConnection.external_email` stays NULL forever. The connector card then renders the documented "Unknown account" fallback. Adding provider-specific identity probes to core would couple it to each provider — instead, ask the connector. This SPI hook lets each connector implement its provider's identity endpoint locally; the SDK owns the wire contract.

## Pairs with

- kamiwaza-internal/kamiwaza `fix/connector-verify-azp-and-tab-flicker` — adds the matching in-core `server_kit` hook + the core-side `_email_from_connector_identity` fallback that calls `/v1/whoami` from the OAuth callback.
- kamiwaza-internal/kamiwaza-connector-hubspot `feat/whoami-identity-probe` — HubSpot dispatcher's `whoami` implementation.
- kamiwaza-internal/kamiwaza-connector-linear `feat/whoami-identity-probe` — Linear dispatcher's `whoami` implementation.

## Test plan

- [ ] `make test` (or `uv run pytest`) — three new tests in `tests/unit/test_connectors_spi.py` cover: dispatcher with `whoami` gets routed through, dispatcher without `whoami` returns 404, empty access_token rejected by pydantic validation, error classifier flows on connector-side errors.
- [ ] Cross-check with a connector image that implements `dispatcher.whoami` (the companion connector PRs) — `POST /v1/whoami {"access_token":"..."}` returns the identity dict.

## Linear

- [ENG-7874](https://linear.app/kamiwaza/issue/ENG-7874) — /v1/whoami route mounted in server_kit when dispatcher implements whoami()
