### PR TITLE
feat(connectors): identity-proxy request schema for core-mediated whoami egress

### DIFF
--- a/kamiwaza_sdk/connectors/__init__.py
+++ b/kamiwaza_sdk/connectors/__init__.py
@@ -24,7 +24,11 @@ from .config_schema import (
     FieldWidth,
     Importance,
 )
-from .connector_proxy import ConnectorProxyRequest, ConnectorProxyResponse
+from .connector_proxy import (
+    ConnectorIdentityProxyRequest,
+    ConnectorProxyRequest,
+    ConnectorProxyResponse,
+)
 from .connector_token import ConnectorMintRequest, ConnectorMintResponse
 from .exceptions import ConnectorException, InvalidConfigException
 from .provider import (
@@ -59,6 +63,7 @@ __all__ = [
     "ConnectorMintRequest",
     "ConnectorMintResponse",
     "ConnectorProvider",
+    "ConnectorIdentityProxyRequest",
     "ConnectorProxyRequest",
     "ConnectorProxyResponse",
     "ConnectorSpec",

--- a/kamiwaza_sdk/connectors/connector_proxy.py
+++ b/kamiwaza_sdk/connectors/connector_proxy.py
@@ -43,6 +43,34 @@ class ConnectorProxyRequest(ConnectorMintRequest):
     )
 
 
+class ConnectorIdentityProxyRequest(BaseModel):
+    """A connector's pre-connection identity fetch for core to execute.
+
+    Used only by the ``/v1/whoami`` OAuth-callback path. Unlike
+    ``ConnectorProxyRequest`` there is no connection or acting subject yet, so core
+    can't mint a scoped credential from storage -- the connector supplies the
+    freshly-minted provider ``access_token`` (which core just handed it) and core
+    performs the egress the connector pod cannot, enforcing the same workload
+    binding + egress allowlist. The token never leaves the deployment mesh and is
+    kept out of logs/reprs.
+    """
+
+    method: Literal["GET", "POST"] = Field("GET", description="HTTP method")
+    url: str = Field(
+        ...,
+        description="Absolute URL; its host must be in the connector's egress allowlist",
+    )
+    params: dict[str, Any] | None = Field(None, description="Query parameters")
+    body: dict[str, Any] | None = Field(None, description="JSON body (POST)")
+    # Identity endpoints are JSON; binary downloads never go through this path.
+    response_format: Literal["json"] = Field("json", description="JSON-only")
+    access_token: str = Field(
+        ...,
+        repr=False,
+        description="Freshly-minted provider token; core attaches it as the bearer",
+    )
+
+
 class ConnectorProxyResponse(BaseModel):
     """The upstream response, returned to the connector."""
 

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -18,6 +18,7 @@ from kamiwaza_sdk.connectors import (
     ConfigField,
     ConfigSchema,
     ConfigType,
+    ConnectorIdentityProxyRequest,
     ConnectorMintRequest,
     ConnectorMintResponse,
     ConnectorProvider,
@@ -355,6 +356,18 @@ def test_mint_request_lease_bounds() -> None:
     # the proxy request inherits the same bound
     with pytest.raises(ValidationError):
         ConnectorProxyRequest(url="https://api.acme.test/x", lease_duration=10)
+
+
+def test_identity_proxy_request_requires_token_and_hides_it() -> None:
+    # The pre-connection whoami request carries the provider token itself (no
+    # connection to mint from yet); it must be supplied and must not surface in repr.
+    with pytest.raises(ValidationError):
+        ConnectorIdentityProxyRequest(url="https://api.acme.test/userinfo")
+    req = ConnectorIdentityProxyRequest(
+        url="https://api.acme.test/userinfo", access_token="prov-secret"
+    )
+    assert req.response_format == "json"
+    assert "prov-secret" not in repr(req)
 
 
 def test_from_json_schema_required_field_must_be_supplied() -> None:


### PR DESCRIPTION
## Why
The OAuth-2.0 `/v1/whoami` identity probe was a **direct** connector-pod → provider call. But `type: connector` workloads deploy with no external egress (`allow_external_access` defaults false), so in the default/secure posture that call is blocked, swallowed, and the account silently stays "Unknown account". The fix routes whoami through core's proxy (the way `execute`/`verify` already work).

## What
Adds `ConnectorIdentityProxyRequest` — the request schema for core's new pre-connection identity-proxy endpoint (`POST /connectors/{id}/identity-proxy`). Unlike `ConnectorProxyRequest`:
- no `subject_token`/`scope_subset`/`lease_duration` (there's no acting subject or connection at the OAuth callback), and
- it carries the freshly-minted provider `access_token` (`repr=False`) because there's no stored connection for core to mint from yet.

Exported from `kamiwaza_sdk.connectors`.

## Pairs with
- **kamiwaza**: `POST /connectors/{id}/identity-proxy` (workload-authorized, egress-allowlist-enforced).
- **connector-hubspot / connector-linear**: whoami routes its fetch through this instead of raw httpx.

Refs ENG-7874

🤖 Generated with [Claude Code](https://claude.com/claude-code)