### PR TITLE
ENG-7969: Retry transient connector workroom smoke 403

### DIFF
--- a/test_support/__init__.py
+++ b/test_support/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test-only helpers."""

--- a/test_support/workroom_isolation.py
+++ b/test_support/workroom_isolation.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Sequence
+from typing import Any, Protocol
+
+from kamiwaza_sdk.exceptions import APIError
+
+CONNECTOR_LIST_RETRY_DELAYS_SECONDS = (0.5, 1.0, 2.0, 3.0, 3.5)
+
+
+class ConnectorListClient(Protocol):
+    def get(self, endpoint: str, **kwargs: Any) -> dict[str, Any]: ...
+
+
+def retryable_connector_list_error(exc: APIError) -> bool:
+    return exc.status_code == 403 and not (exc.response_text or "").strip()
+
+
+def connector_list_retry_message(
+    *,
+    workroom_id: str,
+    attempts: int,
+    elapsed_seconds: float,
+    exc: APIError,
+) -> str:
+    return (
+        "GET /dde/connectors/ remained forbidden for explicit "
+        f"X-Workroom-Id={workroom_id!r} after {attempts} attempts "
+        f"over {elapsed_seconds:.1f}s. "
+        f"Last status={exc.status_code}, response_text={exc.response_text!r}. "
+        "Set KAMIWAZA_HTTP_TRACE=1 or KAMIWAZA_HTTP_TRACE_FILE to capture "
+        "request and response headers."
+    )
+
+
+def list_connectors(
+    sdk: ConnectorListClient,
+    workroom_id: str,
+    *,
+    retry_delays: Sequence[float] = CONNECTOR_LIST_RETRY_DELAYS_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> list:
+    """List DDE connectors scoped to a workroom via header.
+
+    Retries only the blank-body 403 seen on immediate authorized self-access.
+    Non-empty 403s and non-403 errors fail fast; persistent blank 403s use a
+    bounded ~10s default retry budget before failing with diagnostics.
+    """
+    started_at = monotonic()
+
+    for attempt_index in range(len(retry_delays) + 1):
+        try:
+            resp = sdk.get("/dde/connectors/", headers={"X-Workroom-Id": workroom_id})
+        except APIError as exc:
+            if not retryable_connector_list_error(exc):
+                raise
+            if attempt_index >= len(retry_delays):
+                raise AssertionError(
+                    connector_list_retry_message(
+                        workroom_id=workroom_id,
+                        attempts=attempt_index + 1,
+                        elapsed_seconds=monotonic() - started_at,
+                        exc=exc,
+                    )
+                ) from exc
+            sleep(retry_delays[attempt_index])
+            continue
+        return resp.get("items", [])
+
+    # Defensive guard: the loop always returns, retries, or raises.
+    raise AssertionError("unreachable connector-list retry state")

--- a/tests/integration/test_workroom_isolation_live.py
+++ b/tests/integration/test_workroom_isolation_live.py
@@ -16,6 +16,7 @@ Requirements:
     - A running Kamiwaza instance (auto-skips if unavailable)
     - Authenticated SDK client (API key or user/password)
 """
+
 from __future__ import annotations
 
 from uuid import uuid4
@@ -24,6 +25,7 @@ import pytest
 
 from kamiwaza_sdk import KamiwazaClient
 from kamiwaza_sdk.exceptions import APIError, NotFoundError
+from test_support.workroom_isolation import list_connectors as _list_connectors
 
 pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
 
@@ -38,6 +40,7 @@ def _unique(prefix: str) -> str:
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def sdk(live_kamiwaza_client) -> KamiwazaClient:
     """Authenticated SDK client."""
@@ -47,7 +50,9 @@ def sdk(live_kamiwaza_client) -> KamiwazaClient:
 @pytest.fixture
 def workroom_a(sdk: KamiwazaClient):
     """Create an ephemeral Workroom A, delete on teardown."""
-    wr = sdk.workrooms.create(_unique("wr-a"), "ephemeral", description="Isolation test A")
+    wr = sdk.workrooms.create(
+        _unique("wr-a"), "ephemeral", description="Isolation test A"
+    )
     yield wr
     try:
         sdk.workrooms.delete(str(wr.id))
@@ -58,22 +63,14 @@ def workroom_a(sdk: KamiwazaClient):
 @pytest.fixture
 def workroom_b(sdk: KamiwazaClient):
     """Create an ephemeral Workroom B, delete on teardown."""
-    wr = sdk.workrooms.create(_unique("wr-b"), "ephemeral", description="Isolation test B")
+    wr = sdk.workrooms.create(
+        _unique("wr-b"), "ephemeral", description="Isolation test B"
+    )
     yield wr
     try:
         sdk.workrooms.delete(str(wr.id))
     except (APIError, NotFoundError):
         pass
-
-
-# ---------------------------------------------------------------------------
-# Helpers -- raw HTTP wrappers that inject X-Workroom-Id
-# ---------------------------------------------------------------------------
-
-def _list_connectors(sdk: KamiwazaClient, workroom_id: str) -> list:
-    """List DDE connectors scoped to a workroom via header."""
-    resp = sdk.get("/dde/connectors/", headers={"X-Workroom-Id": workroom_id})
-    return resp.get("items", [])
 
 
 def _list_deployments(sdk: KamiwazaClient, workroom_id: str | None = None) -> list:
@@ -94,6 +91,7 @@ def _list_extensions(sdk: KamiwazaClient, workroom_id: str) -> list:
 # ---------------------------------------------------------------------------
 # 1. WORKROOM CRUD ISOLATION
 # ---------------------------------------------------------------------------
+
 
 class TestWorkroomCrudIsolation:
     """Verify workroom CRUD operations respect ownership."""
@@ -146,6 +144,7 @@ class TestWorkroomCrudIsolation:
 # 2. SELF-ACCESS: A -> A, B -> B
 # ---------------------------------------------------------------------------
 
+
 class TestSelfAccess:
     """Workspace A sees its own resources; B sees its own."""
 
@@ -172,12 +171,20 @@ class TestSelfAccess:
         b_exts = _list_extensions(sdk, str(workroom_b.id))
 
         for ext in a_exts:
-            wid = ext.get("workroom_id") if isinstance(ext, dict) else getattr(ext, "workroom_id", None)
+            wid = (
+                ext.get("workroom_id")
+                if isinstance(ext, dict)
+                else getattr(ext, "workroom_id", None)
+            )
             if wid is not None:
                 assert wid == str(workroom_a.id), f"A sees non-A extension: {wid}"
 
         for ext in b_exts:
-            wid = ext.get("workroom_id") if isinstance(ext, dict) else getattr(ext, "workroom_id", None)
+            wid = (
+                ext.get("workroom_id")
+                if isinstance(ext, dict)
+                else getattr(ext, "workroom_id", None)
+            )
             if wid is not None:
                 assert wid == str(workroom_b.id), f"B sees non-B extension: {wid}"
 
@@ -186,6 +193,7 @@ class TestSelfAccess:
 # 3. CROSS-WORKSPACE: A <-> B = NEVER
 # ---------------------------------------------------------------------------
 
+
 class TestCrossWorkspaceBlocked:
     """Nothing outside of A can see into A; nothing outside of B can see into B."""
 
@@ -193,20 +201,30 @@ class TestCrossWorkspaceBlocked:
         """B's connector listing must not include any of A's connectors."""
         b_connectors = _list_connectors(sdk, str(workroom_b.id))
         b_wids = {c.get("workroom_id") for c in b_connectors}
-        assert str(workroom_a.id) not in b_wids, "B sees A's connectors -- cross-workspace leak!"
+        assert str(workroom_a.id) not in b_wids, (
+            "B sees A's connectors -- cross-workspace leak!"
+        )
 
     def test_a_cannot_see_b_connectors(self, sdk, workroom_a, workroom_b):
         """A's connector listing must not include any of B's connectors."""
         a_connectors = _list_connectors(sdk, str(workroom_a.id))
         a_wids = {c.get("workroom_id") for c in a_connectors}
-        assert str(workroom_b.id) not in a_wids, "A sees B's connectors -- cross-workspace leak!"
+        assert str(workroom_b.id) not in a_wids, (
+            "A sees B's connectors -- cross-workspace leak!"
+        )
 
     def test_b_cannot_see_a_extensions(self, sdk, workroom_a, workroom_b):
         """B's extension listing must not include any of A's extensions."""
         b_exts = _list_extensions(sdk, str(workroom_b.id))
         for ext in b_exts:
-            wid = ext.get("workroom_id") if isinstance(ext, dict) else getattr(ext, "workroom_id", None)
-            assert wid != str(workroom_a.id), "B sees A's extension -- cross-workspace leak!"
+            wid = (
+                ext.get("workroom_id")
+                if isinstance(ext, dict)
+                else getattr(ext, "workroom_id", None)
+            )
+            assert wid != str(workroom_a.id), (
+                "B sees A's extension -- cross-workspace leak!"
+            )
 
     def test_workroom_export_only_shows_own_resources(self, sdk, workroom_a):
         """Export manifest for A should not reference B's resources."""
@@ -220,6 +238,7 @@ class TestCrossWorkspaceBlocked:
 # 4. GLOBAL -> WORKSPACE = NEVER
 # ---------------------------------------------------------------------------
 
+
 class TestGlobalCannotSeeWorkspaces:
     """From Global Workroom context, workspace-scoped resources are invisible."""
 
@@ -227,16 +246,22 @@ class TestGlobalCannotSeeWorkspaces:
         """Connectors listed under Global must not include A's connectors."""
         global_connectors = _list_connectors(sdk, GLOBAL_WORKROOM_ID)
         global_wids = {c.get("workroom_id") for c in global_connectors}
-        assert str(workroom_a.id) not in global_wids, \
+        assert str(workroom_a.id) not in global_wids, (
             "Global sees Workspace A's connectors -- Global->Workspace leak!"
+        )
 
     def test_global_extensions_exclude_workspace_b(self, sdk, workroom_b):
         """Extensions listed under Global must not include B's extensions."""
         global_exts = _list_extensions(sdk, GLOBAL_WORKROOM_ID)
         for ext in global_exts:
-            wid = ext.get("workroom_id") if isinstance(ext, dict) else getattr(ext, "workroom_id", None)
-            assert wid != str(workroom_b.id), \
+            wid = (
+                ext.get("workroom_id")
+                if isinstance(ext, dict)
+                else getattr(ext, "workroom_id", None)
+            )
+            assert wid != str(workroom_b.id), (
                 "Global sees Workspace B's extension -- Global->Workspace leak!"
+            )
 
     def test_global_export_excludes_workspace_resources(self, sdk):
         """Export manifest for Global should not reference workspace-scoped resources."""
@@ -247,6 +272,7 @@ class TestGlobalCannotSeeWorkspaces:
 # ---------------------------------------------------------------------------
 # 5. WORKSPACE -> GLOBAL (default: allowed)
 # ---------------------------------------------------------------------------
+
 
 class TestWorkspaceCanSeeGlobal:
     """By default (Admin ON), workspace context can access Global resources.
@@ -281,6 +307,7 @@ class TestWorkspaceCanSeeGlobal:
 # ---------------------------------------------------------------------------
 # 6. LIFECYCLE + ISOLATION INTERACTIONS
 # ---------------------------------------------------------------------------
+
 
 class TestLifecycleIsolation:
     """Verify workroom lifecycle operations don't break isolation."""
@@ -323,10 +350,13 @@ class TestLifecycleIsolation:
 # 7. SENTINEL VALUE: ?workroom_id=all (admin bypass)
 # ---------------------------------------------------------------------------
 
+
 class TestSentinelAllBypass:
     """The ?workroom_id=all sentinel bypasses workroom filtering (admin use)."""
 
-    def test_deployments_all_returns_across_workrooms(self, sdk, workroom_a, workroom_b):
+    def test_deployments_all_returns_across_workrooms(
+        self, sdk, workroom_a, workroom_b
+    ):
         """Passing workroom_id=all returns deployments from all workrooms."""
         all_deployments = _list_deployments(sdk, workroom_id="all")
         assert isinstance(all_deployments, list)
@@ -338,5 +368,6 @@ class TestSentinelAllBypass:
         for c in items:
             wid = c.get("workroom_id")
             if wid is not None:
-                assert wid == GLOBAL_WORKROOM_ID, \
+                assert wid == GLOBAL_WORKROOM_ID, (
                     f"No-header request returned non-Global connector: {wid}"
+                )

--- a/tests/unit/test_workroom_isolation_connector_retry.py
+++ b/tests/unit/test_workroom_isolation_connector_retry.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+
+from kamiwaza_sdk.exceptions import APIError
+from test_support.workroom_isolation import (
+    CONNECTOR_LIST_RETRY_DELAYS_SECONDS,
+    list_connectors,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _ConnectorListClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def get(self, endpoint, **kwargs):
+        self.calls.append((endpoint, kwargs))
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+
+class _ManualClock:
+    def __init__(self):
+        self.value = 0.0
+        self.sleeps = []
+
+    def monotonic(self):
+        return self.value
+
+    def sleep(self, delay):
+        self.sleeps.append(delay)
+        self.value += delay
+
+
+def test_retries_transient_blank_403_before_success():
+    client = _ConnectorListClient(
+        [
+            APIError("forbidden", status_code=403, response_text=""),
+            {"items": [{"id": "connector-1"}]},
+        ]
+    )
+    sleeps = []
+
+    result = list_connectors(
+        client,
+        "wr-1",
+        retry_delays=(0.25,),
+        sleep=sleeps.append,
+    )
+
+    assert result == [{"id": "connector-1"}]
+    assert sleeps == [0.25]
+    assert client.calls == [
+        ("/dde/connectors/", {"headers": {"X-Workroom-Id": "wr-1"}}),
+        ("/dde/connectors/", {"headers": {"X-Workroom-Id": "wr-1"}}),
+    ]
+
+
+def test_retries_whitespace_only_403_before_success():
+    client = _ConnectorListClient(
+        [
+            APIError("forbidden", status_code=403, response_text="\n  "),
+            {"items": [{"id": "connector-1"}]},
+        ]
+    )
+    sleeps = []
+
+    result = list_connectors(
+        client,
+        "wr-1",
+        retry_delays=(0.25,),
+        sleep=sleeps.append,
+    )
+
+    assert result == [{"id": "connector-1"}]
+    assert sleeps == [0.25]
+    assert len(client.calls) == 2
+
+
+def test_raises_diagnostic_after_default_retry_budget():
+    errors = [
+        APIError("forbidden", status_code=403, response_text="")
+        for _ in range(len(CONNECTOR_LIST_RETRY_DELAYS_SECONDS) + 1)
+    ]
+    client = _ConnectorListClient(errors)
+    clock = _ManualClock()
+
+    with pytest.raises(AssertionError) as exc_info:
+        list_connectors(
+            client,
+            "wr-2",
+            sleep=clock.sleep,
+            monotonic=clock.monotonic,
+        )
+
+    message = str(exc_info.value)
+    assert "X-Workroom-Id='wr-2'" in message
+    assert "after 6 attempts" in message
+    assert "over 10.0s" in message
+    assert "status=403" in message
+    assert "response_text=''" in message
+    assert len(client.calls) == len(CONNECTOR_LIST_RETRY_DELAYS_SECONDS) + 1
+    assert clock.sleeps == list(CONNECTOR_LIST_RETRY_DELAYS_SECONDS)
+    assert exc_info.value.__cause__ is errors[-1]
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        APIError("forbidden", status_code=403, response_text="missing connector scope"),
+        APIError("server error", status_code=500, response_text="boom"),
+        APIError("transport", status_code=None, response_text=""),
+    ],
+)
+def test_non_transient_errors_raise_immediately(error):
+    client = _ConnectorListClient([error])
+    sleeps = []
+
+    with pytest.raises(APIError) as exc_info:
+        list_connectors(
+            client,
+            "wr-3",
+            retry_delays=(0.25,),
+            sleep=sleeps.append,
+        )
+
+    assert exc_info.value is error
+    assert len(client.calls) == 1
+    assert sleeps == []


### PR DESCRIPTION
## Summary

- Add a bounded retry around the SDK live workroom isolation helper that lists `/dde/connectors/` with an explicit `X-Workroom-Id`.
- Retry only the transient blank-body HTTP 403 signature from authorized connector-list reads; non-empty 403s and non-403 API failures raise immediately.
- Preserve failure after the retry budget with a diagnostic that includes the workroom id, final status, response text, and HTTP trace hint.
- Move deterministic retry-helper tests into `tests/unit/` so they run under the default unit selector instead of inheriting live/integration markers.
- Extract the connector-list retry helper into `test_support/workroom_isolation.py` so unit and live tests share it through a normal import.

## Why

Kajiya periodic mesh smoke run `28487208412` had a single SDK E2E failure in `test_connectors_scoped_to_own_workroom`: the second immediate self-access connector list returned a blank-body 403. A later periodic mesh smoke passed with the same SDK SHA, which points to a transient explicit workroom-header/auth visibility window rather than a deterministic runtime regression.

This keeps the smoke contract intact: self-access must still succeed after a short visibility window, and a persistent blank-body 403 remains a hard failure with diagnostics.

Linear: ENG-7969

## Validation

- `uv run pytest -m "not integration and not live and not e2e" tests/unit/test_workroom_isolation_connector_retry.py -q`
- `uv run pytest -m "not integration and not live and not e2e" tests/integration/test_workroom_isolation_live.py tests/unit/test_workroom_isolation_connector_retry.py --collect-only -q`
- `uv run ruff check tests/integration/test_workroom_isolation_live.py tests/unit/test_workroom_isolation_connector_retry.py test_support/workroom_isolation.py test_support/__init__.py`
- `uv run ruff format --check tests/integration/test_workroom_isolation_live.py tests/unit/test_workroom_isolation_connector_retry.py test_support/workroom_isolation.py test_support/__init__.py`
- `git diff --check`