### PR TITLE
ENG-7969 retry transient self-access connector smoke

### DIFF
--- a/tests/integration/test_workroom_isolation_live.py
+++ b/tests/integration/test_workroom_isolation_live.py
@@ -18,16 +18,18 @@ Requirements:
 """
 from __future__ import annotations
 
+import time
 from uuid import uuid4
 
 import pytest
 
 from kamiwaza_sdk import KamiwazaClient
-from kamiwaza_sdk.exceptions import APIError, NotFoundError
+from kamiwaza_sdk.exceptions import APIError, KamiwazaError, NotFoundError
 
 pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
 
 GLOBAL_WORKROOM_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+_SELF_ACCESS_CONNECTOR_RETRY_DELAYS_SECONDS = (0.5, 1.0)
 
 
 def _unique(prefix: str) -> str:
@@ -74,6 +76,48 @@ def _list_connectors(sdk: KamiwazaClient, workroom_id: str) -> list:
     """List DDE connectors scoped to a workroom via header."""
     resp = sdk.get("/dde/connectors/", headers={"X-Workroom-Id": workroom_id})
     return resp.get("items", [])
+
+
+def _list_connectors_self_access(
+    sdk: KamiwazaClient,
+    workroom_id: str,
+    *,
+    label: str,
+) -> list:
+    """List connectors for an allowed self-access check, retrying transient 403s.
+
+    This retry is intentionally scoped to the positive A->A/B->B smoke path.
+    Negative isolation checks must fail immediately so real cross-workroom
+    authorization regressions are never hidden by retry behavior.
+    """
+    attempts = 0
+    last_error: KamiwazaError | None = None
+    delays = (None, *_SELF_ACCESS_CONNECTOR_RETRY_DELAYS_SECONDS)
+    for delay in delays:
+        attempts += 1
+        if delay is not None:
+            time.sleep(delay)
+        try:
+            return _list_connectors(sdk, workroom_id)
+        except KamiwazaError as exc:
+            if exc.status_code != 403:
+                raise
+            last_error = exc
+
+    if last_error is None:  # Defensive guard; the retry loop should always set this.
+        raise RuntimeError("connector self-access retry exhausted without an error")
+    status_code = last_error.status_code
+    response_data = getattr(last_error, "response_data", None)
+    if response_data is None:
+        response_data = last_error.body
+    raise APIError(
+        "positive connector self-access failed after transient 403 retry: "
+        f"label={label} endpoint=/dde/connectors/ workroom_id={workroom_id} "
+        f"status={status_code} attempts={attempts}",
+        status_code=status_code,
+        response_text=getattr(last_error, "response_text", None),
+        response_data=response_data,
+    ) from last_error
 
 
 def _list_deployments(sdk: KamiwazaClient, workroom_id: str | None = None) -> list:
@@ -168,8 +212,16 @@ class TestSelfAccess:
 
     def test_connectors_scoped_to_own_workroom(self, sdk, workroom_a, workroom_b):
         """Connectors listed with A's header return only A or shared Global connectors."""
-        a_connectors = _list_connectors(sdk, str(workroom_a.id))
-        b_connectors = _list_connectors(sdk, str(workroom_b.id))
+        a_connectors = _list_connectors_self_access(
+            sdk,
+            str(workroom_a.id),
+            label="A",
+        )
+        b_connectors = _list_connectors_self_access(
+            sdk,
+            str(workroom_b.id),
+            label="B",
+        )
 
         _assert_only_own_or_global(a_connectors, str(workroom_a.id), "A")
         _assert_only_own_or_global(b_connectors, str(workroom_b.id), "B")
@@ -192,13 +244,23 @@ class TestCrossWorkspaceBlocked:
 
     def test_b_cannot_see_a_connectors(self, sdk, workroom_a, workroom_b):
         """B's connector listing must not include any of A's connectors."""
-        b_connectors = _list_connectors(sdk, str(workroom_b.id))
+        # This request is B -> B self-access; the leak assertion below stays strict.
+        b_connectors = _list_connectors_self_access(
+            sdk,
+            str(workroom_b.id),
+            label="B",
+        )
         b_wids = {c.get("workroom_id") for c in b_connectors}
         assert str(workroom_a.id) not in b_wids, "B sees A's connectors -- cross-workspace leak!"
 
     def test_a_cannot_see_b_connectors(self, sdk, workroom_a, workroom_b):
         """A's connector listing must not include any of B's connectors."""
-        a_connectors = _list_connectors(sdk, str(workroom_a.id))
+        # This request is A -> A self-access; the leak assertion below stays strict.
+        a_connectors = _list_connectors_self_access(
+            sdk,
+            str(workroom_a.id),
+            label="A",
+        )
         a_wids = {c.get("workroom_id") for c in a_connectors}
         assert str(workroom_b.id) not in a_wids, "A sees B's connectors -- cross-workspace leak!"
 

--- a/tests/unit/test_workroom_isolation_live_helpers.py
+++ b/tests/unit/test_workroom_isolation_live_helpers.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from kamiwaza_sdk.exceptions import APIError, AuthorizationError
+from tests.integration import test_workroom_isolation_live as isolation_live
+
+pytestmark = pytest.mark.unit
+
+
+@dataclass
+class _FakeSdk:
+    responses: list[Any]
+    calls: list[tuple[str, dict[str, str]]]
+
+    def get(self, endpoint: str, *, headers: dict[str, str]):
+        self.calls.append((endpoint, headers))
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _forbidden() -> APIError:
+    return APIError(
+        "API request failed with status 403: ",
+        status_code=403,
+        response_text="",
+        response_data=None,
+    )
+
+
+def test_self_access_connector_list_first_success_does_not_sleep_or_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workroom_id = "wr-a"
+    sdk = _FakeSdk(responses=[{"items": [{"workroom_id": workroom_id}]}], calls=[])
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        isolation_live,
+        "time",
+        SimpleNamespace(sleep=sleeps.append),
+        raising=False,
+    )
+
+    result = isolation_live._list_connectors_self_access(sdk, workroom_id, label="A")
+
+    assert result == [{"workroom_id": workroom_id}]
+    assert sdk.calls == [("/dde/connectors/", {"X-Workroom-Id": workroom_id})]
+    assert sleeps == []
+
+
+def test_self_access_connector_list_non_403_propagates_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workroom_id = "wr-b"
+    server_error = APIError(
+        "API request failed with status 500: boom",
+        status_code=500,
+        response_text="boom",
+        response_data={"detail": "boom"},
+    )
+    sdk = _FakeSdk(responses=[server_error], calls=[])
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        isolation_live,
+        "time",
+        SimpleNamespace(sleep=sleeps.append),
+        raising=False,
+    )
+
+    with pytest.raises(APIError) as exc_info:
+        isolation_live._list_connectors_self_access(sdk, workroom_id, label="B")
+
+    assert exc_info.value is server_error
+    assert sdk.calls == [("/dde/connectors/", {"X-Workroom-Id": workroom_id})]
+    assert sleeps == []
+
+
+def test_self_access_connector_list_retries_typed_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workroom_id = "wr-b"
+    sdk = _FakeSdk(
+        responses=[
+            AuthorizationError("workroom binding not visible yet", status_code=403),
+            {"items": [{"workroom_id": workroom_id}]},
+        ],
+        calls=[],
+    )
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        isolation_live,
+        "_SELF_ACCESS_CONNECTOR_RETRY_DELAYS_SECONDS",
+        (0.01,),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        isolation_live,
+        "time",
+        SimpleNamespace(sleep=sleeps.append),
+        raising=False,
+    )
+
+    result = isolation_live._list_connectors_self_access(sdk, workroom_id, label="B")
+
+    assert result == [{"workroom_id": workroom_id}]
+    assert len(sdk.calls) == 2
+    assert sleeps == [0.01]
+
+
+def test_self_access_connector_list_retries_one_transient_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workroom_id = "wr-b"
+    sdk = _FakeSdk(
+        responses=[_forbidden(), {"items": [{"workroom_id": workroom_id}]}],
+        calls=[],
+    )
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        isolation_live,
+        "_SELF_ACCESS_CONNECTOR_RETRY_DELAYS_SECONDS",
+        (0.01,),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        isolation_live,
+        "time",
+        SimpleNamespace(sleep=sleeps.append),
+        raising=False,
+    )
+
+    result = isolation_live._list_connectors_self_access(sdk, workroom_id, label="B")
+
+    assert result == [{"workroom_id": workroom_id}]
+    assert sdk.calls == [
+        ("/dde/connectors/", {"X-Workroom-Id": workroom_id}),
+        ("/dde/connectors/", {"X-Workroom-Id": workroom_id}),
+    ]
+    assert sleeps == [0.01]
+
+
+def test_self_access_connector_list_persistent_403_keeps_diagnostic_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workroom_id = "wr-b"
+    sdk = _FakeSdk(responses=[_forbidden(), _forbidden()], calls=[])
+    monkeypatch.setattr(
+        isolation_live,
+        "_SELF_ACCESS_CONNECTOR_RETRY_DELAYS_SECONDS",
+        (0.01,),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        isolation_live,
+        "time",
+        SimpleNamespace(sleep=lambda _delay: None),
+        raising=False,
+    )
+
+    with pytest.raises(APIError) as exc_info:
+        isolation_live._list_connectors_self_access(sdk, workroom_id, label="B")
+
+    error = exc_info.value
+    assert error.status_code == 403
+    assert "positive connector self-access failed" in str(error)
+    assert "label=B" in str(error)
+    assert "workroom_id=wr-b" in str(error)
+    assert "endpoint=/dde/connectors/" in str(error)
+    assert "attempts=2" in str(error)
+
+
+def test_self_access_connector_list_persistent_typed_403_preserves_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workroom_id = "wr-b"
+    body = {"detail": {"reason": "workroom_binding_not_visible"}}
+    last_error = AuthorizationError(
+        "workroom binding not visible yet",
+        status_code=403,
+        body=body,
+    )
+    sdk = _FakeSdk(responses=[last_error], calls=[])
+    monkeypatch.setattr(
+        isolation_live,
+        "_SELF_ACCESS_CONNECTOR_RETRY_DELAYS_SECONDS",
+        (),
+        raising=False,
+    )
+
+    with pytest.raises(APIError) as exc_info:
+        isolation_live._list_connectors_self_access(sdk, workroom_id, label="B")
+
+    error = exc_info.value
+    assert error.__cause__ is last_error
+    assert error.response_data == body


### PR DESCRIPTION
## Summary

- Add a self-access-only connector-list retry helper for the live workroom isolation smoke.
- Retry only transient SDK errors with `status_code == 403` for positive own-workroom connector-list paths, including typed 403 exceptions.
- Preserve strict behavior for actual leak assertions: cross-workroom/global tests still assert foreign workroom IDs are absent and persistent 403 remains a failure.
- Improve persistent-403 diagnostics with label, endpoint, workroom id, status, attempts, and preserved typed-error body payloads.

Linear: ENG-7969

## Review Follow-Up

Addressed the prior Medium/coverage items:

- Added non-403 immediate-propagation coverage with zero sleeps/retries.
- Added first-attempt success coverage with zero sleeps/retries.
- Preserved typed `KamiwazaError.body` when wrapping persistent 403 diagnostics.
- Replaced the optimized-away `assert last_error is not None` with an explicit defensive guard.
- Interpolated the final status in the diagnostic instead of hardcoding `status=403`.
- Applied the retry helper to own-workroom list requests inside the cross-workroom connector tests while keeping the leak assertions strict.

## Verification

- `uv run pytest tests/unit/test_workroom_isolation_live_helpers.py tests/unit/test_live_server_available_fixture.py -q` -> `12 passed`
- `uv run ruff check tests/integration/test_workroom_isolation_live.py tests/unit/test_workroom_isolation_live_helpers.py` -> `All checks passed!`
- `git diff --check` -> clean

## Live test note

`uv run pytest tests/integration/test_workroom_isolation_live.py::TestSelfAccess::test_connectors_scoped_to_own_workroom -q` could not run locally because `https://kamiwaza.test/api` was unreachable from this machine. The change is covered with fake-SDK unit tests at the helper seam; CI/live smoke should provide the environment-backed signal.
