### PR TITLE
feat(connectors): content-param tolerance + framework logging (ENG-7981)

### DIFF
--- a/kamiwaza_sdk/connectors/__init__.py
+++ b/kamiwaza_sdk/connectors/__init__.py
@@ -49,7 +49,9 @@ from .server_kit import (
     OpResult,
     VerifyRequest,
     WhoamiRequest,
+    accepted_params,
     create_connector_app,
+    get_connector_logger,
 )
 
 __all__ = [
@@ -60,10 +62,10 @@ __all__ = [
     "ConfigSchema",
     "ConfigType",
     "ConnectorException",
+    "ConnectorIdentityProxyRequest",
     "ConnectorMintRequest",
     "ConnectorMintResponse",
     "ConnectorProvider",
-    "ConnectorIdentityProxyRequest",
     "ConnectorProxyRequest",
     "ConnectorProxyResponse",
     "ConnectorSpec",
@@ -80,7 +82,9 @@ __all__ = [
     "SurfaceDescriptor",
     "VerifyRequest",
     "WhoamiRequest",
+    "accepted_params",
     "auth_model_from_kind",
     "create_connector_app",
+    "get_connector_logger",
     "validate_icon",
 ]

--- a/kamiwaza_sdk/connectors/server_kit.py
+++ b/kamiwaza_sdk/connectors/server_kit.py
@@ -97,16 +97,28 @@ def get_connector_logger(name: str) -> logging.Logger:
     return _LOG.getChild(name)
 
 
+def _resolve_log_level() -> int:
+    """Numeric level from ``KAMIWAZA_CONNECTOR_LOG_LEVEL``; ``INFO`` on an unknown
+    value so a typo'd env var can never crash connector app construction."""
+    name = os.environ.get("KAMIWAZA_CONNECTOR_LOG_LEVEL", "INFO").upper()
+    level = logging.getLevelName(name)
+    return level if isinstance(level, int) else logging.INFO
+
+
 def _ensure_connector_logging() -> None:
-    """Attach one stderr handler to the framework logger (idempotent).
+    """Configure the framework logger for a standalone connector app.
 
     A connector process is a standalone app, but uvicorn only configures its own
     loggers -- so without this the app's INFO logs are invisible and failures are
-    swallowed behind the bare access line. The framework wires up its own
-    namespace logger with ``propagate=False`` so it neither duplicates through
-    uvicorn/root nor depends on the connector calling ``logging.basicConfig``.
-    Level from ``KAMIWAZA_CONNECTOR_LOG_LEVEL`` (default ``INFO``).
+    swallowed behind the bare access line. Level and ``propagate`` are set
+    **unconditionally** (a pre-existing handler must never leave the logger at the
+    default WARNING and silently drop the INFO op-outcome lines); the stderr
+    handler is attached once. ``propagate=False`` keeps lines from duplicating
+    through uvicorn/root. Level from ``KAMIWAZA_CONNECTOR_LOG_LEVEL`` (default
+    ``INFO``).
     """
+    _LOG.setLevel(_resolve_log_level())
+    _LOG.propagate = False
     if _LOG.handlers:
         return
     handler = logging.StreamHandler()
@@ -114,8 +126,6 @@ def _ensure_connector_logging() -> None:
         logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
     )
     _LOG.addHandler(handler)
-    _LOG.setLevel(os.environ.get("KAMIWAZA_CONNECTOR_LOG_LEVEL", "INFO").upper())
-    _LOG.propagate = False
 
 
 class ExecuteRequest(BaseModel):
@@ -259,15 +269,19 @@ def create_connector_app(
         status, kind, _ = classify_error(exc)
         _LOG.warning(
             "connector=%s op=%s params=%s outcome=error kind=%s status=%s "
-            "dur_ms=%d: %s",
+            "dur_ms=%d error_type=%s",
             title,
             op,
             keys,
             kind,
             status,
             duration_ms,
-            exc,
+            type(exc).__name__,
         )
+        # Full exception text only at DEBUG: a provider error message can embed
+        # upstream response fragments / user data, so it stays out of the default
+        # WARNING line (operators opt in via KAMIWAZA_CONNECTOR_LOG_LEVEL=DEBUG).
+        _LOG.debug("connector=%s op=%s error detail: %s", title, op, exc)
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:

--- a/kamiwaza_sdk/connectors/server_kit.py
+++ b/kamiwaza_sdk/connectors/server_kit.py
@@ -29,6 +29,10 @@ pulling the core service stack.
 
 from __future__ import annotations
 
+import inspect
+import logging
+import os
+import time
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -42,6 +46,76 @@ from pydantic import BaseModel, Field
 DispatcherFactory = Callable[[], Any]
 # Maps a connector error -> (http_status, error_kind, upstream_status | None).
 ErrorClassifier = Callable[[Exception], "tuple[int, str, int | None]"]
+
+
+def accepted_params(fn: Callable[..., Any], params: dict[str, Any]) -> dict[str, Any]:
+    """Drop params the op ``fn`` does not declare (unless it accepts ``**kwargs``).
+
+    Core forwards content-routing hints (e.g. ``mime_type``) to every content op
+    uniformly, and a node's ``content.query`` can carry provider-specific keys; an
+    op that does not consume a given key must ignore it rather than fail with a
+    ``TypeError``. A genuinely missing *required* param still raises when the op is
+    called, so real contract mismatches stay loud.
+
+    Framework behaviour so every connector dispatcher tolerates the platform's
+    content-param contract without copy-pasting the filter. Call it at the dispatch
+    call site: ``await fn(subject_token=tok, **accepted_params(fn, params))``.
+    """
+    signature = inspect.signature(fn)
+    if any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in signature.parameters.values()
+    ):
+        return params
+    allowed = {
+        name
+        for name, param in signature.parameters.items()
+        if param.kind
+        in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    }
+    return {key: value for key, value in params.items() if key in allowed}
+
+
+# One namespace for every connector so operators filter/format connector logs in
+# one place. Op code should use ``get_connector_logger`` rather than the stdlib
+# ``logging.getLogger`` so it lands under this namespace and inherits the handler.
+_LOG = logging.getLogger("kamiwaza_sdk.connectors")
+
+
+def get_connector_logger(name: str) -> logging.Logger:
+    """A namespaced logger for connector op code (child of the framework logger).
+
+    Logging discipline for connectors:
+
+    - **Never** log a ``subject_token`` / ``access_token`` / provider bearer, or a
+      raw param *value* -- params can carry user data (a search query, a file
+      path). Log op names and param *keys* only.
+    - Use ``exception``/``error`` for failures the operator must act on,
+      ``warning`` for handled/expected faults, ``info`` for op outcomes, ``debug``
+      for detail. The framework already logs every op's outcome + latency, so op
+      code should add only what the framework can't see.
+    """
+    return _LOG.getChild(name)
+
+
+def _ensure_connector_logging() -> None:
+    """Attach one stderr handler to the framework logger (idempotent).
+
+    A connector process is a standalone app, but uvicorn only configures its own
+    loggers -- so without this the app's INFO logs are invisible and failures are
+    swallowed behind the bare access line. The framework wires up its own
+    namespace logger with ``propagate=False`` so it neither duplicates through
+    uvicorn/root nor depends on the connector calling ``logging.basicConfig``.
+    Level from ``KAMIWAZA_CONNECTOR_LOG_LEVEL`` (default ``INFO``).
+    """
+    if _LOG.handlers:
+        return
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+    )
+    _LOG.addHandler(handler)
+    _LOG.setLevel(os.environ.get("KAMIWAZA_CONNECTOR_LOG_LEVEL", "INFO").upper())
+    _LOG.propagate = False
 
 
 class ExecuteRequest(BaseModel):
@@ -145,6 +219,7 @@ def create_connector_app(
                 app.state.dispatcher = None
                 await disp.aclose()
 
+    _ensure_connector_logging()
     app = FastAPI(title=title, lifespan=_lifespan)
     app.state.dispatcher = dispatcher
 
@@ -153,8 +228,45 @@ def create_connector_app(
         return JSONResponse(
             status_code=status,
             content={
-                "error": {"kind": kind, "message": str(exc), "upstream_status": upstream}
+                "error": {
+                    "kind": kind,
+                    "message": str(exc),
+                    "upstream_status": upstream,
+                }
             },
+        )
+
+    def _log_outcome(
+        op: str,
+        started: float,
+        *,
+        params: dict[str, Any] | None = None,
+        exc: Exception | None = None,
+    ) -> None:
+        """Log one op's outcome + latency. Secret-safe: param *keys* only, never
+        values or tokens."""
+        duration_ms = int((time.monotonic() - started) * 1000)
+        keys = sorted(params) if params else []
+        if exc is None:
+            _LOG.info(
+                "connector=%s op=%s params=%s outcome=ok dur_ms=%d",
+                title,
+                op,
+                keys,
+                duration_ms,
+            )
+            return
+        status, kind, _ = classify_error(exc)
+        _LOG.warning(
+            "connector=%s op=%s params=%s outcome=error kind=%s status=%s "
+            "dur_ms=%d: %s",
+            title,
+            op,
+            keys,
+            kind,
+            status,
+            duration_ms,
+            exc,
         )
 
     @app.get("/healthz")
@@ -175,12 +287,15 @@ def create_connector_app(
 
     @app.post("/v1/execute")
     async def execute(req: ExecuteRequest, request: Request) -> Any:
+        started = time.monotonic()
         try:
             result = await request.app.state.dispatcher.execute(
                 req.op, subject_token=req.subject_token, params=req.params
             )
         except error_type as exc:
+            _log_outcome(req.op, started, params=req.params, exc=exc)
             return _error_response(exc)
+        _log_outcome(req.op, started, params=req.params)
         # An op may return an OpResult to hand continuation (state/session) back to
         # core; a plain return value is the body with no continuation. The
         # continuation keys are only added when present, so a stateless op's response
@@ -196,12 +311,16 @@ def create_connector_app(
 
     @app.post("/v1/verify")
     async def verify(req: VerifyRequest, request: Request) -> Any:
+        started = time.monotonic()
         try:
-            return await request.app.state.dispatcher.verify(
+            result = await request.app.state.dispatcher.verify(
                 subject_token=req.subject_token
             )
         except error_type as exc:
+            _log_outcome("verify", started, exc=exc)
             return _error_response(exc)
+        _log_outcome("verify", started)
+        return result
 
     @app.post("/v1/whoami")
     async def whoami(req: WhoamiRequest, request: Request) -> Any:
@@ -228,9 +347,13 @@ def create_connector_app(
                     }
                 },
             )
+        started = time.monotonic()
         try:
-            return await handler(access_token=req.access_token)
+            result = await handler(access_token=req.access_token)
         except error_type as exc:
+            _log_outcome("whoami", started, exc=exc)
             return _error_response(exc)
+        _log_outcome("whoami", started)
+        return result
 
     return app

--- a/tests/unit/test_connectors_server_kit_logging.py
+++ b/tests/unit/test_connectors_server_kit_logging.py
@@ -1,0 +1,57 @@
+"""Unit tests for the connector framework's logging initializer."""
+
+import logging
+
+import pytest
+from kamiwaza_sdk.connectors import server_kit as sk
+
+pytestmark = pytest.mark.unit
+
+
+def _reset_framework_logger():
+    log = sk._LOG
+    for handler in list(log.handlers):
+        log.removeHandler(handler)
+    log.setLevel(logging.NOTSET)
+    log.propagate = True
+
+
+def test_ensure_logging_sets_level_handler_and_propagate(monkeypatch):
+    monkeypatch.delenv("KAMIWAZA_CONNECTOR_LOG_LEVEL", raising=False)
+    _reset_framework_logger()
+    sk._ensure_connector_logging()
+    assert sk._LOG.level == logging.INFO
+    assert sk._LOG.propagate is False
+    assert len(sk._LOG.handlers) == 1
+
+
+def test_ensure_logging_sets_level_even_with_preexisting_handler(monkeypatch):
+    # Regression for PR #204 review (High #1): a pre-existing handler must not
+    # short-circuit level config and leave the logger at the default WARNING,
+    # which would silently drop the INFO op-outcome lines.
+    monkeypatch.delenv("KAMIWAZA_CONNECTOR_LOG_LEVEL", raising=False)
+    _reset_framework_logger()
+    sk._LOG.addHandler(logging.NullHandler())
+    sk._LOG.setLevel(logging.WARNING)
+    sk._ensure_connector_logging()
+    assert sk._LOG.level == logging.INFO  # level set despite the handler
+    assert len(sk._LOG.handlers) == 1  # existing handler kept, not duplicated
+
+
+def test_ensure_logging_is_idempotent(monkeypatch):
+    monkeypatch.delenv("KAMIWAZA_CONNECTOR_LOG_LEVEL", raising=False)
+    _reset_framework_logger()
+    sk._ensure_connector_logging()
+    sk._ensure_connector_logging()
+    assert len(sk._LOG.handlers) == 1
+
+
+def test_resolve_log_level_env_override(monkeypatch):
+    monkeypatch.setenv("KAMIWAZA_CONNECTOR_LOG_LEVEL", "debug")
+    assert sk._resolve_log_level() == logging.DEBUG
+
+
+def test_resolve_log_level_bad_value_falls_back_to_info(monkeypatch):
+    # A typo'd env value must not crash connector app construction.
+    monkeypatch.setenv("KAMIWAZA_CONNECTOR_LOG_LEVEL", "NOT_A_LEVEL")
+    assert sk._resolve_log_level() == logging.INFO

--- a/tests/unit/test_connectors_server_kit_params.py
+++ b/tests/unit/test_connectors_server_kit_params.py
@@ -1,7 +1,6 @@
 """Unit tests for the connector dispatch param-tolerance helper."""
 
 import pytest
-
 from kamiwaza_sdk.connectors.server_kit import accepted_params
 
 pytestmark = pytest.mark.unit
@@ -40,6 +39,18 @@ def test_var_keyword_op_keeps_everything():
     """An op that declares **kwargs opts out of filtering entirely."""
     params = {"node_id": "n1", "mime_type": "x", "anything": "y"}
     assert accepted_params(_accepts_kwargs, params) == params
+
+
+class _Ops:
+    async def get_content(self, *, node_id, subject_token=None):
+        return {"node_id": node_id}
+
+
+def test_bound_method_signature_is_respected():
+    """inspect.signature drops ``self`` on a bound method, so a real op method
+    (the connector dispatch shape) filters correctly."""
+    got = accepted_params(_Ops().get_content, {"node_id": "n", "mime_type": "x"})
+    assert got == {"node_id": "n"}
 
 
 def test_missing_required_param_still_raises_at_call():

--- a/tests/unit/test_connectors_server_kit_params.py
+++ b/tests/unit/test_connectors_server_kit_params.py
@@ -1,0 +1,50 @@
+"""Unit tests for the connector dispatch param-tolerance helper."""
+
+import pytest
+
+from kamiwaza_sdk.connectors.server_kit import accepted_params
+
+pytestmark = pytest.mark.unit
+
+
+async def _content_with_drive(*, node_id, drive_id, subject_token=None):
+    return {"node_id": node_id, "drive_id": drive_id}
+
+
+async def _content_plain(*, node_id, subject_token=None):
+    return {"node_id": node_id}
+
+
+async def _accepts_kwargs(*, node_id, subject_token=None, **rest):
+    return {"node_id": node_id, "rest": rest}
+
+
+def test_drops_undeclared_param():
+    """A hint the op does not declare (mime_type) is dropped, not passed through."""
+    got = accepted_params(
+        _content_plain, {"node_id": "n1", "mime_type": "text/markdown"}
+    )
+    assert got == {"node_id": "n1"}
+
+
+def test_keeps_declared_param():
+    """A param the op declares (drive_id) is kept; an extra hint is still dropped."""
+    got = accepted_params(
+        _content_with_drive,
+        {"node_id": "n1", "drive_id": "d1", "mime_type": "application/pdf"},
+    )
+    assert got == {"node_id": "n1", "drive_id": "d1"}
+
+
+def test_var_keyword_op_keeps_everything():
+    """An op that declares **kwargs opts out of filtering entirely."""
+    params = {"node_id": "n1", "mime_type": "x", "anything": "y"}
+    assert accepted_params(_accepts_kwargs, params) == params
+
+
+def test_missing_required_param_still_raises_at_call():
+    """Filtering never invents a required param, so a real omission stays loud."""
+    filtered = accepted_params(_content_with_drive, {"node_id": "n1"})
+    assert filtered == {"node_id": "n1"}  # drive_id absent -> op will TypeError
+    with pytest.raises(TypeError):
+        _content_with_drive(**filtered)

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 import pytest
 from fastapi.testclient import TestClient
-from pydantic import ValidationError
-
 from kamiwaza_sdk.connectors import (
     ConfigField,
     ConfigSchema,
@@ -38,6 +36,7 @@ from kamiwaza_sdk.connectors import (
     create_connector_app,
     validate_icon,
 )
+from pydantic import ValidationError
 
 
 class _DummyProvider(ConnectorProvider):
@@ -583,4 +582,9 @@ def test_execute_error_is_logged_at_warning() -> None:
     finally:
         detach()
     assert resp.status_code == 429
-    assert any("outcome=error" in m and "kind=rate_limited" in m for m in messages)
+    blob = "\n".join(messages)
+    assert "outcome=error" in blob and "kind=rate_limited" in blob
+    assert "error_type=_BoomError" in blob
+    # The raw exception text is DEBUG-only (can embed upstream fragments), so it
+    # must not appear in the default-level (INFO) capture.
+    assert "kaboom" not in blob

--- a/tests/unit/test_connectors_spi.py
+++ b/tests/unit/test_connectors_spi.py
@@ -199,9 +199,7 @@ class _WhoamiDispatcher(_StubDispatcher):
 
 def test_whoami_routes_to_dispatcher_when_implemented() -> None:
     """A dispatcher with whoami gets the identity call routed through."""
-    dispatcher = _WhoamiDispatcher(
-        {"email": "user@example.com", "name": "User"}
-    )
+    dispatcher = _WhoamiDispatcher({"email": "user@example.com", "name": "User"})
     with TestClient(_app(dispatcher)) as client:
         resp = client.post("/v1/whoami", json={"access_token": "hs-at"})
     assert resp.status_code == 200
@@ -529,3 +527,60 @@ def test_response_models_retain_extra_fields() -> None:
         {"status_code": 200, "body": None, "new_core_field": "keep-me"}
     )
     assert proxy.model_dump()["new_core_field"] == "keep-me"
+
+
+# --- framework logging -------------------------------------------------------
+
+
+def _capture_connector_logs():
+    """Attach a capturing handler to the framework logger (returns messages, detach)."""
+    import logging
+
+    logger = logging.getLogger("kamiwaza_sdk.connectors")
+    messages: list[str] = []
+    handler = logging.Handler()
+    handler.emit = lambda record: messages.append(record.getMessage())  # type: ignore[method-assign]
+    logger.addHandler(handler)
+    return messages, lambda: logger.removeHandler(handler)
+
+
+def test_execute_logs_outcome_and_redacts_token_and_values() -> None:
+    messages, detach = _capture_connector_logs()
+    try:
+        with TestClient(_app(_StubDispatcher(execute_result={"ok": 1}))) as client:
+            resp = client.post(
+                "/v1/execute",
+                json={
+                    "op": "files.get_content",
+                    "subject_token": "SECRET-TOKEN",
+                    "params": {
+                        "node_id": "NODEVAL",
+                        "drive_id": "DRIVEVAL",
+                        "mime_type": "application/pdf",
+                    },
+                },
+            )
+    finally:
+        detach()
+    assert resp.status_code == 200
+    blob = "\n".join(messages)
+    assert "op=files.get_content" in blob and "outcome=ok" in blob
+    # param KEYS are logged for debuggability...
+    assert "node_id" in blob and "drive_id" in blob and "mime_type" in blob
+    # ...but never the acting-subject token or any param VALUE.
+    assert "SECRET-TOKEN" not in blob
+    assert "application/pdf" not in blob
+    assert "NODEVAL" not in blob and "DRIVEVAL" not in blob
+
+
+def test_execute_error_is_logged_at_warning() -> None:
+    messages, detach = _capture_connector_logs()
+    try:
+        with TestClient(
+            _app(_StubDispatcher(execute_exc=_BoomError("kaboom")))
+        ) as client:
+            resp = client.post("/v1/execute", json={"op": "list", "params": {}})
+    finally:
+        detach()
+    assert resp.status_code == 429
+    assert any("outcome=error" in m and "kind=rate_limited" in m for m in messages)


### PR DESCRIPTION
**Linear:** https://linear.app/kamiwaza/issue/ENG-7981

## Summary
Connector framework fix motivated by ENG-7981 (m365/google file import + all-surface content failures).

- **`accepted_params(fn, params)`** in `server_kit`: a dispatcher drops op-params an op doesn't declare (e.g. core's `mime_type` content hint) instead of raising `TypeError`; a genuinely missing *required* param still fails loud. Fixes `invalid params ... unexpected keyword argument 'mime_type'` (400) across every connector/surface without copy-pasting a filter into each connector.
- **Default framework logging**: `create_connector_app` wires a namespaced, secret-safe logger (op outcome + latency; op name + param **keys** only — never tokens or values) so op failures are visible instead of swallowed behind the bare uvicorn access line. Adds `get_connector_logger()` for op code.

## Tests
`tests/unit/test_connectors_server_kit_params.py` (filter behaviour) + logging/redaction cases in `test_connectors_spi.py`. Full connector SPI suite green.

## Rollout
Connector repos bump their `kamiwaza-sdk` pin to pick up `accepted_params` (see the paired connector PRs).

Refs ENG-7981