### PR TITLE
feat(connectors): log dropped op params at DEBUG (ENG-7981 follow-up)

### DIFF
--- a/kamiwaza_sdk/connectors/server_kit.py
+++ b/kamiwaza_sdk/connectors/server_kit.py
@@ -72,6 +72,16 @@ def accepted_params(fn: Callable[..., Any], params: dict[str, Any]) -> dict[str,
         if param.kind
         in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
     }
+    dropped = [key for key in params if key not in allowed]
+    if dropped:
+        # Observability for core<->connector contract drift: a genuinely mistyped
+        # or newly-forwarded key is dropped silently at the op boundary, so record
+        # which keys were dropped (names only -- never values) at DEBUG.
+        _LOG.debug(
+            "dropping params not declared by %s: %s",
+            getattr(fn, "__qualname__", repr(fn)),
+            sorted(dropped),
+        )
     return {key: value for key, value in params.items() if key in allowed}
 
 

--- a/tests/unit/test_connectors_server_kit_params.py
+++ b/tests/unit/test_connectors_server_kit_params.py
@@ -41,6 +41,29 @@ def test_var_keyword_op_keeps_everything():
     assert accepted_params(_accepts_kwargs, params) == params
 
 
+def test_dropped_params_logged_at_debug():
+    """Dropped keys are recorded (names only, never values) for contract-drift
+    observability."""
+    import logging
+
+    from kamiwaza_sdk.connectors import server_kit as sk
+
+    messages: list[str] = []
+    handler = logging.Handler()
+    handler.emit = lambda record: messages.append(record.getMessage())  # type: ignore[method-assign]
+    sk._LOG.addHandler(handler)
+    previous = sk._LOG.level
+    sk._LOG.setLevel(logging.DEBUG)
+    try:
+        accepted_params(_content_plain, {"node_id": "n", "mime_type": "x", "bogus": 1})
+    finally:
+        sk._LOG.removeHandler(handler)
+        sk._LOG.setLevel(previous)
+    blob = "\n".join(messages)
+    assert "mime_type" in blob and "bogus" in blob  # dropped keys are named
+    assert "node_id" not in blob  # a kept param is not reported as dropped
+
+
 class _Ops:
     async def get_content(self, *, node_id, subject_token=None):
         return {"node_id": node_id}


### PR DESCRIPTION
**Linear:** https://linear.app/kamiwaza/issue/ENG-7981

Follow-up to #204 (merged). `accepted_params` now records the param **names** it drops (names only, never values) at DEBUG, so a mistyped or newly-forwarded core→connector key is observable instead of silently swallowed — the recurring observability note across the connector PRs, addressed centrally in the framework.

Non-blocking; connectors pick it up on their next `@develop` relock.

Refs ENG-7981