### PR TITLE
ENG-8053: use session auth for workroom-enter live tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1115,6 +1115,39 @@ def live_kamiwaza_session_client(
 
 
 @pytest.fixture(scope="session")
+def live_workroom_session_client(
+    live_server_available: str,
+    resolved_live_password: str,
+    live_username: str,
+) -> KamiwazaClient:
+    """Password-session client for live tests that exercise workroom enter.
+
+    PAT/API-key clients intentionally cannot mutate selected-workroom session
+    state on DB-backed binding installs. Tests that call ``workrooms.enter``
+    must use a real session token so a 409 ``binding_invalid`` remains a core
+    regression signal instead of a fixture artifact.
+    """
+    os.environ.setdefault("KAMIWAZA_VERIFY_SSL", "false")
+
+    username = live_username.strip()
+    password = resolved_live_password.strip()
+    if not username or not password:
+        pytest.skip(
+            "Unable to build workroom session client. "
+            "Provide username/password (kz-login-backed) to exercise workroom enter."
+        )
+
+    client = KamiwazaClient(live_server_available)
+    client.authenticator = UserPasswordAuthenticator(
+        username,
+        password,
+        client._auth_service,
+        token_store=_NoCacheTokenStore(),
+    )
+    return client
+
+
+@pytest.fixture(scope="session")
 def embedding_model_prerequisite(
     live_kamiwaza_session_client: KamiwazaClient,
 ) -> dict[str, str]:

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -12,8 +12,6 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
-from kamiwaza_sdk import KamiwazaClient
-from kamiwaza_sdk.authentication import UserPasswordAuthenticator
 from kamiwaza_sdk.exceptions import APIError, NotFoundError
 from kamiwaza_sdk.services.context import ContextService
 
@@ -266,33 +264,12 @@ def _safe_delete_group(
 
 @pytest.fixture(scope="session")
 def shared_context_service(
-    live_server_available: str,
-    live_session_api_key: str,
-    resolved_live_password: str,
-    live_username: str,
+    live_workroom_session_client,
 ) -> ContextService:
     """Session-scoped context service client for shared provisioning fixtures."""
     os.environ.setdefault("KAMIWAZA_VERIFY_SSL", "false")
 
-    api_key = live_session_api_key.strip()
-    if api_key:
-        client = KamiwazaClient(live_server_available, api_key=api_key)
-    else:
-        username = live_username.strip()
-        password = resolved_live_password.strip()
-        if not username or not password:
-            pytest.skip(
-                "Unable to build authenticated context client. "
-                "Provide username/password (kz-login-backed) or KAMIWAZA_API_KEY."
-            )
-        client = KamiwazaClient(live_server_available)
-        client.authenticator = UserPasswordAuthenticator(
-            username,
-            password,
-            client._auth_service,
-        )
-
-    service = client.context
+    service = live_workroom_session_client.context
     assert isinstance(service, ContextService)
     return service
 

--- a/tests/integration/test_seeding_live.py
+++ b/tests/integration/test_seeding_live.py
@@ -29,13 +29,14 @@ def test_find_template_resolves_against_live_catalog(live_write_client):
     assert live_write_client.apps.find_template("seed-probe-does-not-exist") is None
 
 
-def test_workroom_create_enter_scopes_a_client(live_write_client):
+def test_workroom_create_enter_scopes_a_client(live_workroom_session_client):
     """Create a workroom, mint a workroom-scoped client via enter, then clean up."""
+    client = live_workroom_session_client
     name = f"seed-probe-{uuid4().hex[:8]}"
-    workroom = live_write_client.workrooms.create(name=name, workroom_type="persistent")
+    workroom = client.workrooms.create(name=name, workroom_type="persistent")
     try:
         try:
-            scoped = scoped_client_for_workroom(live_write_client, workroom.id)
+            scoped = scoped_client_for_workroom(client, workroom.id)
         except APIError as exc:
             if _is_workroom_binding_unavailable(exc):
                 pytest.skip(
@@ -45,4 +46,4 @@ def test_workroom_create_enter_scopes_a_client(live_write_client):
         # Either a reminted-token client or a graceful fall back to the parent.
         assert scoped is not None
     finally:
-        live_write_client.workrooms.delete(workroom.id)
+        client.workrooms.delete(workroom.id)


### PR DESCRIPTION
## Summary
- Add a password-session live client fixture for tests that intentionally exercise `workrooms.enter`.
- Move the Context shared live service and the seeding `workroom_create_enter` smoke off PAT-backed clients for the selected-session binding seam.
- Keep PAT/write-scope clients for non-admin explicit-scope coverage; this does not relax core PAT binding behavior.

## Root Cause
Kajiya run `28592438718` reported 21 SDK failures, but they collapsed to two real `POST /workrooms/{id}/enter` calls returning `409 binding_invalid`; the other context-suite errors were fixture fallout. The affected SDK live paths were using PAT-backed clients for `enter`. After core PR #2234, that is intentionally rejected on DB-backed binding installs because PATs carry `jti` but no stable `sid`/`session_state`; binding mutable selected-workroom state to a portable API key would be the wrong security model.

## Fix
Tests that call `workrooms.enter` now use a password/session-token client. A true session-token `409 binding_invalid` still fails the smoke, so this preserves the core regression signal instead of skipping it.

Linear: ENG-8053

## Validation
- `uv run ruff check tests/integration/conftest.py tests/integration/test_context_live.py tests/integration/test_seeding_live.py` -> passed
- `uv run pytest tests/unit/test_seeding_client.py tests/unit/test_context_live_helpers.py -q` -> 19 passed
- `uv run pytest --collect-only tests/integration/test_context_live.py tests/integration/test_seeding_live.py -q` -> 33 tests collected
- `git diff --check` -> passed
- UAT seam proof against `https://test.kamiwaza.dev/api`: PAT-backed `enter` returned `409 binding_invalid`; password-session `enter` succeeded for the same workroom.
- UAT representative pytest run with Cloudflare Access bridge: `test_context_workroom_lists_and_job_creation` and `test_workroom_create_enter_scopes_a_client` both passed (`2 passed`).