### PR TITLE
ENG-8193: SDK register_type() for the DB-backed connector catalog

### DIFF
--- a/kamiwaza_sdk/schemas/connectors.py
+++ b/kamiwaza_sdk/schemas/connectors.py
@@ -129,6 +129,44 @@ class AvailableConnector(BaseModel):
     scopes: List[str] = []
 
 
+class ConnectorCatalogRegister(BaseModel):
+    """Register a connector *type* in the cluster's DB-backed catalog.
+
+    Parity with registering an app template: the connector's self-describing
+    manifest is stored so it surfaces in the admin catalog as a configurable
+    entry, without editing the remote ``connectors.json``. Identity fields
+    (``connector_type``/``provider_label``/``icon``) are derived from the manifest
+    server-side. No config is stored — an admin fills it in afterwards.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    manifest: Dict[str, Any] = Field(
+        ...,
+        description="The connector's self-describing manifest (ConnectorSpec.to_manifest()).",
+    )
+    version: Optional[str] = Field(
+        default=None, description="Optional catalog version tag (advisory)."
+    )
+
+
+class CatalogConnector(BaseModel):
+    """A connector available to subscribe from the catalog (remote or DB-backed).
+
+    ``manifest`` carries the connector's ``config_schema``/``config_fields`` so the
+    admin UI can render its config form. ``already_subscribed`` flags types this
+    deployment already has.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    connector_type: str
+    provider_label: str
+    icon: Optional[str] = None
+    already_subscribed: bool = False
+    manifest: Dict[str, Any]
+
+
 # Deprecated aliases: these schemas were renamed ExternalConnector* -> Connector*
 # (PR #193). The old names are kept so existing importers keep working; prefer the
 # Connector* names in new code.

--- a/kamiwaza_sdk/services/connectors.py
+++ b/kamiwaza_sdk/services/connectors.py
@@ -18,7 +18,9 @@ from .base_service import BaseService
 from ..exceptions import APIError, NotFoundError
 from ..schemas.connectors import (
     AvailableConnector,
+    CatalogConnector,
     Connector,
+    ConnectorCatalogRegister,
     ConnectorCreate,
     ConnectorSubscriptionCreate,
     ConnectorUpdate,
@@ -89,6 +91,20 @@ class ConnectorService(BaseService):
             "/connectors", json=request.model_dump(mode="json")
         )
         return Connector.model_validate(response)
+
+    def register_type(self, request: ConnectorCatalogRegister) -> CatalogConnector:
+        """Register a connector *type* in the cluster's DB-backed catalog (admin).
+
+        Parity with registering an app template: stores the connector's manifest so
+        it surfaces in ``GET /connectors/catalog`` as a configurable entry the admin
+        can then set up (fill config + create the instance). Idempotent per
+        ``connector_type`` — re-registering updates the stored manifest. Registers
+        the type only; it deploys no workload and stores no config.
+        """
+        response = self.client.post(
+            "/connectors/catalog", json=request.model_dump(mode="json")
+        )
+        return CatalogConnector.model_validate(response)
 
     def subscribe(
         self,

--- a/kamiwaza_sdk/services/connectors.py
+++ b/kamiwaza_sdk/services/connectors.py
@@ -102,7 +102,8 @@ class ConnectorService(BaseService):
         the type only; it deploys no workload and stores no config.
         """
         response = self.client.post(
-            "/connectors/catalog", json=request.model_dump(mode="json")
+            "/connectors/catalog",
+            json=request.model_dump(mode="json", exclude_none=True),
         )
         return CatalogConnector.model_validate(response)
 

--- a/tests/unit/test_connectors_service.py
+++ b/tests/unit/test_connectors_service.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from pydantic import ValidationError
 
 from kamiwaza_sdk.exceptions import APIError, NotFoundError
-from kamiwaza_sdk.schemas.connectors import ConnectorCreate, ConnectorUpdate
+from kamiwaza_sdk.schemas.connectors import (
+    CatalogConnector,
+    ConnectorCatalogRegister,
+    ConnectorCreate,
+    ConnectorUpdate,
+)
 from kamiwaza_sdk.services.connectors import ConnectorService
 
 pytestmark = pytest.mark.unit
@@ -306,3 +312,67 @@ def test_create_allows_empty_scopes():
     assert conn.connector_type == "m365"  # echoes the response connector_type
     body = client.calls[0][2]["json"]
     assert body["scopes"] == []
+
+
+# --- register_type: DB-backed connector catalog (ENG-8193) ---
+
+
+def _catalog_resp(ctype="hubspot"):
+    return {
+        "connector_type": ctype,
+        "provider_label": "HubSpot",
+        "icon": None,
+        "already_subscribed": False,
+        "manifest": {"connector_type": ctype, "config_fields": [{"name": "client_id"}]},
+    }
+
+
+def test_register_type_posts_manifest_to_catalog():
+    manifest = {
+        "connector_type": "hubspot",
+        "provider_id": "hubspot",
+        "provider_label": "HubSpot",
+    }
+    client = DummyClient({("POST", "/connectors/catalog"): _catalog_resp()})
+    service = ConnectorService(client)
+
+    result = service.register_type(
+        ConnectorCatalogRegister(manifest=manifest, version="1.0")
+    )
+
+    assert isinstance(result, CatalogConnector)
+    assert result.connector_type == "hubspot"
+    assert result.already_subscribed is False
+    method, path, kwargs = client.calls[0]
+    assert (method, path) == ("POST", "/connectors/catalog")
+    body = kwargs["json"]
+    assert body["manifest"] == manifest
+    assert body["version"] == "1.0"
+
+
+def test_register_type_omits_none_version():
+    """`version` is optional/advisory; exclude_none keeps it out of the body."""
+    manifest = {
+        "connector_type": "linear",
+        "provider_id": "linear",
+        "provider_label": "Linear",
+    }
+    client = DummyClient({("POST", "/connectors/catalog"): _catalog_resp("linear")})
+    service = ConnectorService(client)
+
+    service.register_type(ConnectorCatalogRegister(manifest=manifest))
+
+    body = client.calls[0][2]["json"]
+    assert "version" not in body
+
+
+def test_connector_catalog_schemas_roundtrip():
+    req = ConnectorCatalogRegister(manifest={"connector_type": "x"})
+    assert req.version is None  # optional
+    with pytest.raises(ValidationError):
+        ConnectorCatalogRegister()  # manifest is required
+
+    resp = CatalogConnector(
+        connector_type="x", provider_label="X", manifest={"connector_type": "x"}
+    )
+    assert resp.already_subscribed is False and resp.icon is None


### PR DESCRIPTION
Linear: ENG-8193

## Summary
Add `ConnectorService.register_type(ConnectorCatalogRegister) -> CatalogConnector`, which POSTs a connector manifest to `/connectors/catalog` so a client can register a connector *type* into the cluster's DB-backed catalog (parity with app-template registration). Adds the `ConnectorCatalogRegister` request and `CatalogConnector` response schemas.

## Requires
Platform change: kamiwaza-internal/kamiwaza#2245 (adds `POST /connectors/catalog`).

## Verification
- 14 existing SDK connector-service tests pass (no regression).
- New schemas import + round-trip; `client.connectors.register_type` posts to `/connectors/catalog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
