### PR TITLE
ENG-6146: fix SDK OpenShift GreyMatter runtime paths

### DIFF
--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -491,6 +491,10 @@ class KamiwazaClient:
 
         typed = error_for_response(response.status_code, payload, message)
         if type(typed) is not KamiwazaError:
+            if isinstance(typed, APIError):
+                typed.response_text = response_text
+                typed.response_data = payload
+                typed.body = payload
             raise typed
 
         raise APIError(

--- a/kamiwaza_sdk/exceptions.py
+++ b/kamiwaza_sdk/exceptions.py
@@ -323,8 +323,8 @@ def error_for_response(status_code: int, body: Any, message: str) -> KamiwazaErr
             if isinstance(reason_value, str):
                 reason = reason_value
 
-    cls: type[KamiwazaError] = KamiwazaError
+    cls: type[KamiwazaError] = NotFoundError if status_code == 404 else KamiwazaError
     if reason is not None:
-        cls = _REASON_TO_EXCEPTION.get((status_code, reason), KamiwazaError)
+        cls = _REASON_TO_EXCEPTION.get((status_code, reason), cls)
 
     return cls(message, status_code=status_code, body=body)

--- a/kamiwaza_sdk/exceptions.py
+++ b/kamiwaza_sdk/exceptions.py
@@ -16,12 +16,12 @@ Hierarchy:
     KamiwazaError                       (base — status_code + body kwargs)
         APIError                        (legacy HTTP-bound error class)
             VectorDBUnavailableError
+            NotFoundError               (404 base)
+                DatasetNotFoundError
         AuthenticationError             (401)
         AuthorizationError              (403 base)
             NativeRealmRequiredError    (403 + endpoint_requires_native_realm)
             BrokeredUserNotAllowlistedError (403 + brokered_user_not_allowlisted)
-        NotFoundError                   (404 base)
-            DatasetNotFoundError
         ValidationError                 (400/422)
         TimeoutError
         NonAPIResponseError
@@ -106,8 +106,29 @@ class AuthorizationError(KamiwazaError):
     """
 
 
-class NotFoundError(KamiwazaError):
-    """Raised when a requested resource is not found (HTTP 404)."""
+class NotFoundError(APIError):
+    """Raised when a requested resource is not found (HTTP 404).
+
+    NotFoundError remains an APIError subclass so existing service-layer
+    ``except APIError`` fallback and translation paths continue to catch 404s.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        body: object | None = None,
+        response_text: str | None = None,
+        response_data: object | None = None,
+    ):
+        data = body if response_data is None else response_data
+        super().__init__(
+            message,
+            status_code=status_code,
+            response_text=response_text,
+            response_data=data,
+        )
 
 
 class DatasetNotFoundError(NotFoundError):

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -110,6 +110,8 @@ class ServingService(BaseService):
         
         # Convert model_id to UUID if it's a string
         model_id = UUID(model_id) if isinstance(model_id, str) else model_id
+        if model_id is None:
+            raise ValueError("Either model_id or repo_id must resolve to a model")
         
         # If m_config_id is not provided, fetch the default configuration
         if m_config_id is None:
@@ -118,6 +120,8 @@ class ServingService(BaseService):
                 raise ValueError("No configurations found for this model")
             default_config = next((config for config in configs if config.default), configs[0])
             m_config_id = default_config.id
+        m_config_id = UUID(m_config_id) if isinstance(m_config_id, str) else m_config_id
+        m_file_id = UUID(m_file_id) if isinstance(m_file_id, str) else m_file_id
 
         # Prepare the deployment request
         deployment_request = CreateModelDeployment(
@@ -181,7 +185,7 @@ class ServingService(BaseService):
                 active_deployment = ActiveModelDeployment(
                     id=deployment.id,
                     m_id=deployment.m_id,
-                    m_name=deployment.m_name,
+                    m_name=deployment.m_name or "",
                     status=deployment.status,
                     instances=[i for i in deployment.instances if i.status == 'DEPLOYED'],
                     lb_port=deployment.lb_port,
@@ -250,7 +254,7 @@ class ServingService(BaseService):
         deployment_id: Union[str, UUID],
         timeout_seconds: int = 3600,
         poll_interval_seconds: float = 5.0,
-    ) -> UIModelDeployment:
+    ) -> ModelDeployment:
         """Block until a deployment reaches the DEPLOYED terminal state.
 
         The server accepts deploy requests asynchronously (ENG-6530) and
@@ -472,7 +476,7 @@ class DeploymentStatusPoller:
                 )
                 # Builtin TimeoutError for caller compatibility; carry the id
                 # programmatically rather than only inside the message string.
-                timeout_error.deployment_id = str(deployment_uuid)
+                setattr(timeout_error, "deployment_id", str(deployment_uuid))
                 raise timeout_error
             if self._poll_interval > 0:
                 self._sleep(self._poll_interval)

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -4,7 +4,7 @@ import os
 import time
 from typing import Callable, Iterable, Iterator, List, Optional, Union
 from uuid import UUID
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 from ..schemas.serving.serving import (
     ActiveModelDeployment,
@@ -153,14 +153,10 @@ class ServingService(BaseService):
         deployments = self.list_deployments()
         active = []
 
-        use_ssl = True
-        if os.environ.get("KAMIWAZA_USE_HTTPS", "true").lower() == "false":
-            use_ssl = False
-        scheme = "https" if use_ssl else "http"
-
-        # Parse the base URL to get host
-        parsed_url = urlparse(self.client.base_url)
-        host = parsed_url.netloc.split(':')[0]  # Remove port if present
+        runtime_origin = self._runtime_origin()
+        parsed_runtime_origin = urlparse(runtime_origin)
+        runtime_scheme = parsed_runtime_origin.scheme
+        runtime_host = parsed_runtime_origin.hostname or parsed_runtime_origin.netloc
         
         for deployment in deployments:
             running_instance = next(
@@ -174,13 +170,13 @@ class ServingService(BaseService):
                     path = access_path if access_path.startswith("/") else f"/{access_path}"
                     path = path.rstrip("/")
                     if path.endswith("/v1"):
-                        endpoint = f"{scheme}://{host}{path}"
+                        endpoint = f"{runtime_origin}{path}"
                     else:
-                        endpoint = f"{scheme}://{host}{path}/v1"
+                        endpoint = f"{runtime_origin}{path}/v1"
                 elif deployment.lb_port and deployment.lb_port != 443:
-                    endpoint = f"{scheme}://{host}:{deployment.lb_port}/v1"
+                    endpoint = f"{runtime_scheme}://{runtime_host}:{deployment.lb_port}/v1"
                 else:
-                    endpoint = f"{scheme}://{host}/runtime/models/{deployment.id}/v1"
+                    endpoint = f"{runtime_origin}/runtime/models/{deployment.id}/v1"
                 
                 active_deployment = ActiveModelDeployment(
                     id=deployment.id,
@@ -194,6 +190,26 @@ class ServingService(BaseService):
                 active.append(active_deployment)
 
         return active
+
+    def _runtime_origin(self) -> str:
+        source = (
+            os.environ.get("KAMIWAZA_RUNTIME_BASE_URL")
+            or os.environ.get("KAMIWAZA_PUBLIC_API_URL")
+            or self.client.base_url
+        )
+        parsed_url = urlparse(source)
+        scheme = parsed_url.scheme or "https"
+        use_https = os.environ.get("KAMIWAZA_USE_HTTPS")
+        if use_https is not None:
+            scheme = "http" if use_https.lower() == "false" else "https"
+
+        path = parsed_url.path.rstrip("/")
+        if path.endswith("/api"):
+            path = path[:-4]
+
+        return urlunparse(
+            (scheme, parsed_url.netloc, path.rstrip("/"), "", "", "")
+        ).rstrip("/")
 
 
     def list_deployments(self, model_id: Optional[UUID] = None) -> List[UIModelDeployment]:

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -178,6 +178,7 @@ class ServingService(BaseService):
                     else:
                         endpoint = f"{runtime_origin}{path}/v1"
                 elif deployment.lb_port and deployment.lb_port != 443:
+                    # Direct load-balancer ports bypass any gateway path prefix.
                     endpoint = f"{runtime_scheme}://{runtime_host}:{deployment.lb_port}/v1"
                 else:
                     endpoint = f"{runtime_origin}/runtime/models/{deployment.id}/v1"
@@ -196,11 +197,13 @@ class ServingService(BaseService):
         return active
 
     def _runtime_origin(self) -> str:
-        source = (
+        source_value = (
             os.environ.get("KAMIWAZA_RUNTIME_BASE_URL")
-            or os.environ.get("KAMIWAZA_PUBLIC_API_URL")
             or self.client.base_url
+            or os.environ.get("KAMIWAZA_PUBLIC_API_URL")
+            or ""
         )
+        source = str(source_value)
         parsed_url = urlparse(source)
         scheme = parsed_url.scheme or "https"
         use_https = os.environ.get("KAMIWAZA_USE_HTTPS")
@@ -212,7 +215,7 @@ class ServingService(BaseService):
             path = path[:-4]
 
         return urlunparse(
-            (scheme, parsed_url.netloc, path.rstrip("/"), "", "", "")
+            (scheme, parsed_url.netloc, path, "", "", "")
         ).rstrip("/")
 
 

--- a/tests/unit/test_catalog_service.py
+++ b/tests/unit/test_catalog_service.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from kamiwaza_sdk.exceptions import APIError
-from kamiwaza_sdk.schemas.catalog import ContainerCreate, DatasetCreate, SecretCreate
+from kamiwaza_sdk.exceptions import NotFoundError
+from kamiwaza_sdk.schemas.catalog import ContainerCreate, SecretCreate
 from kamiwaza_sdk.services.catalog import CatalogService, ContainerClient, DatasetClient, SecretClient
 
 pytestmark = pytest.mark.unit
@@ -101,6 +101,62 @@ def test_secret_client_preserves_opaque_urn(dummy_client):
     assert "params" not in client.calls[1][2]
     assert client.calls[2][1].endswith(raw)
     assert "params" not in client.calls[2][2]
+
+
+def test_secret_client_falls_back_to_by_urn_after_v2_not_found():
+    class FallbackClient:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, dict]] = []
+
+        def get(self, path: str, **kwargs):
+            self.calls.append(("get", path, kwargs))
+            if path == "/catalog/secrets/v2/urn:li:dataHubSecret:demo":
+                raise NotFoundError(
+                    "missing",
+                    status_code=404,
+                    response_data={"detail": "not found"},
+                )
+            if path == "/catalog/secrets/by-urn":
+                return {
+                    "urn": kwargs["params"]["urn"],
+                    "name": "demo",
+                    "owner": "urn:li:corpuser:demo",
+                }
+            raise AssertionError(f"Unexpected GET {path}")
+
+        def delete(self, path: str, **kwargs):
+            self.calls.append(("delete", path, kwargs))
+            if path == "/catalog/secrets/v2/urn:li:dataHubSecret:demo":
+                raise NotFoundError(
+                    "missing",
+                    status_code=404,
+                    response_data={"detail": "not found"},
+                )
+            if path == "/catalog/secrets/by-urn":
+                return None
+            raise AssertionError(f"Unexpected DELETE {path}")
+
+    client = FallbackClient()
+    secrets = SecretClient(client)
+
+    secret = secrets.get("urn:li:dataHubSecret:demo")
+    secrets.delete("urn:li:dataHubSecret:demo")
+
+    assert secret.urn == "urn:li:dataHubSecret:demo"
+    assert client.calls == [
+        ("get", "/catalog/secrets/v2/urn:li:dataHubSecret:demo", {}),
+        (
+            "get",
+            "/catalog/secrets/by-urn",
+            {"params": {"urn": "urn:li:dataHubSecret:demo"}},
+        ),
+        ("delete", "/catalog/secrets/v2/urn:li:dataHubSecret:demo", {}),
+        (
+            "delete",
+            "/catalog/secrets/by-urn",
+            {"params": {"urn": "urn:li:dataHubSecret:demo"}},
+        ),
+    ]
 
 
 def test_dataset_client_encode_helper():

--- a/tests/unit/test_client_request_error_mapping.py
+++ b/tests/unit/test_client_request_error_mapping.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from kamiwaza_sdk.client import KamiwazaClient
-from kamiwaza_sdk.exceptions import APIError, VectorDBUnavailableError
+from kamiwaza_sdk.exceptions import APIError, NotFoundError, VectorDBUnavailableError
 
 
 pytestmark = pytest.mark.unit
@@ -81,3 +81,20 @@ def test_501_non_vectordb_path_raises_api_error(monkeypatch: pytest.MonkeyPatch)
 
     assert not isinstance(exc_info.value, VectorDBUnavailableError)
     assert exc_info.value.status_code == 501
+
+
+def test_generic_404_raises_not_found_api_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = _StubResponse(
+        status_code=404,
+        text='{"detail":"Document not found"}',
+        json_data={"detail": "Document not found"},
+    )
+    client = _make_client_with_response(monkeypatch, response)
+
+    with pytest.raises(NotFoundError) as exc_info:
+        client.get("/context/storage/raw/missing")
+
+    assert isinstance(exc_info.value, APIError)
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.response_data == {"detail": "Document not found"}
+    assert exc_info.value.response_text == '{"detail":"Document not found"}'

--- a/tests/unit/test_kamiwaza_sdk_exceptions.py
+++ b/tests/unit/test_kamiwaza_sdk_exceptions.py
@@ -232,6 +232,26 @@ def test_error_for_response_falls_back_on_403_without_reason() -> None:
     assert not isinstance(err, NativeRealmRequiredError)
 
 
+def test_error_for_response_dispatches_generic_404_to_not_found() -> None:
+    """A plain 404 without detail.reason still surfaces as NotFoundError."""
+    from kamiwaza_sdk.exceptions import NotFoundError, error_for_response
+
+    body = {"detail": "Document not found"}
+    err = error_for_response(404, body, "Missing document")
+    assert isinstance(err, NotFoundError)
+    assert err.status_code == 404
+    assert err.body == body
+
+
+def test_error_for_response_prefers_specific_404_reason() -> None:
+    """A known 404 detail.reason keeps its more specific subclass."""
+    from kamiwaza_sdk.exceptions import GatePackageNotFoundError, error_for_response
+
+    body = {"detail": {"reason": "gate_package_not_found"}}
+    err = error_for_response(404, body, "Missing package")
+    assert isinstance(err, GatePackageNotFoundError)
+
+
 def test_error_for_response_handles_none_body() -> None:
     """Non-JSON or empty responses produce body=None; dispatch must not
     crash and falls back to KamiwazaError."""

--- a/tests/unit/test_kamiwaza_sdk_exceptions.py
+++ b/tests/unit/test_kamiwaza_sdk_exceptions.py
@@ -11,11 +11,11 @@ Per WS-M3.2 design (§6.2 v0.3.7), the unified hierarchy is:
 
     KamiwazaError                     (base — extended with status_code + body kwargs)
         ├─ APIError                   (existing legacy)
+        │      └─ NotFoundError       (existing legacy)
         ├─ AuthenticationError        (existing legacy)
         ├─ AuthorizationError         (existing legacy)
         │      └─ NativeRealmRequiredError      (NEW M3.2)
         │      └─ BrokeredUserNotAllowlistedError (NEW M3.2)
-        ├─ NotFoundError              (existing legacy)
         ├─ ValidationError            (existing legacy)
         ├─ TimeoutError               (existing legacy)
         ├─ FederationPairTimeoutError (NEW M3.2)
@@ -142,6 +142,23 @@ def test_authorization_subclasses_inherit_correctly() -> None:
 
     assert issubclass(NativeRealmRequiredError, AuthorizationError)
     assert issubclass(BrokeredUserNotAllowlistedError, AuthorizationError)
+
+
+def test_not_found_error_inherits_api_error_for_compatibility() -> None:
+    """Service modules catch APIError to translate or retry 404s."""
+    from kamiwaza_sdk.exceptions import APIError, NotFoundError
+
+    assert issubclass(NotFoundError, APIError)
+    err = NotFoundError(
+        "missing",
+        status_code=404,
+        body={"detail": "Document not found"},
+        response_text='{"detail":"Document not found"}',
+    )
+    assert err.status_code == 404
+    assert err.response_data == {"detail": "Document not found"}
+    assert err.body == {"detail": "Document not found"}
+    assert err.response_text == '{"detail":"Document not found"}'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_retrieval_service.py
+++ b/tests/unit/test_retrieval_service.py
@@ -6,7 +6,7 @@ import pytest
 
 from datetime import datetime
 
-from kamiwaza_sdk.exceptions import APIError, DatasetNotFoundError, TransportNotSupportedError
+from kamiwaza_sdk.exceptions import DatasetNotFoundError, NotFoundError, TransportNotSupportedError
 from kamiwaza_sdk.schemas.retrieval import RetrievalRequest
 from kamiwaza_sdk.services.retrieval import RetrievalResult, RetrievalService
 
@@ -161,7 +161,7 @@ def test_materialize_grpc_returns_handshake(dummy_client):
 def test_create_job_translates_not_found():
     class FailingClient:
         def post(self, *_args, **_kwargs):
-            raise APIError(
+            raise NotFoundError(
                 "not found",
                 status_code=404,
                 response_data={"detail": "Dataset missing"},

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -51,6 +51,66 @@ def test_deploy_model_builds_payload_with_repo_lookup(dummy_client):
     assert payload["json"]["m_config_id"] == str(config_id)
 
 
+def _active_deployment_payload(
+    deployment_id: UUID,
+    *,
+    access_path: str | None = "/runtime/models/dep-1",
+    lb_port: int = 0,
+) -> dict:
+    return {
+        "id": str(deployment_id),
+        "m_id": str(uuid4()),
+        "m_config_id": str(uuid4()),
+        "requested_at": "2026-06-09T00:00:00Z",
+        "status": "DEPLOYED",
+        "access_path": access_path,
+        "lb_port": lb_port,
+        "instances": [
+            {
+                "id": str(uuid4()),
+                "deployment_id": str(deployment_id),
+                "deployed_at": "2026-06-09T00:01:00Z",
+                "status": "DEPLOYED",
+            }
+        ],
+        "m_name": "test-model",
+    }
+
+
+def test_list_active_deployments_preserves_runtime_origin_port(mock_client):
+    deployment_id = uuid4()
+    mock_client.base_url = "https://kamiwaza.test:18446/api"
+    mock_client.expect("GET", "/serving/deployments", [_active_deployment_payload(deployment_id)])
+    service = ServingService(mock_client)
+
+    deployments = service.list_active_deployments()
+
+    assert deployments[0].endpoint == "https://kamiwaza.test:18446/runtime/models/dep-1/v1"
+
+
+def test_list_active_deployments_preserves_gateway_path_prefix(mock_client):
+    deployment_id = uuid4()
+    mock_client.base_url = "https://gateway.example.com/kamiwaza/api"
+    mock_client.expect("GET", "/serving/deployments", [_active_deployment_payload(deployment_id)])
+    service = ServingService(mock_client)
+
+    deployments = service.list_active_deployments()
+
+    assert deployments[0].endpoint == "https://gateway.example.com/kamiwaza/runtime/models/dep-1/v1"
+
+
+def test_list_active_deployments_uses_runtime_base_override(mock_client, monkeypatch):
+    deployment_id = uuid4()
+    mock_client.base_url = "http://127.0.0.1:17779/api"
+    monkeypatch.setenv("KAMIWAZA_RUNTIME_BASE_URL", "https://kamiwaza.test:18446/api")
+    mock_client.expect("GET", "/serving/deployments", [_active_deployment_payload(deployment_id)])
+    service = ServingService(mock_client)
+
+    deployments = service.list_active_deployments()
+
+    assert deployments[0].endpoint == "https://kamiwaza.test:18446/runtime/models/dep-1/v1"
+
+
 def test_deploy_model_waits_until_ready_by_default(mock_client):
     """wait is omitted (default True) — the deploy polls through to
     DEPLOYED. poll_interval_seconds/timeout_seconds are forwarded to the

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -77,7 +77,14 @@ def _active_deployment_payload(
     }
 
 
-def test_list_active_deployments_preserves_runtime_origin_port(mock_client):
+def _clear_runtime_url_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KAMIWAZA_RUNTIME_BASE_URL", raising=False)
+    monkeypatch.delenv("KAMIWAZA_PUBLIC_API_URL", raising=False)
+    monkeypatch.delenv("KAMIWAZA_USE_HTTPS", raising=False)
+
+
+def test_list_active_deployments_preserves_runtime_origin_port(mock_client, monkeypatch):
+    _clear_runtime_url_env(monkeypatch)
     deployment_id = uuid4()
     mock_client.base_url = "https://kamiwaza.test:18446/api"
     mock_client.expect("GET", "/serving/deployments", [_active_deployment_payload(deployment_id)])
@@ -88,7 +95,8 @@ def test_list_active_deployments_preserves_runtime_origin_port(mock_client):
     assert deployments[0].endpoint == "https://kamiwaza.test:18446/runtime/models/dep-1/v1"
 
 
-def test_list_active_deployments_preserves_gateway_path_prefix(mock_client):
+def test_list_active_deployments_preserves_gateway_path_prefix(mock_client, monkeypatch):
+    _clear_runtime_url_env(monkeypatch)
     deployment_id = uuid4()
     mock_client.base_url = "https://gateway.example.com/kamiwaza/api"
     mock_client.expect("GET", "/serving/deployments", [_active_deployment_payload(deployment_id)])
@@ -100,8 +108,10 @@ def test_list_active_deployments_preserves_gateway_path_prefix(mock_client):
 
 
 def test_list_active_deployments_uses_runtime_base_override(mock_client, monkeypatch):
+    _clear_runtime_url_env(monkeypatch)
     deployment_id = uuid4()
     mock_client.base_url = "http://127.0.0.1:17779/api"
+    monkeypatch.setenv("KAMIWAZA_PUBLIC_API_URL", "http://localhost:8000/api")
     monkeypatch.setenv("KAMIWAZA_RUNTIME_BASE_URL", "https://kamiwaza.test:18446/api")
     mock_client.expect("GET", "/serving/deployments", [_active_deployment_payload(deployment_id)])
     service = ServingService(mock_client)
@@ -109,6 +119,22 @@ def test_list_active_deployments_uses_runtime_base_override(mock_client, monkeyp
     deployments = service.list_active_deployments()
 
     assert deployments[0].endpoint == "https://kamiwaza.test:18446/runtime/models/dep-1/v1"
+
+
+def test_list_active_deployments_prefers_client_base_url_over_public_url(
+    mock_client,
+    monkeypatch,
+):
+    _clear_runtime_url_env(monkeypatch)
+    deployment_id = uuid4()
+    mock_client.base_url = "http://host.docker.internal:8000/api"
+    monkeypatch.setenv("KAMIWAZA_PUBLIC_API_URL", "http://localhost:8000/api")
+    mock_client.expect("GET", "/serving/deployments", [_active_deployment_payload(deployment_id)])
+    service = ServingService(mock_client)
+
+    deployments = service.list_active_deployments()
+
+    assert deployments[0].endpoint == "http://host.docker.internal:8000/runtime/models/dep-1/v1"
 
 
 def test_deploy_model_waits_until_ready_by_default(mock_client):


### PR DESCRIPTION
## Linear
ENG-6146

## Summary
- Map unstructured HTTP 404 API responses to `NotFoundError` while keeping `NotFoundError` as an `APIError` subclass for existing service fallback/translation compatibility.
- Preserve `response_text`, `response_data`, and `body` for typed API error subclasses raised at the client response boundary.
- Preserve scheme, port, and path prefix when building OpenAI-compatible runtime endpoints for active deployments.
- Add `KAMIWAZA_RUNTIME_BASE_URL` support so tests can authenticate through a private core API tunnel while invoking models through private GreyMatter Edge.
- Keep runtime origin precedence explicit: `KAMIWAZA_RUNTIME_BASE_URL` overrides all, otherwise the caller client base URL is used before any public API fallback.

## Validation
- `uv run ruff check kamiwaza_sdk/exceptions.py kamiwaza_sdk/client.py kamiwaza_sdk/services/serving.py tests/unit/test_kamiwaza_sdk_exceptions.py tests/unit/test_client_request_error_mapping.py tests/unit/test_catalog_service.py tests/unit/test_retrieval_service.py tests/unit/test_serving_service.py tests/unit/test_dataset_schema_retry.py` -> passed
- `uv run mypy --follow-imports=silent kamiwaza_sdk/exceptions.py kamiwaza_sdk/client.py kamiwaza_sdk/services/serving.py` -> passed
- `uv run pytest -q tests/unit/test_kamiwaza_sdk_exceptions.py tests/unit/test_client_request_error_mapping.py tests/unit/test_catalog_service.py tests/unit/test_retrieval_service.py tests/unit/test_serving_service.py tests/unit/test_dataset_schema_retry.py` -> `70 passed`
- `uv run pytest -q tests/unit` -> `2688 passed, 1 skipped`
- CI on head `f090c52` is green for lint, mypy, unit, coverage, package build, seeder build, Linear check, and extension contract.
- Live ARO/GreyMatter: `tests/integration/test_context_live.py::test_context_document_download_url_requires_stored_document` passed.
- Live ARO/GreyMatter: `tests/integration/test_inference_matrix_live.py::test_deploy_and_infer_llamacpp_gguf` passed with `KAMIWAZA_RUNTIME_BASE_URL=https://kamiwaza.test:18446/api` through the private Edge tunnel.

No ingress exposure changes.