### PR TITLE
Back-merge release/1.0.0 into develop

### DIFF
--- a/tests/integration/capability_markers.py
+++ b/tests/integration/capability_markers.py
@@ -47,9 +47,9 @@ class ClusterCapabilitySnapshot:
 # --------------------------------------------------------------------------- #
 # Defensive parsing of the untyped GPU dicts (Hardware.gpus: List[Dict])
 # --------------------------------------------------------------------------- #
-_VENDOR_KEYS = ("vendor", "gpu_vendor", "brand", "manufacturer")
+_VENDOR_KEYS = ("vendor", "gpu_vendor", "brand", "manufacturer", "type")
 _NAME_KEYS = ("name", "model", "product", "product_name", "gpu_name")
-_MEM_GB_KEYS = ("memory_gb", "mem_gb", "vram_gb")
+_MEM_GB_KEYS = ("memory_gb", "mem_gb", "vram_gb", "vram", "gpu_memory_gb")
 _MEM_MB_KEYS = ("memory_mb", "mem_mb", "vram_mb", "memory_total_mb")
 _MEM_BYTES_KEYS = ("memory_bytes", "memory_total", "mem_bytes", "total_memory")
 _MIG_KEYS = ("mig", "mig_enabled", "mig_capable", "mig_support", "mig_supported")
@@ -145,6 +145,13 @@ def _hardware_node_key(hardware: Any) -> str:
     return str(node_id) if node_id is not None else f"_anon_{id(hardware)}"
 
 
+def _hardware_active(hardware: Any) -> Optional[bool]:
+    active = getattr(hardware, "active", None)
+    if active is None and isinstance(hardware, dict):
+        active = hardware.get("active")
+    return active if isinstance(active, bool) else None
+
+
 def build_capability_snapshot(
     hardware_entries: Iterable[Any],
     node_count: Optional[int] = None,
@@ -156,8 +163,11 @@ def build_capability_snapshot(
     available; otherwise it is inferred from distinct hardware node ids.
     """
     entries = list(hardware_entries or [])
+    active_entries = [
+        hardware for hardware in entries if _hardware_active(hardware) is not False
+    ]
     gpu_dicts: list[dict] = []
-    for hardware in entries:
+    for hardware in active_entries:
         gpus = _hardware_gpus(hardware)
         if gpus:
             gpu_dicts.extend(gpu for gpu in gpus if isinstance(gpu, dict))
@@ -177,7 +187,7 @@ def build_capability_snapshot(
             mig_flags.append(mig)
 
     if node_count is None:
-        node_count = len({_hardware_node_key(hw) for hw in entries})
+        node_count = len({_hardware_node_key(hw) for hw in active_entries})
 
     return ClusterCapabilitySnapshot(
         gpu_count=len(gpu_dicts),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -122,19 +122,25 @@ _TEXT_BODY_MARKERS = (
     "application/graphql",
     "text/",
 )
-CONTEXT_TEST_LLM_REPO = os.environ.get(
-    "KAMIWAZA_CONTEXT_LLM_REPO",
+_CONTEXT_TEST_LLM_REPO_OVERRIDE = os.environ.get("KAMIWAZA_CONTEXT_LLM_REPO", "").strip()
+_CONTEXT_TEST_LLM_ENGINE_OVERRIDE = os.environ.get("KAMIWAZA_CONTEXT_LLM_ENGINE", "").strip()
+CONTEXT_TEST_MLX_LLM_REPO = os.environ.get(
+    "KAMIWAZA_CONTEXT_MLX_LLM_REPO",
     "mlx-community/Qwen3-4B-4bit",
+)
+CONTEXT_TEST_VLLM_LLM_REPO = os.environ.get(
+    "KAMIWAZA_CONTEXT_VLLM_LLM_REPO",
+    "Qwen/Qwen3-0.6B",
 )
 CONTEXT_TEST_LLM_DEPLOY_TIMEOUT_SECONDS = float(
     os.environ.get("KAMIWAZA_CONTEXT_LLM_DEPLOY_TIMEOUT_SECONDS", "600")
 )
 # Must stay in sync with TEST_REPO_ID in test_serving_workflow.py and
-# test_cli_live.py: the capability probe deploys the SAME model the gated tests
-# deploy, so the gate's skip/run verdict matches what the tests will actually do.
-# Intentionally not env-overridable — an override here that the test modules
-# don't honor would let the probe pass while the tests deploy a different model
-# and fail instead of skip.
+# test_cli_live.py: the capability probe deploys the same model through the
+# same default-engine path the gated tests use, so the gate's skip/run verdict
+# matches what the tests will actually do. Intentionally not env-overridable —
+# an override here that the test modules don't honor would let the probe pass
+# while the tests deploy a different model and fail instead of skip.
 DEPLOYABLE_TEST_MODEL_REPO = "mlx-community/Qwen3-4B-4bit"
 DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS = float(
     os.environ.get("KAMIWAZA_DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS", "600")
@@ -385,7 +391,7 @@ def _runtime_endpoint(endpoint: str) -> str:
     if host not in {"localhost", "127.0.0.1", "::1"}:
         return endpoint
 
-    target_host = os.environ.get("KAMIWAZA_RUNTIME_HOST", RUNTIME_HOST_ALIAS).strip()
+    target_host = _runtime_host_for_cluster()
     if not target_host:
         return endpoint
 
@@ -396,10 +402,44 @@ def _runtime_endpoint(endpoint: str) -> str:
 
 def _runtime_host(host: str) -> str:
     if host in {"localhost", "127.0.0.1", "::1"}:
-        target = os.environ.get("KAMIWAZA_RUNTIME_HOST", RUNTIME_HOST_ALIAS).strip()
+        target = _runtime_host_for_cluster()
         if target:
             return target
     return host
+
+
+def _runtime_host_for_cluster() -> str:
+    explicit = os.environ.get("KAMIWAZA_RUNTIME_HOST", "").strip()
+    if explicit:
+        return explicit
+
+    if sys.platform.startswith("linux"):
+        for interface in ("kube-bridge", "cni0"):
+            address = _interface_ipv4(interface)
+            if address:
+                return address
+
+    return RUNTIME_HOST_ALIAS.strip()
+
+
+def _interface_ipv4(interface: str) -> str:
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "-o", "addr", "show", "dev", interface],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return ""
+    if result.returncode != 0:
+        return ""
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        for index, field in enumerate(fields):
+            if field == "inet" and index + 1 < len(fields):
+                return fields[index + 1].split("/", 1)[0]
+    return ""
 
 
 def _runtime_bootstrap(bootstrap: str) -> str:
@@ -576,6 +616,24 @@ def _preferred_active_model_deployment(
             if deployment["repo_model_id"] == preferred_repo_id:
                 return deployment
     return deployments[0] if deployments else None
+
+
+def _context_llm_target(
+    snapshot: _cap.ClusterCapabilitySnapshot | None,
+) -> tuple[str, str | None]:
+    """Select a context-test LLM repo/engine for the live host.
+
+    MLX remains the default for non-NVIDIA hosts, but Linux/NVIDIA release UAT
+    must not send the MLX-quantized smoke model through vLLM by accident.
+    """
+    if _CONTEXT_TEST_LLM_REPO_OVERRIDE:
+        return (
+            _CONTEXT_TEST_LLM_REPO_OVERRIDE,
+            _CONTEXT_TEST_LLM_ENGINE_OVERRIDE or None,
+        )
+    if snapshot is not None and "nvidia" in snapshot.gpu_vendors:
+        return CONTEXT_TEST_VLLM_LLM_REPO, _CONTEXT_TEST_LLM_ENGINE_OVERRIDE or "vllm"
+    return CONTEXT_TEST_MLX_LLM_REPO, _CONTEXT_TEST_LLM_ENGINE_OVERRIDE or "mlx"
 
 
 def _active_embedding_deployment(client: KamiwazaClient) -> dict[str, str] | None:
@@ -1189,6 +1247,7 @@ def embedding_test_target(
 def context_llm_prerequisite(
     live_kamiwaza_session_client: KamiwazaClient,
     ensure_repo_ready,
+    cluster_capability_snapshot: _cap.ClusterCapabilitySnapshot | None,
 ) -> Iterator[str]:
     """Ensure a usable LLM deployment exists for context ontology operations, or skip once.
 
@@ -1200,6 +1259,7 @@ def context_llm_prerequisite(
     instead of a cascade of fixture-setup ERRORs.
     """
     client = live_kamiwaza_session_client
+    context_repo_id, context_engine_name = _context_llm_target(cluster_capability_snapshot)
 
     def _stop_provisioned(deployment_id: str | None) -> None:
         """Best-effort teardown of a deployment THIS fixture provisioned."""
@@ -1213,7 +1273,7 @@ def context_llm_prerequisite(
     existing = _preferred_active_model_deployment(
         client,
         desired_type="llm",
-        preferred_repo_id=CONTEXT_TEST_LLM_REPO,
+        preferred_repo_id=context_repo_id,
     )
     if existing is not None:
         yield existing["deployment_id"]
@@ -1224,11 +1284,11 @@ def context_llm_prerequisite(
     # capacity-limited host) would be orphaned when we skip.
     provisioned_deployment_id: str | None = None
     try:
-        model = ensure_repo_ready(client, CONTEXT_TEST_LLM_REPO)
+        model = ensure_repo_ready(client, context_repo_id)
         configs = client.models.get_model_configs(model.id)
         if not configs:
             pytest.skip(
-                f"No model configs available for context LLM repo '{CONTEXT_TEST_LLM_REPO}'"
+                f"No model configs available for context LLM repo '{context_repo_id}'"
             )
         default_config = next(
             (config for config in configs if config.default), configs[0]
@@ -1237,21 +1297,25 @@ def context_llm_prerequisite(
         # deploy_model returns Union[UUID, bool] — False on failure (no raise).
         # Guard before str() so a refused deploy skips cleanly instead of turning
         # into the truthy id "False".
-        raw_deployment_id = client.serving.deploy_model(
-            model_id=str(model.id),
-            m_config_id=default_config.id,
-            lb_port=0,
-            autoscaling=False,
-            min_copies=1,
-            starting_copies=1,
+        deploy_kwargs: dict[str, Any] = {
+            "model_id": str(model.id),
+            "m_config_id": default_config.id,
+            "lb_port": 0,
+            "autoscaling": False,
+            "min_copies": 1,
+            "starting_copies": 1,
             # The fixture's wait_for_deployment below owns the timeout; the
             # SDK-internal wait would block up to its own 3600s default first.
-            wait=False,
-        )
+            "wait": False,
+        }
+        if context_engine_name:
+            deploy_kwargs["engine_name"] = context_engine_name
+        raw_deployment_id = client.serving.deploy_model(**deploy_kwargs)
         if not raw_deployment_id:
             pytest.skip(
                 "deploy_model did not return a deployment id for context LLM repo "
-                f"'{CONTEXT_TEST_LLM_REPO}' (deploy refused on this host)."
+                f"'{context_repo_id}' (engine={context_engine_name or 'default'}, "
+                "deploy refused on this host)."
             )
         provisioned_deployment_id = str(raw_deployment_id)
         deployment = client.serving.wait_for_deployment(
@@ -1263,7 +1327,8 @@ def context_llm_prerequisite(
         _stop_provisioned(provisioned_deployment_id)
         pytest.skip(
             "No active LLM deployment for context ontology tests and one could not "
-            f"be provisioned (repo={CONTEXT_TEST_LLM_REPO}): "
+            f"be provisioned (repo={context_repo_id}, "
+            f"engine={context_engine_name or 'default'}): "
             f"{type(exc).__name__}: {exc}"
         )
 
@@ -1539,12 +1604,17 @@ def live_kamiwaza_peer_client(
 def pytest_collection_modifyitems(
     config: pytest.Config, items: list[pytest.Item]
 ) -> None:
-    """Order: smoke first, embedding-dependent next, others last.
+    """Order: smoke first, embedding-dependent files next, others last.
 
     ENG-5784: also deselect @pytest.mark.requires_two_clusters when neither
     --live-peer-base-url nor KAMIWAZA_PEER_BASE_URL is set. Mirrors the
     requires_embedding_model deselection convention so contributor PRs
     without peer creds don't show false reds.
+
+    Keep modules intact when front-loading embedding work. Several live fixtures
+    are module/session scoped; splitting one module into embedding/non-embedding
+    halves makes those fixtures live across unrelated tests and can invalidate
+    workroom-scoped state before the later half resumes.
     """
     peer_url = str(config.getoption("live_peer_base_url")).strip()
     if not peer_url:
@@ -1565,8 +1635,13 @@ def pytest_collection_modifyitems(
     remaining_items = [
         item for item in items if not Path(str(item.fspath)).name.startswith("test_00_")
     ]
+    embedding_paths = {
+        Path(str(item.fspath))
+        for item in remaining_items
+        if "requires_embedding_model" in item.keywords
+    }
     embedding_items = [
-        item for item in remaining_items if "requires_embedding_model" in item.keywords
+        item for item in remaining_items if Path(str(item.fspath)) in embedding_paths
     ]
     if not smoke_items and not embedding_items:
         return
@@ -1574,7 +1649,7 @@ def pytest_collection_modifyitems(
     other_items = [
         item
         for item in remaining_items
-        if "requires_embedding_model" not in item.keywords
+        if Path(str(item.fspath)) not in embedding_paths
     ]
     items[:] = smoke_items + embedding_items + other_items
 

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -168,20 +168,6 @@ def _vectordb_ids(resources: list[dict[str, object]]) -> set[str]:
     return {str(resource["id"]) for resource in resources if resource.get("id")}
 
 
-def _assert_scoped_vectordb_view(
-    service: ContextService,
-    *,
-    visible_id: str,
-    hidden_ids: set[str],
-    label: str,
-) -> None:
-    ids = _vectordb_ids(service.list_vectordbs())
-    assert visible_id in ids, f"{label} did not see its own VectorDB"
-    assert ids.isdisjoint(hidden_ids), (
-        f"{label} saw foreign VectorDBs: {ids & hidden_ids}"
-    )
-
-
 def _safe_scale_vectordb(
     service: ContextService,
     vectordb_id: str,
@@ -368,8 +354,8 @@ def session_workroom(
     """Writable workroom for Context Service explicit-scope tests.
 
     Room-scoped Context routes require an explicit non-Global workroom scope.
-    Context calls below pass explicit workroom_id so authority is not inferred
-    from SDK-local or server-side selected-session state.
+    PAT-backed automation cannot mutate selected-session state with
+    ``workrooms.enter``; Context calls below carry the workroom explicitly.
     """
     workrooms = shared_context_service.client.workrooms
     workroom = workrooms.create(
@@ -466,17 +452,11 @@ def test_context_vectordb_create_without_workroom_uses_global_scope(
 def test_context_workroom_scope_clients_isolate_vectordb_views(
     shared_context_service: ContextService,
 ) -> None:
-    """Derived SDK clients keep A, B, and Global workroom-scoped resources separate."""
+    """Derived SDK clients can carry workroom scope as a context manager."""
     root_client = shared_context_service.client
     workrooms = root_client.workrooms
     workroom_a = None
-    workroom_b = None
-    client_a: KamiwazaClient | None = None
-    client_b: KamiwazaClient | None = None
-    client_global: KamiwazaClient | None = None
     vdb_a: str | None = None
-    vdb_b: str | None = None
-    vdb_global: str | None = None
 
     try:
         workroom_a = workrooms.create(
@@ -484,56 +464,27 @@ def test_context_workroom_scope_clients_isolate_vectordb_views(
             "ephemeral",
             description="SDK workroom scope isolation A",
         )
-        workroom_b = workrooms.create(
-            f"sdk-scope-b-{uuid4().hex[:8]}",
-            "ephemeral",
-            description="SDK workroom scope isolation B",
-        )
-        client_a = root_client.workroom_scope(workroom_a.id)
-        client_b = root_client.workroom_scope(workroom_b.id)
-        client_global = root_client.workroom_scope(None)
+        with root_client.workroom_scope(workroom_a.id) as scoped_client:
+            service_a = scoped_client.context
+            vdb_a = _create_temp_vectordb(
+                service_a,
+                prefix="sdk-scope-a",
+            )
+            scoped_vdbs = service_a.list_vectordbs()
 
-        service_a = client_a.context
-        service_b = client_b.context
-        service_global = client_global.context
-
-        vdb_a = _create_temp_vectordb(service_a, prefix="sdk-scope-a")
-        vdb_b = _create_temp_vectordb(service_b, prefix="sdk-scope-b")
-        vdb_global = _create_temp_vectordb(service_global, prefix="sdk-scope-global")
-
-        _assert_scoped_vectordb_view(
-            service_a,
-            visible_id=vdb_a,
-            hidden_ids={vdb_b, vdb_global},
-            label="A",
+        assert vdb_a in _vectordb_ids(scoped_vdbs)
+        created = next(
+            resource for resource in scoped_vdbs if str(resource.get("id")) == vdb_a
         )
-        _assert_scoped_vectordb_view(
-            service_b,
-            visible_id=vdb_b,
-            hidden_ids={vdb_a, vdb_global},
-            label="B",
-        )
-        _assert_scoped_vectordb_view(
-            service_global,
-            visible_id=vdb_global,
-            hidden_ids={vdb_a, vdb_b},
-            label="Global",
-        )
+        assert str(created.get("workroom_id")) == str(workroom_a.id)
     finally:
-        if vdb_a is not None and client_a is not None:
-            _safe_delete_vectordb(client_a.context, vdb_a)
-        if vdb_b is not None and client_b is not None:
-            _safe_delete_vectordb(client_b.context, vdb_b)
-        if vdb_global is not None and client_global is not None:
-            _safe_delete_vectordb(client_global.context, vdb_global)
-        for scoped_client in (client_a, client_b, client_global):
-            if scoped_client is not None:
-                scoped_client.close()
-        for workroom in (workroom_a, workroom_b):
-            if workroom is None:
-                continue
+        if vdb_a is not None and workroom_a is not None:
+            _safe_delete_vectordb(
+                root_client.context, vdb_a, workroom_id=str(workroom_a.id)
+            )
+        if workroom_a is not None:
             try:
-                workrooms.delete(str(workroom.id))
+                workrooms.delete(str(workroom_a.id))
             except (APIError, NotFoundError):
                 pass
 
@@ -659,16 +610,16 @@ def _vectordb_replicas(instance: dict) -> int | None:
     return None
 
 
-def test_context_vectordb_update_round_trips(
+def test_context_vectordb_update_accepts_config_and_redacts_public_response(
     shared_context_service: ContextService,
     session_workroom: str,
     shared_workroom_vectordb: str,
 ) -> None:
-    """update_vectordb mutation is observable via a follow-up get_vectordb.
+    """update_vectordb accepts config while public reads redact that config.
 
-    Assertion posture is API round-trip: confirm the PUT is accepted and the
-    requested config/replicas change is reflected when the instance is re-read.
-    Physical replica provisioning is out of scope (local Milvus is single-node).
+    Assertion posture is acceptance + public-shape: config patches are accepted
+    by the endpoint, but the public VectorDBInstance schema intentionally
+    redacts config so credentials do not leak through lifecycle responses.
     """
     service = shared_context_service
     vectordb_id = shared_workroom_vectordb
@@ -684,12 +635,12 @@ def test_context_vectordb_update_round_trips(
         workroom_id=session_workroom,
     )
     assert updated["id"] == vectordb_id
+    assert _vectordb_replicas(updated) == baseline_replicas
 
     refetched = service.get_vectordb(vectordb_id, workroom_id=session_workroom)
     assert refetched["id"] == vectordb_id
-    config = refetched.get("config")
-    assert isinstance(config, dict)
-    assert config.get("sdk_test_marker") == config_marker
+    assert "config" not in refetched
+    assert _vectordb_replicas(refetched) == baseline_replicas
 
 
 def test_context_vectordb_scale_reflects_requested_replicas(
@@ -1353,8 +1304,9 @@ def test_context_document_download_url_requires_stored_document(
     except NotFoundError:
         pass
     except APIError as exc:
+        # 404 = generic legacy SDK APIError mapping for unknown documents.
         # 501 = document storage not configured on this host; expected on bare core.
-        if exc.status_code != 501:
+        if exc.status_code not in {404, 501}:
             raise
     else:
         pytest.fail("expected NotFoundError or 501 for an unknown source URN")

--- a/tests/integration/test_inference_matrix_live.py
+++ b/tests/integration/test_inference_matrix_live.py
@@ -47,7 +47,9 @@ pytestmark = [
 # GGUF tests skip-not-fail if the repo can't be made ready.
 LLAMACPP_REPO = "unsloth/Qwen3-4B-Instruct-2507-GGUF"
 LLAMACPP_QUANT = "q4_k"
-VLLM_REPO = "Qwen/Qwen3-4B-Instruct-2507"
+# Keep the vLLM lane intentionally small. This is a CUDA engine smoke, not a
+# model-size certification, and it must fit on a busy single-node release UAT.
+VLLM_REPO = "Qwen/Qwen3-0.6B"
 
 WAIT_TIMEOUT = 600
 FRACTIONAL_COPIES = 2
@@ -148,8 +150,18 @@ def _stop_quietly(client, deployment_id):
 def _assert_chat_completion(client, deployment_id):
     """Serve a chat prompt via the OpenAI-compatible client and assert a reply."""
     openai_client = client.openai.get_client(deployment_id=deployment_id)
+    model_name = "kamiwaza"
+    try:
+        served_models = openai_client.models.list()
+        for served_model in getattr(served_models, "data", []) or []:
+            served_model_id = str(getattr(served_model, "id", "") or "")
+            if served_model_id:
+                model_name = served_model_id
+                break
+    except Exception:  # noqa: BLE001 - older engines accept the fallback alias
+        pass
     response = openai_client.chat.completions.create(
-        model="kamiwaza",
+        model=model_name,
         messages=_CHAT_PROMPT,
         temperature=0.0,
     )

--- a/tests/unit/extensions/test_dev_local.py
+++ b/tests/unit/extensions/test_dev_local.py
@@ -912,16 +912,22 @@ class TestParsePortMapping:
 @pytest.mark.unit
 class TestIsPortAvailable:
     def test_available_port(self):
-        # High ephemeral port should be available
-        assert is_port_available(59123) is True
+        import socket
+
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("0.0.0.0", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+
+        assert is_port_available(port) is True
 
     def test_occupied_port_via_bind(self):
         import socket
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.bind(("0.0.0.0", 59124))
+        sock.bind(("0.0.0.0", 0))
         try:
-            assert is_port_available(59124) is False
+            assert is_port_available(sock.getsockname()[1]) is False
         finally:
             sock.close()
 
@@ -930,10 +936,10 @@ class TestIsPortAvailable:
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind(("0.0.0.0", 59125))
+        sock.bind(("0.0.0.0", 0))
         sock.listen(1)
         try:
-            assert is_port_available(59125) is False
+            assert is_port_available(sock.getsockname()[1]) is False
         finally:
             sock.close()
 
@@ -959,9 +965,12 @@ class TestIsPortAvailable:
         except (AttributeError, OSError):
             pass
         try:
-            sock.bind(("::1", 59126))
+            try:
+                sock.bind(("::1", 0))
+            except OSError as exc:
+                pytest.skip(f"IPv6 loopback bind unavailable: {exc}")
             sock.listen(1)
-            assert is_port_available(59126) is False
+            assert is_port_available(sock.getsockname()[1]) is False
         finally:
             sock.close()
 
@@ -988,9 +997,12 @@ class TestIsPortAvailable:
         except (AttributeError, OSError):
             pass
         try:
-            sock.bind(("::1", 59127))
+            try:
+                sock.bind(("::1", 0))
+            except OSError as exc:
+                pytest.skip(f"IPv6 loopback bind unavailable: {exc}")
             # No listen() — connect probe will get ECONNREFUSED.
-            assert is_port_available(59127) is False
+            assert is_port_available(sock.getsockname()[1]) is False
         finally:
             sock.close()
 
@@ -1069,18 +1081,19 @@ class TestResolvePortConflicts:
         import socket
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.bind(("0.0.0.0", 59302))
+        sock.bind(("0.0.0.0", 0))
         try:
+            occupied_port = sock.getsockname()[1]
             compose = {
                 "services": {
-                    "frontend": {"ports": ["59302:3000"]},
+                    "frontend": {"ports": [f"{occupied_port}:3000"]},
                 }
             }
             remaps = resolve_port_conflicts(compose)
             assert "frontend" in remaps
             orig, new = remaps["frontend"]
-            assert orig == 59302
-            assert new > 59302
+            assert orig == occupied_port
+            assert new > occupied_port
         finally:
             sock.close()
 

--- a/tests/unit/test_capability_markers.py
+++ b/tests/unit/test_capability_markers.py
@@ -52,6 +52,12 @@ def test_build_snapshot_parses_memory_bytes_to_gb():
     assert snap.gpu_mem_gb and snap.gpu_mem_gb[0] == pytest.approx(24.0, abs=0.01)
 
 
+def test_build_snapshot_parses_platform_vram_string_to_gb():
+    snap = cap.build_capability_snapshot([_hw([{"type": "cuda", "vram": "31.00"}])])
+    assert snap.gpu_vendors == frozenset({"nvidia"})
+    assert snap.gpu_mem_gb and snap.gpu_mem_gb[0] == pytest.approx(31.0, abs=0.01)
+
+
 def test_build_snapshot_detects_vendor_from_explicit_key():
     snap = cap.build_capability_snapshot([_hw([{"vendor": "AMD"}])])
     assert snap.gpu_vendors == frozenset({"amd"})
@@ -78,6 +84,29 @@ def test_build_snapshot_empty_inventory_is_cpu_only():
     snap = cap.build_capability_snapshot([], node_count=1)
     assert snap.gpu_count == 0
     assert snap.gpu_mem_gb == ()
+    assert snap.node_count == 1
+
+
+def test_build_snapshot_ignores_explicitly_inactive_hardware_entries():
+    snap = cap.build_capability_snapshot(
+        [
+            {"active": False, "node_id": "old", "gpus": [{"type": "cuda", "vram": "31"}]},
+            {"active": True, "node_id": "new", "gpus": [{"type": "cuda", "vram": "24"}]},
+        ],
+        node_count=1,
+    )
+    assert snap.gpu_count == 1
+    assert snap.gpu_mem_gb == (24.0,)
+
+
+def test_build_snapshot_ignores_inactive_hardware_for_fallback_node_count():
+    snap = cap.build_capability_snapshot(
+        [
+            {"active": False, "node_id": "old", "gpus": [{"type": "cuda", "vram": "31"}]},
+            {"active": True, "node_id": "new", "gpus": []},
+        ]
+    )
+
     assert snap.node_count == 1
 
 

--- a/tests/unit/test_integration_conftest_runtime_host.py
+++ b/tests/unit/test_integration_conftest_runtime_host.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+CONFTEST_PATH = (
+    Path(__file__).resolve().parents[1] / "integration" / "conftest.py"
+)
+
+
+@pytest.fixture
+def integration_conftest():
+    spec = importlib.util.spec_from_file_location(
+        "_integration_conftest_runtime_host_under_test", CONFTEST_PATH
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> Any:
+    return SimpleNamespace(stdout=stdout, stderr="", returncode=returncode)
+
+
+def test_runtime_host_explicit_override_wins(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KAMIWAZA_RUNTIME_HOST", "192.0.2.10")
+    monkeypatch.setattr(integration_conftest.sys, "platform", "linux")
+    monkeypatch.setattr(
+        integration_conftest.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("explicit runtime host should not probe"),
+    )
+
+    assert (
+        integration_conftest._runtime_endpoint("http://localhost:19100/data")
+        == "http://192.0.2.10:19100/data"
+    )
+
+
+def test_runtime_host_uses_linux_kube_bridge(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KAMIWAZA_RUNTIME_HOST", raising=False)
+    monkeypatch.setattr(integration_conftest.sys, "platform", "linux")
+
+    def fake_run(args: list[str], **_kwargs: Any) -> Any:
+        if args[-1] == "kube-bridge":
+            return _completed("667: kube-bridge inet 10.244.0.1/24 brd 10.244.0.255\n")
+        return _completed(returncode=1)
+
+    monkeypatch.setattr(integration_conftest.subprocess, "run", fake_run)
+
+    assert integration_conftest._runtime_host("localhost") == "10.244.0.1"
+    assert (
+        integration_conftest._runtime_endpoint("http://127.0.0.1:41687/bucket")
+        == "http://10.244.0.1:41687/bucket"
+    )
+
+
+def test_runtime_host_falls_back_when_ip_binary_is_missing(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KAMIWAZA_RUNTIME_HOST", raising=False)
+    monkeypatch.setattr(integration_conftest.sys, "platform", "linux")
+    monkeypatch.setattr(integration_conftest, "RUNTIME_HOST_ALIAS", "host.docker.internal")
+
+    def fake_run(*_args: Any, **_kwargs: Any) -> Any:
+        raise FileNotFoundError("ip")
+
+    monkeypatch.setattr(integration_conftest.subprocess, "run", fake_run)
+
+    assert integration_conftest._runtime_host("localhost") == "host.docker.internal"
+
+
+def test_runtime_endpoint_leaves_remote_hosts_alone(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KAMIWAZA_RUNTIME_HOST", "192.0.2.10")
+
+    assert (
+        integration_conftest._runtime_endpoint("http://minio.example.test:9000/bucket")
+        == "http://minio.example.test:9000/bucket"
+    )


### PR DESCRIPTION
Git-flow back-merge of `release/1.0.0` into `develop` — **merge commit, no squash** (full history preserved).

`git merge-tree` confirms a **conflict-free** merge. `release/1.0.0` is **retained** — org ruleset `protect-release-branches-from-deletion` blocks the `delete_branch_on_merge` auto-delete.
