### PR TITLE
fix(extensions): reject catalog entries with uncovered env image refs (ENG-8270)

### DIFF
--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -306,6 +306,7 @@ def _publish_one(
     from kamiwaza_extensions.profile_manager import ProfileManager
     from kamiwaza_extensions.registry_builder import (
         RegistryBuilder,
+        find_uncovered_env_image_refs,
         resolve_extra_image,
     )
     from kamiwaza_extensions.validators.compose import ComposeValidator
@@ -676,6 +677,19 @@ def _publish_one(
         revision=revision,
         digest_map=digest_map or None,
     )
+
+    # Coverage gate (ENG-8270): a registry-owned image ref that only lives
+    # in a compose env value (a dynamic-spawn image like Kaizen's
+    # AGENT_SERVER_IMAGE default) must be covered by docker_images /
+    # extra_docker_images — those lists are what offline bundles relocate.
+    # An uncovered ref ships an entry whose sandbox image is unpullable on
+    # every air-gapped install, so reject it here rather than on the box.
+    coverage_violations = find_uncovered_env_image_refs(entry, registry)
+    if coverage_violations:
+        console.print("  [red]✗ catalog entry validation failed[/red]")
+        for violation in coverage_violations:
+            console.print(f"\n[red]Error:[/red] {violation}")
+        raise typer.Exit(code=int(ExitCode.VALIDATION))
 
     # 8. Publish to catalog
     console.print("  Publishing catalog...", end="")

--- a/kamiwaza_extensions/registry_builder.py
+++ b/kamiwaza_extensions/registry_builder.py
@@ -516,6 +516,98 @@ def _apply_env_image_rewrites(
     return result
 
 
+def _iter_env_pairs(env: Any):
+    """Yield ``(name, value)`` string pairs from a compose environment block.
+
+    Handles the dict shape, the ``NAME=value`` list shape, and list items
+    that are ``{name, value}`` mappings. Non-string values are skipped.
+    """
+    if isinstance(env, dict):
+        for name, value in env.items():
+            if isinstance(value, str):
+                yield str(name), value
+    elif isinstance(env, list):
+        for item in env:
+            if isinstance(item, str) and "=" in item:
+                name, _, value = item.partition("=")
+                yield name, value
+            elif isinstance(item, dict) and isinstance(item.get("value"), str):
+                yield str(item.get("name", "")), item["value"]
+
+
+def _env_value_image_ref(value: str) -> Optional[str]:
+    """Extract the statically-known image ref from an env value, if any.
+
+    Returns the default from a ``${VAR:-default}`` wrapper, or the bare
+    value itself. Returns ``None`` when the candidate still carries a
+    compose variable (unresolvable statically) or whitespace/commas (a
+    CSV or sentence, not a single image ref).
+    """
+    match = _ENV_DEFAULT_SUB_RE.match(value)
+    token = match.group(2) if match else value
+    if "$" in token or "," in token or any(ch.isspace() for ch in token):
+        return None
+    return token
+
+
+def find_uncovered_env_image_refs(
+    entry: Dict[str, Any], registry: str
+) -> List[str]:
+    """Return violations for env image refs the entry's lists don't cover.
+
+    The offline bundler relocates exactly ``docker_images`` +
+    ``extra_docker_images``; a registry-owned, tag-carrying image ref that
+    only appears inside a compose environment value (a dynamic-spawn image
+    like Kaizen's ``${AGENT_SERVER_IMAGE:-...}`` default) is unpullable on
+    air-gapped installs. ENG-8270 shipped exactly that shape to the prod
+    catalog: services retagged to the release tag while the env default
+    kept the extension-version tag, so every offline sandbox spawn
+    ImagePullBackOff'd. Coverage compares ``name:tag`` with digests
+    stripped — relocation re-digests, so digest equality can't be required.
+
+    Out of scope (can't or shouldn't be statically enforced): values still
+    carrying a compose variable, bare repo prefixes with no tag (allowlist
+    entries, not pullable refs), and refs outside *registry* (independent
+    release cadence — the extras surface's literal-tag-passthrough rule).
+    """
+    try:
+        compose = yaml.safe_load(entry.get("compose_yml") or "")
+    except yaml.YAMLError:
+        return []
+    if not isinstance(compose, dict):
+        return []
+    covered = {
+        ref.partition("@")[0]
+        for ref in (
+            list(entry.get("docker_images") or [])
+            + list(entry.get("extra_docker_images") or [])
+        )
+        if isinstance(ref, str)
+    }
+    registry_prefix = f"{registry.rstrip('/')}/"
+    violations: List[str] = []
+    for svc_name, svc in (compose.get("services") or {}).items():
+        if not isinstance(svc, dict):
+            continue
+        for var, value in _iter_env_pairs(svc.get("environment")):
+            ref = _env_value_image_ref(value)
+            if ref is None or not ref.startswith(registry_prefix):
+                continue
+            name_and_tag = ref.partition("@")[0]
+            if ":" not in name_and_tag[name_and_tag.rfind("/") + 1:]:
+                continue  # bare repo prefix, not a pullable ref
+            if name_and_tag not in covered:
+                violations.append(
+                    f"service '{svc_name}' environment '{var}' references "
+                    f"image '{ref}', which is not covered by docker_images/"
+                    f"extra_docker_images — offline bundles only relocate "
+                    f"listed images, so this ref is unpullable on air-gapped "
+                    f"installs. Declare it in extra_docker_images or align "
+                    f"its tag with this publish."
+                )
+    return violations
+
+
 def _rewrite_env_image_ref(
     value: str, stage: str, digest_map: Dict[str, str],
     revision: Optional[str] = None,

--- a/tests/unit/extensions/test_entry_image_consistency.py
+++ b/tests/unit/extensions/test_entry_image_consistency.py
@@ -1,0 +1,178 @@
+"""Catalog-entry image-coverage validation (ENG-8270).
+
+The offline bundler relocates exactly the images a catalog entry lists in
+``docker_images`` + ``extra_docker_images``. An image ref that only appears
+inside a compose *environment value* (e.g. Kaizen's dynamic-spawn
+``${AGENT_SERVER_IMAGE:-...}`` default) but is missing from those lists is
+unpullable on air-gapped installs: the sandbox pod ImagePullBackOffs and the
+extension breaks at runtime. ENG-8270 shipped exactly that shape to the prod
+catalog — services retagged to ``release-1.0.0`` while the env default kept
+the extension-version tag ``2.0.2``.
+
+``find_uncovered_env_image_refs`` is the publish-time guard that makes such
+an entry unpublishable.
+"""
+
+import pytest
+
+from kamiwaza_extensions.registry_builder import find_uncovered_env_image_refs
+
+pytestmark = pytest.mark.unit
+
+KAIZEN_REGISTRY = "ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images"
+
+
+def _entry(compose_yml: str, docker_images, extra_docker_images=None):
+    entry = {
+        "name": "kaizen",
+        "version": "2.0.2",
+        "compose_yml": compose_yml,
+        "docker_images": docker_images,
+    }
+    if extra_docker_images is not None:
+        entry["extra_docker_images"] = extra_docker_images
+    return entry
+
+
+class TestUncoveredEnvImageRefs:
+    def test_stale_env_default_is_flagged(self):
+        """Regression: the exact prod-catalog kaizen shape from ENG-8270.
+
+        Services retagged to release-1.0.0 (and listed), but the
+        AGENT_SERVER_IMAGE env default still at the extension-version tag
+        2.0.2 — a ref no list covers, so no offline bundle relocates it.
+        """
+        compose = f"""
+services:
+  backend:
+    image: {KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0
+    environment:
+      AGENT_SERVER_IMAGE: ${{AGENT_SERVER_IMAGE:-{KAIZEN_REGISTRY}/kaizen-agent:2.0.2}}
+  agent:
+    image: {KAIZEN_REGISTRY}/kaizen-agent:release-1.0.0
+"""
+        entry = _entry(
+            compose,
+            docker_images=[
+                f"{KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0",
+                f"{KAIZEN_REGISTRY}/kaizen-agent:release-1.0.0",
+            ],
+            extra_docker_images=[f"{KAIZEN_REGISTRY}/kaizen-agent:release-1.0.0"],
+        )
+        violations = find_uncovered_env_image_refs(entry, KAIZEN_REGISTRY)
+        assert len(violations) == 1
+        assert f"{KAIZEN_REGISTRY}/kaizen-agent:2.0.2" in violations[0]
+        assert "AGENT_SERVER_IMAGE" in violations[0]
+
+    def test_consistent_entry_passes(self):
+        """The correct (stage-catalog) shape: env default restamped to the
+        same tag the lists carry, digest-pinned. Digests may differ between
+        surfaces (relocation re-digests); coverage compares name:tag."""
+        digest = "sha256:" + "f" * 64
+        compose = f"""
+services:
+  backend:
+    image: {KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0@{digest}
+    environment:
+      AGENT_SERVER_IMAGE: ${{AGENT_SERVER_IMAGE:-{KAIZEN_REGISTRY}/kaizen-agent:release-1.0.0@{digest}}}
+"""
+        entry = _entry(
+            compose,
+            docker_images=[f"{KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0@{digest}"],
+            extra_docker_images=[
+                f"{KAIZEN_REGISTRY}/kaizen-agent:release-1.0.0@sha256:{'a' * 64}"
+            ],
+        )
+        assert find_uncovered_env_image_refs(entry, KAIZEN_REGISTRY) == []
+
+    def test_variable_bearing_values_are_skipped(self):
+        """A bare ``${VAR}`` and a default whose tag is itself a variable
+        can't be statically resolved — the runtime rewrite machinery owns
+        those; the validator must not guess."""
+        compose = f"""
+services:
+  backend:
+    image: {KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0
+    environment:
+      A: ${{AGENT_SERVER_IMAGE}}
+      B: ${{AGENT_SERVER_IMAGE:-{KAIZEN_REGISTRY}/kaizen-agent:$TAG}}
+"""
+        entry = _entry(
+            compose,
+            docker_images=[f"{KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0"],
+        )
+        assert find_uncovered_env_image_refs(entry, KAIZEN_REGISTRY) == []
+
+    def test_bare_prefix_value_is_skipped(self):
+        """SANDBOX_ALLOWED_IMAGE_PREFIXES-style values are repo *prefixes*
+        (no tag), not pullable refs — out of scope for coverage."""
+        compose = f"""
+services:
+  backend:
+    image: {KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0
+    environment:
+      SANDBOX_ALLOWED_IMAGE_PREFIXES: {KAIZEN_REGISTRY}/kaizen-agent
+"""
+        entry = _entry(
+            compose,
+            docker_images=[f"{KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0"],
+        )
+        assert find_uncovered_env_image_refs(entry, KAIZEN_REGISTRY) == []
+
+    def test_external_registry_refs_are_skipped(self):
+        """Refs outside the extension's registry keep their independent
+        cadence; the guard only enforces images this registry owns."""
+        compose = f"""
+services:
+  backend:
+    image: {KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0
+    environment:
+      HELPER_IMAGE: docker.io/library/redis:7
+"""
+        entry = _entry(
+            compose,
+            docker_images=[f"{KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0"],
+        )
+        assert find_uncovered_env_image_refs(entry, KAIZEN_REGISTRY) == []
+
+    def test_list_shaped_environment_is_walked(self):
+        compose = f"""
+services:
+  backend:
+    image: {KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0
+    environment:
+      - AGENT_SERVER_IMAGE=${{AGENT_SERVER_IMAGE:-{KAIZEN_REGISTRY}/kaizen-agent:2.0.2}}
+"""
+        entry = _entry(
+            compose,
+            docker_images=[f"{KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0"],
+        )
+        violations = find_uncovered_env_image_refs(entry, KAIZEN_REGISTRY)
+        assert len(violations) == 1
+        assert "AGENT_SERVER_IMAGE" in violations[0]
+
+    def test_bare_env_value_ref_is_checked(self):
+        """An image ref written directly (no ``${VAR:-...}`` wrapper) is the
+        same dynamic-spawn surface and gets the same coverage check."""
+        compose = f"""
+services:
+  backend:
+    image: {KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0
+    environment:
+      AGENT_SERVER_IMAGE: {KAIZEN_REGISTRY}/kaizen-agent:2.0.2
+"""
+        entry = _entry(
+            compose,
+            docker_images=[f"{KAIZEN_REGISTRY}/kaizen-backend:release-1.0.0"],
+        )
+        violations = find_uncovered_env_image_refs(entry, KAIZEN_REGISTRY)
+        assert len(violations) == 1
+
+    def test_missing_or_malformed_compose_yields_no_violations(self):
+        assert find_uncovered_env_image_refs({"name": "x"}, KAIZEN_REGISTRY) == []
+        assert (
+            find_uncovered_env_image_refs(
+                {"compose_yml": ":\nnot yaml: ["}, KAIZEN_REGISTRY
+            )
+            == []
+        )

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -3899,3 +3899,105 @@ class TestPublishDryRunImageBasename:
             "backend": f"{prefix}/workroom-manager-test-backend:testrev",
             "frontend": f"{prefix}/workroom-manager-test-frontend:testrev",
         }
+
+
+# ------------------------------------------------------------------
+# Entry image-coverage guard (ENG-8270)
+# ------------------------------------------------------------------
+
+
+class TestPublishRejectsUncoveredEnvImageRef:
+    """A publish whose final entry carries a registry-owned env image ref
+    that no docker_images/extra_docker_images entry covers must fail
+    validation instead of shipping (ENG-8270: such an entry reached the
+    prod catalog and broke sandbox spawn on every offline install)."""
+
+    @patch("kamiwaza_extensions.catalog_publisher.CatalogPublisher")
+    @patch("kamiwaza_extensions.image_pusher.ImagePusher")
+    @patch("kamiwaza_extensions.image_builder.ImageBuilder")
+    @patch("kamiwaza_extensions.profile_manager.ProfileManager")
+    @patch("kamiwaza_extensions.validators.compose.ComposeValidator")
+    @patch("kamiwaza_extensions.validators.metadata.MetadataValidator")
+    @patch("kamiwaza_extensions.extension_detector.ExtensionDetector")
+    def test_stale_env_default_fails_publish(
+        self,
+        mock_detector_cls,
+        mock_meta_validator_cls,
+        mock_compose_validator_cls,
+        mock_profile_mgr_cls,
+        mock_builder_cls,
+        mock_pusher_cls,
+        mock_publisher_cls,
+        tmp_path,
+    ):
+        # Env default pinned to a tag (1.7.0) this publish does not
+        # produce: != version, so the env-rewrite machinery deliberately
+        # passes it through, and no catalog list covers it. The guard
+        # must reject the entry before it reaches the publisher.
+        metadata = {
+            "name": "kaizenv3",
+            "version": "1.8.13",
+            "description": "Kaizen v3",
+            "extra_docker_images": ["ghcr.io/my-org/images/agent:{version}"],
+        }
+        compose_data = {
+            "services": {
+                "backend": {
+                    "build": {"context": "."},
+                    "image": "ghcr.io/my-org/kaizenv3-backend:1.8.13",
+                    "ports": ["8000"],
+                    "environment": {
+                        "AGENT_SERVER_IMAGE":
+                            "${AGENT_SERVER_IMAGE:-ghcr.io/my-org/images/agent:1.7.0}",
+                    },
+                },
+            },
+        }
+        mock_detector = MagicMock()
+        mock_detector.detect.return_value = _make_extension_info(
+            tmp_path,
+            name="kaizenv3",
+            version="1.8.13",
+            metadata=metadata,
+            compose_data=compose_data,
+        )
+        mock_detector_cls.return_value = mock_detector
+
+        mock_meta_validator = MagicMock()
+        mock_meta_validator.validate.return_value = _make_validation_result()
+        mock_meta_validator_cls.return_value = mock_meta_validator
+
+        mock_compose_validator = MagicMock()
+        mock_compose_validator.validate.return_value = _make_validation_result()
+        mock_compose_validator_cls.return_value = mock_compose_validator
+
+        mock_profile_mgr = MagicMock()
+        mock_profile_mgr.resolve_profile.return_value = _make_profile()
+        mock_profile_mgr_cls.return_value = mock_profile_mgr
+
+        mock_image_builder = MagicMock()
+        mock_image_builder.build.return_value = [
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev",
+        ]
+        mock_builder_cls.return_value = mock_image_builder
+
+        digest_by_ref = {
+            "ghcr.io/my-org/kaizenv3-backend:1.8.13-dev": "sha256:" + "a" * 64,
+            "ghcr.io/my-org/images/agent:1.8.13-dev": "sha256:" + "b" * 64,
+        }
+        mock_pusher_cls.resolve_digest.side_effect = lambda ref: digest_by_ref[ref]
+
+        mock_publisher = MagicMock()
+        mock_publisher_cls.return_value = mock_publisher
+
+        from kamiwaza_extensions.commands.publish import run_publish
+        from kamiwaza_extensions.exit_codes import ExitCode
+
+        with pytest.raises(CLI_EXIT_TYPES) as exc_info:
+            run_publish(stage="dev")
+
+        exit_code = getattr(exc_info.value, "exit_code", None) or getattr(
+            exc_info.value, "code", None
+        )
+        assert exit_code == int(ExitCode.VALIDATION)
+        mock_publisher.publish.assert_not_called()


### PR DESCRIPTION
## Summary

Publish-time coverage gate for catalog entries: `kz-ext publish` now fails with `VALIDATION` when the final entry's `compose_yml` carries a registry-owned, tag-carrying image ref in an **environment value** (a dynamic-spawn image like Kaizen's `${AGENT_SERVER_IMAGE:-…}` default) that `docker_images` ∪ `extra_docker_images` does not cover.

Those two lists are exactly what the offline bundler relocates into the air-gapped local registry mirror — an uncovered env ref ships an entry whose sandbox image is unpullable on every offline install.

## Root cause this guards against (ENG-8270)

The prod catalog's kaizen entry was internally inconsistent: service `image:` fields and the image lists were retagged to `release-1.0.0`, but the `AGENT_SERVER_IMAGE` env default kept the extension-version tag `2.0.2` (published by an older flow where `_apply_env_image_rewrites` was silently skipped because digest resolution degraded to an empty `digest_map`). The offline release/1.0.0 bundle consumed that entry; sandbox pods then requested `host.docker.internal:5001/images/kaizen-agent:2.0.2`, which was never relocated → ImagePullBackOff → Kaizen conversation creates hung into Cloudflare 524s.

Current publishes restamp the env default correctly (stage/dev catalogs are consistent) — this gate makes the broken shape **unpublishable** regardless of which flow produces it.

## Scope rules

Checked: single-token env values (dict, `NAME=value` list, and `{name,value}` list shapes), including `${VAR:-default}` defaults, under the publish registry, with an explicit tag; digests are stripped before comparison (relocation re-digests).
Skipped: values still carrying a compose variable (runtime-resolved), bare repo prefixes (allowlist entries like `SANDBOX_ALLOWED_IMAGE_PREFIXES`, not pullable refs), and external-registry refs (independent cadence — mirrors the extras surface's literal-tag-passthrough rule).

## Testing

- New `tests/unit/extensions/test_entry_image_consistency.py`: regression test replicating the exact prod-catalog kaizen shape (flagged), the consistent stage-catalog shape (passes), plus variable/prefix/external/list-shape edge cases.
- New pipeline test in `test_publish_cmd.py`: a publish whose env default pins a tag the publish doesn't produce exits `VALIDATION` and never reaches the publisher (was: published successfully — the ENG-8270 failure mode).
- Full `tests/unit/extensions/` suite: 1658 passed. Ruff clean; mypy delta vs develop: none.

Linear: ENG-8270

🤖 Generated with [Claude Code](https://claude.com/claude-code)