### PR TITLE
ENG-8190 gate Context embedding tests on functional probe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ markers = [
     "e2e: full workflow tests",
     "slow: intentionally slow tests",
     "withoutresponses: tests needing real network access",
-    "requires_embedding_model: live tests that require an active platform embedding deployment",
+    "requires_embedding_model: live tests that require a platform embedding deployment that can generate embeddings",
     "requires_two_clusters: live tests that require a federation peer cluster reachable via KAMIWAZA_PEER_BASE_URL / KAMIWAZA_PEER_API_KEY (ENG-5784)",
     "requires_deployable_model: live tests that require the host to deploy the integration test model; skips on hosts without compatible inference capacity (e.g. x86 CPU smoke vs an MLX model)",
     "extension_regression: D210 12-issue regression checklist (UAC-17 / EDX-OPS-2). See tests/unit/extensions/regression/inventory.yaml.",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -57,7 +57,7 @@ KAMIWAZA_PEER_API_KEY=... \
 | Marker | What it covers | Skip behavior |
 |---|---|---|
 | `live` | Tests that talk to a running Kamiwaza deployment | always selected when running `-m live` |
-| `requires_embedding_model` | Live tests that need an active platform embedding deployment | auto-provisioned by `embedding_model_prerequisite` fixture; skipped if provisioning fails |
+| `requires_embedding_model` | Live tests that need a platform embedding deployment that can generate embeddings | auto-provisioned by `embedding_model_prerequisite`, then probed by `embedding_test_target`; skipped if provisioning or the functional probe fails |
 | `requires_two_clusters` | Live tests that need a federation peer cluster (ENG-5784) | auto-deselected at collection when `KAMIWAZA_PEER_BASE_URL` is unset; skipped at run time with an explicit reason when peer URL is set but `KAMIWAZA_PEER_API_KEY` is missing (partial-creds case) |
 
 ## Adding a federation-aware integration test

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1441,8 +1441,9 @@ def deployable_model_prerequisite(
 
 @pytest.fixture(autouse=True)
 def _require_embedding_model_for_marked_tests(request: pytest.FixtureRequest) -> None:
+    """Require a functional embedding endpoint, not just a deployment row."""
     if "requires_embedding_model" in request.keywords:
-        request.getfixturevalue("embedding_model_prerequisite")
+        request.getfixturevalue("embedding_test_target")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_embedding_live.py
+++ b/tests/integration/test_embedding_live.py
@@ -19,7 +19,6 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.live,
     pytest.mark.withoutresponses,
-    pytest.mark.requires_embedding_model,
 ]
 
 
@@ -60,6 +59,8 @@ class TestEmbeddingProviders:
 
 class TestEmbeddingChunking:
     """Tests for text chunking operations."""
+
+    pytestmark = pytest.mark.requires_embedding_model
 
     def test_chunk_text_simple(
         self, live_kamiwaza_client, embedding_test_target: dict[str, str]
@@ -109,6 +110,8 @@ class TestEmbeddingChunking:
 class TestEmbeddingGeneration:
     """Tests for embedding generation operations."""
 
+    pytestmark = pytest.mark.requires_embedding_model
+
     def test_create_embedding_post(
         self, live_kamiwaza_client, embedding_test_target: dict[str, str]
     ) -> None:
@@ -149,6 +152,8 @@ class TestEmbeddingGeneration:
 class TestEmbeddingBatch:
     """Tests for batch embedding operations."""
 
+    pytestmark = pytest.mark.requires_embedding_model
+
     def test_embed_chunks_batch(
         self, live_kamiwaza_client, embedding_test_target: dict[str, str]
     ) -> None:
@@ -178,6 +183,8 @@ class TestEmbeddingBatch:
 
 class TestEmbeddingIntegrated:
     """End-to-end embedding workflow tests."""
+
+    pytestmark = pytest.mark.requires_embedding_model
 
     def test_chunk_and_embed_workflow(
         self, live_kamiwaza_client, embedding_test_target: dict[str, str]

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -109,3 +109,42 @@ def test_ensure_repo_ready_post_download_poll_loads_model_files(
     assert client.models.list_calls == [True, True]
     assert client.models.download_calls == 1
     assert client.models.wait_calls == 1
+
+
+def test_requires_embedding_model_marker_requires_functional_embedding_probe(
+    integration_conftest,
+) -> None:
+    class Request:
+        def __init__(self, keywords: dict[str, object]) -> None:
+            self.keywords = keywords
+            self.requested: list[str] = []
+
+        def getfixturevalue(self, name: str) -> object:
+            self.requested.append(name)
+            return object()
+
+    request = Request({"requires_embedding_model": object()})
+
+    integration_conftest._require_embedding_model_for_marked_tests.__wrapped__(request)
+
+    assert request.requested == ["embedding_test_target"]
+
+
+def test_requires_embedding_model_marker_leaves_unmarked_tests_alone(
+    integration_conftest,
+) -> None:
+    class Request:
+        keywords: dict[str, object] = {}
+
+        def __init__(self) -> None:
+            self.requested: list[str] = []
+
+        def getfixturevalue(self, name: str) -> object:
+            self.requested.append(name)
+            return object()
+
+    request = Request()
+
+    integration_conftest._require_embedding_model_for_marked_tests.__wrapped__(request)
+
+    assert request.requested == []


### PR DESCRIPTION
## Summary

- Gate `@pytest.mark.requires_embedding_model` live tests on the existing functional embedding probe (`embedding_test_target`) instead of only checking for an active deployment row.
- Keep `/embedding/health` and `/embedding/providers` coverage outside the functional-generate gate; only generation-dependent embedding tests carry the marker.
- Update the marker docs so the contract is explicit: marked tests require an embedding deployment that can actually generate embeddings.
- Add unit regressions for both marker branches so Context search/retrieve do not run on hosts where the direct embedding endpoint already proves runtime embedding is unavailable, while unmarked tests are not forced through the probe.

## Root cause

The latest Kajiya develop mesh smoke is down to two SDK failures: `test_context_search_contract` and `test_context_retrieve_contract`. The same run shows direct embedding tests skipping because an embedding deployment exists but every preferred embedding target fails to generate embeddings. Context search/retrieve need a query embedding, but their marker gate only required an active deployment row, so they ran and failed later as opaque Context 500s.

This PR aligns Context embedding-dependent tests with the direct embedding live suite: if the embedding runtime cannot produce embeddings, skip the dependent tests with the existing diagnostic instead of treating the test harness as a product regression. It does not replace live validation on a working embedding runtime; after this lands, Kajiya should rerun on a host with a functional embedding endpoint to prove the tests pass rather than skip.

## Linear

https://linear.app/kamiwaza/issue/ENG-8190/release10-fix-kajiya-context-live-workroom-scope-denials-and-embedding

## Validation

- `python -m pytest tests/unit/test_integration_conftest_model_ready.py::test_requires_embedding_model_marker_requires_functional_embedding_probe -q` -> 1 passed
- `python -m pytest tests/unit/test_integration_conftest_model_ready.py -q` -> 4 passed
- `python -m pytest tests/unit/test_integration_conftest_model_ready.py tests/unit/test_capability_markers.py -q` -> 28 passed
- `python -m pytest --collect-only tests/integration/test_embedding_live.py tests/integration/test_context_live.py -q` -> 40 tests collected
- `python -m pytest --collect-only tests/integration/test_embedding_live.py -q -m requires_embedding_model` -> 6/8 selected; health/providers deselected from the functional-generate gate
- `python -m ruff check pyproject.toml tests/integration/conftest.py tests/integration/test_embedding_live.py tests/unit/test_integration_conftest_model_ready.py` -> All checks passed
- `git diff --check` -> passed

Note: `tests/unit/test_context_live_helpers.py` has a local collection/import issue in this shell because another workspace's `tests` package shadows this repo's namespace package; not caused by this diff.
