### PR TITLE
ENG-8190 clean up failed harness embedding deployments

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -57,7 +57,7 @@ KAMIWAZA_PEER_API_KEY=... \
 | Marker | What it covers | Skip behavior |
 |---|---|---|
 | `live` | Tests that talk to a running Kamiwaza deployment | always selected when running `-m live` |
-| `requires_embedding_model` | Live tests that need a platform embedding deployment that can generate embeddings | auto-provisioned by `embedding_model_prerequisite`, then probed by `embedding_test_target`; skipped if provisioning or the functional probe fails |
+| `requires_embedding_model` | Live tests that need a platform embedding deployment that can generate embeddings | auto-provisioned by `embedding_model_prerequisite`, then probed by `embedding_test_target`; skipped if provisioning or the functional probe fails, and harness-provisioned failed deployments are stopped before skip |
 | `requires_two_clusters` | Live tests that need a federation peer cluster (ENG-5784) | auto-deselected at collection when `KAMIWAZA_PEER_BASE_URL` is unset; skipped at run time with an explicit reason when peer URL is set but `KAMIWAZA_PEER_API_KEY` is missing (partial-creds case) |
 
 ## Adding a federation-aware integration test

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -171,6 +171,16 @@ _EMBEDDING_NAME_PATTERNS = re.compile(
     r"(?i)(bge|e5[-_]|nomic[-_]?embed|gte[-_]|all[-_]minilm|"
     r"instructor|jina[-_]?embed|text[-_]?embedding|embed)"
 )
+_HARNESS_PROVISIONED_KEY = "_harness_provisioned"
+_HARNESS_EMBEDDING_STOPPED_NOTE = (
+    "harness-provisioned embedding deployment was stopped"
+)
+_HARNESS_EMBEDDING_STOP_ATTEMPTED_NOTE = (
+    "harness-provisioned embedding deployment stop was attempted"
+)
+_HARNESS_EMBEDDING_NO_DEPLOYMENT_ID_NOTE = (
+    "harness-provisioned embedding deployment had no deployment id to stop"
+)
 
 
 def _http_trace_enabled() -> bool:
@@ -555,14 +565,15 @@ def _platform_deployment_ready(deployment: object) -> bool:
 
 def _stop_deployment_quietly(
     client: KamiwazaClient, deployment_id: str | None
-) -> None:
+) -> bool:
     """Best-effort stop of a deployment (used for capability probes / cleanup)."""
     if not deployment_id:
-        return
+        return False
     try:
         client.serving.stop_deployment(deployment_id=deployment_id, force=True)
     except Exception:  # noqa: BLE001 — teardown is best-effort
-        pass
+        return False
+    return True
 
 
 def _active_model_deployments(
@@ -642,6 +653,14 @@ def _active_embedding_deployment(client: KamiwazaClient) -> dict[str, str] | Non
         desired_type="embedding",
         preferred_repo_id=EMBEDDING_TEST_MODEL_REPO,
     )
+
+
+def _mark_embedding_deployment(
+    deployment: dict[str, str], *, harness_provisioned: bool
+) -> dict[str, str]:
+    marked = dict(deployment)
+    marked[_HARNESS_PROVISIONED_KEY] = "true" if harness_provisioned else "false"
+    return marked
 
 
 def _unique_nonempty_values(*values: str) -> list[str]:
@@ -1179,7 +1198,7 @@ def embedding_model_prerequisite(
 
     deployment = _active_embedding_deployment(client)
     if deployment is not None:
-        return deployment
+        return _mark_embedding_deployment(deployment, harness_provisioned=False)
 
     request_message = _maybe_request_embedding_download_and_deploy(
         client,
@@ -1195,7 +1214,11 @@ def embedding_model_prerequisite(
         nudge_after_seconds=EMBEDDING_TEST_DEPLOY_NUDGE_SECONDS,
     )
     if deployment is not None:
-        return deployment
+        return _mark_embedding_deployment(
+            deployment,
+            harness_provisioned=deployment.get("repo_model_id")
+            == EMBEDDING_TEST_MODEL_REPO,
+        )
 
     details = [f"repo={EMBEDDING_TEST_MODEL_REPO}"]
     if request_message:
@@ -1237,9 +1260,23 @@ def embedding_test_target(
                 }
             failures.append(f"{model}/{provider_type}: {probe_error}")
 
+    cleanup_notes: list[str] = []
+    if embedding_model_prerequisite.get(_HARNESS_PROVISIONED_KEY) == "true":
+        deployment_id = embedding_model_prerequisite.get("deployment_id")
+        stopped = _stop_deployment_quietly(
+            client,
+            deployment_id,
+        )
+        if stopped:
+            cleanup_notes.append(_HARNESS_EMBEDDING_STOPPED_NOTE)
+        elif deployment_id:
+            cleanup_notes.append(_HARNESS_EMBEDDING_STOP_ATTEMPTED_NOTE)
+        else:
+            cleanup_notes.append(_HARNESS_EMBEDDING_NO_DEPLOYMENT_ID_NOTE)
+
     pytest.skip(
         "Embedding deployment is present, but the embedding endpoint could not use "
-        f"any preferred test target ({'; '.join(failures)})."
+        f"any preferred test target ({'; '.join(failures + cleanup_notes)})."
     )
 
 

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -25,6 +25,34 @@ def integration_conftest():
     return module
 
 
+class _EmbeddingProbeClient:
+    class Embedding:
+        def get_providers(self) -> list[str]:
+            return ["sentence_transformers"]
+
+    class Serving:
+        def __init__(self, *, fail_stop: bool = False) -> None:
+            self.stopped: list[tuple[str, bool]] = []
+            self._fail_stop = fail_stop
+
+        def stop_deployment(self, *, deployment_id: str, force: bool) -> None:
+            if self._fail_stop:
+                raise RuntimeError("stop failed")
+            self.stopped.append((deployment_id, force))
+
+    def __init__(self, integration_conftest, *, fail_stop: bool = False) -> None:
+        self.embedding = self.Embedding()
+        self.serving = self.Serving(fail_stop=fail_stop)
+        self._integration_conftest = integration_conftest
+
+    def post(self, *_args: object, **_kwargs: object) -> object:
+        raise self._integration_conftest.APIError(
+            "runtime unavailable",
+            status_code=500,
+            response_data={"detail": "runtime unavailable"},
+        )
+
+
 def test_ensure_repo_ready_fast_path_loads_model_files(integration_conftest) -> None:
     ready_file = SimpleNamespace(
         name="model.safetensors",
@@ -148,3 +176,180 @@ def test_requires_embedding_model_marker_leaves_unmarked_tests_alone(
     integration_conftest._require_embedding_model_for_marked_tests.__wrapped__(request)
 
     assert request.requested == []
+
+
+def test_embedding_model_prerequisite_marks_harness_provisioned_deployment(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployment = {
+        "deployment_id": "dep-123",
+        "model_id": "model-123",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+    }
+    active_calls = 0
+
+    def active_embedding_deployment(_client: object) -> dict[str, str] | None:
+        nonlocal active_calls
+        active_calls += 1
+        return None
+
+    monkeypatch.setattr(
+        integration_conftest,
+        "_active_embedding_deployment",
+        active_embedding_deployment,
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_maybe_request_embedding_download_and_deploy",
+        lambda *_args, **_kwargs: "queued",
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_wait_for_active_embedding_deployment",
+        lambda *_args, **_kwargs: (deployment, None),
+    )
+
+    result = integration_conftest.embedding_model_prerequisite.__wrapped__(object())
+
+    assert active_calls == 1
+    assert result["deployment_id"] == "dep-123"
+    assert result[integration_conftest._HARNESS_PROVISIONED_KEY] == "true"
+    assert integration_conftest._HARNESS_PROVISIONED_KEY not in deployment
+
+
+def test_embedding_model_prerequisite_marks_initial_active_deployment_preexisting(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployment = {
+        "deployment_id": "dep-existing",
+        "model_id": "model-existing",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+    }
+
+    monkeypatch.setattr(
+        integration_conftest,
+        "_active_embedding_deployment",
+        lambda _client: deployment,
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_maybe_request_embedding_download_and_deploy",
+        lambda *_args, **_kwargs: pytest.fail("pre-existing deployment should fast-path"),
+    )
+
+    result = integration_conftest.embedding_model_prerequisite.__wrapped__(object())
+
+    assert result["deployment_id"] == "dep-existing"
+    assert result[integration_conftest._HARNESS_PROVISIONED_KEY] == "false"
+    assert integration_conftest._HARNESS_PROVISIONED_KEY not in deployment
+
+
+def test_embedding_model_prerequisite_marks_raced_foreign_deployment_preexisting(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployment = {
+        "deployment_id": "dep-foreign",
+        "model_id": "model-foreign",
+        "model_name": "nomic-embed-text",
+        "repo_model_id": "nomic-ai/nomic-embed-text-v1.5",
+    }
+
+    monkeypatch.setattr(
+        integration_conftest,
+        "_active_embedding_deployment",
+        lambda _client: None,
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_maybe_request_embedding_download_and_deploy",
+        lambda *_args, **_kwargs: "queued",
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_wait_for_active_embedding_deployment",
+        lambda *_args, **_kwargs: (deployment, None),
+    )
+
+    result = integration_conftest.embedding_model_prerequisite.__wrapped__(object())
+
+    assert result["deployment_id"] == "dep-foreign"
+    assert result[integration_conftest._HARNESS_PROVISIONED_KEY] == "false"
+
+
+def test_embedding_test_target_stops_harness_provisioned_failed_deployment(
+    integration_conftest,
+) -> None:
+    client = _EmbeddingProbeClient(integration_conftest)
+    deployment = {
+        "deployment_id": "dep-456",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        integration_conftest._HARNESS_PROVISIONED_KEY: "true",
+    }
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        integration_conftest.embedding_test_target.__wrapped__(client, deployment)
+
+    assert client.serving.stopped == [("dep-456", True)]
+    assert integration_conftest._HARNESS_EMBEDDING_STOPPED_NOTE in str(exc_info.value)
+
+
+def test_embedding_test_target_does_not_stop_preexisting_failed_deployment(
+    integration_conftest,
+) -> None:
+    client = _EmbeddingProbeClient(integration_conftest)
+    deployment = {
+        "deployment_id": "dep-existing",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        integration_conftest._HARNESS_PROVISIONED_KEY: "false",
+    }
+
+    with pytest.raises(pytest.skip.Exception):
+        integration_conftest.embedding_test_target.__wrapped__(client, deployment)
+
+    assert client.serving.stopped == []
+
+
+def test_embedding_test_target_reports_attempted_stop_when_cleanup_fails(
+    integration_conftest,
+) -> None:
+    client = _EmbeddingProbeClient(integration_conftest, fail_stop=True)
+    deployment = {
+        "deployment_id": "dep-789",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        integration_conftest._HARNESS_PROVISIONED_KEY: "true",
+    }
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        integration_conftest.embedding_test_target.__wrapped__(client, deployment)
+
+    assert client.serving.stopped == []
+    assert integration_conftest._HARNESS_EMBEDDING_STOP_ATTEMPTED_NOTE in str(
+        exc_info.value
+    )
+
+
+def test_embedding_test_target_reports_missing_deployment_id_for_cleanup(
+    integration_conftest,
+) -> None:
+    client = _EmbeddingProbeClient(integration_conftest)
+    deployment = {
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        integration_conftest._HARNESS_PROVISIONED_KEY: "true",
+    }
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        integration_conftest.embedding_test_target.__wrapped__(client, deployment)
+
+    assert client.serving.stopped == []
+    assert integration_conftest._HARNESS_EMBEDDING_NO_DEPLOYMENT_ID_NOTE in str(
+        exc_info.value
+    )


### PR DESCRIPTION
## Summary

- Mark embedding deployments as either pre-existing or SDK-harness provisioned inside the live test fixtures.
- When the harness-provisioned embedding deployment reaches `DEPLOYED` but fails the functional `/embedding/generate` probe, stop that deployment before the dependent embedding/Context tests skip.
- Leave pre-existing/operator-owned embedding deployments alone; deployments that race in during the wait are only marked harness-owned when their `repo_model_id` exactly matches the embedding model the harness requested.
- Document the cleanup contract and add unit coverage for provisioned, pre-existing-at-start, raced-foreign, successful cleanup, failed-cleanup diagnostic, and missing-deployment-id diagnostic paths.

## Why

Follow-up to SDK #215 / ENG-8190. Gating Context search/retrieve on a functional embedding probe is correct, but John called out the missing harness contract: if the SDK test harness itself deploys the embedding model, it should prove that deployment is functional or tear it down before dependent tests run. This PR adds that cleanup path without broadening the SDK harness into managing operator-owned deployments.

The latest head also addresses the marketplace review blocker and follow-up polish: post-wait deployments are not blindly treated as harness-owned, cleanup notes are kept separate from probe failures, and teardown diagnostics distinguish confirmed stop, attempted stop, and missing deployment id.

## Linear

https://linear.app/kamiwaza/issue/ENG-8190/release10-fix-kajiya-context-live-workroom-scope-denials-and-embedding

## Validation

- `python -m pytest tests/unit/test_integration_conftest_model_ready.py -q` -> 11 passed
- `python -m pytest tests/unit/test_integration_conftest_model_ready.py tests/unit/test_capability_markers.py -q` -> 35 passed
- `python -m pytest --collect-only tests/integration/test_embedding_live.py tests/integration/test_context_live.py -q` -> 40 tests collected
- `python -m ruff check pyproject.toml tests/integration/conftest.py tests/unit/test_integration_conftest_model_ready.py` -> All checks passed
- `git diff --check` -> passed
