### PR TITLE
ENG-8190 backport SDK embedding harness fixes to release/1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ markers = [
     "e2e: full workflow tests",
     "slow: intentionally slow tests",
     "withoutresponses: tests needing real network access",
-    "requires_embedding_model: live tests that require an active platform embedding deployment",
+    "requires_embedding_model: live tests that require a platform embedding deployment that can generate embeddings",
     "requires_two_clusters: live tests that require a federation peer cluster reachable via KAMIWAZA_PEER_BASE_URL / KAMIWAZA_PEER_API_KEY (ENG-5784)",
     "requires_deployable_model: live tests that require the host to deploy the integration test model; skips on hosts without compatible inference capacity (e.g. x86 CPU smoke vs an MLX model)",
     "extension_regression: D210 12-issue regression checklist (UAC-17 / EDX-OPS-2). See tests/unit/extensions/regression/inventory.yaml.",

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -57,7 +57,7 @@ KAMIWAZA_PEER_API_KEY=... \
 | Marker | What it covers | Skip behavior |
 |---|---|---|
 | `live` | Tests that talk to a running Kamiwaza deployment | always selected when running `-m live` |
-| `requires_embedding_model` | Live tests that need an active platform embedding deployment | auto-provisioned by `embedding_model_prerequisite` fixture; skipped if provisioning fails |
+| `requires_embedding_model` | Live tests that need a platform embedding deployment that can generate embeddings | auto-provisioned by `embedding_model_prerequisite`, then probed by `embedding_test_target`; skipped if provisioning or the functional probe fails |
 | `requires_two_clusters` | Live tests that need a federation peer cluster (ENG-5784) | auto-deselected at collection when `KAMIWAZA_PEER_BASE_URL` is unset; skipped at run time with an explicit reason when peer URL is set but `KAMIWAZA_PEER_API_KEY` is missing (partial-creds case) |
 
 ## Adding a federation-aware integration test

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -57,7 +57,7 @@ KAMIWAZA_PEER_API_KEY=... \
 | Marker | What it covers | Skip behavior |
 |---|---|---|
 | `live` | Tests that talk to a running Kamiwaza deployment | always selected when running `-m live` |
-| `requires_embedding_model` | Live tests that need a platform embedding deployment that can generate embeddings | auto-provisioned by `embedding_model_prerequisite`, then probed by `embedding_test_target`; skipped if provisioning or the functional probe fails |
+| `requires_embedding_model` | Live tests that need a platform embedding deployment that can generate embeddings | auto-provisioned by `embedding_model_prerequisite`, then probed by `embedding_test_target`; skipped if provisioning or the functional probe fails, and harness-provisioned failed deployments are stopped before skip |
 | `requires_two_clusters` | Live tests that need a federation peer cluster (ENG-5784) | auto-deselected at collection when `KAMIWAZA_PEER_BASE_URL` is unset; skipped at run time with an explicit reason when peer URL is set but `KAMIWAZA_PEER_API_KEY` is missing (partial-creds case) |
 
 ## Adding a federation-aware integration test

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1441,8 +1441,9 @@ def deployable_model_prerequisite(
 
 @pytest.fixture(autouse=True)
 def _require_embedding_model_for_marked_tests(request: pytest.FixtureRequest) -> None:
+    """Require a functional embedding endpoint, not just a deployment row."""
     if "requires_embedding_model" in request.keywords:
-        request.getfixturevalue("embedding_model_prerequisite")
+        request.getfixturevalue("embedding_test_target")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -171,6 +171,16 @@ _EMBEDDING_NAME_PATTERNS = re.compile(
     r"(?i)(bge|e5[-_]|nomic[-_]?embed|gte[-_]|all[-_]minilm|"
     r"instructor|jina[-_]?embed|text[-_]?embedding|embed)"
 )
+_HARNESS_PROVISIONED_KEY = "_harness_provisioned"
+_HARNESS_EMBEDDING_STOPPED_NOTE = (
+    "harness-provisioned embedding deployment was stopped"
+)
+_HARNESS_EMBEDDING_STOP_ATTEMPTED_NOTE = (
+    "harness-provisioned embedding deployment stop was attempted"
+)
+_HARNESS_EMBEDDING_NO_DEPLOYMENT_ID_NOTE = (
+    "harness-provisioned embedding deployment had no deployment id to stop"
+)
 
 
 def _http_trace_enabled() -> bool:
@@ -555,14 +565,15 @@ def _platform_deployment_ready(deployment: object) -> bool:
 
 def _stop_deployment_quietly(
     client: KamiwazaClient, deployment_id: str | None
-) -> None:
+) -> bool:
     """Best-effort stop of a deployment (used for capability probes / cleanup)."""
     if not deployment_id:
-        return
+        return False
     try:
         client.serving.stop_deployment(deployment_id=deployment_id, force=True)
     except Exception:  # noqa: BLE001 — teardown is best-effort
-        pass
+        return False
+    return True
 
 
 def _active_model_deployments(
@@ -642,6 +653,14 @@ def _active_embedding_deployment(client: KamiwazaClient) -> dict[str, str] | Non
         desired_type="embedding",
         preferred_repo_id=EMBEDDING_TEST_MODEL_REPO,
     )
+
+
+def _mark_embedding_deployment(
+    deployment: dict[str, str], *, harness_provisioned: bool
+) -> dict[str, str]:
+    marked = dict(deployment)
+    marked[_HARNESS_PROVISIONED_KEY] = "true" if harness_provisioned else "false"
+    return marked
 
 
 def _unique_nonempty_values(*values: str) -> list[str]:
@@ -1179,7 +1198,7 @@ def embedding_model_prerequisite(
 
     deployment = _active_embedding_deployment(client)
     if deployment is not None:
-        return deployment
+        return _mark_embedding_deployment(deployment, harness_provisioned=False)
 
     request_message = _maybe_request_embedding_download_and_deploy(
         client,
@@ -1195,7 +1214,11 @@ def embedding_model_prerequisite(
         nudge_after_seconds=EMBEDDING_TEST_DEPLOY_NUDGE_SECONDS,
     )
     if deployment is not None:
-        return deployment
+        return _mark_embedding_deployment(
+            deployment,
+            harness_provisioned=deployment.get("repo_model_id")
+            == EMBEDDING_TEST_MODEL_REPO,
+        )
 
     details = [f"repo={EMBEDDING_TEST_MODEL_REPO}"]
     if request_message:
@@ -1237,9 +1260,23 @@ def embedding_test_target(
                 }
             failures.append(f"{model}/{provider_type}: {probe_error}")
 
+    cleanup_notes: list[str] = []
+    if embedding_model_prerequisite.get(_HARNESS_PROVISIONED_KEY) == "true":
+        deployment_id = embedding_model_prerequisite.get("deployment_id")
+        stopped = _stop_deployment_quietly(
+            client,
+            deployment_id,
+        )
+        if stopped:
+            cleanup_notes.append(_HARNESS_EMBEDDING_STOPPED_NOTE)
+        elif deployment_id:
+            cleanup_notes.append(_HARNESS_EMBEDDING_STOP_ATTEMPTED_NOTE)
+        else:
+            cleanup_notes.append(_HARNESS_EMBEDDING_NO_DEPLOYMENT_ID_NOTE)
+
     pytest.skip(
         "Embedding deployment is present, but the embedding endpoint could not use "
-        f"any preferred test target ({'; '.join(failures)})."
+        f"any preferred test target ({'; '.join(failures + cleanup_notes)})."
     )
 
 

--- a/tests/integration/test_embedding_live.py
+++ b/tests/integration/test_embedding_live.py
@@ -19,7 +19,6 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.live,
     pytest.mark.withoutresponses,
-    pytest.mark.requires_embedding_model,
 ]
 
 
@@ -60,6 +59,8 @@ class TestEmbeddingProviders:
 
 class TestEmbeddingChunking:
     """Tests for text chunking operations."""
+
+    pytestmark = pytest.mark.requires_embedding_model
 
     def test_chunk_text_simple(
         self, live_kamiwaza_client, embedding_test_target: dict[str, str]
@@ -109,6 +110,8 @@ class TestEmbeddingChunking:
 class TestEmbeddingGeneration:
     """Tests for embedding generation operations."""
 
+    pytestmark = pytest.mark.requires_embedding_model
+
     def test_create_embedding_post(
         self, live_kamiwaza_client, embedding_test_target: dict[str, str]
     ) -> None:
@@ -149,6 +152,8 @@ class TestEmbeddingGeneration:
 class TestEmbeddingBatch:
     """Tests for batch embedding operations."""
 
+    pytestmark = pytest.mark.requires_embedding_model
+
     def test_embed_chunks_batch(
         self, live_kamiwaza_client, embedding_test_target: dict[str, str]
     ) -> None:
@@ -178,6 +183,8 @@ class TestEmbeddingBatch:
 
 class TestEmbeddingIntegrated:
     """End-to-end embedding workflow tests."""
+
+    pytestmark = pytest.mark.requires_embedding_model
 
     def test_chunk_and_embed_workflow(
         self, live_kamiwaza_client, embedding_test_target: dict[str, str]

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -25,6 +25,34 @@ def integration_conftest():
     return module
 
 
+class _EmbeddingProbeClient:
+    class Embedding:
+        def get_providers(self) -> list[str]:
+            return ["sentence_transformers"]
+
+    class Serving:
+        def __init__(self, *, fail_stop: bool = False) -> None:
+            self.stopped: list[tuple[str, bool]] = []
+            self._fail_stop = fail_stop
+
+        def stop_deployment(self, *, deployment_id: str, force: bool) -> None:
+            if self._fail_stop:
+                raise RuntimeError("stop failed")
+            self.stopped.append((deployment_id, force))
+
+    def __init__(self, integration_conftest, *, fail_stop: bool = False) -> None:
+        self.embedding = self.Embedding()
+        self.serving = self.Serving(fail_stop=fail_stop)
+        self._integration_conftest = integration_conftest
+
+    def post(self, *_args: object, **_kwargs: object) -> object:
+        raise self._integration_conftest.APIError(
+            "runtime unavailable",
+            status_code=500,
+            response_data={"detail": "runtime unavailable"},
+        )
+
+
 def test_ensure_repo_ready_fast_path_loads_model_files(integration_conftest) -> None:
     ready_file = SimpleNamespace(
         name="model.safetensors",
@@ -148,3 +176,180 @@ def test_requires_embedding_model_marker_leaves_unmarked_tests_alone(
     integration_conftest._require_embedding_model_for_marked_tests.__wrapped__(request)
 
     assert request.requested == []
+
+
+def test_embedding_model_prerequisite_marks_harness_provisioned_deployment(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployment = {
+        "deployment_id": "dep-123",
+        "model_id": "model-123",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+    }
+    active_calls = 0
+
+    def active_embedding_deployment(_client: object) -> dict[str, str] | None:
+        nonlocal active_calls
+        active_calls += 1
+        return None
+
+    monkeypatch.setattr(
+        integration_conftest,
+        "_active_embedding_deployment",
+        active_embedding_deployment,
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_maybe_request_embedding_download_and_deploy",
+        lambda *_args, **_kwargs: "queued",
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_wait_for_active_embedding_deployment",
+        lambda *_args, **_kwargs: (deployment, None),
+    )
+
+    result = integration_conftest.embedding_model_prerequisite.__wrapped__(object())
+
+    assert active_calls == 1
+    assert result["deployment_id"] == "dep-123"
+    assert result[integration_conftest._HARNESS_PROVISIONED_KEY] == "true"
+    assert integration_conftest._HARNESS_PROVISIONED_KEY not in deployment
+
+
+def test_embedding_model_prerequisite_marks_initial_active_deployment_preexisting(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployment = {
+        "deployment_id": "dep-existing",
+        "model_id": "model-existing",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+    }
+
+    monkeypatch.setattr(
+        integration_conftest,
+        "_active_embedding_deployment",
+        lambda _client: deployment,
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_maybe_request_embedding_download_and_deploy",
+        lambda *_args, **_kwargs: pytest.fail("pre-existing deployment should fast-path"),
+    )
+
+    result = integration_conftest.embedding_model_prerequisite.__wrapped__(object())
+
+    assert result["deployment_id"] == "dep-existing"
+    assert result[integration_conftest._HARNESS_PROVISIONED_KEY] == "false"
+    assert integration_conftest._HARNESS_PROVISIONED_KEY not in deployment
+
+
+def test_embedding_model_prerequisite_marks_raced_foreign_deployment_preexisting(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deployment = {
+        "deployment_id": "dep-foreign",
+        "model_id": "model-foreign",
+        "model_name": "nomic-embed-text",
+        "repo_model_id": "nomic-ai/nomic-embed-text-v1.5",
+    }
+
+    monkeypatch.setattr(
+        integration_conftest,
+        "_active_embedding_deployment",
+        lambda _client: None,
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_maybe_request_embedding_download_and_deploy",
+        lambda *_args, **_kwargs: "queued",
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_wait_for_active_embedding_deployment",
+        lambda *_args, **_kwargs: (deployment, None),
+    )
+
+    result = integration_conftest.embedding_model_prerequisite.__wrapped__(object())
+
+    assert result["deployment_id"] == "dep-foreign"
+    assert result[integration_conftest._HARNESS_PROVISIONED_KEY] == "false"
+
+
+def test_embedding_test_target_stops_harness_provisioned_failed_deployment(
+    integration_conftest,
+) -> None:
+    client = _EmbeddingProbeClient(integration_conftest)
+    deployment = {
+        "deployment_id": "dep-456",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        integration_conftest._HARNESS_PROVISIONED_KEY: "true",
+    }
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        integration_conftest.embedding_test_target.__wrapped__(client, deployment)
+
+    assert client.serving.stopped == [("dep-456", True)]
+    assert integration_conftest._HARNESS_EMBEDDING_STOPPED_NOTE in str(exc_info.value)
+
+
+def test_embedding_test_target_does_not_stop_preexisting_failed_deployment(
+    integration_conftest,
+) -> None:
+    client = _EmbeddingProbeClient(integration_conftest)
+    deployment = {
+        "deployment_id": "dep-existing",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        integration_conftest._HARNESS_PROVISIONED_KEY: "false",
+    }
+
+    with pytest.raises(pytest.skip.Exception):
+        integration_conftest.embedding_test_target.__wrapped__(client, deployment)
+
+    assert client.serving.stopped == []
+
+
+def test_embedding_test_target_reports_attempted_stop_when_cleanup_fails(
+    integration_conftest,
+) -> None:
+    client = _EmbeddingProbeClient(integration_conftest, fail_stop=True)
+    deployment = {
+        "deployment_id": "dep-789",
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        integration_conftest._HARNESS_PROVISIONED_KEY: "true",
+    }
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        integration_conftest.embedding_test_target.__wrapped__(client, deployment)
+
+    assert client.serving.stopped == []
+    assert integration_conftest._HARNESS_EMBEDDING_STOP_ATTEMPTED_NOTE in str(
+        exc_info.value
+    )
+
+
+def test_embedding_test_target_reports_missing_deployment_id_for_cleanup(
+    integration_conftest,
+) -> None:
+    client = _EmbeddingProbeClient(integration_conftest)
+    deployment = {
+        "model_name": "all-MiniLM-L6-v2",
+        "repo_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        integration_conftest._HARNESS_PROVISIONED_KEY: "true",
+    }
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        integration_conftest.embedding_test_target.__wrapped__(client, deployment)
+
+    assert client.serving.stopped == []
+    assert integration_conftest._HARNESS_EMBEDDING_NO_DEPLOYMENT_ID_NOTE in str(
+        exc_info.value
+    )

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -109,3 +109,42 @@ def test_ensure_repo_ready_post_download_poll_loads_model_files(
     assert client.models.list_calls == [True, True]
     assert client.models.download_calls == 1
     assert client.models.wait_calls == 1
+
+
+def test_requires_embedding_model_marker_requires_functional_embedding_probe(
+    integration_conftest,
+) -> None:
+    class Request:
+        def __init__(self, keywords: dict[str, object]) -> None:
+            self.keywords = keywords
+            self.requested: list[str] = []
+
+        def getfixturevalue(self, name: str) -> object:
+            self.requested.append(name)
+            return object()
+
+    request = Request({"requires_embedding_model": object()})
+
+    integration_conftest._require_embedding_model_for_marked_tests.__wrapped__(request)
+
+    assert request.requested == ["embedding_test_target"]
+
+
+def test_requires_embedding_model_marker_leaves_unmarked_tests_alone(
+    integration_conftest,
+) -> None:
+    class Request:
+        keywords: dict[str, object] = {}
+
+        def __init__(self) -> None:
+            self.requested: list[str] = []
+
+        def getfixturevalue(self, name: str) -> object:
+            self.requested.append(name)
+            return object()
+
+    request = Request()
+
+    integration_conftest._require_embedding_model_for_marked_tests.__wrapped__(request)
+
+    assert request.requested == []


### PR DESCRIPTION
## Summary
- Backport SDK #215 to `release/1.0.0`: Context embedding-dependent live tests now require the existing functional embedding probe, not just an active deployment row.
- Backport SDK #216 to `release/1.0.0`: harness-provisioned embedding deployments that reach `DEPLOYED` but fail the functional probe are stopped before dependent tests skip.
- Keep direct embedding health/provider coverage outside the generate gate, matching the develop contract.

## Why
ENG-8190 Kajiya SDK E2E failures were down to Context search/retrieve running after the embedding runtime was present but not actually functional. The develop fixes are test-harness only, and release-based UAT/Kajiya validation needs the same behavior to distinguish SDK harness correctness from runtime/provisioning failures.

## Validation
- `uv run --frozen python -m pytest tests/unit/test_capability_markers.py -q` -> 24 passed before backport baseline
- `uv run --frozen python -m pytest --collect-only tests/integration/test_embedding_live.py tests/integration/test_context_live.py -q` -> 40 collected before backport baseline
- `uv run --frozen python -m pytest tests/unit/test_integration_conftest_model_ready.py tests/unit/test_capability_markers.py -q` -> 35 passed
- `uv run --frozen python -m pytest --collect-only tests/integration/test_embedding_live.py tests/integration/test_context_live.py -q` -> 40 collected
- `uv run --frozen python -m ruff check pyproject.toml tests/integration/conftest.py tests/integration/test_context_live.py tests/unit/test_integration_conftest_model_ready.py tests/unit/test_capability_markers.py` -> all checks passed
- `git diff --check origin/release/1.0.0...HEAD` -> passed
- `uv run --frozen python -m pytest tests/unit -q` -> 2692 passed, 1 skipped

Linear: ENG-8190
