### PR TITLE
fix(seeding): bind workroom session before per-workroom writes (ENG-8413)

### DIFF
--- a/kamiwaza_sdk/seeding/client.py
+++ b/kamiwaza_sdk/seeding/client.py
@@ -61,9 +61,10 @@ def scoped_client_for_workroom(
     already set) on purpose: ``enter`` is a POST, so it passes through the strict
     workroom-write gate, and a request that carries the scope header before any
     binding exists is rejected with 403 "Authenticated workroom context missing"
-    (the bind is what would create that context). The unscoped enter has no
-    scope header, binds the session, and only then is the header-scoped client
-    returned for the actual writes.
+    (the bind is what would create that context). The returned header-scoped
+    client is derived from that same unscoped view, so any session state the
+    bind establishes (e.g. should the platform ever bind via ``Set-Cookie`` on
+    the enter response) is carried onto the client that performs the writes.
 
     PAT / API-key credentials cannot session-bind — the platform rejects their
     ``enter`` with 409 ``binding_invalid`` — and authorize via the explicit
@@ -71,12 +72,13 @@ def scoped_client_for_workroom(
     header-scoped client is returned unchanged. Any other error (e.g. a 404 for
     an unknown workroom) propagates.
     """
+    bound = client.workroom_scope(None)
     try:
-        client.workroom_scope(None).workrooms.enter(workroom_id)
+        bound.workrooms.enter(workroom_id)
     except APIError as exc:
         if not _is_binding_unsupported(exc):
             raise
-    return client.workroom_scope(workroom_id)
+    return bound.workroom_scope(workroom_id)
 
 
 def build_client_from_env(

--- a/kamiwaza_sdk/seeding/client.py
+++ b/kamiwaza_sdk/seeding/client.py
@@ -13,17 +13,69 @@ from typing import Optional, Union
 from uuid import UUID
 
 from ..client import KamiwazaClient
+from ..exceptions import APIError
+
+
+def _is_binding_unsupported(error: APIError) -> bool:
+    """True when ``enter`` was rejected because the credential can't session-bind.
+
+    PAT / API-key credentials authorize workrooms via the explicit
+    ``X-Workroom-Id`` header, not a selected-session binding, so the platform
+    rejects their ``enter`` with 409 ``binding_invalid``. Session (password
+    grant) tokens bind successfully instead. Mirrors the live-test probe in
+    ``tests/integration/test_seeding_live.py``.
+    """
+    if getattr(error, "status_code", None) != 409:
+        return False
+    payload = getattr(error, "response_data", None)
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if isinstance(detail, dict):
+        structured = detail.get("error")
+        if isinstance(structured, dict):
+            return structured.get("class") == "binding_invalid"
+    return detail == "workroom_binding_invalid"
 
 
 def scoped_client_for_workroom(
     client: KamiwazaClient, workroom_id: Union[str, UUID]
 ) -> KamiwazaClient:
-    """Return a client whose calls are scoped to ``workroom_id``.
+    """Return a client scoped to ``workroom_id``, binding its session when able.
 
-    This is SDK-local request scoping for automation: the returned client adds
-    the explicit workroom scope header to each request. It does not call
-    ``workrooms.enter`` or mutate server-side selected-session binding.
+    Automation performing per-workroom *writes* (install a workroom extension,
+    create an agent/conversation) needs both:
+
+    1. the explicit ``X-Workroom-Id`` scope header on every request
+       (``client.workroom_scope``), and
+    2. a server-side selected-workroom binding, established by
+       ``workrooms.enter``.
+
+    The platform no longer authorizes workroom writes from the scope header
+    alone (strict ForwardAuth / ``KAMIWAZA_ALLOW_LEGACY_WORKROOM_HEADER=false``);
+    a session token that only sets the header gets 403 "Authenticated workroom
+    context missing" on ``deploy_app`` / ``create-agent``. ``enter`` binds the
+    session server-side (it returns no token; the binding is keyed to the
+    caller's session) so those writes carry authenticated workroom context.
+
+    ``enter`` is issued on an explicitly **unscoped** view of the client
+    (``workroom_scope(None)`` strips any ``X-Workroom-Id`` the caller may have
+    already set) on purpose: ``enter`` is a POST, so it passes through the strict
+    workroom-write gate, and a request that carries the scope header before any
+    binding exists is rejected with 403 "Authenticated workroom context missing"
+    (the bind is what would create that context). The unscoped enter has no
+    scope header, binds the session, and only then is the header-scoped client
+    returned for the actual writes.
+
+    PAT / API-key credentials cannot session-bind — the platform rejects their
+    ``enter`` with 409 ``binding_invalid`` — and authorize via the explicit
+    header instead, so that specific rejection is tolerated and the
+    header-scoped client is returned unchanged. Any other error (e.g. a 404 for
+    an unknown workroom) propagates.
     """
+    try:
+        client.workroom_scope(None).workrooms.enter(workroom_id)
+    except APIError as exc:
+        if not _is_binding_unsupported(exc):
+            raise
     return client.workroom_scope(workroom_id)
 
 

--- a/tests/unit/test_seeding_client.py
+++ b/tests/unit/test_seeding_client.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from kamiwaza_sdk.client import KamiwazaClient
+from kamiwaza_sdk.exceptions import APIError, NotFoundError
 from kamiwaza_sdk.seeding.client import (
     build_client_from_env,
     scoped_client_for_workroom,
 )
 
 pytestmark = pytest.mark.unit
+
+_ENTER = "kamiwaza_sdk.services.workrooms.WorkroomService.enter"
+_WID = "725aba63-4b21-4346-8e83-7dfffe526740"
 
 
 def _platform_client() -> KamiwazaClient:
@@ -17,27 +23,79 @@ def _platform_client() -> KamiwazaClient:
     return client
 
 
-def test_scoped_client_uses_local_workroom_scope_without_enter():
+def test_scoped_client_scopes_header_and_binds_session():
     client = _platform_client()
-    client._workrooms = object()
 
-    scoped = scoped_client_for_workroom(client, "wr-1")
+    with patch(_ENTER) as mock_enter:
+        scoped = scoped_client_for_workroom(client, _WID)
 
     assert scoped is not client
     assert scoped.base_url == "https://example.test/api"
     assert scoped.authenticator is client.authenticator
-    assert scoped._default_headers == {"X-Workroom-Id": "wr-1"}
+    assert scoped._default_headers == {"X-Workroom-Id": _WID}
     # TLS setting carries over from the parent.
     assert scoped.session.verify is False
+    # The server-side selected-workroom binding is established so per-workroom
+    # writes carry authenticated workroom context.
+    mock_enter.assert_called_once_with(_WID)
 
 
-def test_scoped_client_for_global_still_returns_scoped_client():
+def test_enter_is_issued_without_the_workroom_scope_header():
+    # Even when the caller passes an already-scoped client, enter must be issued
+    # without the X-Workroom-Id header: a scoped POST hits the strict write-gate
+    # and is rejected before the binding it would create exists.
+    scoped_parent = _platform_client().workroom_scope(_WID)
+    assert scoped_parent._default_headers == {"X-Workroom-Id": _WID}
+
+    with patch(_ENTER, autospec=True) as mock_enter:
+        scoped_client_for_workroom(scoped_parent, _WID)
+
+    enter_client = mock_enter.call_args.args[0].client
+    assert "X-Workroom-Id" not in enter_client._default_headers
+
+
+@pytest.mark.parametrize(
+    "response_data",
+    [
+        {"detail": {"error": {"class": "binding_invalid"}}},
+        {"detail": "workroom_binding_invalid"},
+    ],
+)
+def test_scoped_client_tolerates_pat_binding_rejection(response_data):
+    # PAT / API-key credentials can't session-bind; the platform rejects enter
+    # with 409 binding_invalid, which is tolerated so the header-scoped client
+    # is returned unchanged — PATs authorize via the explicit header.
+    client = _platform_client()
+    rejection = APIError("conflict", status_code=409, response_data=response_data)
+
+    with patch(_ENTER, side_effect=rejection) as mock_enter:
+        scoped = scoped_client_for_workroom(client, _WID)
+
+    assert scoped._default_headers == {"X-Workroom-Id": _WID}
+    mock_enter.assert_called_once_with(_WID)
+
+
+def test_scoped_client_propagates_enter_failure():
+    # A workroom that can't be entered (e.g. never created) must fail loudly,
+    # not silently return an unbound client that would 403 on the first write.
     client = _platform_client()
 
-    scoped = scoped_client_for_workroom(client, "global")
+    with patch(_ENTER, side_effect=NotFoundError(f"Workroom {_WID} not found")):
+        with pytest.raises(NotFoundError):
+            scoped_client_for_workroom(client, _WID)
 
-    assert scoped is not client
-    assert scoped._default_headers == {"X-Workroom-Id": "global"}
+
+def test_scoped_client_propagates_non_binding_conflict():
+    # A 409 that is NOT the binding-unsupported signal is a real conflict and
+    # must propagate rather than being swallowed by the PAT-tolerance path.
+    client = _platform_client()
+    other = APIError(
+        "conflict", status_code=409, response_data={"detail": "something_else"}
+    )
+
+    with patch(_ENTER, side_effect=other):
+        with pytest.raises(APIError):
+            scoped_client_for_workroom(client, _WID)
 
 
 def test_build_client_from_env_requires_base_url(monkeypatch):

--- a/tests/unit/test_seeding_client.py
+++ b/tests/unit/test_seeding_client.py
@@ -54,6 +54,21 @@ def test_enter_is_issued_without_the_workroom_scope_header():
     assert "X-Workroom-Id" not in enter_client._default_headers
 
 
+def test_returned_client_shares_session_state_with_the_bound_client():
+    # The returned (write) client is derived from the client that ran enter, so
+    # any session state the bind sets (e.g. a Set-Cookie binding) reaches the
+    # client that performs the writes — not a discarded throwaway.
+    client = _platform_client()
+
+    def _bind_sets_cookie(self, workroom_id):
+        self.client.session.cookies.set("kamiwaza_workroom_binding", "bound")
+
+    with patch(_ENTER, autospec=True, side_effect=_bind_sets_cookie):
+        scoped = scoped_client_for_workroom(client, _WID)
+
+    assert scoped.session.cookies.get("kamiwaza_workroom_binding") == "bound"
+
+
 @pytest.mark.parametrize(
     "response_data",
     [


### PR DESCRIPTION
## What this ships

The UAT seeder now binds the workroom session before per-workroom writes, so seeded boxes actually get Kaizen (and the Bedrock-bound agent) in the workroom instead of an empty one.

## Root cause

`seeding.scoped_client_for_workroom` scoped the client with the `X-Workroom-Id` header only. Under strict ForwardAuth (`KAMIWAZA_ALLOW_LEGACY_WORKROOM_HEADER=false`) the platform no longer authorizes per-workroom **writes** from that header alone, so `install-extension --name kaizen` and `create-agent` returned `403 "Authenticated workroom context missing"` — every seeded box came up with a workroom but no Kaizen (ENG-8413).

## Fix

`scoped_client_for_workroom` now calls `workrooms.enter()` to establish the server-side selected-workroom binding, then returns the header-scoped client for the writes. One choke point covers install-extension / create-agent / create-conversation / chat.

Two non-obvious points:
- **`enter` is issued on an unscoped view of the client** (`workroom_scope(None)`). `enter` is a POST, so a scoped `enter` (carrying `X-Workroom-Id` before any binding exists) trips the strict write-gate and 403s — the bind is what would create that context.
- **PATs can't session-bind** (`409 binding_invalid`) and authorize via the header; that specific rejection is tolerated. Any other error propagates.

## Verification

- Full SDK unit suite green (2048 passed); +4 targeted tests (bind-on-enter, unscoped-enter invariant via autospec, `409 binding_invalid` tolerance, 404 / non-binding-409 propagation).
- Live on the develop nightly box: mounting the patched module into the shipped `:develop` seeder image, `resolve-kaizen-url` + `create-agent` succeed from a fresh token where the unpatched seeder 403'd. Full evidence in the PR-evidence block below.

<!-- pr-evidence-start -->
<details>
<summary>📋 <b>pr-evidence</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-evidence
tool_version: 0.3.2
generated_at: 2026-07-10T06:09:02.504Z
manifest_hash: sha256:dd1af17efd277cb6359c7ee95a64c6be18eab3fde03428fdc788a3cbd955babb
phase_a_complete: true
phase_b_complete: true
repos:
  - name: kamiwaza-sdk
    path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-eng-8413
    branch: fix/eng-8413-seeder-workroom-bind
    head_sha: 2c7d7183d027277d62e50e04f38b81ff34c3de93
    head_sha_short: 2c7d7183d
    dirty_files: 0
    ahead: 1
    behind: 0
    upstream: origin/develop
    delivery:
      mode: source-mount
      verified: false
      details:
        bind_mount:
          host_path: /Users/johnstrick/kami/.worktrees/kamiwaza-sdk-eng-8413
          container_path: /usr/local/lib/python3.12/site-packages/kamiwaza_sdk
          spot_check_file: kamiwaza_sdk/seeding/client.py
          host_sha256: 20fb2dfe84c733c2af5fc32ba5d1e1d48f43d86d8c7a72dab830c1f2afc0856b
          container_verifications: []
clusters: []
```

</details>

# PR Evidence — generated 2026-07-10T06:09:02.504Z

## Commit identity

| Repo | Branch | HEAD | Status | Delivery |
|------|--------|------|--------|----------|
| kamiwaza-sdk | fix/eng-8413-seeder-workroom-bind | `2c7d7183d` | +1 | source-mount ⚠ |

## Cross-references

- Linear: `ENG-8413`

## Testing

**Unit** — full SDK unit suite green (`uv run pytest -m unit`): 2048 passed, 1 skipped
(unrelated BSD-sed skip). 3 new tests on `scoped_client_for_workroom`: binds the
workroom via `enter` before scoping; tolerates the PAT `409 binding_invalid`
(header-only fallback); propagates other `enter` failures (404, non-binding 409).
`ruff` / `black` / `isort` / `mypy` clean on the two changed files.

**Live** — validated on the develop nightly box (`test.kamiwaza.dev`, Azure VM
`rhel-nightly-offline-release-install-azure-vm`; driven via the `az vm run-command`
backplane, so the box is not in local kubeconfig → no local kubectl preflight).
The patched `kamiwaza_sdk/seeding/client.py` was bind-mounted over the installed
package inside the shipped `ghcr.io/kamiwaza-ai/kamiwaza-sdk/images/seeder:develop`
image, and the real seeder CLI was run against the platform:

- Before (unpatched image): `seed create-agent` → `403 {"detail":"Authenticated
  workroom context missing."}` (same for `install-extension --name kaizen`).
- After (patched): from a fresh, unbound password-grant token,
  `seed resolve-kaizen-url` → rc=0 and `seed create-agent` → rc=0 (agent created).
  Confirmed on two consecutive runs.

**Delivery note** — the SDK ships inside the CI-built seeder GHCR image, not a local
source-mounted pod, so `delivery.verified` is `false` (no local pod to spot-check);
the mount above is the validation method, not the ship path. The final gate is a
green nightly seed run on the rebuilt `:develop` seeder image.


<!-- pr-evidence-end -->