### PR TITLE
[Federation] Shared_idp SDK support + live gated-retrieval tests (ENG-8213/8325)

### DIFF
--- a/kamiwaza_sdk/seeding/federation/__init__.py
+++ b/kamiwaza_sdk/seeding/federation/__init__.py
@@ -7,9 +7,19 @@ test fixtures (``tests/integration/_mini_clearance.py``):
 * ``access``  — manage ReBAC grants on resources (subjects.grants)
 * ``fed``     — shared_idp federation lifecycle (pair / status / allow-user)
 * ``dataset`` / ``gate`` / ``attr`` — the gated-retrieval setup
-* ``idp``     — (dev) Keycloak-side shared-realm seeding (realm / client / mapper /
-                personas), the one half that needs Keycloak admin rather than the
-                platform API
+* ``idp``     — (DEV/TEST ONLY) Keycloak-side shared-realm seeding (realm / client /
+                mapper / personas), the one half that needs Keycloak admin rather
+                than the platform API
+
+``idp bootstrap`` and ``idp persona`` call the Keycloak ADMIN REST API
+(``/admin/*``), which the platform ingress deliberately does NOT expose — so they
+require direct Keycloak access (e.g. ``kubectl port-forward svc/keycloak 8080:80``
+then ``--kc-url http://localhost:8080``). ``idp token`` only does a public ROPC
+grant and works against the normal ingress URL. For PRODUCTION, the shared realm /
+client / clearance-mapper / user-profile policy should be provisioned
+declaratively by the auth chart's install-time Keycloak init-Job pipeline (the
+same path that seeds the ``kamiwaza`` realm), not by this command — see the
+ENG-8571 follow-up. This CLI remains the fast path for dev/test stand-up.
 
 Design invariants (shared with ``kamiwaza-seed``): idempotent, secrets from env
 never argv, thin wrappers around SDK / Keycloak-admin methods, JSON output.

--- a/kamiwaza_sdk/seeding/federation/__init__.py
+++ b/kamiwaza_sdk/seeding/federation/__init__.py
@@ -1,0 +1,20 @@
+"""Federation / shared_idp seeding + ReBAC access CLI.
+
+A deterministic, operator-facing utility (``kamiwaza-fed``) that productizes the
+shared_idp stand-up + resource-access management that previously lived only in
+test fixtures (``tests/integration/_mini_clearance.py``):
+
+* ``access``  — manage ReBAC grants on resources (subjects.grants)
+* ``fed``     — shared_idp federation lifecycle (pair / status / allow-user)
+* ``dataset`` / ``gate`` / ``attr`` — the gated-retrieval setup
+* ``idp``     — (dev) Keycloak-side shared-realm seeding (realm / client / mapper /
+                personas), the one half that needs Keycloak admin rather than the
+                platform API
+
+Design invariants (shared with ``kamiwaza-seed``): idempotent, secrets from env
+never argv, thin wrappers around SDK / Keycloak-admin methods, JSON output.
+"""
+
+from .cli import build_parser, main
+
+__all__ = ["build_parser", "main"]

--- a/kamiwaza_sdk/seeding/federation/cli.py
+++ b/kamiwaza_sdk/seeding/federation/cli.py
@@ -131,10 +131,7 @@ def cmd_fed_pair(args: argparse.Namespace, *, client: Any) -> dict:
 
 
 def cmd_fed_status(args: argparse.Namespace, *, client: Any) -> dict:
-    # GET /cluster/federations is the widened any-authenticated listing surface;
-    # FederationsAPI has no typed list method, so use the request seam directly.
-    feds = client._request("GET", "/cluster/federations")
-    items = feds if isinstance(feds, list) else feds.get("federations", [])
+    items = [f.model_dump() for f in client.federations.list()]
     if args.name:
         items = [
             f

--- a/kamiwaza_sdk/seeding/federation/cli.py
+++ b/kamiwaza_sdk/seeding/federation/cli.py
@@ -1,0 +1,405 @@
+"""``kamiwaza-fed`` — shared_idp seeding + ReBAC access CLI.
+
+Deterministic, idempotent wrappers around SDK / Keycloak-admin methods. Secrets
+are read from env vars (``--*-env``), never argv. Handlers return a dict (printed
+as JSON) or None (self-output, e.g. ``idp token --raw``).
+
+Groups::
+
+    access  grant | revoke | list                 (ReBAC on resources)
+    fed     pair | status | allow-user             (shared_idp lifecycle)
+    dataset gated                                  (create a gate-bound dataset)
+    gate    install                                (install a gate package)
+    attr    declare                                (declare an attribute vocab)
+    idp     bootstrap | persona | token            (Keycloak-side shared-realm)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any, Optional
+
+from ..cli import _read_env_secret
+from ..client import build_client_from_env
+from .keycloak import KeycloakAdmin, jwks_uri_from_issuer
+
+
+def _verify_ssl() -> bool:
+    """TLS verification for direct Keycloak calls (the SDK client honors this env
+    natively; we mirror it for the idp group's raw Keycloak-admin calls)."""
+    return os.environ.get("KAMIWAZA_VERIFY_SSL", "true").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+    )
+
+
+def _split_object(spec: str) -> tuple[str, str]:
+    """Parse ``<namespace>:<id>`` — split on the FIRST colon only, since a
+    resource id (e.g. a dataset URN) itself contains colons."""
+    ns, sep, oid = spec.partition(":")
+    if not sep or not ns or not oid:
+        raise SystemExit(f"--object must be '<namespace>:<id>', got {spec!r}")
+    return ns, oid
+
+
+# --- backend construction (module-level so tests can monkeypatch) ----------
+
+
+def build_kc_admin(args: argparse.Namespace) -> KeycloakAdmin:
+    pw = _read_env_secret(args.kc_admin_pw_env, what="Keycloak admin password")
+    if not pw:
+        raise SystemExit("--kc-admin-pw-env must name an env var holding the password")
+    return KeycloakAdmin(
+        args.kc_url,
+        admin_user=args.kc_admin_user,
+        admin_password=pw,
+        verify=_verify_ssl(),
+    )
+
+
+# --- access: ReBAC on resources -------------------------------------------
+
+
+def cmd_access_grant(args: argparse.Namespace, *, client: Any) -> dict:
+    ns, oid = _split_object(args.object)
+    client.subjects.grants(args.subject).create(
+        object_namespace=ns, object_id=oid, relation=args.relation
+    )
+    return {
+        "granted": {
+            "subject": args.subject,
+            "relation": args.relation,
+            "object": args.object,
+        }
+    }
+
+
+def cmd_access_revoke(args: argparse.Namespace, *, client: Any) -> dict:
+    ns, oid = _split_object(args.object)
+    client.subjects.grants(args.subject).delete(
+        object_namespace=ns, object_id=oid, relation=args.relation
+    )
+    return {
+        "revoked": {
+            "subject": args.subject,
+            "relation": args.relation,
+            "object": args.object,
+        }
+    }
+
+
+def cmd_access_list(args: argparse.Namespace, *, client: Any) -> dict:
+    grants = client.subjects.grants(args.subject).list()
+    return {
+        "subject": args.subject,
+        "grants": [
+            g.model_dump() if hasattr(g, "model_dump") else g for g in grants
+        ],
+    }
+
+
+# --- fed: shared_idp federation lifecycle ---------------------------------
+
+
+def cmd_fed_pair(args: argparse.Namespace, *, client: Any) -> dict:
+    issuer = args.shared_issuer.rstrip("/")
+    # H1-aligned: the JWKS is DERIVED from the issuer, never an arbitrary URL, so
+    # the pairing binds the shared realm's keys to its issuer origin by construction.
+    jwks = jwks_uri_from_issuer(issuer)
+    ca = Path(args.shared_ca_file).read_text() if args.shared_ca_file else None
+    admin_token = _read_env_secret(
+        args.remote_admin_token_env, what="remote admin token"
+    )
+    fed = client.federations.pair(
+        name=args.name,
+        role=args.role,
+        remote_url=args.remote_url,
+        shared_issuer_url=issuer,
+        shared_jwks_url=jwks,
+        shared_ca_pem=ca,
+        remote_admin_token=admin_token,
+    )
+    return {
+        "paired": fed.model_dump() if hasattr(fed, "model_dump") else str(fed),
+        "shared_issuer_url": issuer,
+        "shared_jwks_url": jwks,
+    }
+
+
+def cmd_fed_status(args: argparse.Namespace, *, client: Any) -> dict:
+    feds = client.federations.list()
+    items = [f.model_dump() if hasattr(f, "model_dump") else f for f in feds]
+    if args.name:
+        items = [
+            f
+            for f in items
+            if args.name in (f.get("remote_cluster_name"), str(f.get("id")))
+        ]
+    return {"federations": items}
+
+
+def cmd_fed_allow_user(args: argparse.Namespace, *, client: Any) -> dict:
+    # Build the receiver allowlist entry's initial ReBAC tuples from --seed
+    # (repeatable) ``<namespace>:<id>:<relation>``. ``{{user_id}}`` renders to the
+    # brokered principal's LOCAL uuid at receiver ingress.
+    tuples = []
+    for seed in args.seed or []:
+        parts = seed.rsplit(":", 1)
+        if len(parts) != 2 or ":" not in parts[0]:
+            raise SystemExit(
+                f"--seed must be '<namespace>:<id>:<relation>', got {seed!r}"
+            )
+        obj, relation = parts
+        tuples.append(
+            {"subject": "user:{{user_id}}", "relation": relation, "object": obj}
+        )
+    client._request(
+        "POST",
+        f"/cluster/federations/{args.federation}/users",
+        json={"external_id": args.external_id, "initial_tuples": tuples},
+    )
+    return {
+        "allowed": {
+            "federation": args.federation,
+            "external_id": args.external_id,
+            "initial_tuples": tuples,
+        }
+    }
+
+
+# --- dataset / gate / attr: gated-retrieval setup -------------------------
+
+
+def cmd_dataset_gated(args: argparse.Namespace, *, client: Any) -> dict:
+    gate_spec = {
+        "type": args.gate,
+        "config": json.loads(args.gate_config) if args.gate_config else {},
+    }
+    urn = client.datasets.create(
+        name=args.name,
+        platform="file",
+        properties={"path": args.path, "gate": json.dumps(gate_spec)},
+        description=args.description,
+    )
+    return {"dataset_urn": urn, "gate": gate_spec["type"], "path": args.path}
+
+
+def cmd_gate_install(args: argparse.Namespace, *, client: Any) -> dict:
+    result = client.gates.packages.install(
+        package_spec=args.spec,
+        hash_digest=args.hash,
+        index_url=args.index_url,
+    )
+    return {
+        "installed": result.model_dump()
+        if hasattr(result, "model_dump")
+        else str(result)
+    }
+
+
+def cmd_attr_declare(args: argparse.Namespace, *, client: Any) -> dict:
+    client.cluster.declare_attribute(args.name, type=args.type)
+    return {"declared": {"name": args.name, "type": args.type}}
+
+
+# --- idp: Keycloak-side shared-realm seeding (dev) ------------------------
+
+
+def cmd_idp_bootstrap(args: argparse.Namespace, *, client: Any = None) -> dict:
+    kc = build_kc_admin(args)
+    realm = kc.ensure_realm(args.realm)
+    kc.set_unmanaged_attributes(args.realm)
+    cli = kc.ensure_ropc_client(args.realm, args.ropc_client)
+    for attr in args.attr or ["clearance"]:
+        kc.ensure_attribute_mapper(args.realm, cli["id"], attribute=attr)
+    return {
+        "realm": realm,
+        "ropc_client": cli,
+        "attribute_mappers": args.attr or ["clearance"],
+        "shared_issuer_url": kc.issuer_url(args.realm),
+    }
+
+
+def cmd_idp_persona(args: argparse.Namespace, *, client: Any = None) -> dict:
+    kc = build_kc_admin(args)
+    pw = _read_env_secret(args.pw_env, what="persona password")
+    if not pw:
+        raise SystemExit("--pw-env must name an env var holding the persona password")
+    attributes = {}
+    for pair in args.attr or []:
+        k, sep, v = pair.partition("=")
+        if not sep:
+            raise SystemExit(f"--attr must be 'name=value', got {pair!r}")
+        attributes[k] = v
+    result = kc.ensure_user(
+        args.realm, args.user, password=pw, attributes=attributes
+    )
+    return {"persona": result, "attributes": attributes}
+
+
+def cmd_idp_token(args: argparse.Namespace, *, client: Any = None) -> Optional[dict]:
+    # ROPC (direct access grant) needs only the persona creds + the public client
+    # — no master-realm admin, so it does not use build_kc_admin.
+    kc = KeycloakAdmin(
+        args.kc_url, admin_user="", admin_password="", verify=_verify_ssl()
+    )
+    pw = _read_env_secret(args.pw_env, what="persona password")
+    if not pw:
+        raise SystemExit("--pw-env must name an env var holding the persona password")
+    token = kc.ropc_token(args.realm, args.client, args.user, pw)
+    if args.raw:
+        print(token)
+        return None
+    return {"token": token}
+
+
+# --- parser ---------------------------------------------------------------
+
+
+def _add_kc_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--kc-url", required=True, help="Keycloak base URL, e.g. https://host")
+    p.add_argument("--kc-admin-user", default="admin", help="master-realm admin user")
+    p.add_argument(
+        "--kc-admin-pw-env",
+        required=True,
+        help="env var holding the master-realm admin password (never argv)",
+    )
+    p.set_defaults(needs_kc=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="kamiwaza-fed",
+        description="Shared_idp federation seeding + ReBAC access management.",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Platform API root; defaults to KAMIWAZA_BASE_URL. (Unused by 'idp'.)",
+    )
+    groups = parser.add_subparsers(dest="group")
+
+    # access
+    g = groups.add_parser("access", help="ReBAC grants on resources").add_subparsers(
+        dest="command"
+    )
+    for verb, fn in (("grant", cmd_access_grant), ("revoke", cmd_access_revoke)):
+        p = g.add_parser(verb, help=f"{verb} a relation on a resource")
+        p.add_argument("--subject", required=True, help="e.g. a username / subject id")
+        p.add_argument("--relation", required=True, help="e.g. viewer / editor / owner")
+        p.add_argument("--object", required=True, help="'<namespace>:<id>', e.g. dataset:<urn>")
+        p.set_defaults(func=fn, needs_kc=False)
+    p = g.add_parser("list", help="list a subject's grants")
+    p.add_argument("--subject", required=True)
+    p.set_defaults(func=cmd_access_list, needs_kc=False)
+
+    # fed
+    g = groups.add_parser("fed", help="shared_idp federation lifecycle").add_subparsers(
+        dest="command"
+    )
+    p = g.add_parser("pair", help="pair two clusters in shared_idp mode")
+    p.add_argument("--name", required=True, help="local name for the federation")
+    p.add_argument("--role", required=True, choices=["initiator", "receiver"])
+    p.add_argument("--remote-url", required=True, help="peer API root, e.g. https://peer/api")
+    p.add_argument("--shared-issuer", required=True, help="shared realm issuer URL")
+    p.add_argument("--shared-ca-file", default=None, help="PEM CA for the shared issuer's TLS")
+    p.add_argument(
+        "--remote-admin-token-env",
+        default=None,
+        help="env var holding the peer admin token (never argv)",
+    )
+    p.set_defaults(func=cmd_fed_pair, needs_kc=False)
+    p = g.add_parser("status", help="list federation posture")
+    p.add_argument("--name", default=None, help="filter by name / id")
+    p.set_defaults(func=cmd_fed_status, needs_kc=False)
+    p = g.add_parser("allow-user", help="allowlist a brokered user + seed ReBAC")
+    p.add_argument("--federation", required=True, help="receiver federation id")
+    p.add_argument("--external-id", required=True, help="'<sub>@<source-cluster-id>'")
+    p.add_argument(
+        "--seed",
+        action="append",
+        help="repeatable '<namespace>:<id>:<relation>', e.g. dataset:<urn>:viewer",
+    )
+    p.set_defaults(func=cmd_fed_allow_user, needs_kc=False)
+
+    # dataset
+    g = groups.add_parser("dataset", help="gated dataset setup").add_subparsers(
+        dest="command"
+    )
+    p = g.add_parser("gated", help="create a file dataset bound to a gate")
+    p.add_argument("--name", required=True)
+    p.add_argument("--path", required=True, help="on-cluster file path")
+    p.add_argument("--gate", required=True, help="gate classpath, e.g. acme_gates...MiniClearanceGate")
+    p.add_argument("--gate-config", default=None, help="JSON gate config (default {})")
+    p.add_argument("--description", default=None)
+    p.set_defaults(func=cmd_dataset_gated, needs_kc=False)
+
+    # gate
+    g = groups.add_parser("gate", help="gate packages").add_subparsers(dest="command")
+    p = g.add_parser("install", help="install a hash-pinned gate package")
+    p.add_argument("--spec", required=True, help="pip spec, e.g. acme-gates==1.1.0")
+    p.add_argument("--hash", required=True, help="'sha256:...' of the wheel")
+    p.add_argument("--index-url", default=None, help="pip index override")
+    p.set_defaults(func=cmd_gate_install, needs_kc=False)
+
+    # attr
+    g = groups.add_parser("attr", help="attribute vocabulary").add_subparsers(
+        dest="command"
+    )
+    p = g.add_parser("declare", help="declare an attribute in the vocabulary")
+    p.add_argument("--name", required=True, help="e.g. clearance")
+    p.add_argument("--type", default="string")
+    p.set_defaults(func=cmd_attr_declare, needs_kc=False)
+
+    # idp (Keycloak-admin)
+    g = groups.add_parser(
+        "idp", help="(dev) Keycloak-side shared-realm seeding"
+    ).add_subparsers(dest="command")
+    p = g.add_parser("bootstrap", help="ensure realm + ROPC client + attribute mapper")
+    p.add_argument("--realm", required=True, help="shared realm, e.g. federated")
+    p.add_argument("--ropc-client", required=True, help="public ROPC client id, e.g. fed-mesh-cli")
+    p.add_argument("--attr", action="append", help="attribute mapper(s); default clearance")
+    _add_kc_args(p)
+    p.set_defaults(func=cmd_idp_bootstrap)
+    p = g.add_parser("persona", help="ensure a persona user with attributes")
+    p.add_argument("--realm", required=True)
+    p.add_argument("--user", required=True)
+    p.add_argument("--attr", action="append", help="'name=value', e.g. clearance=U")
+    p.add_argument("--pw-env", required=True, help="env var holding the persona password")
+    _add_kc_args(p)
+    p.set_defaults(func=cmd_idp_persona)
+    p = g.add_parser("token", help="mint a persona ROPC token (test helper)")
+    p.add_argument("--realm", required=True)
+    p.add_argument("--client", required=True, help="ROPC client id")
+    p.add_argument("--user", required=True)
+    p.add_argument("--pw-env", required=True)
+    p.add_argument("--raw", action="store_true", help="print only the bare token")
+    p.add_argument("--kc-url", required=True, help="Keycloak base URL, e.g. https://host")
+    p.set_defaults(func=cmd_idp_token, needs_kc=True)
+
+    return parser
+
+
+def main(
+    argv: Optional[list[str]] = None,
+    *,
+    client_factory: Any = build_client_from_env,
+) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not getattr(args, "func", None):
+        parser.error("a group + command is required (e.g. 'access grant')")
+    # idp commands talk to Keycloak, not the platform API — skip the SDK client.
+    client = None if getattr(args, "needs_kc", False) else client_factory(base_url=args.base_url)
+    result = args.func(args, client=client)
+    if result is not None:
+        print(json.dumps(result, default=str))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/kamiwaza_sdk/seeding/federation/cli.py
+++ b/kamiwaza_sdk/seeding/federation/cli.py
@@ -177,6 +177,11 @@ def cmd_fed_allow_user(args: argparse.Namespace, *, client: Any) -> dict:
     }
 
 
+def cmd_fed_unpair(args: argparse.Namespace, *, client: Any) -> dict:
+    result = client.federations[args.name].disconnect(force=args.force)
+    return {"disconnected": args.name, "result": result}
+
+
 # --- dataset / gate / attr: gated-retrieval setup -------------------------
 
 
@@ -344,6 +349,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="repeatable '<namespace>:<id>:<relation>', e.g. dataset:<urn>:viewer",
     )
     p.set_defaults(func=cmd_fed_allow_user, needs_kc=False)
+    p = g.add_parser("unpair", help="disconnect (tear down) a federation")
+    p.add_argument("--name", required=True, help="federation name")
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="tear down without waiting for the peer's ack (peer already gone)",
+    )
+    p.set_defaults(func=cmd_fed_unpair, needs_kc=False)
 
     # dataset
     g = groups.add_parser("dataset", help="gated dataset setup").add_subparsers(

--- a/kamiwaza_sdk/seeding/federation/cli.py
+++ b/kamiwaza_sdk/seeding/federation/cli.py
@@ -420,6 +420,19 @@ def main(
             "KAMIWAZA_API_TOKEN"
         )
         client = client_factory(base_url=args.base_url, api_key=api_key)
+        # Admin-scoped seeding ops (grants, attr, dataset gate) need a credential
+        # that carries the caller's ROLES. A PAT/api-key authenticates but is
+        # role-limited; a username/password login yields a Bearer token that
+        # carries the admin role. Prefer it when KAMIWAZA_USERNAME +
+        # KAMIWAZA_PASSWORD are in the env (both env, never argv).
+        username = os.environ.get("KAMIWAZA_USERNAME")
+        password = os.environ.get("KAMIWAZA_PASSWORD")
+        if username and password and hasattr(client, "_auth_service"):
+            from kamiwaza_sdk.authentication import UserPasswordAuthenticator
+
+            client.authenticator = UserPasswordAuthenticator(
+                username, password, client._auth_service
+            )
     result = args.func(args, client=client)
     if result is not None:
         print(json.dumps(result, default=str))

--- a/kamiwaza_sdk/seeding/federation/cli.py
+++ b/kamiwaza_sdk/seeding/federation/cli.py
@@ -131,8 +131,10 @@ def cmd_fed_pair(args: argparse.Namespace, *, client: Any) -> dict:
 
 
 def cmd_fed_status(args: argparse.Namespace, *, client: Any) -> dict:
-    feds = client.federations.list()
-    items = [f.model_dump() if hasattr(f, "model_dump") else f for f in feds]
+    # GET /cluster/federations is the widened any-authenticated listing surface;
+    # FederationsAPI has no typed list method, so use the request seam directly.
+    feds = client._request("GET", "/cluster/federations")
+    items = feds if isinstance(feds, list) else feds.get("federations", [])
     if args.name:
         items = [
             f
@@ -394,7 +396,13 @@ def main(
     if not getattr(args, "func", None):
         parser.error("a group + command is required (e.g. 'access grant')")
     # idp commands talk to Keycloak, not the platform API — skip the SDK client.
-    client = None if getattr(args, "needs_kc", False) else client_factory(base_url=args.base_url)
+    if getattr(args, "needs_kc", False):
+        client = None
+    else:
+        api_key = os.environ.get("KAMIWAZA_API_KEY") or os.environ.get(
+            "KAMIWAZA_API_TOKEN"
+        )
+        client = client_factory(base_url=args.base_url, api_key=api_key)
     result = args.func(args, client=client)
     if result is not None:
         print(json.dumps(result, default=str))

--- a/kamiwaza_sdk/seeding/federation/cli.py
+++ b/kamiwaza_sdk/seeding/federation/cli.py
@@ -114,10 +114,16 @@ def cmd_fed_pair(args: argparse.Namespace, *, client: Any) -> dict:
     admin_token = _read_env_secret(
         args.remote_admin_token_env, what="remote admin token"
     )
+    # A two-sided shared_idp pairing needs the SAME preshared key on both
+    # clusters — supply it via env so running this CLI on each side matches.
+    # When omitted, pair() mints a fresh UUID4 (single-operator convenience;
+    # only viable when the same value reaches both sides some other way).
+    psk = _read_env_secret(args.preshared_key_env, what="preshared key")
     fed = client.federations.pair(
         name=args.name,
         role=args.role,
         remote_url=args.remote_url,
+        preshared_key=psk,
         shared_issuer_url=issuer,
         shared_jwks_url=jwks,
         shared_ca_pem=ca,
@@ -127,6 +133,7 @@ def cmd_fed_pair(args: argparse.Namespace, *, client: Any) -> dict:
         "paired": fed.model_dump() if hasattr(fed, "model_dump") else str(fed),
         "shared_issuer_url": issuer,
         "shared_jwks_url": jwks,
+        "preshared_key_source": "env" if psk else "minted-uuid4",
     }
 
 
@@ -174,17 +181,19 @@ def cmd_fed_allow_user(args: argparse.Namespace, *, client: Any) -> dict:
 
 
 def cmd_dataset_gated(args: argparse.Namespace, *, client: Any) -> dict:
-    gate_spec = {
-        "type": args.gate,
-        "config": json.loads(args.gate_config) if args.gate_config else {},
-    }
+    # Create the file dataset, THEN bind the gate via the dedicated endpoint
+    # (set_gate -> PUT /catalog/datasets/{urn}/gate). Stuffing a "gate" property
+    # into the catalog record does NOT enforce a gate; set_gate is what makes
+    # retrieval gated (matches _mini_clearance.create_file_dataset).
     urn = client.datasets.create(
         name=args.name,
         platform="file",
-        properties={"path": args.path, "gate": json.dumps(gate_spec)},
+        properties={"path": args.path},
         description=args.description,
     )
-    return {"dataset_urn": urn, "gate": gate_spec["type"], "path": args.path}
+    config = json.loads(args.gate_config) if args.gate_config else {}
+    client.datasets.set_gate(urn, type=args.gate, config=config)
+    return {"dataset_urn": urn, "gate": args.gate, "path": args.path}
 
 
 def cmd_gate_install(args: argparse.Namespace, *, client: Any) -> dict:
@@ -303,9 +312,20 @@ def build_parser() -> argparse.ArgumentParser:
     p = g.add_parser("pair", help="pair two clusters in shared_idp mode")
     p.add_argument("--name", required=True, help="local name for the federation")
     p.add_argument("--role", required=True, choices=["initiator", "receiver"])
-    p.add_argument("--remote-url", required=True, help="peer API root, e.g. https://peer/api")
+    p.add_argument(
+        "--remote-url",
+        default=None,
+        help="peer API root, e.g. https://peer/api (required for --role initiator; "
+        "omit for --role receiver — the receiver row is created without it)",
+    )
     p.add_argument("--shared-issuer", required=True, help="shared realm issuer URL")
     p.add_argument("--shared-ca-file", default=None, help="PEM CA for the shared issuer's TLS")
+    p.add_argument(
+        "--preshared-key-env",
+        default=None,
+        help="env var holding the shared PSK (never argv); MUST match on both "
+        "clusters. Omitted -> a fresh UUID4 is minted.",
+    )
     p.add_argument(
         "--remote-admin-token-env",
         default=None,

--- a/kamiwaza_sdk/seeding/federation/cli.py
+++ b/kamiwaza_sdk/seeding/federation/cli.py
@@ -274,7 +274,16 @@ def cmd_idp_token(args: argparse.Namespace, *, client: Any = None) -> Optional[d
 
 
 def _add_kc_args(p: argparse.ArgumentParser) -> None:
-    p.add_argument("--kc-url", required=True, help="Keycloak base URL, e.g. https://host")
+    p.add_argument(
+        "--kc-url",
+        required=True,
+        help="Keycloak base URL. NOTE: this reaches the Keycloak ADMIN API "
+        "(/admin/*), which by design is NOT exposed on the public ingress (only "
+        "OIDC endpoints are). Reach Keycloak directly — e.g. `kubectl port-forward "
+        "svc/keycloak 8080:80 -n kamiwaza` then --kc-url http://localhost:8080. For "
+        "production, provision the shared realm via the auth chart's init-Job "
+        "pipeline instead of this dev command.",
+    )
     p.add_argument("--kc-admin-user", default="admin", help="master-realm admin user")
     p.add_argument(
         "--kc-admin-pw-env",
@@ -389,7 +398,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     # idp (Keycloak-admin)
     g = groups.add_parser(
-        "idp", help="(dev) Keycloak-side shared-realm seeding"
+        "idp",
+        help="(DEV/TEST ONLY) Keycloak-side shared-realm seeding — `bootstrap`/"
+        "`persona` need DIRECT Keycloak admin access (port-forward). For "
+        "production, provision the shared realm declaratively via the auth "
+        "chart (see ENG-8571 follow-up).",
     ).add_subparsers(dest="command")
     p = g.add_parser("bootstrap", help="ensure realm + ROPC client + attribute mapper")
     p.add_argument("--realm", required=True, help="shared realm, e.g. federated")
@@ -410,7 +423,13 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--user", required=True)
     p.add_argument("--pw-env", required=True)
     p.add_argument("--raw", action="store_true", help="print only the bare token")
-    p.add_argument("--kc-url", required=True, help="Keycloak base URL, e.g. https://host")
+    p.add_argument(
+        "--kc-url",
+        required=True,
+        help="Keycloak base URL. Unlike bootstrap/persona, this only does an "
+        "ROPC token grant against the PUBLIC OIDC endpoint (/realms/.../token), "
+        "so the normal ingress URL works — no admin access / port-forward needed.",
+    )
     p.set_defaults(func=cmd_idp_token, needs_kc=True)
 
     return parser

--- a/kamiwaza_sdk/seeding/federation/keycloak.py
+++ b/kamiwaza_sdk/seeding/federation/keycloak.py
@@ -93,6 +93,21 @@ class KeycloakAdmin:
         loc = resp.headers.get("Location", "")
         return loc.rstrip("/").rsplit("/", 1)[-1] if loc else None
 
+    @staticmethod
+    def _ok_json(resp: requests.Response, what: str) -> Any:
+        """Parse a successful admin-API JSON body, else raise a clear error.
+
+        Guards against treating an error body (e.g. an ext-authz rejection dict
+        on a gated /admin path) as data — which otherwise surfaces as an opaque
+        KeyError/TypeError far from the real cause.
+        """
+        if resp.status_code >= 400:
+            raise KeycloakAdminError(f"{what} failed ({resp.status_code}): {resp.text[:200]}")
+        try:
+            return resp.json()
+        except ValueError:
+            return None
+
     # -- realm -------------------------------------------------------------
 
     def ensure_realm(self, realm: str) -> Dict[str, Any]:
@@ -131,9 +146,14 @@ class KeycloakAdmin:
 
     def ensure_ropc_client(self, realm: str, client_id: str) -> Dict[str, Any]:
         """Ensure a public, direct-access-grants (ROPC) client. Idempotent."""
-        existing = self._req(
-            "GET", f"/realms/{quote(realm)}/clients", params={"clientId": client_id}
-        ).json()
+        existing = self._ok_json(
+            self._req(
+                "GET",
+                f"/realms/{quote(realm)}/clients",
+                params={"clientId": client_id},
+            ),
+            "list clients",
+        )
         if existing:
             return {"client_id": client_id, "id": existing[0]["id"], "created": False}
         resp = self._req(
@@ -162,7 +182,7 @@ class KeycloakAdmin:
         persona's ``clearance`` (etc.) is projected as a top-level token claim.
         """
         base = f"/realms/{quote(realm)}/clients/{client_uuid}/protocol-mappers/models"
-        existing = self._req("GET", base).json()
+        existing = self._ok_json(self._req("GET", base), "list protocol mappers") or []
         name = f"{attribute}-attr-mapper"
         if any(m.get("name") == name for m in existing):
             return
@@ -204,9 +224,14 @@ class KeycloakAdmin:
         email / first / last are set so the direct-access-grant (ROPC) is not
         blocked by "Account is not fully set up".
         """
-        found = self._req(
-            "GET", f"/realms/{quote(realm)}/users", params={"username": username, "exact": "true"}
-        ).json()
+        found = self._ok_json(
+            self._req(
+                "GET",
+                f"/realms/{quote(realm)}/users",
+                params={"username": username, "exact": "true"},
+            ),
+            "search users",
+        )
         attrs = {k: (v if isinstance(v, list) else [str(v)]) for k, v in (attributes or {}).items()}
         rep = {
             "username": username,

--- a/kamiwaza_sdk/seeding/federation/keycloak.py
+++ b/kamiwaza_sdk/seeding/federation/keycloak.py
@@ -1,0 +1,278 @@
+"""Minimal Keycloak admin client for shared_idp dev seeding.
+
+The platform API cannot create the shared *realm* / ROPC client / persona users /
+clearance mapper — that is Keycloak-admin territory. This module is a small,
+idempotent wrapper over the Keycloak Admin REST API covering exactly what the
+``idp`` command group needs to stand up a shared_idp realm the way the L3 fixture
+did by hand. It is intentionally dependency-light (``requests`` only) and
+dev-scoped; production IdPs are managed by the customer's own tooling.
+
+All operations are idempotent (ensure-semantics): safe to re-run.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from urllib.parse import quote
+
+import requests
+
+
+class KeycloakAdminError(RuntimeError):
+    """A Keycloak admin REST call failed."""
+
+
+class KeycloakAdmin:
+    """Idempotent Keycloak-admin operations for shared_idp seeding.
+
+    Args:
+        base_url: Keycloak base, e.g. ``https://host/`` (the realms live at
+            ``<base_url>/realms/<realm>``; the admin API at
+            ``<base_url>/admin/realms/...``).
+        admin_user / admin_password: master-realm admin credentials (the password
+            is read from an env var by the CLI, never argv).
+        verify: TLS verification (False for the dev self-signed cluster cert).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        admin_user: str,
+        admin_password: str,
+        verify: Any = True,
+        timeout: float = 30.0,
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._admin_user = admin_user
+        self._admin_password = admin_password
+        self._verify = verify
+        self._timeout = timeout
+        self._token: Optional[str] = None
+
+    # -- low-level ---------------------------------------------------------
+
+    def _admin_token(self) -> str:
+        if self._token:
+            return self._token
+        resp = requests.post(
+            f"{self._base}/realms/master/protocol/openid-connect/token",
+            data={
+                "grant_type": "password",
+                "client_id": "admin-cli",
+                "username": self._admin_user,
+                "password": self._admin_password,
+            },
+            verify=self._verify,
+            timeout=self._timeout,
+        )
+        if resp.status_code != 200:
+            raise KeycloakAdminError(
+                f"admin token request failed ({resp.status_code}); check "
+                "Keycloak URL + master-realm admin credentials"
+            )
+        token = str(resp.json()["access_token"])
+        self._token = token
+        return token
+
+    def _req(self, method: str, path: str, **kwargs: Any) -> requests.Response:
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = f"Bearer {self._admin_token()}"
+        return requests.request(
+            method,
+            f"{self._base}/admin{path}",
+            headers=headers,
+            verify=self._verify,
+            timeout=self._timeout,
+            **kwargs,
+        )
+
+    @staticmethod
+    def _created_id(resp: requests.Response) -> Optional[str]:
+        """Extract the created entity id from a Keycloak 201 Location header."""
+        loc = resp.headers.get("Location", "")
+        return loc.rstrip("/").rsplit("/", 1)[-1] if loc else None
+
+    # -- realm -------------------------------------------------------------
+
+    def ensure_realm(self, realm: str) -> Dict[str, Any]:
+        """Create the realm if absent (enabled). Idempotent."""
+        got = self._req("GET", f"/realms/{quote(realm)}")
+        if got.status_code == 200:
+            return {"realm": realm, "created": False}
+        resp = self._req(
+            "POST", "/realms", json={"realm": realm, "enabled": True}
+        )
+        if resp.status_code not in (201, 409):
+            raise KeycloakAdminError(
+                f"create realm {realm!r} failed ({resp.status_code}): {resp.text[:200]}"
+            )
+        return {"realm": realm, "created": resp.status_code == 201}
+
+    def set_unmanaged_attributes(self, realm: str, *, policy: str = "ENABLED") -> None:
+        """Set the realm user-profile ``unmanagedAttributePolicy`` so persona
+        custom attributes (e.g. ``clearance``) are accepted (ENG-4946).
+
+        NOTE: this lives on the user-profile config endpoint, NOT the realm
+        representation (setting it on the realm rep 400s "Unrecognized field").
+        """
+        path = f"/realms/{quote(realm)}/users/profile"
+        got = self._req("GET", path)
+        profile = got.json() if got.status_code == 200 else {}
+        profile["unmanagedAttributePolicy"] = policy
+        resp = self._req("PUT", path, json=profile)
+        if resp.status_code not in (200, 204):
+            raise KeycloakAdminError(
+                f"set unmanagedAttributePolicy failed ({resp.status_code}): "
+                f"{resp.text[:200]}"
+            )
+
+    # -- client ------------------------------------------------------------
+
+    def ensure_ropc_client(self, realm: str, client_id: str) -> Dict[str, Any]:
+        """Ensure a public, direct-access-grants (ROPC) client. Idempotent."""
+        existing = self._req(
+            "GET", f"/realms/{quote(realm)}/clients", params={"clientId": client_id}
+        ).json()
+        if existing:
+            return {"client_id": client_id, "id": existing[0]["id"], "created": False}
+        resp = self._req(
+            "POST",
+            f"/realms/{quote(realm)}/clients",
+            json={
+                "clientId": client_id,
+                "enabled": True,
+                "publicClient": True,
+                "directAccessGrantsEnabled": True,
+                "standardFlowEnabled": False,
+                "serviceAccountsEnabled": False,
+            },
+        )
+        if resp.status_code not in (201, 409):
+            raise KeycloakAdminError(
+                f"create client {client_id!r} failed ({resp.status_code}): "
+                f"{resp.text[:200]}"
+            )
+        return {"client_id": client_id, "id": self._created_id(resp), "created": True}
+
+    def ensure_attribute_mapper(
+        self, realm: str, client_uuid: str, *, attribute: str
+    ) -> None:
+        """Ensure a user-attribute -> access-token claim mapper on the client so a
+        persona's ``clearance`` (etc.) is projected as a top-level token claim.
+        """
+        base = f"/realms/{quote(realm)}/clients/{client_uuid}/protocol-mappers/models"
+        existing = self._req("GET", base).json()
+        name = f"{attribute}-attr-mapper"
+        if any(m.get("name") == name for m in existing):
+            return
+        resp = self._req(
+            "POST",
+            base,
+            json={
+                "name": name,
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-usermodel-attribute-mapper",
+                "config": {
+                    "user.attribute": attribute,
+                    "claim.name": attribute,
+                    "jsonType.label": "String",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "userinfo.token.claim": "true",
+                },
+            },
+        )
+        if resp.status_code not in (201, 409):
+            raise KeycloakAdminError(
+                f"create attribute mapper {name!r} failed ({resp.status_code}): "
+                f"{resp.text[:200]}"
+            )
+
+    # -- user --------------------------------------------------------------
+
+    def ensure_user(
+        self,
+        realm: str,
+        username: str,
+        *,
+        password: str,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Ensure a persona user with attributes + a non-temporary password.
+
+        email / first / last are set so the direct-access-grant (ROPC) is not
+        blocked by "Account is not fully set up".
+        """
+        found = self._req(
+            "GET", f"/realms/{quote(realm)}/users", params={"username": username, "exact": "true"}
+        ).json()
+        attrs = {k: (v if isinstance(v, list) else [str(v)]) for k, v in (attributes or {}).items()}
+        rep = {
+            "username": username,
+            "enabled": True,
+            "emailVerified": True,
+            "email": f"{username}@shared.local",
+            "firstName": username,
+            "lastName": "persona",
+            "attributes": attrs,
+        }
+        if found:
+            uid = found[0]["id"]
+            self._req("PUT", f"/realms/{quote(realm)}/users/{uid}", json=rep)
+            created = False
+        else:
+            resp = self._req("POST", f"/realms/{quote(realm)}/users", json=rep)
+            if resp.status_code not in (201, 409):
+                raise KeycloakAdminError(
+                    f"create user {username!r} failed ({resp.status_code}): "
+                    f"{resp.text[:200]}"
+                )
+            uid = self._created_id(resp)
+            created = True
+        pw = self._req(
+            "PUT",
+            f"/realms/{quote(realm)}/users/{uid}/reset-password",
+            json={"type": "password", "value": password, "temporary": False},
+        )
+        if pw.status_code not in (200, 204):
+            raise KeycloakAdminError(
+                f"set password for {username!r} failed ({pw.status_code})"
+            )
+        return {"username": username, "id": uid, "created": created}
+
+    # -- token (test helper) ----------------------------------------------
+
+    def ropc_token(
+        self, realm: str, client_id: str, username: str, password: str
+    ) -> str:
+        """Mint an access token for a persona via ROPC (direct access grant)."""
+        resp = requests.post(
+            f"{self._base}/realms/{quote(realm)}/protocol/openid-connect/token",
+            data={
+                "grant_type": "password",
+                "client_id": client_id,
+                "username": username,
+                "password": password,
+            },
+            verify=self._verify,
+            timeout=self._timeout,
+        )
+        if resp.status_code != 200:
+            raise KeycloakAdminError(
+                f"ROPC token for {username!r} failed ({resp.status_code}): "
+                f"{resp.text[:200]}"
+            )
+        return str(resp.json().get("access_token", ""))
+
+    def issuer_url(self, realm: str) -> str:
+        """The realm's OIDC issuer — the shared_issuer for ``fed pair``."""
+        return f"{self._base}/realms/{realm}"
+
+
+def jwks_uri_from_issuer(issuer: str) -> str:
+    """Derive a Keycloak realm's JWKS endpoint (mirrors the server-side helper;
+    ``fed pair`` uses this so JWKS is pinned to the issuer — #2298 H1)."""
+    return issuer.rstrip("/") + "/protocol/openid-connect/certs"
+
+

--- a/kamiwaza_sdk/seeding/federation/keycloak.py
+++ b/kamiwaza_sdk/seeding/federation/keycloak.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import Any, Dict, Optional
 from urllib.parse import quote
 
-import requests
+import requests  # type: ignore[import-untyped]
 
 
 class KeycloakAdminError(RuntimeError):

--- a/kamiwaza_sdk/services/federations.py
+++ b/kamiwaza_sdk/services/federations.py
@@ -215,6 +215,23 @@ class FederationsAPI(BaseService):
         )
         return Federation.model_validate(paired)
 
+    def _list_raw(self) -> List[Any]:
+        """GET the federation list and return the raw item dicts.
+
+        The server may return a bare list or ``{"items": [...]}``; both are
+        normalized to a list here. Shared by :meth:`list` (which validates each
+        item into a ``Federation``) and :meth:`_resolve_id` (which only needs
+        the ``id`` / ``remote_cluster_name`` identity fields and must not depend
+        on the full ``Federation`` schema being satisfied).
+        """
+        body = self.client._request("GET", "/cluster/federations")
+        if isinstance(body, dict):
+            raw = body.get("items")
+            return raw if isinstance(raw, list) else []
+        if isinstance(body, list):
+            return body
+        return []
+
     def list(self) -> List[Federation]:
         """List all federations on this cluster.
 
@@ -222,15 +239,7 @@ class FederationsAPI(BaseService):
         surface (mode, issuer, PAIRED state, brokering config). The server may
         return a bare list or ``{"items": [...]}``; both are handled.
         """
-        body = self.client._request("GET", "/cluster/federations")
-        if isinstance(body, dict):
-            raw = body.get("items")
-            items: List[Any] = raw if isinstance(raw, list) else []
-        elif isinstance(body, list):
-            items = body
-        else:
-            items = []
-        return [Federation.model_validate(item) for item in items]
+        return [Federation.model_validate(item) for item in self._list_raw()]
 
     def get(self, federation_id: Any) -> Federation:
         """Fetch a single federation by id (``GET /cluster/federations/{id}``)."""
@@ -246,14 +255,19 @@ class FederationsAPI(BaseService):
     def _resolve_id(self, name: str) -> str:
         """Resolve a federation by name to its UUID id.
 
-        Walks the federation list once; result is cached on the
-        ``FederationProxy`` after first resolution so ``users.add`` /
-        ``users.revoke`` don't refetch.
+        Walks the raw federation list once and matches on
+        ``remote_cluster_name``; result is cached on the ``FederationProxy``
+        after first resolution so ``users.add`` / ``users.revoke`` don't
+        refetch. Deliberately reads the raw list dicts rather than constructing
+        full ``Federation`` models: id-resolution only needs the ``id`` +
+        ``remote_cluster_name`` identity fields and must not fail if the list
+        endpoint omits an unrelated ``Federation`` field (e.g. ``status``).
         """
-        for fed in self.list():
-            data = fed.model_dump()
-            if data.get("remote_cluster_name") == name:
-                return str(data["id"])
+        for item in self._list_raw():
+            if isinstance(item, dict) and item.get("remote_cluster_name") == name:
+                fed_id = item.get("id")
+                if fed_id:
+                    return str(fed_id)
 
         from ..exceptions import KamiwazaError
 

--- a/kamiwaza_sdk/services/federations.py
+++ b/kamiwaza_sdk/services/federations.py
@@ -215,6 +215,30 @@ class FederationsAPI(BaseService):
         )
         return Federation.model_validate(paired)
 
+    def list(self) -> List[Federation]:
+        """List all federations on this cluster.
+
+        ``GET /cluster/federations`` — the widened any-authenticated posture
+        surface (mode, issuer, PAIRED state, brokering config). The server may
+        return a bare list or ``{"items": [...]}``; both are handled.
+        """
+        body = self.client._request("GET", "/cluster/federations")
+        if isinstance(body, dict):
+            raw = body.get("items")
+            items: List[Any] = raw if isinstance(raw, list) else []
+        elif isinstance(body, list):
+            items = body
+        else:
+            items = []
+        return [Federation.model_validate(item) for item in items]
+
+    def get(self, federation_id: Any) -> Federation:
+        """Fetch a single federation by id (``GET /cluster/federations/{id}``)."""
+        body = self.client._request(
+            "GET", f"/cluster/federations/{federation_id}"
+        )
+        return Federation.model_validate(body)
+
     def __getitem__(self, name: str) -> "FederationProxy":
         """``client.federations["ORION"]`` — proxy for sub-resource access."""
         return FederationProxy(client=self.client, federations_api=self, name=name)
@@ -226,23 +250,16 @@ class FederationsAPI(BaseService):
         ``FederationProxy`` after first resolution so ``users.add`` /
         ``users.revoke`` don't refetch.
         """
-        body = self.client._request("GET", "/cluster/federations")
-        items: List[Any] = []
-        if isinstance(body, dict):
-            raw = body.get("items")
-            if isinstance(raw, list):
-                items = raw
-        elif isinstance(body, list):
-            items = body
-        for item in items:
-            if isinstance(item, dict) and item.get("remote_cluster_name") == name:
-                return str(item["id"])
+        for fed in self.list():
+            data = fed.model_dump()
+            if data.get("remote_cluster_name") == name:
+                return str(data["id"])
 
         from ..exceptions import KamiwazaError
 
         raise KamiwazaError(
             f"No federation named {name!r} on this cluster. "
-            "List federations with client.federations.list() (T5.x in WS-M2)."
+            "List federations with client.federations.list()."
         )
 
 
@@ -276,9 +293,11 @@ class FederationProxy:
 
         Routes ``GET /api/cluster/cluster_capabilities`` through the local
         mesh proxy at ``/api/mesh/{name}/...``. The mesh proxy resolves
-        ``name`` to the federation, applies the federation:operator ReBAC
-        guard, signs the request with the local cluster's HMAC, and
-        forwards to the remote cluster.
+        ``name`` to the federation, signs the request with the local
+        cluster's HMAC, and forwards to the remote cluster. (Mesh egress is
+        authenticated-only; cross-cluster authorization is receiver-controlled
+        per F10 — the initiator ``federation:operator`` gate was dropped in
+        ENG-8571.)
 
         The federation selector is the cluster name itself — no separate
         federation-id resolution round-trip required.

--- a/kamiwaza_sdk/services/federations.py
+++ b/kamiwaza_sdk/services/federations.py
@@ -67,6 +67,9 @@ class FederationsAPI(BaseService):
         local_kc_jwks_url: Optional[str] = None,
         local_broker_client_id: Optional[str] = None,
         local_broker_client_secret: Optional[str] = None,
+        shared_issuer_url: Optional[str] = None,
+        shared_jwks_url: Optional[str] = None,
+        shared_ca_pem: Optional[str] = None,
     ) -> Federation:
         """Initiate or accept a federation pairing.
 
@@ -174,6 +177,18 @@ class FederationsAPI(BaseService):
             create_body["local_broker_client_id"] = local_broker_client_id
         if local_broker_client_secret is not None:
             create_body["local_broker_client_secret"] = local_broker_client_secret
+        # ENG-8213 — shared_idp (Alt C). Supplying ``shared_issuer_url`` creates
+        # the federation in the receiver-controlled shared_idp mode (both
+        # clusters trust this shared realm) instead of the legacy source-trusted
+        # peer_kc mode, and it is NOT gated by ALLOW_UNTRUSTED_FEDERATION.
+        # ``shared_jwks_url`` is derived from the issuer server-side when omitted;
+        # ``shared_ca_pem`` pins the JWKS-fetch trust root for a self-signed realm.
+        if shared_issuer_url is not None:
+            create_body["shared_issuer_url"] = shared_issuer_url
+        if shared_jwks_url is not None:
+            create_body["shared_jwks_url"] = shared_jwks_url
+        if shared_ca_pem is not None:
+            create_body["shared_ca_pem"] = shared_ca_pem
 
         created = self.client._request(
             "POST",

--- a/kamiwaza_sdk/services/federations.py
+++ b/kamiwaza_sdk/services/federations.py
@@ -308,6 +308,21 @@ class FederationProxy:
         )
         return ClusterCapabilities.model_validate(body)
 
+    def disconnect(self, *, force: bool = False) -> Any:
+        """Disconnect (unpair) this federation.
+
+        ``POST /cluster/federations/{id}/disconnect``. Resolves the federation
+        id from the name first. ``force=True`` tears down without waiting for the
+        peer's acknowledgement (use when the peer is already gone). Returns the
+        server's confirmation payload.
+        """
+        params = {"force": "true"} if force else None
+        return self._client._request(
+            "POST",
+            f"/cluster/federations/{self._id()}/disconnect",
+            params=params,
+        )
+
     def _id(self) -> str:
         cached = self._cached_id
         if cached is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ build-backend = "setuptools.build_meta"
 [project.scripts]
 kz-ext = "kamiwaza_extensions.cli:app"
 kamiwaza-seed = "kamiwaza_sdk.seeding.cli:main"
+kamiwaza-fed = "kamiwaza_sdk.seeding.federation.cli:main"
 
 # `kamiwaza-extensions-lib` is published as its own PyPI distribution
 # from `kamiwaza_extensions_lib/pyproject.toml`. For local dev / tests we

--- a/tests/integration/_mini_clearance.py
+++ b/tests/integration/_mini_clearance.py
@@ -282,6 +282,89 @@ def retrieve_through_gate(client: Any, dataset_urn: str) -> tuple[list[dict], di
     return rows, summary
 
 
+def mesh_retrieve_through_gate(
+    persona_client: Any,
+    base_url: str,
+    token: str,
+    fed_name: str,
+    dataset_urn: str,
+    *,
+    verify: Any,
+) -> tuple[list[dict], dict]:
+    """Create a retrieval job over the mesh, then drain its gated SSE stream over
+    the mesh — the L3 (two-cluster) analogue of ``retrieve_through_gate``.
+
+    ``POST /mesh/{fed}/api/retrieval/jobs`` returns an async job handle, so the
+    gated ``records`` + ``gate_audit`` footer only arrive on
+    ``GET /mesh/{fed}/api/retrieval/jobs/{id}/stream`` (SSE). The mesh proxy
+    forwards both verbatim (StreamingResponse over ``aiter_raw``). The create goes
+    through the SDK client so a 401/403/404 raises APIError for
+    ``_mesh_call_or_skip`` to classify; the stream is a raw SSE GET (the SDK only
+    streams local retrieval paths). Returns (rows, gate_audit summary) in the
+    shape ``assert_persona_result`` expects; ``gate_audit`` is absorbed as either
+    the inline single-dict footer or the federated list-of-dicts seam.
+    """
+    import requests
+
+    job = persona_client._request(
+        "POST", f"/mesh/{fed_name}/api/retrieval/jobs", json={"dataset_urn": dataset_urn}
+    )
+    if isinstance(job, dict):
+        job_id = job.get("job_id") or job.get("id")
+    else:
+        job_id = getattr(job, "job_id", None) or getattr(job, "id", None)
+    assert job_id, f"mesh create-job returned no job id: {job!r}"
+
+    included = redacted = total = 0
+    saw = False
+    rows: list[dict] = []
+
+    def _absorb(entry: Any) -> None:
+        nonlocal included, redacted, total, saw
+        if isinstance(entry, list):
+            for item in entry:
+                _absorb(item)
+        elif isinstance(entry, dict):
+            saw = True
+            included += int(entry.get("included", 0))
+            redacted += int(entry.get("redacted", 0))
+            total += int(entry.get("total", 0))
+
+    url = f"{base_url}/mesh/{fed_name}/api/retrieval/jobs/{job_id}/stream"
+    headers = {"Authorization": f"Bearer {token}", "Accept": "text/event-stream"}
+    with requests.get(
+        url, headers=headers, stream=True, verify=verify, timeout=120
+    ) as sr:
+        if sr.status_code in (403, 404):
+            from kamiwaza_sdk.exceptions import APIError
+
+            exc = APIError(f"mesh retrieval stream returned {sr.status_code}")
+            exc.status_code = sr.status_code  # let _mesh_call_or_skip classify it
+            raise exc
+        sr.raise_for_status()
+        event: Optional[str] = None
+        data_lines: list[str] = []
+        for raw in sr.iter_lines(decode_unicode=True):
+            if raw is None:
+                continue
+            if raw == "":  # SSE event terminator (blank line)
+                if data_lines and event == "chunk":
+                    payload = json.loads("\n".join(data_lines))
+                    rows.extend(payload.get("records") or payload.get("rows") or [])
+                    _absorb((payload.get("metadata") or {}).get("gate_audit"))
+                event, data_lines = None, []
+                continue
+            if raw.startswith(":"):  # SSE comment / heartbeat
+                continue
+            if raw.startswith("event:"):
+                event = raw[len("event:") :].strip()
+            elif raw.startswith("data:"):
+                data_lines.append(raw[len("data:") :].lstrip())
+
+    summary = {"included": included, "redacted": redacted, "total": total} if saw else {}
+    return rows, summary
+
+
 def initiator_cluster_uuid(receiver: Any, receiver_fed_id: str) -> Optional[str]:
     """The initiator cluster's UUID, for building brokered ``external_id``s.
 
@@ -301,40 +384,6 @@ def initiator_cluster_uuid(receiver: Any, receiver_fed_id: str) -> Optional[str]
     record = next((f for f in feds if str(f.get("id")) == str(receiver_fed_id)), None)
     cluster_uuid = (record or {}).get("remote_cluster_id")
     return str(cluster_uuid) if cluster_uuid else None
-
-
-def parse_mesh_retrieval_result(result: Any, initiator: Any, fed_name: str) -> tuple[list[dict], dict]:
-    """Parse a mesh retrieval-jobs response into (rows, gate_audit summary).
-
-    The federated job-result seam emits ``gate_audit`` as a LIST (one entry per
-    gated target dataset), unlike the inline single-dict retrieval footer — so
-    branch on the actual shape. Kept defensive: this is the live-iteration seam
-    that only exercises once the mesh data-plane returns records.
-    """
-    del initiator, fed_name  # reserved for a poll/stream variant if the mesh
-    # returns a job handle rather than an inline result
-
-    included = redacted = total = 0
-    saw = False
-
-    def _absorb(entry: Any) -> None:
-        nonlocal included, redacted, total, saw
-        if isinstance(entry, list):
-            for item in entry:
-                _absorb(item)
-        elif isinstance(entry, dict):
-            saw = True
-            included += int(entry.get("included", 0))
-            redacted += int(entry.get("redacted", 0))
-            total += int(entry.get("total", 0))
-
-    rows: list[dict] = []
-    if isinstance(result, dict):
-        rows = list(result.get("records") or result.get("rows") or [])
-        meta = result.get("metadata") or result
-        _absorb(meta.get("gate_audit"))
-    summary = {"included": included, "redacted": redacted, "total": total} if saw else {}
-    return rows, summary
 
 
 def assert_persona_result(clearance: str, rows: list[dict], gate_audit: dict) -> None:

--- a/tests/integration/_mini_clearance.py
+++ b/tests/integration/_mini_clearance.py
@@ -84,27 +84,47 @@ def _wheel_sha256(wheel_dir: str) -> str:
     return f"sha256:{digest}"
 
 
-def install_gate_package(kz: Any, wheel_dir: str, index_url: str) -> None:
-    """Install acme-gates==1.1.0 and confirm MiniClearanceGate's classpath is discoverable.
+def _already_installed(kz: Any) -> bool:
+    """True iff acme-gates is installed with MiniClearanceGate's classpath present.
 
-    The dataset gate-bind endpoint enforces the classpath allowlist against
-    ``cluster_gate_packages.classpaths`` (populated by this install's discover
-    step), so a successful install MUST precede ``set_gate`` — otherwise the
-    bind 403s ``classpath_not_allowed``. Uninstall-first so a stale install from
-    an interrupted prior run doesn't 409 ``package_exists``.
+    The desired end-state is idempotent: the gate package being present (with our
+    classpath) is what setup needs, regardless of how it got there. Checking this
+    first makes the fixture resilient to a package left behind by an interrupted
+    prior run — where an uninstall-first would 409 ``uninstall_blocked`` (an
+    orphaned dataset still binds the gate) and a bare install would 409
+    ``package_exists``.
     """
     try:
-        kz.gates.packages.uninstall("acme-gates")
-    except Exception:  # noqa: BLE001 — not-installed is fine
-        pass
-    result = kz.gates.packages.install(
-        PACKAGE_SPEC,
-        hash_digest=_wheel_sha256(wheel_dir),
-        index_url=index_url,
-    )
-    assert GATE_CLASSPATH in result.package.classpaths, (
-        f"{GATE_CLASSPATH} not recorded in installed classpaths: {result.package.classpaths}"
-    )
+        listing = kz.gates.packages.list()
+    except Exception:  # noqa: BLE001 — treat an unreadable listing as not-installed
+        return False
+    for pkg in getattr(listing, "items", listing) or []:
+        if getattr(pkg, "name", None) == "acme-gates" and GATE_CLASSPATH in (
+            getattr(pkg, "classpaths", None) or []
+        ):
+            return True
+    return False
+
+
+def install_gate_package(kz: Any, wheel_dir: str, index_url: str) -> None:
+    """Ensure acme-gates==1.1.0 is installed and MiniClearanceGate is discoverable.
+
+    The dataset gate-bind endpoint enforces the classpath allowlist against
+    ``cluster_gate_packages.classpaths`` (populated by the install's discover
+    step), so the package MUST be present before ``set_gate`` — otherwise the
+    bind 403s ``classpath_not_allowed``. Idempotent: if a prior run already
+    installed it (with our classpath) we keep it, since uninstalling it can be
+    refused while an orphaned dataset still binds the gate.
+    """
+    if not _already_installed(kz):
+        result = kz.gates.packages.install(
+            PACKAGE_SPEC,
+            hash_digest=_wheel_sha256(wheel_dir),
+            index_url=index_url,
+        )
+        assert GATE_CLASSPATH in result.package.classpaths, (
+            f"{GATE_CLASSPATH} not recorded in installed classpaths: {result.package.classpaths}"
+        )
     gate = kz.gates.discover(GATE_CLASSPATH)
     assert gate.name == GATE_NAME
 
@@ -210,6 +230,27 @@ def retrieve_through_gate(client: Any, dataset_urn: str) -> tuple[list[dict], di
         {"included": included, "redacted": redacted, "total": total} if saw_audit else {}
     )
     return rows, summary
+
+
+def initiator_cluster_uuid(receiver: Any, receiver_fed_id: str) -> Optional[str]:
+    """The initiator cluster's UUID, for building brokered ``external_id``s.
+
+    Sourced from the RECEIVER's federation record (``remote_cluster_id``, which
+    the /pair handshake populates), NOT ``initiator.cluster.diagnose()`` (that
+    returns a ClusterDiagnostics with no cluster-id field) nor
+    ``cluster.capabilities()`` (403 ``not_authorized_to_probe_cluster`` for a
+    plain admin). Matched by the receiver-side federation *id* — the /pair
+    handshake overwrites the receiver's ``remote_cluster_name`` with the
+    initiator's cluster name, so a lookup-by-name fails post-pair.
+    ``GET /cluster/federations`` is the widened any-authenticated surface.
+    Returns None if the record/field isn't present yet.
+    """
+    feds = receiver._request("GET", "/cluster/federations") or []
+    if isinstance(feds, dict):  # paginated {"items": [...]} shape
+        feds = feds.get("items") or []
+    record = next((f for f in feds if str(f.get("id")) == str(receiver_fed_id)), None)
+    cluster_uuid = (record or {}).get("remote_cluster_id")
+    return str(cluster_uuid) if cluster_uuid else None
 
 
 def parse_mesh_retrieval_result(result: Any, initiator: Any, fed_name: str) -> tuple[list[dict], dict]:

--- a/tests/integration/_mini_clearance.py
+++ b/tests/integration/_mini_clearance.py
@@ -1,0 +1,237 @@
+"""Shared fixtures + helpers for the ENG-8325 MiniClearanceGate live tests.
+
+Layers 2 (single-cluster) and 3 (two-cluster federated) both prove the
+install -> file-source -> gate-bind -> retrieve-through-gate path end to end
+against a live cluster, using the trivial deterministic fixture:
+
+    5 records [U, U, U, S, TS]  ->  post-gate counts  U:3/2  S:4/1  TS:5/0
+
+The gate *logic* is covered offline in the kamiwaza repo
+(tests/unit/services/authz/gates/test_mini_clearance_gate.py); these live layers
+exercise the wheel install, the ``platform="file"`` parquet/csv source, the
+dataset gate-binding, and the server-side gate invocation at retrieval time.
+
+Every live prerequisite is a soft skip (never a hard fail on a contributor box):
+the WS-M5 gate-packages PVC + a served 1.1.0 wheel, and a filesystem-source root
+the ray-head can read.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+import urllib.request
+from pathlib import Path
+from typing import Any, Optional
+
+GATE_CLASSPATH = "acme_gates.mini_clearance_gate.MiniClearanceGate"
+GATE_NAME = "mini_clearance_gate"
+WHEEL_NAME = "acme_gates-1.1.0-py3-none-any.whl"
+PACKAGE_SPEC = "acme-gates==1.1.0"
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "mini_clearance_records.json"
+
+# persona clearance -> (included, redacted, allowed classifications)
+KNOWN: dict[str, tuple[int, int, set[str]]] = {
+    "U": (3, 2, {"U"}),
+    "S": (4, 1, {"U", "S"}),
+    "TS": (5, 0, {"U", "S", "TS"}),
+}
+
+
+def records() -> list[dict[str, Any]]:
+    return json.loads(_FIXTURE.read_text())
+
+
+def write_dataset_file(path: Path) -> str:
+    """Write the 5-record fixture at ``path`` as parquet (fallback csv).
+
+    The FilesystemAdapter infers the format from the extension. Returns the
+    format actually written ("parquet" | "csv").
+    """
+    rows = records()
+    if path.suffix.lower() == ".parquet":
+        try:
+            import pandas as pd  # noqa: PLC0415 — optional, only on the writer host
+
+            pd.DataFrame(rows).to_parquet(path, index=False)
+            return "parquet"
+        except Exception:  # pandas/pyarrow absent -> csv fallback
+            path = path.with_suffix(".csv")
+    with path.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    return "csv"
+
+
+# ── gate-package install ────────────────────────────────────────────────────
+
+def wheel_and_index() -> Optional[tuple[str, str]]:
+    """(M5_TEST_WHEEL_DIR, M5_TEST_INDEX_URL) iff both set and the 1.1.0 wheel is present."""
+    wheel_dir = os.getenv("M5_TEST_WHEEL_DIR", "").strip()
+    index_url = os.getenv("M5_TEST_INDEX_URL", "").strip()
+    if not wheel_dir or not index_url:
+        return None
+    if not (Path(wheel_dir) / WHEEL_NAME).exists():
+        return None
+    return wheel_dir, index_url
+
+
+def _wheel_sha256(wheel_dir: str) -> str:
+    digest = hashlib.sha256((Path(wheel_dir) / WHEEL_NAME).read_bytes()).hexdigest()
+    return f"sha256:{digest}"
+
+
+def install_gate_package(kz: Any, wheel_dir: str, index_url: str) -> None:
+    """Install acme-gates==1.1.0 and confirm MiniClearanceGate's classpath is discoverable.
+
+    The dataset gate-bind endpoint enforces the classpath allowlist against
+    ``cluster_gate_packages.classpaths`` (populated by this install's discover
+    step), so a successful install MUST precede ``set_gate`` — otherwise the
+    bind 403s ``classpath_not_allowed``.
+    """
+    result = kz.gates.packages.install(
+        PACKAGE_SPEC,
+        hash_digest=_wheel_sha256(wheel_dir),
+        index_url=index_url,
+    )
+    assert GATE_CLASSPATH in result.package.classpaths, (
+        f"{GATE_CLASSPATH} not recorded in installed classpaths: {result.package.classpaths}"
+    )
+    gate = kz.gates.discover(GATE_CLASSPATH)
+    assert gate.name == GATE_NAME
+
+
+# ── clearance personas ──────────────────────────────────────────────────────
+
+def seed_local_persona(kz: Any, username: str, clearance: str) -> None:
+    """Upsert a local subject carrying ``clearance`` (password == username)."""
+    kz.subjects.upsert(username, attributes={"clearance": clearance}, password=username)
+
+
+def grant_dataset_viewer(kz: Any, username: str, dataset_urn: str) -> None:
+    """Grant the subject a viewer ReBAC tuple on the dataset (else retrieval 404s
+    at the seam before the gate runs)."""
+    kz.subjects.grants(username).create(
+        object_namespace="dataset", object_id=dataset_urn, relation="viewer"
+    )
+
+
+def mint_token(base_url: str, username: str, password: str, *, verify: bool) -> str:
+    """Password-grant token for a persona (POST /auth/token)."""
+    import ssl
+
+    body = json.dumps(
+        {"username": username, "password": password, "grant_type": "password"}
+    ).encode()
+    req = urllib.request.Request(
+        f"{base_url.rstrip('/')}/auth/token",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    ctx = None if verify else ssl._create_unverified_context()
+    with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:  # noqa: S310
+        token = json.loads(resp.read()).get("access_token")
+    if not token:
+        raise RuntimeError(f"no access_token minted for {username}")
+    return str(token)
+
+
+def persona_client(base_url: str, token: str, *, verify: bool) -> Any:
+    from kamiwaza_sdk import KamiwazaClient
+
+    return KamiwazaClient(base_url=base_url, api_key=token, verify=verify)
+
+
+# ── file-backed gated dataset ───────────────────────────────────────────────
+
+def create_file_dataset(kz: Any, name: str, file_path: str) -> str:
+    """Create a ``platform="file"`` dataset pointing at ``file_path`` and bind
+    MiniClearanceGate. Returns the dataset URN. Install must have run first."""
+    urn = kz.datasets.create(
+        name=name,
+        platform="file",
+        properties={"path": file_path},
+    )
+    kz.datasets.set_gate(urn, type=GATE_CLASSPATH, config={})
+    return urn
+
+
+def retrieve_through_gate(client: Any, dataset_urn: str) -> tuple[list[dict], dict]:
+    """Retrieve the dataset through the gate; return (rows, gate_audit summary).
+
+    Drains the SSE stream: ``chunk`` events carry ``records`` and a ``metadata``
+    dict whose ``gate_audit`` is the runner footer {gate, included, redacted,
+    total}. Summed across chunks (one chunk for the 5-row fixture).
+    """
+    from kamiwaza_sdk.schemas.retrieval import RetrievalRequest
+
+    job = client.retrieval.create_job(RetrievalRequest(dataset_urn=dataset_urn))
+    rows: list[dict] = []
+    included = redacted = total = 0
+    saw_audit = False
+    for event in client.retrieval.stream_events(job.job_id):
+        if event.event != "chunk":
+            continue
+        data = event.data or {}
+        rows.extend(data.get("records") or data.get("rows") or [])
+        gate_audit = (data.get("metadata") or {}).get("gate_audit")
+        if gate_audit:
+            saw_audit = True
+            included += int(gate_audit.get("included", 0))
+            redacted += int(gate_audit.get("redacted", 0))
+            total += int(gate_audit.get("total", 0))
+    summary = (
+        {"included": included, "redacted": redacted, "total": total} if saw_audit else {}
+    )
+    return rows, summary
+
+
+def parse_mesh_retrieval_result(result: Any, initiator: Any, fed_name: str) -> tuple[list[dict], dict]:
+    """Parse a mesh retrieval-jobs response into (rows, gate_audit summary).
+
+    The federated job-result seam emits ``gate_audit`` as a LIST (one entry per
+    gated target dataset), unlike the inline single-dict retrieval footer — so
+    branch on the actual shape. Kept defensive: this is the live-iteration seam
+    that only exercises once the mesh data-plane returns records.
+    """
+    del initiator, fed_name  # reserved for a poll/stream variant if the mesh
+    # returns a job handle rather than an inline result
+
+    included = redacted = total = 0
+    saw = False
+
+    def _absorb(entry: Any) -> None:
+        nonlocal included, redacted, total, saw
+        if isinstance(entry, list):
+            for item in entry:
+                _absorb(item)
+        elif isinstance(entry, dict):
+            saw = True
+            included += int(entry.get("included", 0))
+            redacted += int(entry.get("redacted", 0))
+            total += int(entry.get("total", 0))
+
+    rows: list[dict] = []
+    if isinstance(result, dict):
+        rows = list(result.get("records") or result.get("rows") or [])
+        meta = result.get("metadata") or result
+        _absorb(meta.get("gate_audit"))
+    summary = {"included": included, "redacted": redacted, "total": total} if saw else {}
+    return rows, summary
+
+
+def assert_persona_result(clearance: str, rows: list[dict], gate_audit: dict) -> None:
+    """Assert the known post-gate counts + zero leakage for a persona."""
+    included, redacted, allowed = KNOWN[clearance]
+    assert gate_audit, "no gate_audit footer in retrieval stream — gate not invoked?"
+    assert gate_audit["included"] == included, gate_audit
+    assert gate_audit["redacted"] == redacted, gate_audit
+    assert gate_audit["total"] == included + redacted
+    # zero leakage: nothing above the caller's clearance survives
+    leaked = [r for r in rows if str(r.get("classification", "")).upper() not in allowed]
+    assert not leaked, f"{clearance} caller leaked rows above clearance: {leaked}"

--- a/tests/integration/_mini_clearance.py
+++ b/tests/integration/_mini_clearance.py
@@ -22,7 +22,6 @@ import csv
 import hashlib
 import json
 import os
-import urllib.request
 from pathlib import Path
 from typing import Any, Optional
 
@@ -91,8 +90,13 @@ def install_gate_package(kz: Any, wheel_dir: str, index_url: str) -> None:
     The dataset gate-bind endpoint enforces the classpath allowlist against
     ``cluster_gate_packages.classpaths`` (populated by this install's discover
     step), so a successful install MUST precede ``set_gate`` — otherwise the
-    bind 403s ``classpath_not_allowed``.
+    bind 403s ``classpath_not_allowed``. Uninstall-first so a stale install from
+    an interrupted prior run doesn't 409 ``package_exists``.
     """
+    try:
+        kz.gates.packages.uninstall("acme-gates")
+    except Exception:  # noqa: BLE001 — not-installed is fine
+        pass
     result = kz.gates.packages.install(
         PACKAGE_SPEC,
         hash_digest=_wheel_sha256(wheel_dir),
@@ -107,6 +111,14 @@ def install_gate_package(kz: Any, wheel_dir: str, index_url: str) -> None:
 
 # ── clearance personas ──────────────────────────────────────────────────────
 
+def declare_clearance_attribute(kz: Any) -> None:
+    """Declare the ``clearance`` attribute in the realm vocabulary (idempotent).
+
+    Required BEFORE binding a gate whose required_attributes() references it, and
+    before seeding personas that carry it (ENG-4946)."""
+    kz.cluster.declare_attribute("clearance", type="string")
+
+
 def seed_local_persona(kz: Any, username: str, clearance: str) -> None:
     """Upsert a local subject carrying ``clearance`` (password == username)."""
     kz.subjects.upsert(username, attributes={"clearance": clearance}, password=username)
@@ -120,28 +132,37 @@ def grant_dataset_viewer(kz: Any, username: str, dataset_urn: str) -> None:
     )
 
 
-def mint_token(base_url: str, username: str, password: str, *, verify: bool) -> str:
-    """Password-grant token for a persona (POST /auth/token)."""
-    import ssl
+class _NoCacheTokenStore:
+    """No-op token store so each persona authenticates fresh (no on-disk bleed
+    between the U/S/TS clients). Duck-types the SDK TokenStore contract."""
 
-    body = json.dumps(
-        {"username": username, "password": password, "grant_type": "password"}
-    ).encode()
-    req = urllib.request.Request(
-        f"{base_url.rstrip('/')}/auth/token",
-        data=body,
-        headers={"Content-Type": "application/json"},
-        method="POST",
+    def load(self) -> None:
+        return None
+
+    def save(self, token: Any) -> None:  # noqa: ARG002
+        return None
+
+    def clear(self) -> None:
+        return None
+
+
+def authed_client(base_url: str, username: str, password: str, *, verify: bool) -> Any:
+    """A KamiwazaClient authenticated as (username/password) via the SDK's
+    password-grant authenticator — the canonical live-test auth path (mirrors
+    conftest's live_kamiwaza_client)."""
+    from kamiwaza_sdk import KamiwazaClient
+    from kamiwaza_sdk.authentication import UserPasswordAuthenticator
+
+    client = KamiwazaClient(base_url=base_url, verify=verify)
+    client.authenticator = UserPasswordAuthenticator(
+        username, password, client._auth_service, token_store=_NoCacheTokenStore()  # type: ignore[arg-type]
     )
-    ctx = None if verify else ssl._create_unverified_context()
-    with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:  # noqa: S310
-        token = json.loads(resp.read()).get("access_token")
-    if not token:
-        raise RuntimeError(f"no access_token minted for {username}")
-    return str(token)
+    return client
 
 
-def persona_client(base_url: str, token: str, *, verify: bool) -> Any:
+def raw_token_client(base_url: str, token: str, *, verify: bool) -> Any:
+    """A KamiwazaClient presenting a raw bearer token verbatim (for the
+    fabrication-negative: a token NOT signed by the shared realm)."""
     from kamiwaza_sdk import KamiwazaClient
 
     return KamiwazaClient(base_url=base_url, api_key=token, verify=verify)

--- a/tests/integration/_mini_clearance.py
+++ b/tests/integration/_mini_clearance.py
@@ -188,6 +188,56 @@ def raw_token_client(base_url: str, token: str, *, verify: bool) -> Any:
     return KamiwazaClient(base_url=base_url, api_key=token, verify=verify)
 
 
+def shared_realm_token(
+    issuer: str,
+    client_id: str,
+    username: str,
+    password: str,
+    *,
+    client_secret: Optional[str] = None,
+    verify: Any = True,
+) -> str:
+    """Mint an access token via ROPC (direct-access-grants) against a shared
+    realm's token endpoint.
+
+    A shared_idp mesh caller must present a token signed by the SHARED realm
+    (``issuer`` == the federation's shared_issuer_url): the mesh forwards the
+    caller's bearer verbatim, and the receiver validates it against the shared
+    realm's JWKS, so a local-realm token's kid is rejected (not in the shared
+    JWKS). The token also carries the realm's projected ``clearance`` claim,
+    which the initiator edge packs into X-User-Attributes for the gate.
+    """
+    import requests  # noqa: PLC0415 — only needed on the persona-auth path
+
+    data = {
+        "grant_type": "password",
+        "client_id": client_id,
+        "username": username,
+        "password": password,
+        "scope": "openid",
+    }
+    if client_secret:
+        data["client_secret"] = client_secret
+    resp = requests.post(
+        f"{issuer.rstrip('/')}/protocol/openid-connect/token",
+        data=data,
+        verify=verify,
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()["access_token"]
+
+
+def jwt_sub(token: str) -> str:
+    """The ``sub`` claim of a JWT (no signature verification — the server does
+    that). The receiver keys the brokered user on ``<sub>@<cluster-uuid>``."""
+    import base64  # noqa: PLC0415
+
+    payload = token.split(".")[1]
+    payload += "=" * ((4 - len(payload) % 4) % 4)
+    return str(json.loads(base64.urlsafe_b64decode(payload)).get("sub", ""))
+
+
 # ── file-backed gated dataset ───────────────────────────────────────────────
 
 def create_file_dataset(kz: Any, name: str, file_path: str) -> str:

--- a/tests/integration/fixtures/mini_clearance_records.json
+++ b/tests/integration/fixtures/mini_clearance_records.json
@@ -1,0 +1,7 @@
+[
+  {"id": "r1", "classification": "U", "payload": "unclassified-alpha"},
+  {"id": "r2", "classification": "U", "payload": "unclassified-bravo"},
+  {"id": "r3", "classification": "U", "payload": "unclassified-charlie"},
+  {"id": "r4", "classification": "S", "payload": "secret-delta"},
+  {"id": "r5", "classification": "TS", "payload": "topsecret-echo"}
+]

--- a/tests/integration/test_federation_identity_gate_live.py
+++ b/tests/integration/test_federation_identity_gate_live.py
@@ -1,0 +1,81 @@
+"""ENG-8213 — live known-answer proof of the federation identity gate + posture.
+
+Single-cluster live checks (no peer required): the receiving cluster REFUSES a
+new source-trusted ``peer_kc`` federation when ``ALLOW_UNTRUSTED_FEDERATION`` is
+off (the secure default), and ADMITS a receiver-controlled ``shared_idp``
+federation, surfacing its trust posture. Known-answer: exact reason string and
+exact posture fields, not a reachability smoke.
+
+The two-cluster known-answer gated-retrieval round-trip (shared_idp mesh + a
+seeded dataset with exact gated/ungated counts) is the sibling
+``requires_two_clusters`` test; these single-cluster checks validate the
+create-time gate + posture surface that it builds on.
+
+Verified live on spark-1 (2026-07-08).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from kamiwaza_sdk.exceptions import APIError
+
+pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
+
+
+def _cleanup(client, name_prefix: str) -> None:
+    """Delete any federation rows this test created (best-effort)."""
+    for fed in client._request("GET", "/cluster/federations") or []:
+        if str(fed.get("remote_cluster_name", "")).startswith(name_prefix):
+            try:
+                client._request("DELETE", f"/cluster/federations/{fed['id']}")
+            except APIError:
+                pass
+
+
+def test_new_peer_kc_federation_refused_when_untrusted_disabled(
+    live_kamiwaza_client,
+) -> None:
+    """A new peer_kc federation is refused with 400 untrusted_federation_disabled
+    when ALLOW_UNTRUSTED_FEDERATION is off (default). ENG-8322 / design §13.5."""
+    name = f"uat-peerkc-{uuid.uuid4().hex[:8]}"
+    try:
+        with pytest.raises(APIError) as excinfo:
+            live_kamiwaza_client._request(
+                "POST",
+                "/cluster/federations",
+                json={
+                    "remote_cluster_name": name,
+                    "role": "receiver",
+                    "preshared_key": str(uuid.uuid4()),
+                },
+            )
+        msg = str(excinfo.value)
+        assert "400" in msg
+        assert "untrusted_federation_disabled" in msg
+    finally:
+        _cleanup(live_kamiwaza_client, name)
+
+
+def test_shared_idp_federation_admitted_with_posture(live_kamiwaza_client) -> None:
+    """A shared_idp federation is admitted (not gated) and surfaces its
+    receiver-controlled trust posture. ENG-8324 / design §13.8."""
+    name = f"uat-sharedidp-{uuid.uuid4().hex[:8]}"
+    try:
+        created = live_kamiwaza_client._request(
+            "POST",
+            "/cluster/federations",
+            json={
+                "remote_cluster_name": name,
+                "role": "receiver",
+                "preshared_key": str(uuid.uuid4()),
+                "shared_issuer_url": "https://shared.example/realms/federated",
+            },
+        )
+        assert created["identity_mode"] == "shared_idp"
+        assert created["trust_posture"] == "receiver_controlled_shared"
+        assert created["grandfathered"] is False
+    finally:
+        _cleanup(live_kamiwaza_client, name)

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -259,15 +259,14 @@ def test_federated_persona_sees_exact_post_gate_counts(
     persona = mc.raw_token_client(initiator.base_url, token, verify=wiring["verify"])
 
     def _retrieve():
-        # Mesh retrieval-jobs on the receiver, routed through the federation.
-        return persona._request(
-            "POST",
-            f"/mesh/{name}/api/retrieval/jobs",
-            json={"dataset_urn": urn},
+        # Create the retrieval job over the mesh AND drain its gated SSE stream
+        # over the mesh — the results + gate_audit footer arrive on the stream,
+        # not the async create response. A 403/404 on either leg soft-skips.
+        return mc.mesh_retrieve_through_gate(
+            persona, initiator.base_url, token, name, urn, verify=wiring["verify"]
         )
 
-    result = _mesh_call_or_skip(_retrieve)
-    rows, gate_audit = mc.parse_mesh_retrieval_result(result, initiator, name)
+    rows, gate_audit = _mesh_call_or_skip(_retrieve)
     mc.assert_persona_result(clearance, rows, gate_audit)
 
 

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -110,7 +110,13 @@ def shared_idp_gated_pair(
     psk = uuid.uuid4().hex
 
     # 1. shared_idp pairing (receiver-controlled; not gated by ALLOW_UNTRUSTED).
-    receiver.federations.pair(name=name, role="receiver", preshared_key=psk, **shared)
+    #    Capture the receiver-side federation id — brokered-user writes and the
+    #    initiator-cluster-uuid lookup both key on it, since /pair overwrites the
+    #    receiver's remote_cluster_name with the initiator's cluster name.
+    recv_fed = receiver.federations.pair(
+        name=name, role="receiver", preshared_key=psk, **shared
+    )
+    receiver_id = str(recv_fed.id)
     initiator.federations.pair(
         name=name, role="initiator", remote_url=live_peer_base_url, preshared_key=psk, **shared
     )
@@ -122,17 +128,27 @@ def shared_idp_gated_pair(
 
     # 3. Brokered shared-realm identities (external_id keyed on the initiator
     #    cluster uuid). Their shared-realm JWT projects the `clearance` claim,
-    #    which arrives as X-User-Attributes on mesh inbound; grant viewer so the
-    #    request reaches the gate rather than 404-ing at the retrieval seam.
-    src_uuid = str(initiator.cluster.diagnose().get("cluster_id") or "").strip() or "initiator"
+    #    which arrives as X-User-Attributes on mesh inbound; seed a viewer tuple
+    #    so the auto-provisioned user reaches the gate rather than 404-ing at the
+    #    retrieval seam. POST against the receiver-side federation id (name
+    #    lookup fails post-pair) with the canonical subject/relation/object shape.
+    src_uuid = mc.initiator_cluster_uuid(receiver, receiver_id) or "initiator"
     externals = {}
     for clearance, base in _PERSONAS.items():
         external_id = f"{base}@{src_uuid}"
-        receiver.federations[name].users.add(
-            external_id=external_id,
-            initial_tuples=[
-                {"object_namespace": "dataset", "object_id": urn, "relation": "viewer"}
-            ],
+        receiver._request(
+            "POST",
+            f"/cluster/federations/{receiver_id}/users",
+            json={
+                "external_id": external_id,
+                "initial_tuples": [
+                    {
+                        "subject": f"user:{external_id}",
+                        "relation": "viewer",
+                        "object": f"dataset:{urn}",
+                    }
+                ],
+            },
         )
         externals[clearance] = external_id
 

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -1,0 +1,199 @@
+"""ENG-8325 Layer 3 — two-cluster shared_idp known-answer gated retrieval.
+
+The sibling that ``test_federation_identity_gate_live.py`` forward-declares: the
+data-plane round-trip on top of the single-cluster create-gate + posture surface.
+A federated (shared_idp) caller on the initiator (spark-1) retrieves a
+gate-bound dataset on the receiver (spark-2) over the mesh and receives ONLY the
+rows its clearance permits — asserted by exact post-gate counts, not reachability.
+
+Layers:
+  * gate-as-dataset-feature (single cluster) is Layer 2
+    (test_mini_clearance_gate_retrieval_live.py);
+  * gate LOGIC is Layer 1 (kamiwaza tests/unit/.../test_mini_clearance_gate.py).
+
+requires_two_clusters — auto-deselected without --live-peer-base-url. Data-plane
+assertions are tiered behind _mesh_call_or_skip: an authentic-persona 401 is a
+hard ENG-7203 regression; a 403/404 (gate-package PVC, filesystem root, or mesh
+data-plane precondition unmet) is a soft skip. Beyond the two-cluster rig, the
+operator must have provisioned on the RECEIVER: the WS-M5 gate-packages PVC + a
+served 1.1.0 wheel (M5_TEST_WHEEL_DIR/M5_TEST_INDEX_URL), the fixture file under
+RETRIEVAL_FILESYSTEM_ALLOWED_ROOTS (MINI_CLEARANCE_DATASET_PATH), and a shared
+realm that projects the ``clearance`` claim into brokered persona JWTs
+(SHARED_ISSUER_URL[/SHARED_JWKS_URL/SHARED_CA_PEM]); else the round-trip skips.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Iterator
+
+import pytest
+
+from . import _mini_clearance as mc
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.live,
+    pytest.mark.withoutresponses,
+    pytest.mark.requires_two_clusters,
+]
+
+_PERSONAS = {"U": "fed-clr-u", "S": "fed-clr-s", "TS": "fed-clr-ts"}
+
+
+def _mesh_call_or_skip(call):
+    """401 -> hard fail (ENG-7203 HMAC-strip regression); 403/404 -> soft skip
+    (mesh auth verified, downstream precondition unmet); else propagate."""
+    from kamiwaza_sdk.exceptions import APIError, AuthenticationError
+
+    try:
+        return call()
+    except AuthenticationError as exc:
+        pytest.fail(
+            "ENG-7203 regression: authentic mesh call returned 401 'Not "
+            f"authenticated' — x-kz-mesh-* HMAC stripped before ext-authz: {exc!r}"
+        )
+    except APIError as exc:
+        if getattr(exc, "status_code", None) in (403, 404):
+            pytest.skip(
+                "mesh auth verified (not ENG-7203); reached the receiver but hit a "
+                f"downstream precondition (gate PVC / fs-root / unseeded): {exc!r}"
+            )
+        raise
+
+
+def _shared_realm() -> dict[str, str]:
+    issuer = os.getenv("SHARED_ISSUER_URL", "").strip()
+    if not issuer:
+        pytest.skip(
+            "SHARED_ISSUER_URL not set — shared_idp pairing needs a shared realm "
+            "(and it must project the `clearance` claim into brokered JWTs)"
+        )
+    cfg = {"shared_issuer_url": issuer}
+    for env, key in (("SHARED_JWKS_URL", "shared_jwks_url"), ("SHARED_CA_PEM", "shared_ca_pem")):
+        val = os.getenv(env, "").strip()
+        if val:
+            cfg[key] = val
+    return cfg
+
+
+def _fed_name() -> str:
+    return f"eng8325-sharedidp-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture(scope="module")
+def _receiver_prereqs() -> tuple[str, str, str]:
+    wi = mc.wheel_and_index()
+    if wi is None:
+        pytest.skip("gate-packages wheel/index not configured on the receiver")
+    dataset_path = os.getenv("MINI_CLEARANCE_DATASET_PATH", "").strip()
+    if not dataset_path:
+        pytest.skip("MINI_CLEARANCE_DATASET_PATH not set (receiver fixture file)")
+    return wi[0], wi[1], dataset_path
+
+
+@pytest.fixture(scope="module")
+def shared_idp_gated_pair(
+    _receiver_prereqs,
+    live_kamiwaza_session_client,
+    live_kamiwaza_peer_client,
+    live_peer_base_url,
+) -> Iterator[dict]:
+    """Pair spark-1<->spark-2 in shared_idp mode; seed the receiver's gated
+    dataset + brokered U/S/TS identities. Yields the wiring; tears down at exit."""
+    wheel_dir, index_url, dataset_path = _receiver_prereqs
+    initiator = live_kamiwaza_session_client
+    receiver = live_kamiwaza_peer_client
+    shared = _shared_realm()
+    name = _fed_name()
+    psk = uuid.uuid4().hex
+
+    # 1. shared_idp pairing (receiver-controlled; not gated by ALLOW_UNTRUSTED).
+    receiver.federations.pair(name=name, role="receiver", preshared_key=psk, **shared)
+    initiator.federations.pair(
+        name=name, role="initiator", remote_url=live_peer_base_url, preshared_key=psk, **shared
+    )
+
+    # 2. Seed the receiver's gated dataset.
+    mc.install_gate_package(receiver, wheel_dir, index_url)
+    urn = mc.create_file_dataset(receiver, f"mini-clearance-{name}", dataset_path)
+
+    # 3. Brokered shared-realm identities (external_id keyed on the initiator
+    #    cluster uuid). Their shared-realm JWT projects the `clearance` claim,
+    #    which arrives as X-User-Attributes on mesh inbound; grant viewer so the
+    #    request reaches the gate rather than 404-ing at the retrieval seam.
+    src_uuid = str(initiator.cluster.diagnose().get("cluster_id") or "").strip() or "initiator"
+    externals = {}
+    for clearance, base in _PERSONAS.items():
+        external_id = f"{base}@{src_uuid}"
+        receiver.federations[name].users.add(
+            external_id=external_id,
+            initial_tuples=[
+                {"object_namespace": "dataset", "object_id": urn, "relation": "viewer"}
+            ],
+        )
+        externals[clearance] = external_id
+
+    try:
+        yield {"name": name, "urn": urn, "externals": externals, "shared": shared}
+    finally:
+        for who in (initiator, receiver):
+            try:
+                who.federations[name].disconnect()
+            except Exception:  # noqa: BLE001
+                pass
+        try:
+            receiver.datasets.delete(urn)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            receiver.gates.packages.uninstall("acme-gates")
+        except Exception:  # noqa: BLE001
+            pass
+
+
+@pytest.mark.parametrize("clearance", ["U", "S", "TS"])
+def test_federated_persona_sees_exact_post_gate_counts(
+    clearance, shared_idp_gated_pair, live_kamiwaza_session_client
+) -> None:
+    """A shared_idp persona mesh-retrieves exactly its allowed rows — known answer."""
+    wiring = shared_idp_gated_pair
+    initiator = live_kamiwaza_session_client
+    name, urn = wiring["name"], wiring["urn"]
+
+    def _retrieve():
+        # Mesh retrieval-jobs on the receiver, routed through the federation.
+        return initiator._request(
+            "POST",
+            f"/mesh/{name}/api/retrieval/jobs",
+            json={"dataset_urn": urn},
+        )
+
+    result = _mesh_call_or_skip(_retrieve)
+    rows, gate_audit = mc.parse_mesh_retrieval_result(result, initiator, name)
+    mc.assert_persona_result(clearance, rows, gate_audit)
+
+
+def test_fabricated_non_shared_token_rejected_before_gate(
+    shared_idp_gated_pair, live_peer_base_url
+) -> None:
+    """A token NOT signed by the shared realm is rejected at the receiver's
+    ext-authz JWKS check (401) and never reaches the gate — the shared_idp trust
+    boundary. Here a 401 for the fabricated token is the PASS."""
+    from kamiwaza_sdk.exceptions import APIError, AuthenticationError
+
+    verify = os.getenv("KAMIWAZA_VERIFY_SSL", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+    forged = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb3JnZWQifQ.not-a-real-signature"
+    client = mc.persona_client(live_peer_base_url, forged, verify=verify)
+    with pytest.raises((AuthenticationError, APIError)) as exc:
+        client._request("GET", "/cluster/diagnose")
+    status = getattr(exc.value, "status_code", None)
+    assert isinstance(exc.value, AuthenticationError) or status in (401, 403), (
+        f"fabricated non-shared token was not rejected fail-closed: {exc.value!r}"
+    )

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -20,6 +20,29 @@ served 1.1.0 wheel (M5_TEST_WHEEL_DIR/M5_TEST_INDEX_URL), the fixture file under
 RETRIEVAL_FILESYSTEM_ALLOWED_ROOTS (MINI_CLEARANCE_DATASET_PATH), and a shared
 realm that projects the ``clearance`` claim into brokered persona JWTs
 (SHARED_ISSUER_URL[/SHARED_JWKS_URL/SHARED_CA_PEM]); else the round-trip skips.
+
+Persona auth (SHARED_REALM_CLIENT_ID / FED_PERSONA_PASSWORD): each persona mints
+a token via ROPC against the shared realm's token endpoint (a direct-access-
+grants client), so the receiver's shared_idp peer-JWT validation accepts it
+(its kid is in the shared JWKS — an admin/local-realm token's kid is not) and
+the gate sees the realm-projected ``clearance`` claim. Shared-realm setup shape
+(on the shared realm, e.g. spark-1 ``federated``): a ROPC client (public,
+directAccessGrantsEnabled); persona users ``fed-clr-{u,s,ts}`` with a
+``clearance`` user-attribute (needs the realm user-profile's
+``unmanagedAttributePolicy=ENABLED``) + email/first/last so ROPC isn't blocked
+"Account is not fully set up"; and an ``oidc-usermodel-attribute-mapper``
+projecting ``clearance`` as a top-level access-token claim.
+
+LIVE STATUS (2026-07-11): the auth boundary is CROSSED — with the persona
+shared-realm token the receiver's peer-JWT validation PASSES (the historic
+``peer_jwt_validation_failed: kid not present`` is gone) and the mesh reaches
+the data plane. The 3 persona assertions still tier to SKIP on a downstream
+403 ``Forbidden``: the mesh retrieval's dataset-view authz
+(catalog.identity.resolve_requester_urn → a DataHub ``urn:li:corpuser`` URN) is
+NOT satisfied by the federation allowlist's ``initial_tuples`` viewer grant
+(a ``user:{{user_id}}`` namespaced ReBAC tuple). Reconciling those two subject
+namespaces for a brokered mesh caller is the remaining layer to flip the SKIPs
+to exact-count assertions.
 """
 
 from __future__ import annotations
@@ -78,6 +101,37 @@ def _shared_realm() -> dict[str, str]:
     return cfg
 
 
+def _persona_auth() -> dict:
+    """Shared-realm ROPC config for the personas (soft-skip when absent).
+
+    The mesh data-plane assertions need each persona to present a token minted
+    by the SHARED realm (a direct-access-grants client + the persona password),
+    so the receiver's shared_idp peer-JWT validation accepts it (kid is in the
+    shared JWKS) and the gate sees the realm-projected `clearance` claim.
+    """
+    client_id = os.getenv("SHARED_REALM_CLIENT_ID", "").strip()
+    password = os.getenv("FED_PERSONA_PASSWORD", "").strip()
+    if not client_id or not password:
+        pytest.skip(
+            "SHARED_REALM_CLIENT_ID / FED_PERSONA_PASSWORD not set — the personas "
+            "must present a shared-realm ROPC token for the mesh data-plane "
+            "assertions (a direct-access-grants client + persona password on the "
+            "shared realm that projects the `clearance` claim)"
+        )
+    verify = os.getenv("KAMIWAZA_VERIFY_SSL", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+    return {
+        "client_id": client_id,
+        "client_secret": os.getenv("SHARED_REALM_CLIENT_SECRET", "").strip() or None,
+        "password": password,
+        "verify": verify,
+    }
+
+
 def _fed_name() -> str:
     return f"eng8325-sharedidp-{uuid.uuid4().hex[:8]}"
 
@@ -126,34 +180,55 @@ def shared_idp_gated_pair(
     mc.install_gate_package(receiver, wheel_dir, index_url)
     urn = mc.create_file_dataset(receiver, f"mini-clearance-{name}", dataset_path)
 
-    # 3. Brokered shared-realm identities (external_id keyed on the initiator
-    #    cluster uuid). Their shared-realm JWT projects the `clearance` claim,
-    #    which arrives as X-User-Attributes on mesh inbound; seed a viewer tuple
-    #    so the auto-provisioned user reaches the gate rather than 404-ing at the
-    #    retrieval seam. POST against the receiver-side federation id (name
-    #    lookup fails post-pair) with the canonical subject/relation/object shape.
+    # 3. Brokered shared-realm identities. Each persona authenticates to the
+    #    SHARED realm (ROPC) for a token whose `sub` is the federated user id and
+    #    whose `clearance` claim rides X-User-Attributes to the gate. The receiver
+    #    keys the brokered user on `<sub>@<initiator-cluster-uuid>` (the
+    #    X-KZ-Mesh-User-Id the initiator forwards), so seed the viewer tuple on the
+    #    token `sub`, not the username. POST against the receiver-side federation
+    #    id (name lookup fails post-pair) with the canonical tuple shape.
     src_uuid = mc.initiator_cluster_uuid(receiver, receiver_id) or "initiator"
-    externals = {}
+    auth = _persona_auth()
+    issuer = shared["shared_issuer_url"]
+    personas: dict = {}
     for clearance, base in _PERSONAS.items():
-        external_id = f"{base}@{src_uuid}"
+        token = mc.shared_realm_token(
+            issuer,
+            auth["client_id"],
+            base,
+            auth["password"],
+            client_secret=auth["client_secret"],
+            verify=auth["verify"],
+        )
+        sub = mc.jwt_sub(token) or base
+        external_id = f"{sub}@{src_uuid}"
         receiver._request(
             "POST",
             f"/cluster/federations/{receiver_id}/users",
             json={
                 "external_id": external_id,
                 "initial_tuples": [
+                    # {{user_id}} renders to the local provisioned user id at
+                    # ingress (brokering._render_placeholder), so the viewer grant
+                    # lands on the subject the retrieval authz actually evaluates.
                     {
-                        "subject": f"user:{external_id}",
+                        "subject": "user:{{user_id}}",
                         "relation": "viewer",
                         "object": f"dataset:{urn}",
                     }
                 ],
             },
         )
-        externals[clearance] = external_id
+        personas[clearance] = {"token": token, "external_id": external_id, "sub": sub}
 
     try:
-        yield {"name": name, "urn": urn, "externals": externals, "shared": shared}
+        yield {
+            "name": name,
+            "urn": urn,
+            "personas": personas,
+            "shared": shared,
+            "verify": auth["verify"],
+        }
     finally:
         for who in (initiator, receiver):
             try:
@@ -178,10 +253,14 @@ def test_federated_persona_sees_exact_post_gate_counts(
     wiring = shared_idp_gated_pair
     initiator = live_kamiwaza_session_client
     name, urn = wiring["name"], wiring["urn"]
+    # Present the persona's SHARED-realm token (carries `clearance`) on the mesh
+    # call — not the admin/local-realm client, whose kid isn't in the shared JWKS.
+    token = wiring["personas"][clearance]["token"]
+    persona = mc.raw_token_client(initiator.base_url, token, verify=wiring["verify"])
 
     def _retrieve():
         # Mesh retrieval-jobs on the receiver, routed through the federation.
-        return initiator._request(
+        return persona._request(
             "POST",
             f"/mesh/{name}/api/retrieval/jobs",
             json={"dataset_urn": urn},

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -116,6 +116,7 @@ def shared_idp_gated_pair(
     )
 
     # 2. Seed the receiver's gated dataset.
+    mc.declare_clearance_attribute(receiver)
     mc.install_gate_package(receiver, wheel_dir, index_url)
     urn = mc.create_file_dataset(receiver, f"mini-clearance-{name}", dataset_path)
 
@@ -190,7 +191,7 @@ def test_fabricated_non_shared_token_rejected_before_gate(
         "off",
     }
     forged = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb3JnZWQifQ.not-a-real-signature"
-    client = mc.persona_client(live_peer_base_url, forged, verify=verify)
+    client = mc.raw_token_client(live_peer_base_url, forged, verify=verify)
     with pytest.raises((AuthenticationError, APIError)) as exc:
         client._request("GET", "/cluster/diagnose")
     status = getattr(exc.value, "status_code", None)

--- a/tests/integration/test_mini_clearance_gate_retrieval_live.py
+++ b/tests/integration/test_mini_clearance_gate_retrieval_live.py
@@ -52,15 +52,41 @@ def _prereqs() -> tuple[str, str, str]:
     return wi[0], wi[1], dataset_path
 
 
+def _verify() -> bool:
+    return os.getenv("KAMIWAZA_VERIFY_SSL", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+
+
 @pytest.fixture(scope="module")
-def gated_dataset(_prereqs, live_kamiwaza_client) -> Iterator[str]:
+def _admin(request) -> tuple:
+    """(base_url, module-scoped admin client, verify) from the --live-* options.
+
+    Built directly from config rather than the function-scoped
+    live_kamiwaza_client, so the one-time install/seed setup can be module-scoped.
+    """
+    base = str(request.config.getoption("live_base_url")).rstrip("/")
+    user = str(request.config.getoption("live_username"))
+    pw = str(request.config.getoption("live_password"))
+    if not base or not pw:
+        pytest.skip("live cluster base-url/password not provided")
+    verify = _verify()
+    return base, mc.authed_client(base, user, pw, verify=verify), verify
+
+
+@pytest.fixture(scope="module")
+def gated_dataset(_prereqs, _admin) -> Iterator[str]:
     """Install the gate, create the file dataset, bind the gate, seed personas.
 
     Yields the dataset URN; tears everything down at module exit.
     """
     wheel_dir, index_url, dataset_path = _prereqs
-    kz = live_kamiwaza_client
+    _base, kz, _v = _admin
 
+    mc.declare_clearance_attribute(kz)
     mc.install_gate_package(kz, wheel_dir, index_url)
     urn = mc.create_file_dataset(kz, _unique("mini-clearance"), dataset_path)
 
@@ -87,19 +113,11 @@ def gated_dataset(_prereqs, live_kamiwaza_client) -> Iterator[str]:
 
 
 @pytest.mark.parametrize("clearance", ["U", "S", "TS"])
-def test_persona_sees_exact_post_gate_counts(
-    clearance, gated_dataset, live_base_url
-) -> None:
+def test_persona_sees_exact_post_gate_counts(clearance, gated_dataset, _admin) -> None:
     """Each clearance persona retrieves exactly its allowed rows — known answer."""
-    verify = os.getenv("KAMIWAZA_VERIFY_SSL", "1").strip().lower() not in {
-        "0",
-        "false",
-        "no",
-        "off",
-    }
+    base_url, _admin_client, verify = _admin
     username = _unique(_PERSONAS[clearance])
-    token = mc.mint_token(live_base_url, username, username, verify=verify)
-    client = mc.persona_client(live_base_url, token, verify=verify)
+    client = mc.authed_client(base_url, username, username, verify=verify)
 
     rows, gate_audit = mc.retrieve_through_gate(client, gated_dataset)
     mc.assert_persona_result(clearance, rows, gate_audit)

--- a/tests/integration/test_mini_clearance_gate_retrieval_live.py
+++ b/tests/integration/test_mini_clearance_gate_retrieval_live.py
@@ -1,0 +1,105 @@
+"""ENG-8325 Layer 2 — single-cluster live gated-retrieval (no federation).
+
+Proves the full install -> file-source -> gate-bind -> invoke path on ONE live
+cluster (a gate is a dataset feature, so the data-plane is provable without a
+mesh): install the acme-gates==1.1.0 wheel, back a ``platform="file"`` dataset
+with the deterministic 5-row [U,U,U,S,TS] parquet/csv, bind MiniClearanceGate,
+then retrieve as U/S/TS personas and assert the exact post-gate counts
+(U:3/2, S:4/1, TS:5/0) with zero leakage.
+
+Soft-skips (contributor boxes stay green) unless the operator has provisioned:
+  * the WS-M5 gate-packages PVC, and a served 1.1.0 wheel/index
+    (M5_TEST_WHEEL_DIR + M5_TEST_INDEX_URL, per gate_packages/test_lifecycle.py);
+  * a filesystem-source file the ray-head can read: place the fixture (see
+    _mini_clearance.write_dataset_file) at an absolute path under the cluster's
+    RETRIEVAL_FILESYSTEM_ALLOWED_ROOTS and pass it via MINI_CLEARANCE_DATASET_PATH.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+
+from . import _mini_clearance as mc
+
+pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
+
+_PERSONAS = {"U": "mini-clr-u", "S": "mini-clr-s", "TS": "mini-clr-ts"}
+
+
+def _unique(base: str) -> str:
+    # Per-worker/per-run uniqueness without RNG/clock in the assertion path.
+    return f"{base}-{os.getpid()}"
+
+
+@pytest.fixture(scope="module")
+def _prereqs() -> tuple[str, str, str]:
+    wi = mc.wheel_and_index()
+    if wi is None:
+        pytest.skip(
+            "gate-packages wheel/index not configured (set M5_TEST_WHEEL_DIR + "
+            "M5_TEST_INDEX_URL to the served acme-gates 1.1.0 wheel)"
+        )
+    dataset_path = os.getenv("MINI_CLEARANCE_DATASET_PATH", "").strip()
+    if not dataset_path:
+        pytest.skip(
+            "MINI_CLEARANCE_DATASET_PATH not set — place the 5-row fixture "
+            "(parquet/csv) at an absolute path under the cluster's "
+            "RETRIEVAL_FILESYSTEM_ALLOWED_ROOTS and point this env var at it"
+        )
+    return wi[0], wi[1], dataset_path
+
+
+@pytest.fixture(scope="module")
+def gated_dataset(_prereqs, live_kamiwaza_client) -> Iterator[str]:
+    """Install the gate, create the file dataset, bind the gate, seed personas.
+
+    Yields the dataset URN; tears everything down at module exit.
+    """
+    wheel_dir, index_url, dataset_path = _prereqs
+    kz = live_kamiwaza_client
+
+    mc.install_gate_package(kz, wheel_dir, index_url)
+    urn = mc.create_file_dataset(kz, _unique("mini-clearance"), dataset_path)
+
+    for clearance, username in _PERSONAS.items():
+        mc.seed_local_persona(kz, _unique(username), clearance)
+        mc.grant_dataset_viewer(kz, _unique(username), urn)
+
+    try:
+        yield urn
+    finally:
+        for username in _PERSONAS.values():
+            try:
+                kz.subjects.delete(_unique(username), cascade_grants=True)
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+        try:
+            kz.datasets.delete(urn)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            kz.gates.packages.uninstall("acme-gates")
+        except Exception:  # noqa: BLE001
+            pass
+
+
+@pytest.mark.parametrize("clearance", ["U", "S", "TS"])
+def test_persona_sees_exact_post_gate_counts(
+    clearance, gated_dataset, live_base_url
+) -> None:
+    """Each clearance persona retrieves exactly its allowed rows — known answer."""
+    verify = os.getenv("KAMIWAZA_VERIFY_SSL", "1").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }
+    username = _unique(_PERSONAS[clearance])
+    token = mc.mint_token(live_base_url, username, username, verify=verify)
+    client = mc.persona_client(live_base_url, token, verify=verify)
+
+    rows, gate_audit = mc.retrieve_through_gate(client, gated_dataset)
+    mc.assert_persona_result(clearance, rows, gate_audit)

--- a/tests/unit/seeding/test_federation_cli.py
+++ b/tests/unit/seeding/test_federation_cli.py
@@ -237,3 +237,14 @@ def test_idp_token_raw(monkeypatch, capsys):
     )
     assert rc == 0
     assert capsys.readouterr().out.strip() == "TOK123"
+
+
+def test_fed_unpair_disconnects():
+    mc = MagicMock()
+    proxy = mc.federations.__getitem__.return_value
+    proxy.disconnect.return_value = {"message": "disconnected"}
+    rc, out = _run(["fed", "unpair", "--name", "ORION"], client=mc)
+    assert rc == 0
+    mc.federations.__getitem__.assert_called_once_with("ORION")
+    proxy.disconnect.assert_called_once_with(force=False)
+    assert out["disconnected"] == "ORION"

--- a/tests/unit/seeding/test_federation_cli.py
+++ b/tests/unit/seeding/test_federation_cli.py
@@ -1,0 +1,215 @@
+"""Unit tests for the kamiwaza-fed CLI (mocked SDK client + Keycloak admin)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from kamiwaza_sdk.seeding.federation import cli
+
+
+def _run(argv, client=None):
+    """Invoke main with an injected mock client; capture the printed JSON."""
+    printed = {}
+
+    def _factory(**_kw):
+        return client
+
+    # main prints JSON for dict results; grab it via monkeypatching print.
+    import builtins
+
+    orig = builtins.print
+    builtins.print = lambda *a, **k: printed.setdefault("out", a[0] if a else None)
+    try:
+        rc = cli.main(argv, client_factory=_factory)
+    finally:
+        builtins.print = orig
+    out = printed.get("out")
+    return rc, (json.loads(out) if isinstance(out, str) else out)
+
+
+# --- access ---------------------------------------------------------------
+
+
+def test_access_grant_splits_object_on_first_colon():
+    mc = MagicMock()
+    urn = "urn:li:dataset:(urn:li:dataPlatform:file,mini,PROD)"
+    rc, out = _run(
+        ["access", "grant", "--subject", "alice", "--relation", "viewer",
+         "--object", f"dataset:{urn}"],
+        client=mc,
+    )
+    assert rc == 0
+    mc.subjects.grants.assert_called_once_with("alice")
+    mc.subjects.grants.return_value.create.assert_called_once_with(
+        object_namespace="dataset", object_id=urn, relation="viewer"
+    )
+    assert out["granted"]["object"] == f"dataset:{urn}"
+
+
+def test_access_revoke_calls_delete():
+    mc = MagicMock()
+    rc, _ = _run(
+        ["access", "revoke", "--subject", "bob", "--relation", "editor",
+         "--object", "dataset:d1"],
+        client=mc,
+    )
+    assert rc == 0
+    mc.subjects.grants.return_value.delete.assert_called_once_with(
+        object_namespace="dataset", object_id="d1", relation="editor"
+    )
+
+
+def test_access_list_returns_grants():
+    mc = MagicMock()
+    g = MagicMock()
+    g.model_dump.return_value = {"object_id": "d1", "relation": "viewer"}
+    mc.subjects.grants.return_value.list.return_value = [g]
+    rc, out = _run(["access", "list", "--subject", "carol"], client=mc)
+    assert rc == 0
+    assert out["subject"] == "carol"
+    assert out["grants"] == [{"object_id": "d1", "relation": "viewer"}]
+
+
+def test_access_bad_object_errors():
+    with pytest.raises(SystemExit):
+        _run(["access", "grant", "--subject", "a", "--relation", "viewer",
+              "--object", "no-colon"], client=MagicMock())
+
+
+# --- fed ------------------------------------------------------------------
+
+
+def test_fed_pair_derives_jwks_from_issuer():
+    mc = MagicMock()
+    mc.federations.pair.return_value.model_dump.return_value = {"id": "fed-1"}
+    issuer = "https://kc.example/realms/federated"
+    rc, out = _run(
+        ["fed", "pair", "--name", "f1", "--role", "initiator",
+         "--remote-url", "https://peer/api", "--shared-issuer", issuer + "/"],
+        client=mc,
+    )
+    assert rc == 0
+    kwargs = mc.federations.pair.call_args.kwargs
+    # issuer normalized (trailing slash stripped), JWKS derived from it (not arbitrary)
+    assert kwargs["shared_issuer_url"] == issuer
+    assert kwargs["shared_jwks_url"] == issuer + "/protocol/openid-connect/certs"
+    assert out["shared_jwks_url"] == issuer + "/protocol/openid-connect/certs"
+
+
+def test_fed_allow_user_builds_initial_tuples():
+    mc = MagicMock()
+    urn = "dataset:urn:li:dataset:(urn:li:dataPlatform:file,mini,PROD)"
+    rc, out = _run(
+        ["fed", "allow-user", "--federation", "fed-1",
+         "--external-id", "sub@cluster", "--seed", f"{urn}:viewer"],
+        client=mc,
+    )
+    assert rc == 0
+    method, path = mc._request.call_args.args
+    body = mc._request.call_args.kwargs["json"]
+    assert method == "POST" and path == "/cluster/federations/fed-1/users"
+    assert body["external_id"] == "sub@cluster"
+    assert body["initial_tuples"] == [
+        {"subject": "user:{{user_id}}", "relation": "viewer", "object": urn}
+    ]
+
+
+def test_fed_status_lists():
+    mc = MagicMock()
+    f = MagicMock()
+    f.model_dump.return_value = {"id": "fed-1", "remote_cluster_name": "peer"}
+    mc.federations.list.return_value = [f]
+    rc, out = _run(["fed", "status"], client=mc)
+    assert rc == 0
+    assert out["federations"] == [{"id": "fed-1", "remote_cluster_name": "peer"}]
+
+
+# --- dataset / gate / attr ------------------------------------------------
+
+
+def test_dataset_gated_creates_file_dataset_with_gate():
+    mc = MagicMock()
+    mc.datasets.create.return_value = "urn:li:dataset:(x)"
+    rc, out = _run(
+        ["dataset", "gated", "--name", "d", "--path", "/data/x.csv",
+         "--gate", "acme_gates.mini.MiniClearanceGate"],
+        client=mc,
+    )
+    assert rc == 0
+    kwargs = mc.datasets.create.call_args.kwargs
+    assert kwargs["platform"] == "file"
+    assert kwargs["properties"]["path"] == "/data/x.csv"
+    gate = json.loads(kwargs["properties"]["gate"])
+    assert gate == {"type": "acme_gates.mini.MiniClearanceGate", "config": {}}
+    assert out["dataset_urn"] == "urn:li:dataset:(x)"
+
+
+def test_gate_install_wraps_packages():
+    mc = MagicMock()
+    mc.gates.packages.install.return_value.model_dump.return_value = {"name": "acme-gates"}
+    rc, out = _run(
+        ["gate", "install", "--spec", "acme-gates==1.1.0", "--hash", "sha256:abc"],
+        client=mc,
+    )
+    assert rc == 0
+    mc.gates.packages.install.assert_called_once_with(
+        package_spec="acme-gates==1.1.0", hash_digest="sha256:abc", index_url=None
+    )
+
+
+def test_attr_declare():
+    mc = MagicMock()
+    rc, out = _run(["attr", "declare", "--name", "clearance"], client=mc)
+    assert rc == 0
+    mc.cluster.declare_attribute.assert_called_once_with("clearance", type="string")
+
+
+# --- idp (Keycloak-admin, monkeypatched) ----------------------------------
+
+
+def test_idp_bootstrap_ensures_realm_client_mapper(monkeypatch):
+    kc = MagicMock()
+    kc.ensure_realm.return_value = {"realm": "federated", "created": True}
+    kc.ensure_ropc_client.return_value = {"client_id": "fed-mesh-cli", "id": "uuid"}
+    kc.issuer_url.return_value = "https://kc/realms/federated"
+    monkeypatch.setattr(cli, "build_kc_admin", lambda args: kc)
+    rc, out = _run(
+        ["idp", "bootstrap", "--realm", "federated", "--ropc-client", "fed-mesh-cli",
+         "--kc-url", "https://kc", "--kc-admin-pw-env", "KCPW"],
+    )
+    assert rc == 0
+    kc.set_unmanaged_attributes.assert_called_once_with("federated")
+    kc.ensure_attribute_mapper.assert_called_once_with("federated", "uuid", attribute="clearance")
+    assert out["shared_issuer_url"] == "https://kc/realms/federated"
+
+
+def test_idp_persona_parses_attrs(monkeypatch):
+    kc = MagicMock()
+    kc.ensure_user.return_value = {"username": "fed-clr-u", "id": "u1", "created": True}
+    monkeypatch.setattr(cli, "build_kc_admin", lambda args: kc)
+    monkeypatch.setenv("PPW", "secret")
+    rc, out = _run(
+        ["idp", "persona", "--realm", "federated", "--user", "fed-clr-u",
+         "--attr", "clearance=U", "--pw-env", "PPW",
+         "--kc-url", "https://kc", "--kc-admin-pw-env", "KCPW"],
+    )
+    assert rc == 0
+    assert kc.ensure_user.call_args.kwargs["attributes"] == {"clearance": "U"}
+    assert out["attributes"] == {"clearance": "U"}
+
+
+def test_idp_token_raw(monkeypatch, capsys):
+    kc = MagicMock()
+    kc.ropc_token.return_value = "TOK123"
+    monkeypatch.setattr(cli, "build_kc_admin", lambda args: kc)
+    monkeypatch.setenv("PPW", "secret")
+    monkeypatch.setattr(cli, "KeycloakAdmin", lambda *a, **k: kc)
+    rc = cli.main(
+        ["idp", "token", "--realm", "federated", "--client", "fed-mesh-cli",
+         "--user", "fed-clr-u", "--pw-env", "PPW", "--raw", "--kc-url", "https://kc"],
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "TOK123"

--- a/tests/unit/seeding/test_federation_cli.py
+++ b/tests/unit/seeding/test_federation_cli.py
@@ -119,12 +119,14 @@ def test_fed_allow_user_builds_initial_tuples():
 
 def test_fed_status_lists():
     mc = MagicMock()
-    mc._request.return_value = [
-        {"id": "fed-1", "remote_cluster_name": "peer", "identity_mode": "shared_idp"}
-    ]
+    f = MagicMock()
+    f.model_dump.return_value = {
+        "id": "fed-1", "remote_cluster_name": "peer", "identity_mode": "shared_idp"
+    }
+    mc.federations.list.return_value = [f]
     rc, out = _run(["fed", "status"], client=mc)
     assert rc == 0
-    mc._request.assert_called_once_with("GET", "/cluster/federations")
+    mc.federations.list.assert_called_once_with()
     assert out["federations"][0]["identity_mode"] == "shared_idp"
 
 

--- a/tests/unit/seeding/test_federation_cli.py
+++ b/tests/unit/seeding/test_federation_cli.py
@@ -99,6 +99,25 @@ def test_fed_pair_derives_jwks_from_issuer():
     assert out["shared_jwks_url"] == issuer + "/protocol/openid-connect/certs"
 
 
+def test_fed_pair_receiver_uses_shared_psk_and_omits_remote_url(monkeypatch):
+    mc = MagicMock()
+    mc.federations.pair.return_value.model_dump.return_value = {"id": "fed-1"}
+    monkeypatch.setenv("PSK", "shared-psk-123")
+    issuer = "https://kc.example/realms/federated"
+    rc, out = _run(
+        ["fed", "pair", "--name", "f1", "--role", "receiver",
+         "--shared-issuer", issuer, "--preshared-key-env", "PSK"],
+        client=mc,
+    )
+    assert rc == 0
+    kwargs = mc.federations.pair.call_args.kwargs
+    # H2: the shared PSK comes from env (same value both sides), not a random UUID
+    assert kwargs["preshared_key"] == "shared-psk-123"
+    assert out["preshared_key_source"] == "env"
+    # H4: receiver omits --remote-url (would derive a wrong remote_ips)
+    assert kwargs["remote_url"] is None
+
+
 def test_fed_allow_user_builds_initial_tuples():
     mc = MagicMock()
     urn = "dataset:urn:li:dataset:(urn:li:dataPlatform:file,mini,PROD)"
@@ -133,7 +152,7 @@ def test_fed_status_lists():
 # --- dataset / gate / attr ------------------------------------------------
 
 
-def test_dataset_gated_creates_file_dataset_with_gate():
+def test_dataset_gated_binds_gate_via_set_gate():
     mc = MagicMock()
     mc.datasets.create.return_value = "urn:li:dataset:(x)"
     rc, out = _run(
@@ -144,9 +163,11 @@ def test_dataset_gated_creates_file_dataset_with_gate():
     assert rc == 0
     kwargs = mc.datasets.create.call_args.kwargs
     assert kwargs["platform"] == "file"
-    assert kwargs["properties"]["path"] == "/data/x.csv"
-    gate = json.loads(kwargs["properties"]["gate"])
-    assert gate == {"type": "acme_gates.mini.MiniClearanceGate", "config": {}}
+    # the gate is NOT smuggled into properties — it is bound via set_gate
+    assert kwargs["properties"] == {"path": "/data/x.csv"}
+    mc.datasets.set_gate.assert_called_once_with(
+        "urn:li:dataset:(x)", type="acme_gates.mini.MiniClearanceGate", config={}
+    )
     assert out["dataset_urn"] == "urn:li:dataset:(x)"
 
 

--- a/tests/unit/seeding/test_federation_cli.py
+++ b/tests/unit/seeding/test_federation_cli.py
@@ -119,12 +119,13 @@ def test_fed_allow_user_builds_initial_tuples():
 
 def test_fed_status_lists():
     mc = MagicMock()
-    f = MagicMock()
-    f.model_dump.return_value = {"id": "fed-1", "remote_cluster_name": "peer"}
-    mc.federations.list.return_value = [f]
+    mc._request.return_value = [
+        {"id": "fed-1", "remote_cluster_name": "peer", "identity_mode": "shared_idp"}
+    ]
     rc, out = _run(["fed", "status"], client=mc)
     assert rc == 0
-    assert out["federations"] == [{"id": "fed-1", "remote_cluster_name": "peer"}]
+    mc._request.assert_called_once_with("GET", "/cluster/federations")
+    assert out["federations"][0]["identity_mode"] == "shared_idp"
 
 
 # --- dataset / gate / attr ------------------------------------------------

--- a/tests/unit/test_kamiwaza_sdk_services_federations.py
+++ b/tests/unit/test_kamiwaza_sdk_services_federations.py
@@ -467,6 +467,43 @@ def test_users_add_posts_initial_tuples() -> None:
     assert add_call["json"]["initial_tuples"] == initial_tuples
 
 
+def test_resolve_id_tolerates_list_item_missing_status() -> None:
+    """Regression: name→id resolution must not require the full Federation
+    schema. A list entry missing an unrelated field (``status``) must still
+    resolve — ``_resolve_id`` reads the raw ``id`` / ``remote_cluster_name``
+    identity fields, not a validated ``Federation`` (which would raise a
+    ValidationError on the missing ``status``)."""
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    # Note: NO "status" key — the posture-surface list may omit fields the
+    # full Federation schema requires; id-resolution must not care.
+    client.expect(
+        "GET",
+        "/cluster/federations",
+        {"items": [{"id": "fed-orion-id", "remote_cluster_name": "ORION"}]},
+    )
+    client.expect(
+        "POST",
+        "/cluster/federations/fed-orion-id/users",
+        {
+            "federation_id": "fed-orion-id",
+            "external_id": "cdr-baker@lyra-uuid",
+            "auto_provisioned": False,
+        },
+    )
+
+    api = FederationsAPI(client)
+    user = api["ORION"].users.add(external_id="cdr-baker@lyra-uuid")
+
+    assert user.federation_id == "fed-orion-id"
+    # Resolved the id from a status-less entry and POSTed to the right path.
+    assert any(
+        p == "/cluster/federations/fed-orion-id/users"
+        for _, p, _ in client.calls
+    )
+
+
 # ---------------------------------------------------------------------------
 # Three-mode PSK contract documented in docstring (operator-facing intent)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_kamiwaza_sdk_services_federations.py
+++ b/tests/unit/test_kamiwaza_sdk_services_federations.py
@@ -632,3 +632,65 @@ def test_pair_forwards_partial_brokering_kwargs_to_server() -> None:
         "local_broker_client_secret",
     ):
         assert key not in body, f"unexpected {key!r} in partial-mode body"
+
+
+# --- list / get (ENG-8213 — typed listing surface) ------------------------
+
+
+def test_list_returns_federations() -> None:
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    client.expect(
+        "GET",
+        "/cluster/federations",
+        [
+            {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "status": "PAIRED",
+                "remote_cluster_name": "ORION",
+                "identity_mode": "shared_idp",
+            }
+        ],
+    )
+    feds = FederationsAPI(client).list()
+    assert len(feds) == 1
+    assert feds[0].remote_cluster_name == "ORION"
+    # extra fields flow through via extra="allow"
+    assert feds[0].model_dump()["identity_mode"] == "shared_idp"
+
+
+def test_list_handles_items_envelope() -> None:
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    client.expect(
+        "GET",
+        "/cluster/federations",
+        {
+            "items": [
+                {
+                    "id": "22222222-2222-2222-2222-222222222222",
+                    "status": "PAIRED",
+                    "remote_cluster_name": "LYRA",
+                }
+            ]
+        },
+    )
+    feds = FederationsAPI(client).list()
+    assert [f.remote_cluster_name for f in feds] == ["LYRA"]
+
+
+def test_get_fetches_single_federation() -> None:
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    fid = "33333333-3333-3333-3333-333333333333"
+    client.expect(
+        "GET",
+        f"/cluster/federations/{fid}",
+        {"id": fid, "status": "PAIRED", "remote_cluster_name": "VELA"},
+    )
+    fed = FederationsAPI(client).get(fid)
+    assert fed.id == fid
+    assert fed.remote_cluster_name == "VELA"

--- a/tests/unit/test_kamiwaza_sdk_services_federations.py
+++ b/tests/unit/test_kamiwaza_sdk_services_federations.py
@@ -185,6 +185,49 @@ def test_pair_uses_caller_supplied_preshared_key_verbatim() -> None:
     assert body["preshared_key"] == "custom-psk-from-vault-12345"
 
 
+def test_pair_forwards_shared_idp_fields_when_supplied() -> None:
+    """ENG-8213 — supplying shared_issuer_url (+ optional jwks/ca) creates the
+    federation in shared_idp mode; the SDK forwards them on the create body."""
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    _stage_pair_responses(client)
+
+    api = FederationsAPI(client)
+    api.pair(
+        name="ORION",
+        role="initiator",
+        remote_url="https://orion.example.com",
+        shared_issuer_url="https://idp.example.com/realms/federated",
+        shared_jwks_url=(
+            "https://idp.example.com/realms/federated/protocol/openid-connect/certs"
+        ),
+        shared_ca_pem="-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----",
+    )
+
+    _, body = _create_call(client)
+    assert body["shared_issuer_url"] == "https://idp.example.com/realms/federated"
+    assert body["shared_jwks_url"].endswith("/certs")
+    assert "BEGIN CERTIFICATE" in body["shared_ca_pem"]
+
+
+def test_pair_omits_shared_idp_fields_when_not_supplied() -> None:
+    """Without shared_issuer_url the create body carries no shared_* keys
+    (the federation stays peer_kc)."""
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    _stage_pair_responses(client)
+
+    api = FederationsAPI(client)
+    api.pair(name="ORION", role="initiator", remote_url="https://orion.example.com")
+
+    _, body = _create_call(client)
+    assert "shared_issuer_url" not in body
+    assert "shared_jwks_url" not in body
+    assert "shared_ca_pem" not in body
+
+
 def test_pair_minted_psk_is_unique_per_call() -> None:
     """Two consecutive pair() calls without caller PSK must mint distinct
     values — otherwise two adjacent demos would share a PSK accidentally."""

--- a/tests/unit/test_kamiwaza_sdk_services_federations.py
+++ b/tests/unit/test_kamiwaza_sdk_services_federations.py
@@ -694,3 +694,39 @@ def test_get_fetches_single_federation() -> None:
     fed = FederationsAPI(client).get(fid)
     assert fed.id == fid
     assert fed.remote_cluster_name == "VELA"
+
+
+def test_disconnect_resolves_id_and_posts() -> None:
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    fid = "44444444-4444-4444-4444-444444444444"
+    client.expect(
+        "GET",
+        "/cluster/federations",
+        [{"id": fid, "status": "PAIRED", "remote_cluster_name": "ORION"}],
+    )
+    client.expect(
+        "POST", f"/cluster/federations/{fid}/disconnect", {"message": "disconnected"}
+    )
+    result = FederationsAPI(client)["ORION"].disconnect()
+    assert result == {"message": "disconnected"}
+    assert ("POST", f"/cluster/federations/{fid}/disconnect") in [
+        (m, p) for m, p, _ in client.calls
+    ]
+
+
+def test_disconnect_force_passes_param() -> None:
+    from kamiwaza_sdk.services.federations import FederationsAPI
+
+    client = _MockClient()
+    fid = "55555555-5555-5555-5555-555555555555"
+    client.expect(
+        "GET",
+        "/cluster/federations",
+        [{"id": fid, "status": "PAIRED", "remote_cluster_name": "LYRA"}],
+    )
+    client.expect("POST", f"/cluster/federations/{fid}/disconnect", {"message": "ok"})
+    FederationsAPI(client)["LYRA"].disconnect(force=True)
+    post = [kw for m, p, kw in client.calls if m == "POST"][0]
+    assert post.get("params") == {"force": "true"}


### PR DESCRIPTION
SDK support + live acceptance tests for the federation identity work (Linear project: **Federation Keycloak Patterns**). **Draft** — for review; merge gated.

- shared_idp (Alt C) support in `federations.pair` (ENG-8213)
- live known-answer test for the federation identity gate + posture (ENG-8213)
- ENG-8325 gated-retrieval suite: single-cluster **L2 GREEN on spark-2**; two-cluster shared_idp **L3** advanced past the mesh auth boundary via shared-realm persona tokens — data-plane assertions tier/skip pending the ENG-8561 core image + remaining chain.

https://claude.ai/code/session_01TBsK4XcXxpq4EGe9p8Pt96
