### PR TITLE
fix(extensions): kz-ext dev builds owned images into the cluster registry (ENG-8626)

### DIFF
--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -173,6 +173,7 @@ def _prior_artifacts_in_registry(
     try:
         canonical_refs = compute_canonical_refs(
             (info.compose_data or {}).get("services") or {},
+            purpose="dev",
             registry=registry,
             extension_name=info.name,
             revision_tag=prior_revision,
@@ -644,6 +645,7 @@ def run_dev_remote(
         extension_name=info.name,
         revision_tag=rev_tag,
         registry=registry,
+        purpose="dev",
         image_basename=info.image_basename,
     )
     # The catalog overlay (step 12) is a template destination: the platform
@@ -654,14 +656,16 @@ def run_dev_remote(
     catalog_compose = transformed
     transformed = transformer.resolve_env_placeholders(transformed)
 
-    # Canonical image refs for every build-context service. Single
-    # source of truth shared with the transformed compose so the image
-    # we build and push matches the ref the K8s payload will pull. The
-    # transformer honors a service's declared image namespace; without
-    # this map ImageBuilder would synthesize the legacy {ext}-{svc}
-    # form and ship a pod referencing an image that was never pushed.
+    # Canonical image refs for every build-context service, profiled ones
+    # included. Single source of truth shared with the transformed compose
+    # so the image we build and push matches the ref the K8s payload will
+    # pull, computed under the same ``purpose="dev"`` policy the transform
+    # above used: an owned build image lands in *this cluster's* registry
+    # even when its compose declares a qualified publish namespace
+    # (ENG-8626).
     canonical_refs: Dict[str, str] = compute_canonical_refs(
         info.compose_data.get("services") or {},
+        purpose="dev",
         registry=registry,
         extension_name=info.name,
         revision_tag=rev_tag,
@@ -675,10 +679,10 @@ def run_dev_remote(
     # ImagePullBackOff, chat 500. Rewrite that ref (and the sandbox
     # ``SANDBOX_ALLOWED_IMAGE_PREFIXES`` allowlist, in lockstep) to the
     # dev-built agent ref — the dev analog of ENG-5260's publish-side fix.
-    # ``build_image_ref_map`` mirrors ImageBuilder's per-service ref choice,
-    # so the env ref equals exactly what was built and pushed (the profiled
-    # ``image-only`` agent resolves to the ``{registry}/{ext}-agent`` fallback
-    # path). Applied to both the K8s payload (bare refs, post-resolve) and
+    # ``build_image_ref_map`` reads the canonical map directly, so the env ref
+    # equals exactly what was built and pushed — the profiled ``image-only``
+    # agent included, since ``purpose="dev"`` puts it in the map alongside its
+    # siblings. Applied to both the K8s payload (bare refs, post-resolve) and
     # the catalog overlay compose (``${VAR:-default}`` form).
     #
     # Caveat: env_ref_map spans ALL build-context services, so under
@@ -692,10 +696,6 @@ def run_dev_remote(
     env_ref_map = build_image_ref_map(
         info.compose_data.get("services") or {},
         canonical_refs,
-        registry=registry,
-        extension_name=info.name,
-        revision_tag=rev_tag,
-        image_basename=info.image_basename,
     )
     transformed = rewrite_env_image_refs(transformed, env_ref_map)
     catalog_compose = rewrite_env_image_refs(catalog_compose, env_ref_map)
@@ -788,18 +788,33 @@ def run_dev_remote(
         # payload will reference.
         #
         # ENG-7110: profiled ``image-only`` services (the agent, referenced
-        # via AGENT_SERVER_IMAGE — see the env rewrite above) are excluded
-        # from canonical_refs and so are intentionally NOT in this push list.
-        # A full run builds+pushes them via ImageBuilder (which iterates all
-        # build-context services); under --no-build they rely on a prior
-        # run's registry push (resume adopts that revision tag, so the agent
-        # ref the env rewrite points at already exists). Re-pushing them here
-        # would tag from the local engine store, which a resumed run may no
-        # longer hold — regressing the path that works.
+        # via AGENT_SERVER_IMAGE — see the env rewrite above) must NOT be in
+        # this push list. A full run builds+pushes them via ImageBuilder
+        # (which iterates all build-context services); under --no-build they
+        # rely on a prior run's registry push (resume adopts that revision
+        # tag, so the agent ref the env rewrite points at already exists).
+        # Re-pushing them here would tag from the local engine store, which a
+        # resumed run may no longer hold — regressing the path that works.
+        #
+        # ENG-8626: this exclusion is now explicit. It used to fall out of
+        # canonical_refs simply omitting profiled services, but the dev
+        # canonical map has to include them (that omission is what sent the
+        # agent to a different repository path than its siblings). Pushing is
+        # a separate question from identity, so the filter lives here.
+        profiled_names = {
+            name
+            for name, svc in (info.compose_data.get("services") or {}).items()
+            if isinstance(svc, dict) and svc.get("profiles")
+        }
+        pushable = {
+            name: ref
+            for name, ref in canonical_refs.items()
+            if name not in profiled_names
+        }
         if service:
-            image_refs = [canonical_refs[service]] if service in canonical_refs else []
+            image_refs = [pushable[service]] if service in pushable else []
         else:
-            image_refs = list(canonical_refs.values())
+            image_refs = list(pushable.values())
         console.print()
 
     # 7. Push images

--- a/kamiwaza_extensions/commands/publish.py
+++ b/kamiwaza_extensions/commands/publish.py
@@ -117,6 +117,7 @@ def _retag_appgarden_compose(
     # published_refs and the dev pipeline.
     canonical_by_name = compute_canonical_refs(
         source_services,
+        purpose="publish",
         registry=registry,
         extension_name=extension_name,
         revision_tag=image_tag,
@@ -146,7 +147,8 @@ def _retag_appgarden_compose(
             # Preserve declared namespace; we only rewrite the tag.
             svc["image"] = _canonical_build_ref(
                 svc, svc_name,
-                fallback_registry=registry,
+                purpose="publish",
+                registry=registry,
                 fallback_extension_name=extension_name,
                 revision_tag=image_tag,
                 fallback_image_basename=image_basename,
@@ -477,6 +479,7 @@ def _publish_one(
             extension_name=info.name,
             revision_tag=image_tag,
             registry=registry,
+            purpose="publish",
             image_basename=info.image_basename,
         )
 
@@ -493,6 +496,7 @@ def _publish_one(
     )
     canonical_refs: Dict[str, str] = compute_canonical_refs(
         info.compose_data.get("services") or {},
+        purpose="publish",
         registry=registry,
         extension_name=info.name,
         revision_tag=image_tag,

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import re
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 # Reuse the validator's bind-mount detection so the "stripped at deploy"
 # info message ComposeValidator emits stays in sync with what the
@@ -12,6 +12,25 @@ from typing import Any, Dict, List, Optional, Tuple
 from kamiwaza_extensions.validators.compose import is_bind_mount
 
 _IMAGE_BASENAME_RE = re.compile(r"^[a-z0-9]([-a-z0-9._/]{0,126}[a-z0-9])?$")
+
+# Which command is asking for a build ref. The two have opposite
+# destination policies for a registry-qualified declared ``image:``, and
+# conflating them is what ENG-8626 fixed:
+#
+# - ``publish`` — the declared namespace IS the destination. An extension
+#   may publish beneath an unconventional namespace (Omniparse, ENG-4909);
+#   preserve it verbatim so catalog refs match the pushed images.
+# - ``dev`` — the declared namespace is the image's *published identity*,
+#   not where this cluster pulls from. A service with ``build:`` is one
+#   ``kz-ext dev`` is building right now, so it must land in the resolved
+#   cluster dev registry; honoring the declared ``ghcr.io`` host pushes an
+#   owned dev image to the org registry and deploys a ref the cluster
+#   can't pull.
+#
+# Required (no default) at every entry point: a call site that forgets it
+# should fail loudly rather than silently inherit publish semantics —
+# exactly the regression ENG-8626 was.
+Purpose = Literal["dev", "publish"]
 
 
 def _replace_image_tag(image_ref: str, new_tag: str) -> str:
@@ -103,6 +122,7 @@ def _repo_part(image_ref: str) -> str:
 def compute_canonical_refs(
     source_services: Optional[Dict[str, Any]],
     *,
+    purpose: Purpose,
     registry: str,
     extension_name: str,
     revision_tag: str,
@@ -113,7 +133,8 @@ def compute_canonical_refs(
 
     Single source of truth for the publish and dev pipelines: build,
     push, digest resolution, and the K8s/catalog image refs all read
-    from this map so they can't drift.
+    from this map so they can't drift. *purpose* selects the destination
+    policy — see :data:`Purpose` and ``_canonical_build_ref``.
 
     Service-image precedence (per service):
     1. ``appgarden_services[name]`` when the key is present (matches
@@ -122,9 +143,19 @@ def compute_canonical_refs(
        via ``_canonical_build_ref`` rather than reading from source).
     2. Source-compose entry otherwise.
 
-    Filters out profile-gated services (matches ``buildable_services``
-    in ``run_publish``) so profile-only helpers don't leak into the
-    push list under ``--no-build``.
+    Profile-gated services (ENG-8626):
+    - ``publish`` skips them (matches ``buildable_services`` in
+      ``run_publish``) so profile-only helpers don't leak into the push
+      list under ``--no-build``. They publish via ``extra_docker_images``.
+    - ``dev`` includes them. ``ImageBuilder`` builds every ``build:``
+      service regardless of profiles, so omitting them here left the
+      builder to synthesize its own legacy ref — which is how Kaizen's
+      profiled ``agent`` ended up in the dev registry while its
+      non-profiled siblings went to GHCR. Dev owns every image it
+      builds, so every image it builds belongs in this map. Callers that
+      must not *push* profiled services (``--no-build``) filter on
+      profiles themselves; that is a push-policy question, not an
+      identity one.
 
     ``image_basename`` (when present and non-empty) overrides
     ``extension_name`` for the legacy ``{registry}/{basename}-{svc}:{tag}``
@@ -134,7 +165,9 @@ def compute_canonical_refs(
     appgarden = appgarden_services or {}
     out: Dict[str, str] = {}
     for name, svc in (source_services or {}).items():
-        if "build" not in svc or svc.get("profiles"):
+        if "build" not in svc:
+            continue
+        if purpose == "publish" and svc.get("profiles"):
             continue
         # Presence-based: a service that is *declared* in the appgarden
         # compose, even as an empty mapping, is owned by the appgarden
@@ -146,7 +179,8 @@ def compute_canonical_refs(
         out[name] = _canonical_build_ref(
             lookup,
             name,
-            fallback_registry=registry,
+            purpose=purpose,
+            registry=registry,
             fallback_extension_name=extension_name,
             revision_tag=revision_tag,
             fallback_image_basename=image_basename,
@@ -158,21 +192,34 @@ def _canonical_build_ref(
     service: Optional[Dict[str, Any]],
     svc_name: str,
     *,
-    fallback_registry: str,
+    purpose: Purpose,
+    registry: str,
     fallback_extension_name: str,
     revision_tag: str,
     fallback_image_basename: Optional[str] = None,
 ) -> str:
     """Return the canonical registry image ref for a buildable service.
 
-    Reads ``image`` from *service*. When the declared ref names an
-    explicit registry host (``ghcr.io/...``, ``localhost:5000/...``),
-    the namespace is preserved and only the tag is rewritten to
-    *revision_tag*. Unqualified refs (``api:latest``,
-    ``my-org/api:1.0``) and missing/empty declarations fall back to the
-    legacy ``{fallback_registry}/{basename}-{svc_name}:{revision_tag}``
-    form — those would otherwise route ``docker push`` to Docker Hub
-    while the cluster registry expects the rewritten path.
+    Reads ``image`` from *service*. Behavior depends on *purpose* when
+    the declared ref names an explicit registry host (``ghcr.io/...``,
+    ``localhost:5000/...``):
+
+    - ``publish`` — namespace preserved verbatim, only the tag is
+      rewritten to *revision_tag*. The declared namespace is where this
+      image actually gets published (ENG-4909).
+    - ``dev`` — the registry host is replaced with *registry* (the
+      resolved cluster dev registry) and the declared **repository path
+      is preserved**, so ``ghcr.io/org/images/api:1.0`` builds and
+      pushes as ``{registry}/org/images/api:{revision_tag}``. Keeping the
+      repository path (rather than flattening to the legacy
+      ``{basename}-{svc}`` form) keeps two declared repos that share a
+      basename distinct, and makes the rewrite idempotent (ENG-8626).
+
+    Unqualified refs (``api:latest``, ``my-org/api:1.0``) and
+    missing/empty declarations fall back — under *both* purposes — to the
+    legacy ``{registry}/{basename}-{svc_name}:{revision_tag}`` form.
+    Those would otherwise route ``docker push`` to Docker Hub while the
+    cluster registry expects the rewritten path.
 
     ``fallback_image_basename`` (when truthy) overrides
     ``fallback_extension_name`` as the ``{basename}`` segment. This
@@ -180,7 +227,8 @@ def _canonical_build_ref(
     from its kamiwaza.json ``name`` (e.g. ``name=workroom-manager`` but
     images pushed as ``outcome-d563-workroom-manager-<svc>``) declare
     the override via ``image_basename`` in kamiwaza.json without
-    touching the manifest's primary identifier.
+    touching the manifest's primary identifier. It applies only to the
+    fallback form; a qualified declared ref already carries its identity.
 
     Shared by ``ComposeTransformer.transform_service``,
     ``_retag_appgarden_compose``, ``ImageBuilder.build``, and
@@ -191,7 +239,11 @@ def _canonical_build_ref(
     if isinstance(declared, str):
         stripped = declared.strip()
         if stripped and _looks_registry_qualified(stripped):
-            return _replace_image_tag(stripped, revision_tag)
+            if purpose == "publish":
+                return _replace_image_tag(stripped, revision_tag)
+            # dev: keep the repository identity, relocate the host.
+            _declared_registry, repository, _tag = _split_image_ref(stripped)
+            return f"{registry}/{repository}:{revision_tag}"
     # Strip whitespace so a malformed-but-truthy override (e.g. "   "
     # — caller forgot to normalize) doesn't synthesize a broken
     # `{registry}/   -svc:tag`. ExtensionDetector + MetadataValidator
@@ -202,7 +254,7 @@ def _canonical_build_ref(
         fallback_extension_name,
         fallback_image_basename=fallback_image_basename,
     )
-    return f"{fallback_registry}/{basename}-{svc_name}:{revision_tag}"
+    return f"{registry}/{basename}-{svc_name}:{revision_tag}"
 
 
 def _fallback_image_basename(
@@ -282,6 +334,8 @@ class ComposeTransformer:
         extension_name: str,
         revision_tag: str,
         registry: str,
+        *,
+        purpose: Purpose,
         image_basename: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Return a deployment-ready copy of *compose_data*.
@@ -293,6 +347,11 @@ class ComposeTransformer:
         4. Add / update ``image`` fields with *registry*/*revision_tag*
         5. Add resource limits if missing
         6. Remove ``extra_hosts``, ``container_name``, ``networks`` keys
+
+        *purpose* selects the image-destination policy for buildable
+        services — see :data:`Purpose`. It must match the purpose the
+        caller passed to ``compute_canonical_refs``, or the deployed
+        ``image:`` would name a ref the build/push side never produced.
 
         ``image_basename`` (when present) overrides ``extension_name`` as
         the prefix in the legacy ``{registry}/{basename}-{svc}:{tag}``
@@ -306,7 +365,11 @@ class ComposeTransformer:
         """
         out = copy.deepcopy(compose_data)
 
-        # Drop services that have a profiles key (local-only services)
+        # Drop services that have a profiles key (local-only services).
+        # Note this is about what gets *deployed*: dev still builds and
+        # pushes profiled image-only services (Kaizen's agent, launched
+        # dynamically via AGENT_SERVER_IMAGE rather than by the operator),
+        # so they appear in the dev canonical-ref map but never here.
         services = out.get("services") or {}
         profiled = [name for name, svc in services.items() if svc.get("profiles")]
         for name in profiled:
@@ -319,6 +382,7 @@ class ComposeTransformer:
                 extension_name,
                 revision_tag,
                 registry,
+                purpose=purpose,
                 image_basename=image_basename,
             )
 
@@ -334,6 +398,8 @@ class ComposeTransformer:
         extension_name: str,
         revision_tag: str,
         registry: str,
+        *,
+        purpose: Purpose,
         image_basename: Optional[str] = None,
     ) -> Dict[str, Any]:
         svc = copy.deepcopy(service)
@@ -353,15 +419,18 @@ class ComposeTransformer:
         svc.pop("build", None)
 
         if had_build:
-            # The declared image's namespace is the canonical record of
-            # where this build's image lives in the registry; publish
-            # only owns the tag (stage suffix or --revision SHA). Fall
-            # back to the legacy {ext}-{svc} convention when no image
-            # is declared (auto-generated image fields).
+            # Under publish, the declared image's namespace is the
+            # canonical record of where this build's image lives, and
+            # publish owns only the tag (stage suffix or --revision SHA).
+            # Under dev, the image is one we're building for this cluster,
+            # so it is relocated into the dev registry (ENG-8626). Either
+            # way, fall back to the legacy {ext}-{svc} convention when no
+            # image is declared (auto-generated image fields).
             svc["image"] = _canonical_build_ref(
                 svc,
                 service_name,
-                fallback_registry=registry,
+                purpose=purpose,
+                registry=registry,
                 fallback_extension_name=extension_name,
                 revision_tag=revision_tag,
                 fallback_image_basename=image_basename,

--- a/kamiwaza_extensions/dev_env_image_refs.py
+++ b/kamiwaza_extensions/dev_env_image_refs.py
@@ -15,12 +15,12 @@ publish path:
 1. Dev rewrites to the **built ref** (where ``ImageBuilder`` actually
    pushed the image), not a digest-pin — the dev tag is unique per build.
 2. It must align the ``SANDBOX_ALLOWED_IMAGE_PREFIXES`` allowlist in
-   lockstep, because a profiled ``image-only`` agent is built at the
-   legacy ``{registry}/{ext}-agent:{tag}`` fallback path, outside the
-   source whitelist. The platform's ``image_rewrite.py`` encodes the
-   same env-name coupling (``IMAGE_ENV_NAMES`` / ``IMAGE_PREFIX_ENV_NAMES``)
-   for the offline-relocation install type; this is the dev-tooling
-   equivalent for normal (non-relocation) dev clusters.
+   lockstep, because the agent is built into the cluster dev registry
+   rather than the ``ghcr.io`` namespace the source whitelist names. The
+   platform's ``image_rewrite.py`` encodes the same env-name coupling
+   (``IMAGE_ENV_NAMES`` / ``IMAGE_PREFIX_ENV_NAMES``) for the
+   offline-relocation install type; this is the dev-tooling equivalent
+   for normal (non-relocation) dev clusters.
 """
 
 from __future__ import annotations
@@ -29,10 +29,7 @@ import copy
 import re
 from typing import Any, Dict, List, Optional
 
-from kamiwaza_extensions.compose_transformer import (
-    _fallback_image_basename,
-    _repo_part,
-)
+from kamiwaza_extensions.compose_transformer import _repo_part
 
 # Env vars whose value is a single container image reference (possibly
 # wrapped in a ``${NAME:-default}`` shell default). Mirrors the platform's
@@ -53,11 +50,6 @@ _DEFAULT_SUB_RE = re.compile(r"\A(\$\{[A-Za-z_][A-Za-z0-9_]*:?-)([^}]+)(\})\Z")
 def build_image_ref_map(
     source_services: Optional[Dict[str, Any]],
     canonical_refs: Dict[str, str],
-    *,
-    registry: str,
-    extension_name: str,
-    revision_tag: str,
-    image_basename: Optional[str] = None,
 ) -> Dict[str, str]:
     """Map each build-context service's declared image repo to its built ref.
 
@@ -66,17 +58,18 @@ def build_image_ref_map(
     ``AGENT_SERVER_IMAGE`` defaulting to the released ``:2.0.2`` while the
     service declares the same repo) still matches.
 
-    The built ref is selected exactly as ``ImageBuilder.build`` does
-    (``image_builder.py``): ``canonical_refs[name]`` when present, else the
-    legacy ``{registry}/{basename}-{name}:{tag}`` fallback. A profiled
-    ``image-only`` service (the agent) is absent from ``canonical_refs``,
-    so it resolves to the fallback path — which is where it actually lives
-    in the registry. Keeping this in step with the builder is the whole
-    point: the env ref must equal what was pushed.
+    The built ref is read straight from *canonical_refs*, which under
+    ``purpose="dev"`` covers every build-context service — profiled
+    ``image-only`` ones (the agent) included. This function used to
+    re-derive a legacy ``{registry}/{basename}-{name}:{tag}`` fallback for
+    exactly those profiled services, because they were absent from the map;
+    that made it a fourth site that had to stay in lockstep with
+    ``ImageBuilder``, and it is why the agent landed on a different
+    repository path than its siblings (ENG-8626). A build service missing
+    from the map is skipped rather than assigned an invented ref: the env
+    ref must equal what was actually built and pushed, and a ref nobody
+    built is worse than no rewrite at all.
     """
-    basename = _fallback_image_basename(
-        extension_name, fallback_image_basename=image_basename
-    )
     out: Dict[str, str] = {}
     for name, svc in (source_services or {}).items():
         if not isinstance(svc, dict) or "build" not in svc:
@@ -84,13 +77,9 @@ def build_image_ref_map(
         declared = svc.get("image")
         if not isinstance(declared, str) or not declared.strip():
             continue
-        # Presence, not truthiness — the exact mirror of ImageBuilder.build's
-        # ``svc_name in image_refs`` check.
-        built = (
-            canonical_refs[name]
-            if name in canonical_refs
-            else f"{registry}/{basename}-{name}:{revision_tag}"
-        )
+        built = canonical_refs.get(name)
+        if not built:
+            continue
         out[_repo_part(declared.strip())] = built
     return out
 

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -56,17 +56,17 @@ def multi_service_compose():
 class TestStripHostPorts:
     def test_strips_host_port(self, transformer):
         compose = {"services": {"web": {"ports": ["3000:3000"]}}}
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["web"]["ports"] == ["3000"]
 
     def test_strips_with_protocol(self, transformer):
         compose = {"services": {"web": {"ports": ["8080:3000/tcp"]}}}
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["web"]["ports"] == ["3000/tcp"]
 
     def test_container_only_port_unchanged(self, transformer):
         compose = {"services": {"web": {"ports": ["8000"]}}}
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["web"]["ports"] == ["8000"]
 
     def test_long_form_port_preserved_with_l7_hints(self, transformer):
@@ -86,7 +86,7 @@ class TestStripHostPorts:
                 }
             }
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["web"]["ports"] == [
             {
                 "target": 19530,
@@ -113,7 +113,7 @@ class TestStripHostPorts:
                 }
             }
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["web"]["ports"] == [{"target": 8080, "name": "http"}]
 
 
@@ -122,17 +122,17 @@ class TestStripBindMounts:
         compose = {
             "services": {"web": {"volumes": ["./data:/app/data", "named:/app/persist"]}}
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["web"]["volumes"] == ["named:/app/persist"]
 
     def test_strips_absolute_bind_mount(self, transformer):
         compose = {"services": {"web": {"volumes": ["/host/path:/container"]}}}
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert "volumes" not in result["services"]["web"]
 
     def test_keeps_named_volumes(self, transformer):
         compose = {"services": {"web": {"volumes": ["data:/app/data"]}}}
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["web"]["volumes"] == ["data:/app/data"]
 
     def test_strips_home_dir_bind_mount(self, transformer):
@@ -140,26 +140,26 @@ class TestStripBindMounts:
         compose = {
             "services": {"web": {"volumes": ["~/data:/app/data", "named:/app/persist"]}}
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["web"]["volumes"] == ["named:/app/persist"]
 
     def test_strips_windows_drive_bind_mount(self, transformer):
         """ENG-4956: Windows drive-letter paths are flagged by the validator."""
         compose = {"services": {"web": {"volumes": [r"C:\host\data:/app/data"]}}}
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert "volumes" not in result["services"]["web"]
 
     def test_strips_cwd_bind_mount(self, transformer):
         """ENG-4956: a bare '.' source is flagged by the validator."""
         compose = {"services": {"web": {"volumes": [".:/app"]}}}
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert "volumes" not in result["services"]["web"]
 
 
 class TestBuildContextRemoval:
     def test_removes_build_adds_image(self, transformer):
         compose = {"services": {"api": {"build": "./backend"}}}
-        result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test")
+        result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test", purpose="publish")
         svc = result["services"]["api"]
         assert "build" not in svc
         assert svc["image"] == "registry.test/my-app-api:1.0.0-dev"
@@ -179,7 +179,7 @@ class TestBuildContextRemoval:
                 }
             }
         }
-        result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test")
+        result = transformer.transform(compose, "my-app", "1.0.0-dev", "registry.test", purpose="publish")
         assert result["services"]["api"]["image"] == (
             "ghcr.io/kamiwazaai/my-app-api:1.0.0-dev"
         )
@@ -206,6 +206,7 @@ class TestBuildContextRemoval:
             "my-app",
             "1.0.0-dev",
             "registry.test",
+            purpose="publish",
         )
         assert result["services"]["api"]["image"] == (
             "registry.test/my-app-api:1.0.0-dev"
@@ -228,9 +229,50 @@ class TestBuildContextRemoval:
             "tool-omniparse",
             "2.0.14-dev",
             "ghcr.io/kamiwaza-internal/foo/images",
+            purpose="publish",
         )
         assert result["services"]["omniparse-server"]["image"] == (
             "ghcr.io/kamiwaza-internal/foo/images/omniparse:2.0.14-dev"
+        )
+
+    def test_dev_transform_relocates_divergent_namespace_to_dev_registry(
+        self, transformer
+    ):
+        # ENG-8626: the same compose, transformed for dev, must name an image
+        # the cluster can actually pull. The transform feeds the CR payload,
+        # so if it disagreed with the canonical-ref map the pod would
+        # reference an image nobody pushed.
+        compose = {
+            "services": {
+                "omniparse-server": {
+                    "build": "./tool-omniparse",
+                    "image": "ghcr.io/kamiwaza-internal/foo/images/omniparse:2.0.14",
+                }
+            }
+        }
+        result = transformer.transform(
+            compose,
+            "tool-omniparse",
+            "2.0.14-dev",
+            "host.docker.internal:5001",
+            purpose="dev",
+        )
+        assert result["services"]["omniparse-server"]["image"] == (
+            "host.docker.internal:5001/kamiwaza-internal/foo/images/omniparse:2.0.14-dev"
+        )
+
+    def test_dev_transform_leaves_external_images_untouched(self, transformer):
+        # No build: → not ours. Dev must not retag or relocate it.
+        compose = {
+            "services": {
+                "postgres": {"image": "ghcr.io/upstream/images/postgres:v18.4"},
+            }
+        }
+        result = transformer.transform(
+            compose, "my-app", "1.0.0-dev", "host.docker.internal:5001", purpose="dev"
+        )
+        assert result["services"]["postgres"]["image"] == (
+            "ghcr.io/upstream/images/postgres:v18.4"
         )
 
     def test_dict_build_config(self, transformer):
@@ -239,7 +281,7 @@ class TestBuildContextRemoval:
                 "web": {"build": {"context": ".", "dockerfile": "frontend/Dockerfile"}}
             }
         }
-        result = transformer.transform(compose, "my-app", "v1", "reg")
+        result = transformer.transform(compose, "my-app", "v1", "reg", purpose="publish")
         assert "build" not in result["services"]["web"]
         assert result["services"]["web"]["image"] == "reg/my-app-web:v1"
 
@@ -247,12 +289,12 @@ class TestBuildContextRemoval:
 class TestExternalImages:
     def test_postgres_preserved(self, transformer):
         compose = {"services": {"db": {"image": "postgres:15"}}}
-        result = transformer.transform(compose, "my-app", "v1", "reg")
+        result = transformer.transform(compose, "my-app", "v1", "reg", purpose="publish")
         assert result["services"]["db"]["image"] == "postgres:15"
 
     def test_redis_preserved(self, transformer):
         compose = {"services": {"cache": {"image": "redis:7-alpine"}}}
-        result = transformer.transform(compose, "my-app", "v1", "reg")
+        result = transformer.transform(compose, "my-app", "v1", "reg", purpose="publish")
         assert result["services"]["cache"]["image"] == "redis:7-alpine"
 
 
@@ -275,6 +317,7 @@ class TestNonBuildableInternalImages:
             "my-app",
             "1.0.0-dev-abc1234",
             "kamiwazaai",
+            purpose="publish",
         )
         # Tag preserved verbatim despite the SHA-pinned revision_tag.
         assert result["services"]["helper"]["image"] == "kamiwazaai/my-app-helper:0.5.0"
@@ -292,6 +335,7 @@ class TestNonBuildableInternalImages:
             "my-app",
             "1.0.0-dev-abc1234",
             "kamiwazaai",
+            purpose="publish",
         )
         # Buildable: rewritten with the revision tag.
         assert (
@@ -307,7 +351,7 @@ class TestNonBuildableInternalImages:
 class TestResourceLimits:
     def test_adds_default_limits(self, transformer):
         compose = {"services": {"api": {"image": "my-app/api:1"}}}
-        result = transformer.transform(compose, "my-app", "v1", "reg")
+        result = transformer.transform(compose, "my-app", "v1", "reg", purpose="publish")
         limits = result["services"]["api"]["deploy"]["resources"]["limits"]
         assert limits["cpus"] == "1.0"
         assert limits["memory"] == "1G"
@@ -323,13 +367,13 @@ class TestResourceLimits:
                 }
             }
         }
-        result = transformer.transform(compose, "my-app", "v1", "reg")
+        result = transformer.transform(compose, "my-app", "v1", "reg", purpose="publish")
         limits = result["services"]["api"]["deploy"]["resources"]["limits"]
         assert limits["cpus"] == "2.0"
 
     def test_postgres_gets_smaller_limits(self, transformer):
         compose = {"services": {"db": {"image": "postgres:15"}}}
-        result = transformer.transform(compose, "my-app", "v1", "reg")
+        result = transformer.transform(compose, "my-app", "v1", "reg", purpose="publish")
         limits = result["services"]["db"]["deploy"]["resources"]["limits"]
         assert limits["cpus"] == "0.5"
         assert limits["memory"] == "512M"
@@ -340,12 +384,12 @@ class TestCleanup:
         compose = {
             "services": {"api": {"extra_hosts": ["host.docker.internal:host-gateway"]}}
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert "extra_hosts" not in result["services"]["api"]
 
     def test_removes_container_name(self, transformer):
         compose = {"services": {"api": {"container_name": "my-api"}}}
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert "container_name" not in result["services"]["api"]
 
     def test_removes_networks(self, transformer):
@@ -353,7 +397,7 @@ class TestCleanup:
             "services": {"api": {"networks": ["default"]}},
             "networks": {"default": None},
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert "networks" not in result["services"]["api"]
         assert "networks" not in result
 
@@ -369,7 +413,7 @@ class TestCleanup:
                 }
             }
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["postgres"]["x-kamiwaza"] == {
             "containerSecurityContext": {"runAsNonRoot": False},
             "healthCheck": {"tcpSocket": {"port": 5432}},
@@ -379,7 +423,11 @@ class TestCleanup:
 class TestFullTransform:
     def test_multi_service(self, transformer, multi_service_compose):
         result = transformer.transform(
-            multi_service_compose, "my-app", "1.0.0-dev-abc.123", "registry.test"
+            multi_service_compose,
+            "my-app",
+            "1.0.0-dev-abc.123",
+            "registry.test",
+            purpose="publish",
         )
         # Frontend
         fe = result["services"]["frontend"]
@@ -406,7 +454,7 @@ class TestFullTransform:
     def test_does_not_mutate_input(self, transformer):
         compose = {"services": {"api": {"build": ".", "ports": ["8000:8000"]}}}
         original_ports = list(compose["services"]["api"]["ports"])
-        transformer.transform(compose, "test", "v1", "reg")
+        transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert compose["services"]["api"]["ports"] == original_ports
         assert "build" in compose["services"]["api"]
 
@@ -551,7 +599,7 @@ class TestTransformPreservesEnvPlaceholders:
                 },
             },
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["neo4j"]["environment"] == {
             "NEO4J_AUTH": "neo4j/${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}",
             "KZ_NEO4J_PASSWORD": "${NEO4J_PASSWORD:?NEO4J_PASSWORD must be set}",
@@ -572,7 +620,7 @@ class TestTransformPreservesEnvPlaceholders:
                 },
             },
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["graphiti"]["environment"] == {
             "KAMIWAZA_ENDPOINT": "${KAMIWAZA_ENDPOINT:-http://host.docker.internal:8080}",
             "OPENAI_API_KEY": "${OPENAI_API_KEY:-not-needed-kamiwaza}",
@@ -590,7 +638,7 @@ class TestTransformPreservesEnvPlaceholders:
                 },
             },
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["backend"]["environment"] == {
             "OPENAI_BASE_URL": "${OPENAI_BASE_URL}",
         }
@@ -611,7 +659,7 @@ class TestTransformPreservesEnvPlaceholders:
                 },
             },
         }
-        result = transformer.transform(compose, "test", "v1", "reg")
+        result = transformer.transform(compose, "test", "v1", "reg", purpose="publish")
         assert result["services"]["backend"]["environment"] == [
             "NEO4J_PASSWORD=${NEO4J_PASSWORD:?required}",
             "BACKEND_URL=${BACKEND_URL:-http://backend:8000}",
@@ -802,7 +850,7 @@ class TestCanonicalBuildRef:
     falling back to the legacy form for everything else."""
 
     @staticmethod
-    def _call(image=None, *, has_build=True, declared_only=False):
+    def _call(image=None, *, has_build=True, declared_only=False, purpose="publish"):
         from kamiwaza_extensions.compose_transformer import _canonical_build_ref
 
         svc: Dict[str, Any] = {}
@@ -815,7 +863,8 @@ class TestCanonicalBuildRef:
         return _canonical_build_ref(
             svc,
             "api",
-            fallback_registry="registry.test",
+            purpose=purpose,
+            registry="registry.test",
             fallback_extension_name="my-ext",
             revision_tag="2.0.0-dev",
         )
@@ -876,6 +925,76 @@ class TestCanonicalBuildRef:
             )
             == "ghcr.io/my-org/api:2.0.0-dev"
         )
+
+
+class TestCanonicalBuildRefDevPurpose:
+    """ENG-8626: under ``purpose="dev"`` a qualified declared ``image:`` on a
+    service with ``build:`` is an image *identity*, not a destination.
+
+    ``kz-ext dev`` is building that image for this cluster right now, so it
+    must land in the resolved cluster dev registry. Honoring the declared
+    ``ghcr.io`` host pushed owned dev images to the org registry (failing the
+    whole command when the developer can't write dev tags there) and deployed
+    a CR the cluster couldn't pull. Publish keeps the declared namespace —
+    see ``TestCanonicalBuildRef`` — because there the namespace IS where the
+    image gets published (ENG-4909).
+    """
+
+    _call = staticmethod(TestCanonicalBuildRef._call)
+
+    def _dev(self, image=None, **kw):
+        return self._call(image=image, purpose="dev", **kw)
+
+    def test_qualified_ref_relocated_to_dev_registry(self):
+        assert self._dev("ghcr.io/my-org/api:1.0") == "registry.test/my-org/api:2.0.0-dev"
+
+    def test_declared_repository_path_preserved(self):
+        # The full repo path survives the host swap. Flattening to the legacy
+        # {ext}-{svc} form would discard the declared identity and collide —
+        # see test_same_basename_different_repos_do_not_collide.
+        assert self._dev(
+            "ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images/kaizen-controller:2.0.2"
+        ) == (
+            "registry.test/kamiwaza-internal/kamiwaza-extensions-kaizen/images"
+            "/kaizen-controller:2.0.0-dev"
+        )
+
+    def test_same_basename_different_repos_do_not_collide(self):
+        a = self._dev("ghcr.io/a/images/svc:1")
+        b = self._dev("ghcr.io/b/images/svc:1")
+        assert a == "registry.test/a/images/svc:2.0.0-dev"
+        assert b == "registry.test/b/images/svc:2.0.0-dev"
+        assert a != b
+
+    def test_relocation_is_idempotent(self):
+        # A ref already under the dev registry (a resumed run re-deriving from
+        # its own prior output) must not accrete another registry prefix.
+        once = self._dev("ghcr.io/my-org/api:1.0")
+        assert self._dev(once) == once
+
+    def test_digest_pinned_ref_relocated_and_retagged(self):
+        assert (
+            self._dev("ghcr.io/my-org/api@sha256:" + "a" * 64)
+            == "registry.test/my-org/api:2.0.0-dev"
+        )
+
+    def test_registry_with_port_relocated(self):
+        # Qualified-by-port refs are relocated too: a declared localhost:5000
+        # is some other machine's registry, not this cluster's.
+        assert self._dev("localhost:5000/api:1.0") == "registry.test/api:2.0.0-dev"
+
+    def test_unqualified_bare_repo_still_falls_back_to_legacy(self):
+        # Unchanged from publish: `api:latest` would push to Docker Hub.
+        assert self._dev("api:latest") == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_unqualified_short_form_still_falls_back_to_legacy(self):
+        assert self._dev("my-org/api:1.0") == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_no_declared_image_still_falls_back_to_legacy(self):
+        assert self._dev() == "registry.test/my-ext-api:2.0.0-dev"
+
+    def test_blank_declared_image_still_falls_back_to_legacy(self):
+        assert self._dev("   ") == "registry.test/my-ext-api:2.0.0-dev"
 
 
 class TestSplitImageRef:
@@ -1015,11 +1134,13 @@ class TestComputeCanonicalRefs:
         registry="registry.test",
         extension_name="my-ext",
         revision_tag="2.0.0-dev",
+        purpose="publish",
     ):
         from kamiwaza_extensions.compose_transformer import compute_canonical_refs
 
         return compute_canonical_refs(
             source,
+            purpose=purpose,
             registry=registry,
             extension_name=extension_name,
             revision_tag=revision_tag,
@@ -1039,9 +1160,11 @@ class TestComputeCanonicalRefs:
         assert "neo4j" not in result
 
     def test_profile_gated_services_excluded(self):
-        # Mirrors the buildable_services filter in run_publish. A
-        # service with a profiles: key is local-only; pushing it under
-        # --no-build would leak a dev helper into the registry.
+        # Publish only. Mirrors the buildable_services filter in run_publish.
+        # A service with a profiles: key is local-only; pushing it under
+        # --no-build would leak a dev helper into the registry. Profiled
+        # images that DO get published go via extra_docker_images.
+        # Dev includes them — see TestComputeCanonicalRefsDevPurpose.
         source = {
             "backend": {"build": ".", "image": "ghcr.io/my-org/backend:1.0"},
             "dev-helper": {
@@ -1050,7 +1173,7 @@ class TestComputeCanonicalRefs:
                 "profiles": ["dev"],
             },
         }
-        result = self._call(source)
+        result = self._call(source, purpose="publish")
         assert list(result.keys()) == ["backend"]
 
     def test_appgarden_entry_overrides_source(self):
@@ -1111,6 +1234,79 @@ class TestComputeCanonicalRefs:
         }
 
 
+class TestComputeCanonicalRefsDevPurpose:
+    """ENG-8626: the dev map covers every image ``kz-ext dev`` builds, and
+    every one of them lands in the cluster dev registry."""
+
+    _call = staticmethod(TestComputeCanonicalRefs._call)
+
+    def _dev(self, source, **kw):
+        return self._call(source, purpose="dev", **kw)
+
+    def test_profile_gated_build_services_included(self):
+        # The inverse of TestComputeCanonicalRefs.test_profile_gated_services_
+        # excluded. ImageBuilder builds every build: service regardless of
+        # profiles, so omitting profiled ones here left the builder to
+        # synthesize its own legacy ref — which is exactly how Kaizen's
+        # profiled agent ended up on a different repository path than its
+        # siblings while they went to GHCR.
+        source = {
+            "backend": {"build": ".", "image": "ghcr.io/my-org/backend:1.0"},
+            "agent": {
+                "build": "./agent",
+                "image": "ghcr.io/my-org/agent:1.0",
+                "profiles": ["image-only"],
+            },
+        }
+        assert self._dev(source) == {
+            "backend": "registry.test/my-org/backend:2.0.0-dev",
+            "agent": "registry.test/my-org/agent:2.0.0-dev",
+        }
+
+    def test_external_services_without_build_still_excluded(self):
+        # postgres/redis are not ours; dev must never retag or push them.
+        source = {
+            "backend": {"build": ".", "image": "ghcr.io/my-org/backend:1.0"},
+            "postgres": {"image": "ghcr.io/upstream/containers/images/postgres:v18.4"},
+        }
+        assert self._dev(source) == {
+            "backend": "registry.test/my-org/backend:2.0.0-dev",
+        }
+
+    def test_kaizen_shaped_compose_all_owned_images_under_dev_registry(self):
+        # The exact shape from ENG-8626: four owned builds declaring a
+        # qualified GHCR namespace (one of them profile-gated) plus an
+        # external postgres. Before the fix this produced a mixed batch —
+        # controller/backend/frontend at ghcr.io, agent at the dev registry.
+        ns = "ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images"
+        source = {
+            "postgres": {"image": "ghcr.io/kamiwaza-internal/containers/images/postgres:v18.4"},
+            "sandbox-controller": {"build": ".", "image": f"{ns}/kaizen-controller:2.0.2"},
+            "agent": {
+                "build": ".",
+                "image": f"{ns}/kaizen-agent:2.0.2",
+                "profiles": ["image-only"],
+            },
+            "backend": {"build": ".", "image": f"{ns}/kaizen-backend:2.0.2"},
+            "frontend": {"build": ".", "image": f"{ns}/kaizen-frontend:2.0.2"},
+        }
+        refs = self._dev(
+            source, registry="host.docker.internal:5001", extension_name="kaizen"
+        )
+
+        assert set(refs) == {"sandbox-controller", "agent", "backend", "frontend"}
+        # Every owned image, one revision, all beneath the dev registry.
+        assert all(
+            ref.startswith("host.docker.internal:5001/") for ref in refs.values()
+        ), refs
+        assert all(ref.endswith(":2.0.0-dev") for ref in refs.values()), refs
+        assert not any("ghcr.io" in ref for ref in refs.values()), refs
+        assert refs["sandbox-controller"] == (
+            "host.docker.internal:5001/kamiwaza-internal/kamiwaza-extensions-kaizen"
+            "/images/kaizen-controller:2.0.0-dev"
+        )
+
+
 class TestCanonicalBuildRefImageBasename:
     """``image_basename`` override on the legacy fallback path.
 
@@ -1123,7 +1319,13 @@ class TestCanonicalBuildRefImageBasename:
     """
 
     @staticmethod
-    def _call(*, image=None, fallback_image_basename=None, has_build=True):
+    def _call(
+        *,
+        image=None,
+        fallback_image_basename=None,
+        has_build=True,
+        purpose="publish",
+    ):
         from kamiwaza_extensions.compose_transformer import _canonical_build_ref
 
         svc: Dict[str, Any] = {}
@@ -1134,7 +1336,8 @@ class TestCanonicalBuildRefImageBasename:
         return _canonical_build_ref(
             svc,
             "api",
-            fallback_registry="registry.test",
+            purpose=purpose,
+            registry="registry.test",
             fallback_extension_name="my-ext",
             revision_tag="2.0.0-dev",
             fallback_image_basename=fallback_image_basename,
@@ -1152,7 +1355,8 @@ class TestCanonicalBuildRefImageBasename:
             _canonical_build_ref(
                 {"build": "."},
                 "api",
-                fallback_registry="registry.test",
+                purpose="publish",
+                registry="registry.test",
                 fallback_extension_name="Hello Web",
                 revision_tag="2.0.0-dev",
             )
@@ -1226,6 +1430,7 @@ class TestComposeTransformerImageBasenameRegression:
             revision_tag="0.13.0-dev",
             registry="ghcr.io/kamiwaza-internal",
             image_basename="outcome-d563-workroom-manager",
+            purpose="publish",
         )
         assert out["services"]["backend"]["image"] == (
             "ghcr.io/kamiwaza-internal/outcome-d563-workroom-manager-backend:0.13.0-dev"
@@ -1244,6 +1449,7 @@ class TestComposeTransformerImageBasenameRegression:
         }
         refs = compute_canonical_refs(
             source,
+            purpose="publish",
             registry="ghcr.io/kamiwaza-internal",
             extension_name="workroom-manager",
             revision_tag="0.13.0-dev",
@@ -1265,6 +1471,7 @@ class TestComposeTransformerImageBasenameRegression:
 
         refs = compute_canonical_refs(
             {"api": {"build": "."}},
+            purpose="publish",
             registry="registry.test",
             extension_name="Hello Web",
             revision_tag="dev1",
@@ -1282,6 +1489,7 @@ class TestComposeTransformerImageBasenameRegression:
         source = {"backend": {"build": "./backend"}}
         refs = compute_canonical_refs(
             source,
+            purpose="publish",
             registry="ghcr.io/kamiwaza-internal",
             extension_name="workroom-manager",
             revision_tag="0.13.0-dev",

--- a/tests/unit/extensions/test_dev_canonical_refs.py
+++ b/tests/unit/extensions/test_dev_canonical_refs.py
@@ -1,14 +1,20 @@
 """Tests that ``run_dev_remote`` passes canonical image refs to the builder.
 
-The build/push refs in dev.py must match the namespace declared in
-compose, the same way ``ComposeTransformer`` rewrites them. Without
-``image_refs=`` plumbed through to ``ImageBuilder.build``, the builder
-defaults to the legacy ``{registry}/{ext}-{svc}:{tag}`` form while the
-K8s payload (built from the transformed compose) references the
-declared namespace — extensions that publish under a non-conventional
-path (e.g. ``ghcr.io/.../tool-omniparse/omniparse``) hit
-ImagePullBackOff because the image lives at a different path than the
-pod pulls from.
+One ref, everywhere: whatever ``kz-ext dev`` builds, it must push, and the
+K8s payload must pull exactly that. ``ImageBuilder.build`` therefore takes
+``image_refs=`` from the same ``compute_canonical_refs`` map that feeds the
+transformed compose. Left to itself the builder would synthesize the legacy
+``{registry}/{ext}-{svc}:{tag}`` form while the payload named something else,
+and an extension with a non-conventional repository path (omniparse at
+``.../tool-omniparse/omniparse``) would ImagePullBackOff.
+
+ENG-8626: that map is now computed with ``purpose="dev"``, which relocates an
+owned build image into the *resolved cluster registry* while preserving its
+declared repository path. Dev previously honored the declared ``ghcr.io``
+host, so it built, pushed, and deployed owned dev images to the org registry —
+failing outright when the developer couldn't write dev tags there, and
+depending on an external private registry for local cluster development.
+Publish still preserves the declared namespace; see ``test_publish_cmd.py``.
 """
 
 from __future__ import annotations
@@ -60,9 +66,14 @@ def _active_connection() -> ConnectionInfo:
 
 
 class TestDevRemoteBuildsAtCanonicalRefs:
-    """``ImageBuilder.build`` must receive ``image_refs`` that honor the
-    compose-declared namespace — same source-of-truth as the K8s
-    payload's image refs."""
+    """``ImageBuilder.build`` must receive ``image_refs`` from the dev
+    canonical map — the same source of truth as the K8s payload's image
+    refs, so the ref we build is the ref the cluster pulls.
+
+    ENG-8626: dev relocates an owned build image into the resolved cluster
+    registry, preserving the declared repository path. It used to hand the
+    builder the declared ``ghcr.io`` namespace verbatim, so ``kz-ext dev``
+    built and pushed owned dev images to the org registry."""
 
     def test_divergent_image_namespace_flows_through_to_builder(
         self, tmp_path, monkeypatch
@@ -137,12 +148,19 @@ class TestDevRemoteBuildsAtCanonicalRefs:
         builder.build.assert_called_once()
         assert "image_refs" in captured, (
             "ImageBuilder.build must receive image_refs= so the built ref "
-            "matches the transformed compose's declared namespace."
+            "matches the ref the transformed compose deploys."
         )
-        # Tag rewritten, namespace preserved verbatim.
+        # Registry host relocated to the resolved dev registry; the declared
+        # repository path (tool-omniparse/omniparse — which does NOT follow
+        # the {ext}-{svc} convention) survives, so nothing collides and the
+        # rewrite is idempotent.
         assert captured["image_refs"] == {
-            "omniparse": "ghcr.io/example/tool-omniparse/omniparse:0.1.0-dev-abc.123",
+            "omniparse": (
+                "registry.kamiwaza.test/example/tool-omniparse/omniparse"
+                ":0.1.0-dev-abc.123"
+            ),
         }
+        assert not captured["image_refs"]["omniparse"].startswith("ghcr.io/")
 
     def test_display_name_fallback_image_refs_are_sanitized(self, tmp_path):
         from kamiwaza_extensions.commands import dev as dev_cmd
@@ -1366,14 +1384,23 @@ class TestInsecurePreflightSource:
         assert captured["kwargs"]["insecure"] is True
         assert captured["kwargs"]["engine"] == "docker"
 
-    def test_insecure_preflight_skips_unused_loopback_alias_for_external_refs(
+    def test_qualified_build_ref_pushes_via_vm_alias_transport(
         self, tmp_path, monkeypatch
     ):
-        """Declared external build refs do not retag to the local VM alias.
+        """A split image/push registry changes only the transport alias.
 
-        Registry resolution may still find an auto loopback alias for fallback
-        refs, but the Docker insecure-registry preflight should only require
-        daemon config when at least one actual push ref maps to that alias.
+        ENG-8626: this used to assert the opposite — that a declared
+        ``ghcr.io`` build ref stayed external, was pushed verbatim to GHCR,
+        and got an empty ``target_refs``. That was the bug: the image is one
+        ``kz-ext dev`` builds, so it belongs in the cluster registry.
+
+        Now the canonical (deploy) ref sits under ``image_registry``
+        (``127.0.0.1:30010``), and ``build_push_ref_map`` translates it to the
+        VM-reachable ``push_registry`` alias purely for transport. The ref the
+        CR deploys is the image_registry one; the alias never leaks into it.
+        Because the push ref really does target the alias now, the Docker
+        insecure-registry preflight correctly fires (it used to be skipped —
+        no push ref reached that registry).
         """
 
         from kamiwaza_extensions.commands import dev as dev_cmd
@@ -1449,7 +1476,7 @@ class TestInsecurePreflightSource:
             ),
             patch(
                 "kamiwaza_extensions.registry_resolution.docker_accepts_insecure_push_to",
-                return_value=False,
+                return_value=True,
             ) as mock_accepts,
             patch(
                 "kamiwaza_extensions.dev_state.read_state",
@@ -1463,19 +1490,28 @@ class TestInsecurePreflightSource:
         ):
             dev_cmd.run_dev_remote(no_build=True)
 
-        mock_accepts.assert_not_called()
+        # The push ref now targets the alias, so the daemon preflight applies.
+        mock_accepts.assert_called_once_with("host.docker.internal:30010")
         pusher.push.assert_called_once()
-        assert pusher.push.call_args.args[0] == ["ghcr.io/example/custom-api:dev1"]
-        assert pusher.push.call_args.kwargs["registry"] == "host.docker.internal:30010"
-        assert pusher.push.call_args.kwargs["target_refs"] == {}
 
-    def test_podman_external_refs_do_not_retag_to_local_alias(
+        image_ref = "127.0.0.1:30010/example/custom-api:dev1"
+        push_ref = "host.docker.internal:30010/example/custom-api:dev1"
+        # Pushed under the image registry, never GHCR.
+        assert pusher.push.call_args.args[0] == [image_ref]
+        assert pusher.push.call_args.kwargs["registry"] == "host.docker.internal:30010"
+        # Transport-only: the alias lives in target_refs, not in the ref itself.
+        assert pusher.push.call_args.kwargs["target_refs"] == {image_ref: push_ref}
+
+    def test_podman_qualified_build_ref_pushes_via_vm_alias_transport(
         self, tmp_path, monkeypatch
     ):
-        """Declared external build refs stay external on the Podman path too.
+        """Same alias-transport contract on the Podman path.
 
-        ``ImagePusher`` owns per-ref TLS for this mixed batch; this test keeps
-        ``run_dev_remote`` from inventing a local retag map for external refs.
+        ENG-8626: previously asserted that a declared ``ghcr.io`` build ref
+        stayed external with an empty retag map. Dev owns the image, so it is
+        built under ``image_registry`` and retagged to the Podman VM alias for
+        transport only. The Docker daemon preflight stays skipped here because
+        the push engine is Podman, not because no ref targets the alias.
         """
 
         from kamiwaza_extensions.commands import dev as dev_cmd
@@ -1558,13 +1594,18 @@ class TestInsecurePreflightSource:
         ):
             dev_cmd.run_dev_remote(no_build=True)
 
+        # Skipped because the push engine is Podman — the preflight is
+        # Docker-daemon-specific.
         mock_accepts.assert_not_called()
         pusher.push.assert_called_once()
-        assert pusher.push.call_args.args[0] == ["ghcr.io/example/custom-api:dev1"]
+
+        image_ref = "127.0.0.1:30010/example/custom-api:dev1"
+        push_ref = "host.containers.internal:30010/example/custom-api:dev1"
+        assert pusher.push.call_args.args[0] == [image_ref]
         assert pusher.push.call_args.kwargs["registry"] == (
             "host.containers.internal:30010"
         )
-        assert pusher.push.call_args.kwargs["target_refs"] == {}
+        assert pusher.push.call_args.kwargs["target_refs"] == {image_ref: push_ref}
         assert pusher.push.call_args.kwargs["engine"] == "podman"
 
     def test_fresh_build_forces_docker_push_engine_with_podman_installed(
@@ -1788,3 +1829,287 @@ class TestInsecurePreflightSource:
             dev_cmd.run_dev_remote()
 
         pusher.push.assert_not_called()
+
+
+_KZ_NS = "ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images"
+_KZ_DEV_REGISTRY = "host.docker.internal:5001"
+_KZ_DEV_NS = f"{_KZ_DEV_REGISTRY}/kamiwaza-internal/kamiwaza-extensions-kaizen/images"
+
+
+def _kaizen_info(tmp_path: Path) -> ExtensionInfo:
+    """The exact shape from ENG-8626: four owned builds declaring a qualified
+    GHCR namespace (one profile-gated) plus an external postgres."""
+    compose_data = {
+        "services": {
+            "postgres": {
+                "image": "ghcr.io/kamiwaza-internal/containers/images/postgres:v18.4",
+            },
+            "sandbox-controller": {
+                "build": {"context": "."},
+                "image": f"{_KZ_NS}/kaizen-controller:2.0.2",
+                "environment": {
+                    "AGENT_SERVER_IMAGE": f"{_KZ_NS}/kaizen-agent:2.0.2",
+                    "SANDBOX_ALLOWED_IMAGE_PREFIXES": f"{_KZ_NS}/kaizen-agent",
+                },
+            },
+            "agent": {
+                "profiles": ["image-only"],
+                "build": {"context": "."},
+                "image": f"{_KZ_NS}/kaizen-agent:2.0.2",
+            },
+            "backend": {
+                "build": {"context": "."},
+                "image": f"{_KZ_NS}/kaizen-backend:2.0.2",
+                "environment": {
+                    "AGENT_SERVER_IMAGE": f"{_KZ_NS}/kaizen-agent:2.0.2",
+                },
+            },
+            "frontend": {
+                "build": {"context": "."},
+                "image": f"{_KZ_NS}/kaizen-frontend:2.0.2",
+            },
+        },
+    }
+    return ExtensionInfo(
+        path=tmp_path,
+        name="kaizen",
+        version="2.0.2",
+        metadata={"name": "kaizen", "type": "app"},
+        compose_path=tmp_path / "docker-compose.yml",
+        compose_data=compose_data,
+    )
+
+
+class TestKaizenDevRegistryEndToEnd:
+    """ENG-8626 acceptance: ``kz-ext dev`` performs no GHCR push, and the ref
+    it builds is the ref it pushes is the ref it deploys."""
+
+    @staticmethod
+    def _run(tmp_path, *, no_build=False):
+        """Drive run_dev_remote to the payload stage, capturing every image-ref
+        surface on the way: builder, pusher, and the transformed compose that
+        becomes the CR."""
+        from kamiwaza_extensions.commands import dev as dev_cmd
+
+        captured: dict = {}
+
+        def _capture_build(**kwargs):
+            captured["build"] = kwargs
+            # Mirror ImageBuilder: build every build: service, at image_refs[svc]
+            # when present, and return the refs actually tagged.
+            return list(kwargs["image_refs"].values())
+
+        builder = MagicMock()
+        builder.build.side_effect = _capture_build
+
+        pusher = MagicMock()
+
+        class _StopAtPayload:
+            """Capture the compose that actually becomes the CR.
+
+            It must be read here, not off ``ComposeTransformer.transform``:
+            dev.py resolves env placeholders and rewrites embedded image refs
+            (AGENT_SERVER_IMAGE, the sandbox allowlist) *after* the transform,
+            each producing a new dict. The last one is what the cluster gets.
+            """
+
+            def __init__(self, *a, **kw):
+                pass
+
+            @staticmethod
+            def make_dev_name(*a, **kw):
+                return "kaizen-dev"
+
+            def build(self, **kwargs):
+                captured["deployed"] = kwargs["transformed_compose"]
+                raise RuntimeError("reached-payload-stage")
+
+        conn_mgr = MagicMock()
+        conn_mgr.get_active_connection.return_value = _active_connection()
+        conn_mgr.get_token.return_value = MagicMock(access_token="tok-abc")
+        detector = MagicMock()
+        detector.detect.return_value = _kaizen_info(tmp_path)
+        tagger = MagicMock()
+        tagger.generate_tag.return_value = "2.0.2-dev-abc.123"
+        tagger.get_git_info.return_value = ("abc1234", False)
+
+        with (
+            patch(
+                "kamiwaza_extensions.extension_detector.ExtensionDetector",
+                return_value=detector,
+            ),
+            patch(
+                "kamiwaza_extensions.connections.ConnectionManager",
+                return_value=conn_mgr,
+            ),
+            patch(
+                "kamiwaza_extensions.revision_tagger.RevisionTagger",
+                return_value=tagger,
+            ),
+            patch(
+                "kamiwaza_extensions.image_builder.ImageBuilder",
+                return_value=builder,
+            ),
+            patch(
+                "kamiwaza_extensions.image_pusher.ImagePusher",
+                return_value=pusher,
+            ),
+            patch(
+                "kamiwaza_extensions.registry_resolution.detect_core_config_registry",
+                return_value=_KZ_DEV_REGISTRY,
+            ),
+            patch(
+                "kamiwaza_extensions.registry_resolution.docker_accepts_insecure_push_to",
+                return_value=True,
+            ),
+            patch("kamiwaza_extensions.dev_state.read_state", return_value=None),
+            patch("kamiwaza_extensions.dev_state.resume_message", return_value=None),
+            patch(
+                "kamiwaza_extensions.payload_builder.PayloadBuilder",
+                _StopAtPayload,
+            ),
+            pytest.raises(RuntimeError, match="reached-payload-stage"),
+        ):
+            dev_cmd.run_dev_remote(no_build=no_build)
+
+        captured["pushed"] = list(pusher.push.call_args.args[0])
+        return captured
+
+    def test_no_ghcr_push_and_all_owned_images_under_dev_registry(self, tmp_path):
+        cap = self._run(tmp_path)
+
+        pushed = cap["pushed"]
+        # The headline acceptance criterion: nothing goes to GHCR.
+        assert not any(ref.startswith("ghcr.io/") for ref in pushed), pushed
+        assert all(ref.startswith(f"{_KZ_DEV_REGISTRY}/") for ref in pushed), pushed
+        # All four owned images, one revision.
+        assert sorted(pushed) == sorted(
+            [
+                f"{_KZ_DEV_NS}/kaizen-controller:2.0.2-dev-abc.123",
+                f"{_KZ_DEV_NS}/kaizen-agent:2.0.2-dev-abc.123",
+                f"{_KZ_DEV_NS}/kaizen-backend:2.0.2-dev-abc.123",
+                f"{_KZ_DEV_NS}/kaizen-frontend:2.0.2-dev-abc.123",
+            ]
+        )
+
+    def test_same_ref_reaches_builder_pusher_and_deployed_compose(self, tmp_path):
+        cap = self._run(tmp_path)
+
+        built = cap["build"]["image_refs"]
+        deployed = {
+            name: svc["image"]
+            for name, svc in cap["deployed"]["services"].items()
+            if name != "postgres"
+        }
+        # Builder and pusher agree.
+        assert sorted(cap["pushed"]) == sorted(built.values())
+        # ...and every deployed service pulls exactly the ref that was pushed.
+        for name, ref in deployed.items():
+            assert ref == built[name], name
+            assert ref in cap["pushed"], name
+        # The profiled agent is built and pushed but never deployed as a
+        # service — the backend launches it dynamically.
+        assert "agent" in built
+        assert "agent" not in cap["deployed"]["services"]
+
+    def test_external_image_never_retagged_or_pushed(self, tmp_path):
+        cap = self._run(tmp_path)
+
+        postgres = cap["deployed"]["services"]["postgres"]["image"]
+        # No build: → not ours. Untouched, and never pushed anywhere.
+        assert postgres == "ghcr.io/kamiwaza-internal/containers/images/postgres:v18.4"
+        assert postgres not in cap["pushed"]
+
+    def test_agent_server_image_and_allowlist_match_the_pushed_agent_ref(
+        self, tmp_path
+    ):
+        cap = self._run(tmp_path)
+
+        agent_ref = cap["build"]["image_refs"]["agent"]
+        assert agent_ref in cap["pushed"]
+
+        controller_env = cap["deployed"]["services"]["sandbox-controller"][
+            "environment"
+        ]
+        # The sandbox pod is launched from this ref, and the controller gates
+        # it against the allowlist — both must name the image we actually
+        # pushed, or the sandbox ImagePullBackOffs / is rejected.
+        assert controller_env["AGENT_SERVER_IMAGE"] == agent_ref
+        prefixes = controller_env["SANDBOX_ALLOWED_IMAGE_PREFIXES"].split(",")
+        assert any(agent_ref.startswith(p) for p in prefixes), (
+            prefixes,
+            agent_ref,
+        )
+
+    def test_no_build_does_not_push_the_profiled_agent(self, tmp_path):
+        # ENG-7110 behavior that must survive ENG-8626: profiled services are
+        # in the dev canonical map now, but --no-build must still not push them
+        # — a resumed run may no longer hold the local image. They rely on a
+        # prior run's push.
+        cap = self._run(tmp_path, no_build=True)
+
+        pushed = cap["pushed"]
+        assert not any("kaizen-agent" in ref for ref in pushed), pushed
+        assert sorted(pushed) == sorted(
+            [
+                f"{_KZ_DEV_NS}/kaizen-controller:2.0.2-dev-abc.123",
+                f"{_KZ_DEV_NS}/kaizen-backend:2.0.2-dev-abc.123",
+                f"{_KZ_DEV_NS}/kaizen-frontend:2.0.2-dev-abc.123",
+            ]
+        )
+
+
+class TestResumeProbesDevRegistry:
+    """ENG-8626: the resume probe must look for artifacts where dev actually
+    pushes them.
+
+    ``_prior_artifacts_in_registry`` decides whether a prior run's images are
+    still in the registry (and so whether the build/push can be skipped). It
+    shares ``compute_canonical_refs``, so before the fix it probed **ghcr.io**
+    for a locally-built dev image. That both asked the wrong registry and made
+    resume validity depend on an external one."""
+
+    def test_probe_targets_dev_registry_not_declared_namespace(self, tmp_path):
+        from kamiwaza_extensions.commands import dev as dev_cmd
+
+        probed: list[str] = []
+
+        with patch(
+            "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest",
+            side_effect=lambda ref: probed.append(ref) or "sha256:" + "a" * 64,
+        ):
+            ok = dev_cmd._prior_artifacts_in_registry(
+                _kaizen_info(tmp_path),
+                "2.0.2-dev-old.1",
+                registry=_KZ_DEV_REGISTRY,
+                push_registry=_KZ_DEV_REGISTRY,
+            )
+
+        assert ok is True
+        assert probed, "probe must actually resolve the prior refs"
+        assert not any(ref.startswith("ghcr.io/") for ref in probed), probed
+        assert all(ref.startswith(f"{_KZ_DEV_REGISTRY}/") for ref in probed), probed
+        # Profiled agent included: a full prior run pushed it, so resume must
+        # confirm it is still there before skipping the rebuild that would
+        # otherwise re-create it.
+        assert f"{_KZ_DEV_NS}/kaizen-agent:2.0.2-dev-old.1" in probed
+
+    def test_probe_fails_when_prior_artifacts_are_absent(self, tmp_path):
+        """A dev-state written under the old GHCR policy names refs that were
+        never pushed to the dev registry, so the probe misses and the run
+        correctly falls back to a full rebuild rather than resuming onto
+        images the cluster can't pull."""
+        from kamiwaza_extensions.commands import dev as dev_cmd
+
+        with patch(
+            "kamiwaza_extensions.image_pusher.ImagePusher.resolve_digest",
+            side_effect=RuntimeError("manifest unknown"),
+        ):
+            ok = dev_cmd._prior_artifacts_in_registry(
+                _kaizen_info(tmp_path),
+                "2.0.2-dev-old.1",
+                registry=_KZ_DEV_REGISTRY,
+                push_registry=_KZ_DEV_REGISTRY,
+            )
+
+        assert ok is False

--- a/tests/unit/extensions/test_dev_env_image_refs.py
+++ b/tests/unit/extensions/test_dev_env_image_refs.py
@@ -10,11 +10,14 @@ sandbox pod ImagePullBackOffs on a ref that doesn't exist and chat 500s.
 
 This is the dev analog of ENG-5260 (publish-side env-image rewriting in
 ``registry_builder._apply_env_image_rewrites``). It additionally aligns
-``SANDBOX_ALLOWED_IMAGE_PREFIXES`` in lockstep — the agent (a profiled
-``image-only`` build-context service) is built at the legacy fallback
-``{registry}/{ext}-agent:{tag}`` path, which is *outside* the original
-whitelist, so the sandbox controller would reject the very image the
-backend asks it to run.
+``SANDBOX_ALLOWED_IMAGE_PREFIXES`` in lockstep — the agent is built into the
+cluster dev registry, which is *outside* the original whitelist (that names
+the ghcr.io publish namespace), so the sandbox controller would otherwise
+reject the very image the backend asks it to run.
+
+ENG-8626: the agent used to be built at the legacy ``{registry}/{ext}-agent``
+fallback purely because profiled services were omitted from the canonical-ref
+map. It now shares the same relocation rule as every other owned build image.
 """
 
 from __future__ import annotations
@@ -52,10 +55,23 @@ _BACKEND_GHCR = (
 _CONTROLLER_GHCR = (
     "ghcr.io/kamiwaza-internal/kamiwaza-extensions-kaizen/images/kaizen-controller"
 )
-# What ImageBuilder.build actually tags the agent at: the profiled service
-# is excluded from canonical_refs, so the builder falls back to
-# ``{registry}/{ext}-{svc}:{tag}``.
-_AGENT_BUILT = f"{_REGISTRY}/{_EXT}-agent:{_REV}"
+def _dev_repo(ghcr_repo: str) -> str:
+    """The dev-registry repo for a declared GHCR repo (ENG-8626).
+
+    ``purpose="dev"`` swaps the registry host and keeps the repository path,
+    so every owned Kaizen image lands beneath the cluster dev registry at a
+    distinct, deterministic path.
+    """
+    return ghcr_repo.replace("ghcr.io", _REGISTRY, 1)
+
+
+# What ImageBuilder.build actually tags each owned image at. Pre-ENG-8626 the
+# agent (profiled → absent from canonical_refs) fell back to
+# ``{registry}/{ext}-agent:{tag}`` while its non-profiled siblings kept their
+# declared ghcr.io namespace — the mixed batch this ticket removes.
+_AGENT_BUILT = f"{_dev_repo(_AGENT_GHCR)}:{_REV}"
+_BACKEND_BUILT = f"{_dev_repo(_BACKEND_GHCR)}:{_REV}"
+_CONTROLLER_BUILT = f"{_dev_repo(_CONTROLLER_GHCR)}:{_REV}"
 
 
 def _kaizen_compose() -> dict:
@@ -96,34 +112,41 @@ def _kaizen_compose() -> dict:
 def _ref_map(source_services: dict) -> dict:
     canonical = compute_canonical_refs(
         source_services,
+        purpose="dev",
         registry=_REGISTRY,
         extension_name=_EXT,
         revision_tag=_REV,
     )
-    return build_image_ref_map(
-        source_services,
-        canonical,
-        registry=_REGISTRY,
-        extension_name=_EXT,
-        revision_tag=_REV,
-    )
+    return build_image_ref_map(source_services, canonical)
 
 
 class TestBuildImageRefMap:
-    """``build_image_ref_map`` mirrors ImageBuilder.build's per-service ref
-    selection so the env rewrite targets the exact ref the agent is built and
-    pushed at."""
+    """``build_image_ref_map`` reads the dev canonical map, so the env rewrite
+    targets the exact ref each image is built and pushed at."""
 
-    def test_profiled_agent_maps_to_legacy_fallback_ref(self):
+    def test_profiled_agent_maps_to_dev_registry_ref(self):
         ref_map = _ref_map(_kaizen_compose()["services"])
-        # The profiled agent is excluded from canonical_refs, so ImageBuilder
-        # tags it at {registry}/{ext}-agent:{tag} — that's where it lives.
+        # ENG-8626: the profiled agent is in the dev canonical map now, so it
+        # is built at the same relocated path as its siblings rather than the
+        # legacy {registry}/{ext}-agent fallback it used to get by omission.
         assert ref_map[_AGENT_GHCR] == _AGENT_BUILT
 
-    def test_normal_service_keeps_declared_namespace(self):
+    def test_normal_service_relocated_to_dev_registry(self):
         ref_map = _ref_map(_kaizen_compose()["services"])
-        # Non-profiled services keep their declared namespace (canonical).
-        assert ref_map[_BACKEND_GHCR] == f"{_BACKEND_GHCR}:{_REV}"
+        # ENG-8626: this used to assert the declared ghcr.io namespace was
+        # kept — i.e. that kz-ext dev built and pushed an owned image to the
+        # org registry. It builds into the cluster dev registry instead.
+        assert ref_map[_BACKEND_GHCR] == _BACKEND_BUILT
+        assert not ref_map[_BACKEND_GHCR].startswith("ghcr.io/")
+
+    def test_every_owned_image_lands_under_the_dev_registry(self):
+        ref_map = _ref_map(_kaizen_compose()["services"])
+        # The whole point: one registry for the whole batch, no mixed refs.
+        assert set(ref_map) == {_AGENT_GHCR, _BACKEND_GHCR, _CONTROLLER_GHCR}
+        assert all(
+            built.startswith(f"{_REGISTRY}/") for built in ref_map.values()
+        ), ref_map
+        assert ref_map[_CONTROLLER_GHCR] == _CONTROLLER_BUILT
 
     def test_external_image_excluded(self):
         ref_map = _ref_map(_kaizen_compose()["services"])
@@ -139,7 +162,11 @@ class TestRewriteEnvImageRefs:
         compose = _kaizen_compose()
         transformer = ComposeTransformer()
         transformed = transformer.transform(
-            compose, extension_name=_EXT, revision_tag=_REV, registry=_REGISTRY
+            compose,
+            extension_name=_EXT,
+            revision_tag=_REV,
+            registry=_REGISTRY,
+            purpose="dev",
         )
         return transformer.resolve_env_placeholders(transformed)
 
@@ -163,8 +190,12 @@ class TestRewriteEnvImageRefs:
         env = result["services"]["sandbox-controller"]["environment"]
         prefixes = env["SANDBOX_ALLOWED_IMAGE_PREFIXES"].split(",")
         # The built agent prefix is appended; the originals are preserved
-        # (some flows may still reference the ghcr path).
-        assert f"{_REGISTRY}/{_EXT}-agent" in prefixes
+        # (some flows may still reference the ghcr path). The appended prefix
+        # must be the *relocated* repo — the controller gates the sandbox on
+        # this list, so it has to admit exactly the ref AGENT_SERVER_IMAGE
+        # names, which is now under the dev registry (ENG-8626).
+        assert _dev_repo(_AGENT_GHCR) in prefixes
+        assert _AGENT_BUILT.startswith(_dev_repo(_AGENT_GHCR) + ":")
         assert "ghcr.io/openhands/" in prefixes
         assert _AGENT_GHCR in prefixes
 
@@ -199,7 +230,11 @@ class TestRewriteEnvImageRefsCatalogSurface:
         ref_map = _ref_map(compose["services"])
         # catalog_compose is transformed but NOT resolve_env_placeholders'd.
         catalog = ComposeTransformer().transform(
-            compose, extension_name=_EXT, revision_tag=_REV, registry=_REGISTRY
+            compose,
+            extension_name=_EXT,
+            revision_tag=_REV,
+            registry=_REGISTRY,
+            purpose="dev",
         )
 
         result = rewrite_env_image_refs(catalog, ref_map)
@@ -240,7 +275,7 @@ class TestRewriteEnvImageRefsCatalogSurface:
         # Substitution form preserved, built prefix appended inside it.
         assert wl == (
             f"${{SANDBOX_ALLOWED_IMAGE_PREFIXES:-ghcr.io/openhands/,"
-            f"{_AGENT_GHCR},{_REGISTRY}/{_EXT}-agent}}"
+            f"{_AGENT_GHCR},{_dev_repo(_AGENT_GHCR)}}}"
         )
 
 

--- a/tests/unit/extensions/test_registry_builder.py
+++ b/tests/unit/extensions/test_registry_builder.py
@@ -1238,6 +1238,7 @@ class TestPublishPathOrdering:
             extension_name="service-graphiti",
             revision_tag="1.0.0",
             registry="kamiwazaai",
+            purpose="publish",
         )
         meta = {
             "name": "service-graphiti",
@@ -1262,6 +1263,7 @@ class TestPublishPathOrdering:
             extension_name="service-graphiti",
             revision_tag="1.0.0",
             registry="kamiwazaai",
+            purpose="publish",
         )
         assert list(transformed["services"].keys()) == ["neo4j", "graphiti"]
 


### PR DESCRIPTION
## Summary
`kz-ext dev` built, pushed, and deployed **owned** build images to their declared publish registry (GHCR) instead of the resolved cluster dev registry; this splits the shared canonical-ref policy with a required `purpose="dev" | "publish"` so dev targets the cluster registry while publish keeps preserving the declared namespace.

## Type
- [x] Bug Fix - Corrects existing behavior

## Change Flags
- [ ] API change
- [ ] Configuration change
- [ ] Requirements change
- [ ] Schema change

(Internal SDK signature change only — see Breaking Changes.)

## Breaking Changes
- [x] Internal interface - Other services/modules need coordinated updates

`compute_canonical_refs`, `_canonical_build_ref`, and `ComposeTransformer.transform` / `transform_service` now take a **required** `purpose` keyword, and `dev_env_image_refs.build_image_ref_map` drops four now-unused params. All are internal to `kamiwaza_extensions`; every in-repo call site is updated. `purpose` is deliberately required rather than defaulted — a call site that forgets it should fail loudly, because *silently inheriting publish semantics is exactly this bug*.

No change to `kz-ext publish` behavior (verified byte-identical, below).

## Motivation
`_canonical_build_ref`'s "declared ref is registry-qualified → preserve namespace, rewrite only the tag" early return **is** the entire destination policy, and it was shared by dev and publish.

That is correct for **publish** — an extension may publish beneath an unconventional namespace (Omniparse, ENG-4909), and catalog refs must match the pushed images. It is wrong for **dev**, where a qualified ref on a service with `build:` is the image's *published identity*, not where this cluster pulls from.

For Kaizen the resulting dev batch was mixed:

| Service | Before | After |
| -- | -- | -- |
| `sandbox-controller`, `backend`, `frontend` | `ghcr.io/.../images/kaizen-*:<dev-tag>` | dev registry |
| profile-gated `agent` | `host.docker.internal:5001/kaizen-agent:<dev-tag>` | dev registry (same repo path as siblings) |
| `postgres` (no `build:`) | declared ref, untouched | unchanged |

The controller pushes first, so the command died on a GHCR write **before ever deploying**, and local cluster development depended on an external private registry plus credentials. `build_push_ref_map` could not repair it: it only rewrites refs already prefixed with `image_registry`, so a `ghcr.io` ref never matched and was pushed verbatim.

Introduced by `c3ddc4c8` (ENG-4909), which made `compute_canonical_refs` the shared source of truth for both commands — unifying two genuinely different destination policies. Latent for Kaizen since its May 15 conversion to the flattened `kz-ext` layout.

## Source
- [x] Issue/Ticket: ENG-8626

## Alternatives Considered
- **Fix it in `build_push_ref_map`** (rebase any foreign ref onto the push registry). Rejected: the transformed compose / CR payload would still say `ghcr.io`, so the cluster would pull from GHCR — ImagePullBackOff. The deploy ref and the push ref must move together.
- **Relocate after `compute_canonical_refs`, inside `run_dev_remote` only.** Rejected: `transform_service` derives the CR's `image:` independently via the same helper, so dev would end up with two competing sources of truth for a service's ref — precisely the drift the existing docstrings were written to prevent.
- **Flatten dev repos to `{ext}-{svc}`.** Rejected: collides when two declared repos share a basename, and discards the declared repository identity. Host-replacement preserves the path, stays collision-free, and is idempotent.

## Changes Made
- `compose_transformer.py` — `Purpose` literal; required `purpose` on `compute_canonical_refs` / `_canonical_build_ref` / `transform` / `transform_service`. Dev swaps the registry host and **preserves the declared repository path** (reusing the existing `_split_image_ref`). Dev also **includes profile-gated build services** in the map; publish still excludes them (they publish via `extra_docker_images`).
- `commands/dev.py` — `purpose="dev"` at all three call sites (transform, canonical refs, resume probe). `--no-build` now **explicitly** filters profiled services out of the push list.
- `commands/publish.py` — `purpose="publish"` at all four call sites. No behavior change.
- `dev_env_image_refs.py` — `build_image_ref_map` reads the canonical map directly instead of re-deriving a legacy fallback for profiled services, removing the 4th site that had to stay in lockstep with `ImageBuilder`.

## Technical Notes
- **The `--no-build` exclusion became load-bearing.** Profiled services were kept out of the push list only *because* they were absent from `canonical_refs`. Now that dev includes them, that exclusion had to become an explicit filter — otherwise `--no-build` would try to push an agent image it never built, and a resumed run may no longer hold it locally. Pinned by a test.
- **The agent's repo path changes** from flat `.../kaizen-agent` to the nested declared path, alongside its siblings. `AGENT_SERVER_IMAGE` and the allowlist follow by construction; Kaizen's controller derives its allowlist from `AGENT_SERVER_IMAGE` by prefix (ENG-6663) and is explicitly depth-agnostic — verified in the live pod (below).
- **`build_push_ref_map` stays transport-only** — and now actually prefix-matches, so a split image/push (VM alias) registry works instead of silently no-op'ing.
- Unqualified / blank `image:` declarations keep the legacy `{registry}/{basename}-{svc}` fallback under **both** purposes, so VM-alias, insecure-registry, offline-relocation and `image_basename` behavior is untouched.

## Testing
- [x] Unit tests added/updated
- [x] Manual testing performed

## Verification
| Environment | Steps Performed | Result |
|-------------|-----------------|--------|
| Local | `uv run pytest -m "not integration and not live and not e2e"` | **2869 passed**, 1 skipped (extension baseline was 1649; +25 new) |
| Local | `ruff` + `mypy --follow-imports=silent` on all changed files | Clean (the 7 mypy errors in `dev.py`/`publish.py` are pre-existing on `develop`) |
| Local | Publish-parity: diffed `compute_canonical_refs(purpose="publish")` + transform output vs `develop` for Kaizen / omniparse / unqualified shapes | **Byte-identical** |
| Dev cluster (kamiwaza.test, Podman 5.7.1, registry `host.docker.internal:5001`) | `kz-ext dev` from `kaizen-v3` @ `493449f9` | **EXIT=0.** Zero `ghcr.io` references in the entire run |
| Dev cluster | All 4 owned images pushed at one revision | `{dev-registry}/kamiwaza-internal/kamiwaza-extensions-kaizen/images/kaizen-{controller,agent,backend,frontend}:2.0.2-dev-493449f9.…` |
| Dev cluster | Deployed pod images vs pushed refs | Match exactly; `postgres` still pulls `ghcr.io/.../postgres:v18.4` (external, untouched) |
| Dev cluster | Kaizen CR | `Running` / Ready=`True`, all 4 pods 2/2, no ImagePullBackOff |
| Dev cluster | Agent sandbox path: pulled `AGENT_SERVER_IMAGE` in `kamiwaza-sandboxes` | Pod reached `Running` — cluster pulls the relocated agent image |
| Dev cluster | `resolve_allowed_image_prefixes()` **inside the live controller pod** | Derives the nested repo prefix, **admits** the agent image, still **rejects** a same-prefix sibling (`kaizen-agent-evil`) |

## Test Coverage
Dev policy (qualified ref relocated beneath `image_registry`; repository path preserved; idempotent; digest-pinned refs; same-basename repos don't collide), publish policy unchanged, external `build:`-less services untouched, profile-gated agent included in the dev map, one-ref-everywhere (builder == pusher == deployed compose == CR), `AGENT_SERVER_IMAGE` + allowlist match the pushed agent ref, split image/push registry alters only the transport alias, `--no-build` still refuses to push profiled services, resume probes target the rebased refs.

Revised (these encoded the bug): `test_divergent_image_namespace_flows_through_to_builder`, the two "external refs are not retagged locally" preflight tests (they now exercise the alias-transport path), and `test_normal_service_keeps_declared_namespace`.

## Review Focus
1. **`_canonical_build_ref`'s dev branch** — is host-replacement-with-path-preservation the repository layout we want long-term? (Ticket called the layout an explicit design choice.)
2. **The `--no-build` profiled filter in `dev.py`** — the one prior behavior that had to be preserved by hand.
3. **`purpose` being required** — intentional, but it does touch every call site.

## Deployment Notes
N/A — SDK-internal. Developers on a dev cluster will see owned images move to the cluster registry on their next `kz-ext dev`; the first run after this lands rebuilds (prior dev-state artifacts were recorded under the old GHCR refs, and the resume probe correctly invalidates them).

## Checklist
- [x] Self-reviewed the code
- [x] Tests pass locally
- [x] Verified on live system (see Verification above)
- [ ] Documentation updated (if applicable) — none needed: `README.md` / `developer-guide.md` already documented the (previously false) cluster-registry contract this restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)
