### PR TITLE
ENG-8617: make connector publish honor extension-build's --revision/--no-push contract

### DIFF
--- a/kamiwaza_extensions/connector_publisher.py
+++ b/kamiwaza_extensions/connector_publisher.py
@@ -51,9 +51,11 @@ def _validate_manifest(info: ExtensionInfo) -> dict[str, Any]:
     if not manifest.get("connector_type"):
         _fail(f"{info.name}: manifest.connector_type is required.")
     deployment = manifest.get("deployment")
-    missing = (
-        [k for k in _REQUIRED_DEPLOYMENT_KEYS if not (isinstance(deployment, dict) and deployment.get(k))]
-    )
+    missing = [
+        k
+        for k in _REQUIRED_DEPLOYMENT_KEYS
+        if not (isinstance(deployment, dict) and deployment.get(k))
+    ]
     if missing:
         _fail(
             f"{info.name}: manifest.deployment must include "
@@ -159,6 +161,21 @@ def publish_connector(
     from kamiwaza_extensions.profile_manager import ProfileManager
 
     manifest = _validate_manifest(info)
+    # A supplied revision is the build's canonical image tag and overrides the
+    # manifest's deployment.image_tag, which is only the static authoring default
+    # (e.g. "develop"). Without this, a publish for any stage would resolve and
+    # pin that authoring-default image rather than the one the build produced.
+    # Applied before digest resolution so both the pinned digest and the
+    # published catalog entry reflect the revision tag (matching how the app
+    # publish path rewrites its compose image refs).
+    if revision and manifest["deployment"].get("image_tag") != revision:
+        # The revision changes the tag, so any digest the manifest authored
+        # against the old tag no longer applies; drop it (a fresh digest is
+        # resolved below). A manifest already rendered with this exact tag needs
+        # no change — it keeps its tag and its matching digest.
+        deployment = {**manifest["deployment"], "image_tag": revision}
+        deployment.pop("image_digest", None)
+        manifest = {**manifest, "deployment": deployment}
     image_ref = _image_ref(manifest["deployment"])
 
     dry_label = " [DRY RUN]" if dry_run else ""
@@ -179,11 +196,17 @@ def publish_connector(
 
     # Pin the pre-pushed image so the catalog entry is immutable. kz-ext doesn't
     # build connector images, so the image must already be in the registry (pushed
-    # by the connector's CI); resolution doubles as an existence gate. Skipped on
-    # dry-run / --no-push (no registry round-trip). A supplied --digest is verified
-    # against the registry rather than trusted blind, mirroring the app path.
+    # by the connector's CI); resolution doubles as an existence gate. Resolution
+    # is a read-only registry lookup, so --no-push (don't re-push an
+    # already-pushed image) must NOT skip it on its own — otherwise the entry is
+    # written tag-only and mutable. The four cases mirror the app publish path:
+    #   - dry run: skip (no registry round-trip).
+    #   - --no-push WITH an explicit --digest: publish-only escape hatch — trust
+    #     the precomputed digest, no buildx/registry needed.
+    #   - --digest without --no-push: verify the supplied digest against the registry.
+    #   - otherwise (incl. --no-push without --digest): resolve from the registry.
     pinned = digest
-    if not dry_run and not no_push:
+    if not dry_run and not (no_push and digest is not None):
         from kamiwaza_extensions.image_pusher import ImagePusher, ImagePushError
 
         try:

--- a/tests/unit/extensions/test_connector_publish.py
+++ b/tests/unit/extensions/test_connector_publish.py
@@ -36,7 +36,12 @@ def _manifest() -> dict:
     }
 
 
-def _info(manifest: dict | None = _manifest(), name: str = "m365") -> ExtensionInfo:
+_DEFAULT_MANIFEST = object()  # sentinel: distinguish "use default" from explicit None
+
+
+def _info(manifest=_DEFAULT_MANIFEST, name: str = "m365") -> ExtensionInfo:
+    if manifest is _DEFAULT_MANIFEST:
+        manifest = _manifest()  # build a fresh manifest each call
     metadata = {"name": name, "version": "1.0.0", "type": "connector"}
     if manifest is not None:
         metadata["manifest"] = manifest
@@ -70,9 +75,7 @@ def test_type_file_map_routes_connectors_to_connectors_json():
 
 
 def test_build_connector_entry_carries_manifest_name_version_and_digest():
-    entry = build_connector_entry(
-        _info(), _manifest(), pinned_digest="sha256:deadbeef"
-    )
+    entry = build_connector_entry(_info(), _manifest(), pinned_digest="sha256:deadbeef")
     assert entry["name"] == "m365"
     assert entry["version"] == "1.0.0"
     assert entry["connector_type"] == "m365"  # manifest field preserved
@@ -90,9 +93,7 @@ def test_build_connector_entry_without_digest_omits_it():
 
 
 def _patches(publisher_mock):
-    profile = SimpleNamespace(
-        registry="ghcr.io", catalog_bucket="kamiwaza-catalog"
-    )
+    profile = SimpleNamespace(registry="ghcr.io", catalog_bucket="kamiwaza-catalog")
     return (
         patch(
             "kamiwaza_extensions.profile_manager.ProfileManager.resolve_profile",
@@ -132,26 +133,119 @@ def test_publish_connector_publishes_manifest_to_connectors_catalog():
     assert entry["deployment"]["image_digest"] == "sha256:abc123"
 
 
-def test_publish_connector_skips_digest_resolution_on_no_push():
+def test_publish_connector_honors_revision_as_image_tag():
+    """--revision (the build's canonical tag) overrides the manifest's static
+    deployment.image_tag for BOTH digest resolution and the published entry, so
+    a stage/prod publish pins that stage's image instead of the authoring
+    default (ENG-8617; prevents the ENG-8350 develop-pin tag mismatch)."""
+    publisher = MagicMock()
+    publisher.publish.return_value = SimpleNamespace(
+        action="insert", catalog_file="garden/v3/connectors.json", version="1.0.0"
+    )
+    p_profile, p_buildx, p_digest, p_pub = _patches(publisher)
+    with p_profile, p_buildx, p_digest as digest_mock, p_pub:
+        publish_connector(_info(), stage="stage", revision="release-1.0.0")
+
+    # digest resolved from the REVISION-tagged ref, not the manifest's :1.0.0
+    assert (
+        digest_mock.call_args.args[0]
+        == "ghcr.io/kamiwaza-internal/connectors/m365:release-1.0.0"
+    )
+    entry = publisher.publish.call_args.kwargs["entry"]
+    assert entry["deployment"]["image_tag"] == "release-1.0.0"
+    assert entry["deployment"]["image_digest"] == "sha256:abc123"
+    # original manifest is not mutated by the revision override
+    assert _manifest()["deployment"]["image_tag"] == "1.0.0"
+
+
+def test_publish_connector_resolves_digest_on_no_push():
+    """--no-push means 'the image is already pushed, don't re-push' — resolution
+    is a read-only lookup, so it must still run and pin the digest (matching the
+    app catalog-only-republish path). Otherwise the entry is tag-only/mutable."""
     publisher = MagicMock()
     publisher.publish.return_value = SimpleNamespace(
         action="insert", catalog_file="garden/v3/connectors.json", version="1.0.0"
     )
     p_profile, p_buildx, p_digest, p_pub = _patches(publisher)
     with p_profile, p_buildx as buildx_mock, p_digest as digest_mock, p_pub:
-        publish_connector(_info(), stage="prod", no_push=True)
+        publish_connector(_info(), stage="prod", revision="release-1.0.0", no_push=True)
 
-    # --no-push does no registry round-trip at all: neither preflight nor resolve.
-    buildx_mock.assert_not_called()
+    buildx_mock.assert_called_once()  # preflight ran
+    digest_mock.assert_called_once()  # digest resolved despite --no-push
+    dep = publisher.publish.call_args.kwargs["entry"]["deployment"]
+    assert dep["image_tag"] == "release-1.0.0"
+    assert dep["image_digest"] == "sha256:abc123"  # pinned, not tag-only
+
+
+def test_publish_connector_trusts_supplied_digest_on_no_push():
+    """--no-push WITH an explicit --digest is the publish-only escape hatch: trust
+    the precomputed digest and do no registry round-trip (no buildx needed),
+    matching the app path."""
+    publisher = MagicMock()
+    publisher.publish.return_value = SimpleNamespace(
+        action="insert", catalog_file="garden/v3/connectors.json", version="1.0.0"
+    )
+    p_profile, p_buildx, p_digest, p_pub = _patches(publisher)
+    with p_profile, p_buildx as buildx_mock, p_digest as digest_mock, p_pub:
+        publish_connector(_info(), stage="prod", no_push=True, digest="sha256:supplied")
+
+    buildx_mock.assert_not_called()  # no registry round-trip
     digest_mock.assert_not_called()
-    entry = publisher.publish.call_args.kwargs["entry"]
-    assert "image_digest" not in entry["deployment"]
+    dep = publisher.publish.call_args.kwargs["entry"]["deployment"]
+    assert dep["image_digest"] == "sha256:supplied"  # trusted as-is
+
+
+def test_publish_connector_revision_drops_stale_digest_on_tag_change_dry_run():
+    """On a dry run (no resolution), a revision that changes the tag must drop the
+    manifest's now-stale authored digest rather than emit :<revision>@<old>."""
+    manifest = _manifest()
+    manifest["deployment"]["image_digest"] = "sha256:stale"
+    publisher = MagicMock()
+    publisher.publish.return_value = SimpleNamespace(
+        action="insert", catalog_file="garden/v3/connectors.json", version="1.0.0"
+    )
+    p_profile, p_buildx, p_digest, p_pub = _patches(publisher)
+    with p_profile, p_buildx, p_digest as digest_mock, p_pub:
+        publish_connector(
+            _info(manifest=manifest),
+            stage="stage",
+            revision="release-1.0.0",
+            dry_run=True,
+        )
+
+    digest_mock.assert_not_called()  # dry run resolves nothing
+    dep = publisher.publish.call_args.kwargs["entry"]["deployment"]
+    assert dep["image_tag"] == "release-1.0.0"
+    assert "image_digest" not in dep  # stale digest dropped on tag change
+
+
+def test_publish_connector_revision_keeps_matching_digest_when_tag_unchanged():
+    """A revision equal to the manifest's already-rendered tag must NOT strip its
+    matching authored digest (e.g. CI rendered the final tag+digest, then
+    republishes with --revision <same tag> --dry-run/--no-push)."""
+    manifest = _manifest()  # deployment.image_tag == "1.0.0"
+    manifest["deployment"]["image_digest"] = "sha256:pinned"
+    publisher = MagicMock()
+    publisher.publish.return_value = SimpleNamespace(
+        action="insert", catalog_file="garden/v3/connectors.json", version="1.0.0"
+    )
+    p_profile, p_buildx, p_digest, p_pub = _patches(publisher)
+    with p_profile, p_buildx, p_digest, p_pub:
+        publish_connector(
+            _info(manifest=manifest), stage="stage", revision="1.0.0", dry_run=True
+        )
+
+    dep = publisher.publish.call_args.kwargs["entry"]["deployment"]
+    assert dep["image_tag"] == "1.0.0"
+    assert dep["image_digest"] == "sha256:pinned"  # matching digest preserved
 
 
 def test_publish_connector_verifies_supplied_digest_against_registry():
     """A supplied --digest that disagrees with the registry aborts (not trusted blind)."""
     publisher = MagicMock()
-    p_profile, p_buildx, p_digest, p_pub = _patches(publisher)  # registry -> sha256:abc123
+    p_profile, p_buildx, p_digest, p_pub = _patches(
+        publisher
+    )  # registry -> sha256:abc123
     with p_profile, p_buildx, p_digest as digest_mock, p_pub, pytest.raises(typer.Exit):
         publish_connector(_info(), stage="prod", digest="sha256:wrongwrong")
 
@@ -165,7 +259,9 @@ def test_publish_connector_accepts_matching_supplied_digest():
     publisher.publish.return_value = SimpleNamespace(
         action="insert", catalog_file="garden/v3/connectors.json", version="1.0.0"
     )
-    p_profile, p_buildx, p_digest, p_pub = _patches(publisher)  # registry -> sha256:abc123
+    p_profile, p_buildx, p_digest, p_pub = _patches(
+        publisher
+    )  # registry -> sha256:abc123
     with p_profile, p_buildx, p_digest as digest_mock, p_pub:
         publish_connector(_info(), stage="prod", digest="sha256:abc123")
 


### PR DESCRIPTION
## What this ships

Makes `kz-ext publish` handle the shared `extension-build.yml` invocation (`--revision <canonical-tag> --no-build --no-push`) correctly for **connectors**, so connector catalog entries publish with the same digest-pinning guarantees as every extension. Prerequisite for the connector repos adopting `extension-build.yml` (companion PR: `kamiwaza-internal/kamiwaza-connector-m365#<tbd>`).

## Behavior (connector path, now matching `commands/publish.py`)

- `--revision` overrides the manifest's static `deployment.image_tag` before digest resolution; a stale authored digest is dropped only when the tag actually changes.
- Digest resolution (a read-only registry lookup) runs whenever it's not a dry run **and** not the `--no-push`+explicit-`--digest` escape hatch. Previously `--no-push` skipped resolution entirely, publishing **tag-only / mutable** connector entries.

Four cases now mirror the app path: dry-run → skip; `--no-push --digest` → trust supplied; `--digest` → verify against registry; otherwise → resolve + pin.

## Verification

- **14 unit tests** covering all four resolution combinations, both revision cases (tag-change drops stale digest; tag-unchanged keeps matching digest), and manifest-validation failures. Full extensions suite (1662) green; ruff + mypy (changed file) clean.
- **End-to-end**: real `kz-ext publish --all --stage stage --revision release-1.0.0 --no-build --no-push` against a local S3 (MinIO) with live GHCR digest resolution → a structured, **digest-pinned** `connectors.json` entry (`m365:release-1.0.0@sha256:…`).

## Follow-up (not in scope)

`kz-ext validate` isn't connector-aware — it checks the extension `KamiwazaMetadata` schema, which a connector's `kamiwaza.json` (`{name, version, type, manifest}`) doesn't match. Worth a separate ticket.

<!-- pr-evidence-start -->
<details><summary>PR Evidence</summary>

**Delivery mode:** source (Python library) — not deployed to a cluster as part of this change.
**Clusters exercised:** none.
**Testing performed:**
- `pytest tests/unit/extensions/test_connector_publish.py` (14) + full `tests/unit/extensions/` suite (1662 passed, 1 skipped).
- `ruff check` clean; `mypy` clean on the changed file (pre-existing errors elsewhere unrelated).
- Local end-to-end: patched `kz-ext` (editable venv) publishing the m365 connector to a MinIO S3 bucket under the exact `extension-build.yml` flags, with live `ghcr.io` digest resolution; read-back confirmed a digest-pinned entry.

No live Kamiwaza cluster was involved (this change is a publish-tooling library fix; its consumer is CI).
</details>
<!-- pr-evidence-end -->