### PR TITLE
ENG-8753: bump npm extensions-lib to 0.4.2 so the Next-15 fix actually publishes

### DIFF
--- a/.github/workflows/extensions-lib-version-guard.yml
+++ b/.github/workflows/extensions-lib-version-guard.yml
@@ -4,11 +4,31 @@
 # unpublishable: ENG-8753 — the ENG-1734 Next-15 RouteHandler fix merged
 # without a bump and npm kept serving the stale 0.4.1 build, crash-looping
 # every fresh `kz-ext create -t app` scaffold.
+#
+# Runs on PRs and as a push backstop on develop/main: a PR's passing result
+# goes stale if the base advances (two concurrent PRs picking the same next
+# version both pass, then the second merges into a duplicate-version state) —
+# the push run re-validates the merged tree, diffing against
+# `github.event.before` like the repo's other push-triggered diff jobs.
 name: Extensions Lib Version Guard
 
+# The dist-affecting path list below is intentionally duplicated in the
+# in-job `git diff` pathspec (workflow filters aren't visible to the script;
+# the job must re-diff to neutralize workflow-file-only triggers). Keep both
+# lists in sync.
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'kamiwaza-ai-extensions-lib/src/**'
+      - 'kamiwaza-ai-extensions-lib/package.json'
+      - 'kamiwaza-ai-extensions-lib/package-lock.json'
+      - 'kamiwaza-ai-extensions-lib/bun.lock'
+      - 'kamiwaza-ai-extensions-lib/tsconfig.json'
+      - 'kamiwaza-ai-extensions-lib/tsup.config.ts'
+      - '.github/workflows/extensions-lib-version-guard.yml'
+  push:
+    branches: [develop, main]
     paths:
       - 'kamiwaza-ai-extensions-lib/src/**'
       - 'kamiwaza-ai-extensions-lib/package.json'
@@ -37,14 +57,32 @@ jobs:
 
       - name: Check package.json version against base and npm
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          PUSH_BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
           LIB=kamiwaza-ai-extensions-lib
 
+          # Diff base: on PRs, the merge-base against the *current* base tip
+          # (the event's base.sha can lag it and misattribute base-branch
+          # changes to this PR); on push, the pre-push tip, matching the
+          # repo's other push-triggered diff jobs.
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            BASE_SHA=$(git merge-base "origin/$BASE_REF" HEAD)
+          else
+            BASE_SHA="$PUSH_BEFORE"
+            if [[ "$BASE_SHA" == 0000000000000000000000000000000000000000 ]] \
+              || ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+              echo "No usable pre-push base (new branch or force-push); skipping diff-based check."
+              exit 0
+            fi
+          fi
+
           # Only dist-affecting files demand a bump. Docs, CHANGELOG, and
           # tests never trigger this workflow (paths filter); the workflow
-          # file itself does, so re-check the actual PR diff here.
+          # file itself does, so re-check the actual diff here. This pathspec
+          # mirrors the `paths:` filter above — keep both lists in sync.
           CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD -- \
             "$LIB/src" "$LIB/package.json" "$LIB/package-lock.json" \
             "$LIB/bun.lock" "$LIB/tsconfig.json" "$LIB/tsup.config.ts")
@@ -58,10 +96,18 @@ jobs:
           HEAD_VERSION=$(node -p "require('./$LIB/package.json').version")
           BASE_VERSION=$(git show "$BASE_SHA:$LIB/package.json" \
             | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
-          echo "package.json version: $BASE_VERSION (base) -> $HEAD_VERSION (this PR)"
+          echo "package.json version: $BASE_VERSION (base) -> $HEAD_VERSION (this change)"
 
           if [[ "$HEAD_VERSION" == "$BASE_VERSION" ]]; then
             echo "::error::Dist-affecting files under $LIB changed but package.json is still $BASE_VERSION. Bump the version (package.json + package-lock.json) so the change can actually be published to npm."
+            exit 1
+          fi
+
+          # Require the bump to move forward, not just differ — a lowered
+          # version may be unpublished yet still wrong.
+          HIGHEST=$(printf '%s\n%s\n' "$BASE_VERSION" "$HEAD_VERSION" | sort -V | tail -1)
+          if [[ "$HIGHEST" != "$HEAD_VERSION" ]]; then
+            echo "::error::Version went backwards: $BASE_VERSION -> $HEAD_VERSION. Bump to a version greater than $BASE_VERSION."
             exit 1
           fi
 

--- a/.github/workflows/extensions-lib-version-guard.yml
+++ b/.github/workflows/extensions-lib-version-guard.yml
@@ -1,0 +1,78 @@
+# Guards against merging dist-affecting changes to the npm package
+# `@kamiwaza-ai/extensions-lib` without bumping its version. npm refuses to
+# publish over an existing version, so a merged-but-unbumped change is
+# unpublishable: ENG-8753 — the ENG-1734 Next-15 RouteHandler fix merged
+# without a bump and npm kept serving the stale 0.4.1 build, crash-looping
+# every fresh `kz-ext create -t app` scaffold.
+name: Extensions Lib Version Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'kamiwaza-ai-extensions-lib/src/**'
+      - 'kamiwaza-ai-extensions-lib/package.json'
+      - 'kamiwaza-ai-extensions-lib/package-lock.json'
+      - 'kamiwaza-ai-extensions-lib/bun.lock'
+      - 'kamiwaza-ai-extensions-lib/tsconfig.json'
+      - 'kamiwaza-ai-extensions-lib/tsup.config.ts'
+      - '.github/workflows/extensions-lib-version-guard.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  version-guard:
+    name: Require version bump for dist-affecting changes
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check package.json version against base and npm
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          LIB=kamiwaza-ai-extensions-lib
+
+          # Only dist-affecting files demand a bump. Docs, CHANGELOG, and
+          # tests never trigger this workflow (paths filter); the workflow
+          # file itself does, so re-check the actual PR diff here.
+          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD -- \
+            "$LIB/src" "$LIB/package.json" "$LIB/package-lock.json" \
+            "$LIB/bun.lock" "$LIB/tsconfig.json" "$LIB/tsup.config.ts")
+          if [[ -z "$CHANGED" ]]; then
+            echo "No dist-affecting changes under $LIB — version bump not required."
+            exit 0
+          fi
+          echo "Dist-affecting changes:"
+          echo "$CHANGED"
+
+          HEAD_VERSION=$(node -p "require('./$LIB/package.json').version")
+          BASE_VERSION=$(git show "$BASE_SHA:$LIB/package.json" \
+            | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).version")
+          echo "package.json version: $BASE_VERSION (base) -> $HEAD_VERSION (this PR)"
+
+          if [[ "$HEAD_VERSION" == "$BASE_VERSION" ]]; then
+            echo "::error::Dist-affecting files under $LIB changed but package.json is still $BASE_VERSION. Bump the version (package.json + package-lock.json) so the change can actually be published to npm."
+            exit 1
+          fi
+
+          # A bumped-but-already-published version is just as unpublishable.
+          # npm view exits non-zero (E404) when the version doesn't exist,
+          # which is the healthy case; a registry outage also passes here —
+          # release.sh's preflight still guards the actual publish.
+          if PUBLISHED=$(npm view "@kamiwaza-ai/extensions-lib@$HEAD_VERSION" version 2>/dev/null) \
+            && [[ -n "$PUBLISHED" ]]; then
+            echo "::error::Version $HEAD_VERSION already exists on npm and cannot be re-published. Bump to an unused version."
+            exit 1
+          fi
+
+          echo "OK: $BASE_VERSION -> $HEAD_VERSION, not yet on npm."

--- a/kamiwaza-ai-extensions-lib/CHANGELOG.md
+++ b/kamiwaza-ai-extensions-lib/CHANGELOG.md
@@ -4,6 +4,21 @@ Versions follow semver. Published to npm as a standalone package
 (`@kamiwaza-ai/extensions-lib`) and versioned independently from
 `kamiwaza-sdk`.
 
+## [0.4.2] — 2026-07-16 (ENG-8753)
+
+### Fixed
+
+* **Ships the Next.js 15 `RouteHandler` fix to npm.** The ENG-1734 migration
+  (PR #191, merged 2026-06-22) rewrote the proxy `RouteHandler` type so
+  `createProxyHandlers()` handlers type-check under Next 15's build-time
+  route validation (Next 15 made dynamic-route `params` a `Promise`; the
+  published type still declared the Next-14 sync `Record` shape). PR #191
+  landed on `main` without a version bump, so the 2026-07-13 release could
+  not publish it over the existing `0.4.1` — every fresh
+  `kz-ext create -t app` scaffold (which installs `next ^15` and this lib
+  from npm) failed `next build` at container startup and crash-looped.
+  This release publishes that fix; no code changes beyond ENG-1734's.
+
 ## [0.4.1] — 2026-06-14 (ENG-6911)
 
 ### Fixed

--- a/kamiwaza-ai-extensions-lib/package-lock.json
+++ b/kamiwaza-ai-extensions-lib/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@kamiwaza-ai/extensions-lib",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@kamiwaza-ai/extensions-lib",
-            "version": "0.4.1",
+            "version": "0.4.2",
             "license": "Apache-2.0",
             "devDependencies": {
                 "@testing-library/react": "^14.0.0",

--- a/kamiwaza-ai-extensions-lib/package.json
+++ b/kamiwaza-ai-extensions-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kamiwaza-ai/extensions-lib",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "TypeScript runtime library for Kamiwaza extensions — SessionProvider, AuthGuard, identity extraction, proxy utilities, local-dev auth bridge",
     "type": "module",
     "main": "./dist/index.js",

--- a/release.sh
+++ b/release.sh
@@ -36,7 +36,7 @@ esac
 
 # Required tooling. Fail loudly up front rather than dying mid-build with
 # a cryptic "command not found".
-for tool in uv npm; do
+for tool in uv npm node; do
     if ! command -v "$tool" &> /dev/null; then
         echo "Error: '$tool' is required but not installed."
         echo "  Install: https://github.com/astral-sh/uv (uv) | https://nodejs.org (npm)"
@@ -53,15 +53,20 @@ done
 NPM_LIB_NAME="@kamiwaza-ai/extensions-lib"
 NPM_LIB_VERSION="$(node -p "require('./kamiwaza-ai-extensions-lib/package.json').version")"
 NPM_VERSION_EXISTS=0
-if NPM_VIEW_OUT=$(npm view "${NPM_LIB_NAME}@${NPM_LIB_VERSION}" version --registry=https://registry.npmjs.org/ 2>&1); then
+# Keep stdout and stderr separate: npm writes notices/warnings (update nags,
+# deprecated .npmrc keys) to stderr even on success, and folding them into
+# the captured output would falsely flag an unpublished version as existing.
+NPM_VIEW_ERR=$(mktemp)
+if NPM_VIEW_OUT=$(npm view "${NPM_LIB_NAME}@${NPM_LIB_VERSION}" version --registry=https://registry.npmjs.org/ 2>"$NPM_VIEW_ERR"); then
     [[ -n "$NPM_VIEW_OUT" ]] && NPM_VERSION_EXISTS=1
-elif [[ "$NPM_VIEW_OUT" != *E404* ]]; then
+elif ! grep -q E404 "$NPM_VIEW_ERR"; then
     # E404 is the healthy case (version not yet published). Anything else
     # means the registry couldn't be consulted — say so, but don't block a
     # release on a registry hiccup; the final publish step still fails hard.
     echo "Warning: could not check npm for ${NPM_LIB_NAME}@${NPM_LIB_VERSION}:"
-    echo "$NPM_VIEW_OUT" | head -3
+    head -3 "$NPM_VIEW_ERR"
 fi
+rm -f "$NPM_VIEW_ERR"
 if [[ $NPM_VERSION_EXISTS -eq 1 ]]; then
     if [[ $BUILD_ONLY -eq 1 ]]; then
         echo "Note: ${NPM_LIB_NAME}@${NPM_LIB_VERSION} is already on npm; a full release would skip the npm upload."

--- a/release.sh
+++ b/release.sh
@@ -44,6 +44,39 @@ for tool in uv npm; do
     fi
 done
 
+# --- npm preflight: catch a stale @kamiwaza-ai/extensions-lib version early ---
+# npm rejects publishing over an existing version, and by the time that
+# surfaces (last publish step) the PyPI uploads have already happened — the
+# 2026-07-13 release shipped PyPI artifacts while the npm fix for ENG-1734
+# silently never landed because the version was still 0.4.1 (ENG-8753).
+# Detect the collision before anything uploads.
+NPM_LIB_NAME="@kamiwaza-ai/extensions-lib"
+NPM_LIB_VERSION="$(node -p "require('./kamiwaza-ai-extensions-lib/package.json').version")"
+NPM_VERSION_EXISTS=0
+if NPM_VIEW_OUT=$(npm view "${NPM_LIB_NAME}@${NPM_LIB_VERSION}" version --registry=https://registry.npmjs.org/ 2>&1); then
+    [[ -n "$NPM_VIEW_OUT" ]] && NPM_VERSION_EXISTS=1
+elif [[ "$NPM_VIEW_OUT" != *E404* ]]; then
+    # E404 is the healthy case (version not yet published). Anything else
+    # means the registry couldn't be consulted — say so, but don't block a
+    # release on a registry hiccup; the final publish step still fails hard.
+    echo "Warning: could not check npm for ${NPM_LIB_NAME}@${NPM_LIB_VERSION}:"
+    echo "$NPM_VIEW_OUT" | head -3
+fi
+if [[ $NPM_VERSION_EXISTS -eq 1 ]]; then
+    if [[ $BUILD_ONLY -eq 1 ]]; then
+        echo "Note: ${NPM_LIB_NAME}@${NPM_LIB_VERSION} is already on npm; a full release would skip the npm upload."
+    else
+        echo "${NPM_LIB_NAME}@${NPM_LIB_VERSION} is ALREADY on npm — re-publishing an existing version is rejected."
+        echo "  If kamiwaza-ai-extensions-lib changed since that publish, bump its package.json version and re-run."
+        read -r -p "Continue with a release that SKIPS the npm upload? (y/n) " REPLY || REPLY=n
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Aborting before any uploads."
+            exit 1
+        fi
+    fi
+fi
+
 # Check for pipx (needed to clear notebook outputs)
 if ! command -v pipx &> /dev/null; then
     echo "Error: pipx is required but not installed."
@@ -155,6 +188,11 @@ if [[ $SDK_GATED -eq 0 ]]; then
     else
         echo "kamiwaza-sdk upload skipped"
     fi
+fi
+
+if [[ $NPM_VERSION_EXISTS -eq 1 ]]; then
+    echo "@kamiwaza-ai/extensions-lib upload skipped: ${NPM_LIB_VERSION} is already on npm (acknowledged at preflight)."
+    exit 0
 fi
 
 read -r -p "Upload @kamiwaza-ai/extensions-lib to npm? (y/n) " REPLY || REPLY=n


### PR DESCRIPTION
## Summary

Fixes [ENG-8753](https://linear.app/kamiwaza/issue/ENG-8753): npm `@kamiwaza-ai/extensions-lib@0.4.1` (published 2026-06-15) predates the ENG-1734 Next-15 `RouteHandler` fix (PR #191, merged 2026-06-22). PR #191 never bumped the package version, so the 2026-07-13 release built a fixed `0.4.1` tarball that npm could not accept over the existing one — the PyPI artifacts shipped, the npm one silently didn't. Result: **every fresh `kz-ext create -t app` scaffold crash-loops** — the frontend installs `next ^15` + the stale published lib, and `next build` (run at container startup) fails Next 15's route type validation on the scaffolded `/api/[...path]` route.

## Changes

1. **Bump `@kamiwaza-ai/extensions-lib` → 0.4.2** (`package.json` + `package-lock.json`), with a CHANGELOG entry covering the ENG-1734 change PR #191 omitted. No code changes — the fix is already on `develop`/`main`; this makes it publishable.
2. **`release.sh` npm preflight**: checks the registry for the lib's version up front, before any PyPI uploads. A stale version now surfaces as an explicit prompt at the start (abort, or consciously continue with a PyPI-only release) instead of a failure at the very last step after PyPI already shipped. `--build-only` just notes it. Registry hiccups warn and continue — the final publish still fails hard.
3. **New CI workflow `extensions-lib-version-guard`**: on PRs touching the lib's dist-affecting files (`src/**`, `package.json`, lockfiles, `tsconfig.json`, `tsup.config.ts`), fails if the version wasn't bumped relative to the base branch, or if the bumped version already exists on npm. Docs/CHANGELOG/tests don't trigger it. This is the guard that would have caught PR #191.

## Verification

- `npm ci && npm run build && npm pack` → `kamiwaza-ai-extensions-lib-0.4.2.tgz` assembles; emitted `dist/server/index.d.ts` carries the Next-15 `RouteHandler` (`(request: NextRequest) => Promise<NextResponse>`).
- Guard logic simulated locally against this branch: passes (0.4.1 → 0.4.2, unpublished); fails when version is unchanged.
- `release.sh` preflight simulated for `0.4.1` (exists → gated) and `0.4.2` (unpublished → proceeds); `bash -n` clean.
- `uv run pytest tests/unit/extensions/test_scaffolder.py tests/unit/extensions/test_app_starter_smoke.py` → 34 passed.

## Post-merge

Publish from the merged branch (`release.sh`, or `npm publish` in `kamiwaza-ai-extensions-lib/` — requires `npm login`). The scaffold's `>=0.4 <0.5` pin picks up 0.4.2 automatically; existing broken scaffolds need an image rebuild without the cached `npm install` layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)