### PR TITLE
ENG-8691: isolate context live smoke backends

### DIFF
--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -168,21 +168,6 @@ def _vectordb_ids(resources: list[dict[str, object]]) -> set[str]:
     return {str(resource["id"]) for resource in resources if resource.get("id")}
 
 
-def _safe_scale_vectordb(
-    service: ContextService,
-    vectordb_id: str,
-    *,
-    replicas: int,
-    workroom_id: str | None = None,
-) -> None:
-    try:
-        service.scale_vectordb(
-            vectordb_id, replicas=replicas, workroom_id=workroom_id
-        )
-    except APIError:
-        pass
-
-
 def _create_temp_ontology(service: ContextService, *, prefix: str) -> str:
     created = service.create_ontology(
         name=f"{prefix}-{uuid4().hex[:8]}",
@@ -646,23 +631,29 @@ def test_context_vectordb_update_accepts_config_and_redacts_public_response(
 def test_context_vectordb_scale_reflects_requested_replicas(
     shared_context_service: ContextService,
     session_workroom: str,
-    shared_workroom_vectordb: str,
 ) -> None:
     """scale_vectordb is accepted and the response echoes the requested replicas.
 
     Assertion posture is API round-trip, not physical provisioning: a single-node
     local Milvus may clamp the effective replica count, so we assert the call
-    succeeds and the returned instance reflects the requested ``replicas``, then
-    scale back to the baseline (session teardown also deletes the VDB).
+    succeeds and the returned instance reflects the requested ``replicas``.
+
+    Use a dedicated backend because scale operations can restart or replace
+    Milvus pods; the search/retrieve contract tests below depend on the shared
+    VectorDB staying settled.
     """
     service = shared_context_service
-    vectordb_id = shared_workroom_vectordb
-
-    before = service.get_vectordb(vectordb_id, workroom_id=session_workroom)
-    baseline_replicas = _vectordb_replicas(before) or 1
-    target_replicas = baseline_replicas + 1
+    vectordb_id = _create_temp_vectordb(
+        service,
+        prefix="sdk-scale-vdb-workroom",
+        workroom_id=session_workroom,
+    )
 
     try:
+        before = service.get_vectordb(vectordb_id, workroom_id=session_workroom)
+        baseline_replicas = _vectordb_replicas(before) or 1
+        target_replicas = baseline_replicas + 1
+
         scaled = service.scale_vectordb(
             vectordb_id,
             replicas=target_replicas,
@@ -671,10 +662,9 @@ def test_context_vectordb_scale_reflects_requested_replicas(
         assert scaled["id"] == vectordb_id
         assert _vectordb_replicas(scaled) == target_replicas
     finally:
-        _safe_scale_vectordb(
+        _safe_delete_vectordb(
             service,
             vectordb_id,
-            replicas=baseline_replicas,
             workroom_id=session_workroom,
         )
 

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -7,6 +7,7 @@ import os
 import time
 from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -27,10 +28,34 @@ DEFAULT_WORKROOM_ID = os.getenv(
     ContextService.DEFAULT_WORKROOM_ID,
 )
 TEST_VECTOR = [round(index * 0.01, 4) for index in range(1, 33)]
+CONTEXT_SEARCH_VECTOR_DIMENSION = 384
+CONTEXT_SEARCH_FIELD_LIST: list[list[Any]] = [
+    ["source_file", "str"],
+    ["source_urn", "str"],
+    ["file_id", "str"],
+    ["page_number", "int"],
+    ["chunk_index", "int"],
+    ["content", "str"],
+    ["created_at", "str"],
+    ["media_type", "str"],
+    ["media_section", "str"],
+    ["timestamp_seconds", "float"],
+    ["frame_id", "str"],
+    ["frame_uri", "str"],
+    ["omniparse_doc_id", "str"],
+    ["omniparse_chunk_id", "str"],
+]
 
 
 def _sample_vector() -> list[float]:
     return list(TEST_VECTOR)
+
+
+def _sample_context_search_vector() -> list[float]:
+    return [
+        round(((index % 19) + 1) * 0.001, 6)
+        for index in range(CONTEXT_SEARCH_VECTOR_DIMENSION)
+    ]
 
 
 def _sdk_collection_name() -> str:
@@ -158,10 +183,16 @@ def _safe_delete_vectordb(
     *,
     workroom_id: str | None = None,
 ) -> None:
-    try:
-        service.delete_vectordb(vectordb_id, workroom_id=workroom_id)
-    except APIError:
-        pass
+    for attempt in range(3):
+        try:
+            service.delete_vectordb(vectordb_id, workroom_id=workroom_id)
+            return
+        except NotFoundError:
+            return
+        except APIError:
+            if attempt == 2:
+                return
+            time.sleep(2.0)
 
 
 def _vectordb_ids(resources: list[dict[str, object]]) -> set[str]:
@@ -213,6 +244,49 @@ def _safe_delete_collection(
         )
     except APIError:
         pass
+
+
+def _seed_searchable_context_collection(
+    service: ContextService,
+    *,
+    workroom_id: str,
+    vectordb_id: str,
+) -> str:
+    collection_name = _sdk_collection_name()
+    service.insert_vectors(
+        vectordb_id,
+        collection_name=collection_name,
+        vectors=[_sample_context_search_vector()],
+        metadata=[
+            {
+                "source_file": "sdk-context-live.txt",
+                "source_urn": f"urn:kamiwaza-sdk:context-live:{uuid4().hex[:8]}",
+                "file_id": "",
+                "page_number": 1,
+                "chunk_index": 0,
+                "content": "hello context from the SDK live smoke contract",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "media_type": "",
+                "media_section": "",
+                "timestamp_seconds": 0.0,
+                "frame_id": "",
+                "frame_uri": "",
+                "omniparse_doc_id": "",
+                "omniparse_chunk_id": "",
+            }
+        ],
+        field_list=CONTEXT_SEARCH_FIELD_LIST,
+        workroom_id=workroom_id,
+    )
+    ready = service.query_vectors(
+        vectordb_id,
+        collection_name=collection_name,
+        vectors=[_sample_context_search_vector()],
+        limit=1,
+        workroom_id=workroom_id,
+    )
+    assert isinstance(ready["results"], list)
+    return collection_name
 
 
 def _safe_delete_group(
@@ -352,9 +426,8 @@ def session_workroom(
     try:
         yield workroom_id
     finally:
-        # delete() raises NotFoundError (a sibling of APIError, not a subclass)
-        # when the workroom is already gone, so catch both to keep teardown
-        # best-effort -- matching the sibling test_workroom_isolation_live.py.
+        # Workroom teardown is best-effort because earlier cleanup or backend
+        # races can report the room as already gone.
         try:
             workrooms.delete(workroom_id)
         except (APIError, NotFoundError):
@@ -598,7 +671,6 @@ def _vectordb_replicas(instance: dict) -> int | None:
 def test_context_vectordb_update_accepts_config_and_redacts_public_response(
     shared_context_service: ContextService,
     session_workroom: str,
-    shared_workroom_vectordb: str,
 ) -> None:
     """update_vectordb accepts config while public reads redact that config.
 
@@ -607,25 +679,35 @@ def test_context_vectordb_update_accepts_config_and_redacts_public_response(
     redacts config so credentials do not leak through lifecycle responses.
     """
     service = shared_context_service
-    vectordb_id = shared_workroom_vectordb
-
-    before = service.get_vectordb(vectordb_id, workroom_id=session_workroom)
-    baseline_replicas = _vectordb_replicas(before) or 1
-    config_marker = f"sdk-live-update-{uuid4().hex[:8]}"
-
-    updated = service.update_vectordb(
-        vectordb_id,
-        config={"sdk_test_marker": config_marker},
-        replicas=baseline_replicas,
+    vectordb_id = _create_temp_vectordb(
+        service,
+        prefix="sdk-update-vdb-workroom",
         workroom_id=session_workroom,
     )
-    assert updated["id"] == vectordb_id
-    assert _vectordb_replicas(updated) == baseline_replicas
+    try:
+        before = service.get_vectordb(vectordb_id, workroom_id=session_workroom)
+        baseline_replicas = _vectordb_replicas(before) or 1
+        config_marker = f"sdk-live-update-{uuid4().hex[:8]}"
 
-    refetched = service.get_vectordb(vectordb_id, workroom_id=session_workroom)
-    assert refetched["id"] == vectordb_id
-    assert "config" not in refetched
-    assert _vectordb_replicas(refetched) == baseline_replicas
+        updated = service.update_vectordb(
+            vectordb_id,
+            config={"sdk_test_marker": config_marker},
+            replicas=baseline_replicas,
+            workroom_id=session_workroom,
+        )
+        assert updated["id"] == vectordb_id
+        assert _vectordb_replicas(updated) == baseline_replicas
+
+        refetched = service.get_vectordb(vectordb_id, workroom_id=session_workroom)
+        assert refetched["id"] == vectordb_id
+        assert "config" not in refetched
+        assert _vectordb_replicas(refetched) == baseline_replicas
+    finally:
+        _safe_delete_vectordb(
+            service,
+            vectordb_id,
+            workroom_id=session_workroom,
+        )
 
 
 def test_context_vectordb_scale_reflects_requested_replicas(
@@ -991,43 +1073,72 @@ def test_context_workroom_collection_lifecycle(
 def test_context_search_contract(
     shared_context_service: ContextService,
     session_workroom: str,
-    shared_workroom_vectordb: str,
 ) -> None:
     service = shared_context_service
     workroom_id = session_workroom
-    assert shared_workroom_vectordb
-
-    search = service.search(
+    vectordb_id = _create_temp_vectordb(
+        service,
+        prefix="sdk-search-vdb-workroom",
         workroom_id=workroom_id,
-        query="hello context",
-        vectordb_id=shared_workroom_vectordb,
     )
-    assert isinstance(search.get("results"), list)
+    try:
+        collection_name = _seed_searchable_context_collection(
+            service,
+            workroom_id=workroom_id,
+            vectordb_id=vectordb_id,
+        )
+        search = service.search(
+            workroom_id=workroom_id,
+            query="hello context",
+            collection_name=collection_name,
+            vectordb_id=vectordb_id,
+        )
+        assert isinstance(search.get("results"), list)
+    finally:
+        _safe_delete_vectordb(
+            service,
+            vectordb_id,
+            workroom_id=workroom_id,
+        )
 
 
 @pytest.mark.requires_embedding_model
 def test_context_retrieve_contract(
     shared_context_service: ContextService,
     session_workroom: str,
-    shared_workroom_vectordb: str,
 ) -> None:
     service = shared_context_service
     workroom_id = session_workroom
-    assert shared_workroom_vectordb
-
-    retrieve = service.retrieve(
+    vectordb_id = _create_temp_vectordb(
+        service,
+        prefix="sdk-retrieve-vdb-workroom",
         workroom_id=workroom_id,
-        query="hello context",
-        vectordb_id=shared_workroom_vectordb,
     )
-    assert isinstance(retrieve.get("sources"), list)
+    try:
+        collection_name = _seed_searchable_context_collection(
+            service,
+            workroom_id=workroom_id,
+            vectordb_id=vectordb_id,
+        )
+        retrieve = service.retrieve(
+            workroom_id=workroom_id,
+            query="hello context",
+            collection_names=[collection_name],
+            vectordb_id=vectordb_id,
+        )
+        assert isinstance(retrieve.get("sources"), list)
+    finally:
+        _safe_delete_vectordb(
+            service,
+            vectordb_id,
+            workroom_id=workroom_id,
+        )
 
 
 @pytest.mark.requires_embedding_model
 def test_context_agentic_search_contract(
     shared_context_service: ContextService,
     session_workroom: str,
-    shared_workroom_vectordb: str,
     context_required_llm: str,
 ) -> None:
     # agentic_search always sends synthesize=True, so it needs a context LLM in
@@ -1036,20 +1147,36 @@ def test_context_agentic_search_contract(
     assert context_required_llm
     service = shared_context_service
     workroom_id = session_workroom
-    assert shared_workroom_vectordb
-
-    result = service.agentic_search(
+    vectordb_id = _create_temp_vectordb(
+        service,
+        prefix="sdk-agentic-vdb-workroom",
         workroom_id=workroom_id,
-        query="hello context",
-        vectordb_id=shared_workroom_vectordb,
     )
-    assert isinstance(result.get("results"), list)
-    assert isinstance(result.get("sources"), list)
-    # synthesize=True is always sent, so the unified response must carry the
-    # synthesis/citations fields (content depends on the LLM); assert presence
-    # so a server-side regression that silently drops synthesis is caught.
-    assert "synthesis" in result
-    assert "citations" in result
+    try:
+        collection_name = _seed_searchable_context_collection(
+            service,
+            workroom_id=workroom_id,
+            vectordb_id=vectordb_id,
+        )
+        result = service.agentic_search(
+            workroom_id=workroom_id,
+            query="hello context",
+            collection_name=collection_name,
+            vectordb_id=vectordb_id,
+        )
+        assert isinstance(result.get("results"), list)
+        assert isinstance(result.get("sources"), list)
+        # synthesize=True is always sent, so the unified response must carry the
+        # synthesis/citations fields (content depends on the LLM); assert presence
+        # so a server-side regression that silently drops synthesis is caught.
+        assert "synthesis" in result
+        assert "citations" in result
+    finally:
+        _safe_delete_vectordb(
+            service,
+            vectordb_id,
+            workroom_id=workroom_id,
+        )
 
 
 # --- Raw-file object storage CRUD ---

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -678,8 +678,8 @@ def test_context_vectordb_scale_reflects_requested_replicas(
     succeeds and the returned instance reflects the requested ``replicas``.
 
     Use a dedicated backend because scale operations can restart or replace
-    Milvus pods; the search/retrieve contract tests below depend on the shared
-    VectorDB staying settled.
+    Milvus pods; this API round trip should not mutate backends reused by later
+    context contract tests.
     """
     service = shared_context_service
     vectordb_id = _create_temp_vectordb(

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -7,7 +7,6 @@ import os
 import time
 from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
-from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -28,34 +27,10 @@ DEFAULT_WORKROOM_ID = os.getenv(
     ContextService.DEFAULT_WORKROOM_ID,
 )
 TEST_VECTOR = [round(index * 0.01, 4) for index in range(1, 33)]
-CONTEXT_SEARCH_VECTOR_DIMENSION = 384
-CONTEXT_SEARCH_FIELD_LIST: list[list[Any]] = [
-    ["source_file", "str"],
-    ["source_urn", "str"],
-    ["file_id", "str"],
-    ["page_number", "int"],
-    ["chunk_index", "int"],
-    ["content", "str"],
-    ["created_at", "str"],
-    ["media_type", "str"],
-    ["media_section", "str"],
-    ["timestamp_seconds", "float"],
-    ["frame_id", "str"],
-    ["frame_uri", "str"],
-    ["omniparse_doc_id", "str"],
-    ["omniparse_chunk_id", "str"],
-]
 
 
 def _sample_vector() -> list[float]:
     return list(TEST_VECTOR)
-
-
-def _sample_context_search_vector() -> list[float]:
-    return [
-        round(((index % 19) + 1) * 0.001, 6)
-        for index in range(CONTEXT_SEARCH_VECTOR_DIMENSION)
-    ]
 
 
 def _sdk_collection_name() -> str:
@@ -246,49 +221,6 @@ def _safe_delete_collection(
         pass
 
 
-def _seed_searchable_context_collection(
-    service: ContextService,
-    *,
-    workroom_id: str,
-    vectordb_id: str,
-) -> str:
-    collection_name = _sdk_collection_name()
-    service.insert_vectors(
-        vectordb_id,
-        collection_name=collection_name,
-        vectors=[_sample_context_search_vector()],
-        metadata=[
-            {
-                "source_file": "sdk-context-live.txt",
-                "source_urn": f"urn:kamiwaza-sdk:context-live:{uuid4().hex[:8]}",
-                "file_id": "",
-                "page_number": 1,
-                "chunk_index": 0,
-                "content": "hello context from the SDK live smoke contract",
-                "created_at": datetime.now(timezone.utc).isoformat(),
-                "media_type": "",
-                "media_section": "",
-                "timestamp_seconds": 0.0,
-                "frame_id": "",
-                "frame_uri": "",
-                "omniparse_doc_id": "",
-                "omniparse_chunk_id": "",
-            }
-        ],
-        field_list=CONTEXT_SEARCH_FIELD_LIST,
-        workroom_id=workroom_id,
-    )
-    ready = service.query_vectors(
-        vectordb_id,
-        collection_name=collection_name,
-        vectors=[_sample_context_search_vector()],
-        limit=1,
-        workroom_id=workroom_id,
-    )
-    assert isinstance(ready["results"], list)
-    return collection_name
-
-
 def _safe_delete_group(
     service: ContextService,
     *,
@@ -394,9 +326,7 @@ def _cleanup_stale_sdk_vdbs(shared_context_service: ContextService) -> None:
             vdbs = []
         for vdb in vdbs:
             if _is_stale_sdk_resource(vdb, _STALE_THRESHOLD):
-                _safe_delete_vectordb(
-                    service, vdb["id"], workroom_id=workroom_id
-                )
+                _safe_delete_vectordb(service, vdb["id"], workroom_id=workroom_id)
         try:
             ontologies = service.list_ontologies(workroom_id=workroom_id)
         except APIError:
@@ -444,6 +374,33 @@ def shared_workroom_vectordb(
     vectordb_id = _create_temp_vectordb(
         service,
         prefix="sdk-shared-vdb-workroom",
+        workroom_id=session_workroom,
+    )
+    try:
+        yield vectordb_id
+    finally:
+        _safe_delete_vectordb(
+            service,
+            vectordb_id,
+            workroom_id=session_workroom,
+        )
+
+
+@pytest.fixture(scope="session")
+def search_contract_vectordb(
+    shared_context_service: ContextService,
+    session_workroom: str,
+) -> Generator[str, None, None]:
+    """Clean backend for search/retrieve response-shape contracts.
+
+    These live tests assert API contract shape, not ranking/indexing semantics.
+    Keep them off the shared backend so earlier vector insert/query tests cannot
+    leave collections that turn a shape check into a data-search assertion.
+    """
+    service = shared_context_service
+    vectordb_id = _create_temp_vectordb(
+        service,
+        prefix="sdk-search-contract-vdb-workroom",
         workroom_id=session_workroom,
     )
     try:
@@ -1073,72 +1030,43 @@ def test_context_workroom_collection_lifecycle(
 def test_context_search_contract(
     shared_context_service: ContextService,
     session_workroom: str,
+    search_contract_vectordb: str,
 ) -> None:
     service = shared_context_service
     workroom_id = session_workroom
-    vectordb_id = _create_temp_vectordb(
-        service,
-        prefix="sdk-search-vdb-workroom",
+    vectordb_id = search_contract_vectordb
+
+    search = service.search(
         workroom_id=workroom_id,
+        query="hello context",
+        vectordb_id=vectordb_id,
     )
-    try:
-        collection_name = _seed_searchable_context_collection(
-            service,
-            workroom_id=workroom_id,
-            vectordb_id=vectordb_id,
-        )
-        search = service.search(
-            workroom_id=workroom_id,
-            query="hello context",
-            collection_name=collection_name,
-            vectordb_id=vectordb_id,
-        )
-        assert isinstance(search.get("results"), list)
-    finally:
-        _safe_delete_vectordb(
-            service,
-            vectordb_id,
-            workroom_id=workroom_id,
-        )
+    assert isinstance(search.get("results"), list)
 
 
 @pytest.mark.requires_embedding_model
 def test_context_retrieve_contract(
     shared_context_service: ContextService,
     session_workroom: str,
+    search_contract_vectordb: str,
 ) -> None:
     service = shared_context_service
     workroom_id = session_workroom
-    vectordb_id = _create_temp_vectordb(
-        service,
-        prefix="sdk-retrieve-vdb-workroom",
+    vectordb_id = search_contract_vectordb
+
+    retrieve = service.retrieve(
         workroom_id=workroom_id,
+        query="hello context",
+        vectordb_id=vectordb_id,
     )
-    try:
-        collection_name = _seed_searchable_context_collection(
-            service,
-            workroom_id=workroom_id,
-            vectordb_id=vectordb_id,
-        )
-        retrieve = service.retrieve(
-            workroom_id=workroom_id,
-            query="hello context",
-            collection_names=[collection_name],
-            vectordb_id=vectordb_id,
-        )
-        assert isinstance(retrieve.get("sources"), list)
-    finally:
-        _safe_delete_vectordb(
-            service,
-            vectordb_id,
-            workroom_id=workroom_id,
-        )
+    assert isinstance(retrieve.get("sources"), list)
 
 
 @pytest.mark.requires_embedding_model
 def test_context_agentic_search_contract(
     shared_context_service: ContextService,
     session_workroom: str,
+    search_contract_vectordb: str,
     context_required_llm: str,
 ) -> None:
     # agentic_search always sends synthesize=True, so it needs a context LLM in
@@ -1147,36 +1075,20 @@ def test_context_agentic_search_contract(
     assert context_required_llm
     service = shared_context_service
     workroom_id = session_workroom
-    vectordb_id = _create_temp_vectordb(
-        service,
-        prefix="sdk-agentic-vdb-workroom",
+    vectordb_id = search_contract_vectordb
+
+    result = service.agentic_search(
         workroom_id=workroom_id,
+        query="hello context",
+        vectordb_id=vectordb_id,
     )
-    try:
-        collection_name = _seed_searchable_context_collection(
-            service,
-            workroom_id=workroom_id,
-            vectordb_id=vectordb_id,
-        )
-        result = service.agentic_search(
-            workroom_id=workroom_id,
-            query="hello context",
-            collection_name=collection_name,
-            vectordb_id=vectordb_id,
-        )
-        assert isinstance(result.get("results"), list)
-        assert isinstance(result.get("sources"), list)
-        # synthesize=True is always sent, so the unified response must carry the
-        # synthesis/citations fields (content depends on the LLM); assert presence
-        # so a server-side regression that silently drops synthesis is caught.
-        assert "synthesis" in result
-        assert "citations" in result
-    finally:
-        _safe_delete_vectordb(
-            service,
-            vectordb_id,
-            workroom_id=workroom_id,
-        )
+    assert isinstance(result.get("results"), list)
+    assert isinstance(result.get("sources"), list)
+    # synthesize=True is always sent, so the unified response must carry the
+    # synthesis/citations fields (content depends on the LLM); assert presence
+    # so a server-side regression that silently drops synthesis is caught.
+    assert "synthesis" in result
+    assert "citations" in result
 
 
 # --- Raw-file object storage CRUD ---
@@ -1368,9 +1280,7 @@ def test_context_global_settings_round_trips(
         )
 
     try:
-        assert (
-            bool(updated["omniparse"]["force_insecure_model_ssl"]) is not current
-        )
+        assert bool(updated["omniparse"]["force_insecure_model_ssl"]) is not current
     finally:
         # Restore the original value so we don't mutate shared platform state.
         service.update_global_settings(

--- a/tests/unit/test_context_live_fixture_isolation.py
+++ b/tests/unit/test_context_live_fixture_isolation.py
@@ -35,29 +35,6 @@ def _argument_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str
     }
 
 
-def _fixture_scope(function: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
-    for decorator in function.decorator_list:
-        if not isinstance(decorator, ast.Call):
-            continue
-        if isinstance(decorator.func, ast.Attribute):
-            decorator_name = decorator.func.attr
-        elif isinstance(decorator.func, ast.Name):
-            decorator_name = decorator.func.id
-        else:
-            continue
-        if decorator_name != "fixture":
-            continue
-        for keyword in decorator.keywords:
-            if (
-                keyword.arg == "scope"
-                and isinstance(keyword.value, ast.Constant)
-                and isinstance(keyword.value.value, str)
-            ):
-                return keyword.value.value
-        return None
-    raise AssertionError(f"{function.name} has no pytest.fixture decorator")
-
-
 def _call_names(node: ast.AST) -> set[str]:
     calls: set[str] = set()
     for child in ast.walk(node):
@@ -151,8 +128,22 @@ def test_search_contract_vectordb_fixture_provisions_clean_backend_once() -> Non
     fixture = _function_def(source, "search_contract_vectordb")
     argument_names = _argument_names(fixture)
     call_names = _call_names(fixture)
+    fixture_decorators = [
+        decorator
+        for decorator in fixture.decorator_list
+        if isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and decorator.func.attr == "fixture"
+    ]
+    assert len(fixture_decorators) == 1
 
-    assert _fixture_scope(fixture) == "session"
+    fixture_kwargs = {
+        keyword.arg: keyword.value.value
+        for keyword in fixture_decorators[0].keywords
+        if keyword.arg is not None and isinstance(keyword.value, ast.Constant)
+    }
+
+    assert fixture_kwargs["scope"] == "session"
     assert "shared_context_service" in argument_names
     assert "session_workroom" in argument_names
     assert "_create_temp_vectordb" in call_names

--- a/tests/unit/test_context_live_fixture_isolation.py
+++ b/tests/unit/test_context_live_fixture_isolation.py
@@ -16,7 +16,10 @@ def _context_live_source() -> str:
 def _function_def(source: str, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
     module = ast.parse(source)
     for node in module.body:
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ):
             return node
     raise AssertionError(f"{name} not found")
 
@@ -32,15 +35,25 @@ def _argument_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str
     }
 
 
-def _call_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+def _call_names(node: ast.AST) -> set[str]:
+    calls: set[str] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        if isinstance(child.func, ast.Name):
+            calls.add(child.func.id)
+        elif isinstance(child.func, ast.Attribute):
+            calls.add(child.func.attr)
+    return calls
+
+
+def _finally_call_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
     calls: set[str] = set()
     for node in ast.walk(function):
-        if not isinstance(node, ast.Call):
+        if not isinstance(node, ast.Try):
             continue
-        if isinstance(node.func, ast.Name):
-            calls.add(node.func.id)
-        elif isinstance(node.func, ast.Attribute):
-            calls.add(node.func.attr)
+        for final_node in node.finalbody:
+            calls.update(_call_names(final_node))
     return calls
 
 
@@ -60,7 +73,9 @@ def _call_keyword_names(
             continue
         if current_name != call_name:
             continue
-        names.update(keyword.arg for keyword in node.keywords if keyword.arg is not None)
+        names.update(
+            keyword.arg for keyword in node.keywords if keyword.arg is not None
+        )
     return names
 
 
@@ -73,7 +88,28 @@ def _assert_live_test_uses_isolated_vectordb(
     call_names = _call_names(function)
     assert "shared_workroom_vectordb" not in argument_names
     assert "_create_temp_vectordb" in call_names
-    assert "_safe_delete_vectordb" in call_names
+    assert "_safe_delete_vectordb" in _finally_call_names(function)
+    return function
+
+
+def _assert_live_test_uses_search_contract_vectordb(
+    source: str,
+    *,
+    test_name: str,
+    contract_call_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    function = _function_def(source, test_name)
+    argument_names = _argument_names(function)
+    call_names = _call_names(function)
+    contract_keywords = _call_keyword_names(function, contract_call_name)
+
+    assert "shared_workroom_vectordb" not in argument_names
+    assert "search_contract_vectordb" in argument_names
+    assert "_seed_searchable_context_collection" not in call_names
+    assert "_create_temp_vectordb" not in call_names
+    assert "vectordb_id" in contract_keywords
+    assert "collection_name" not in contract_keywords
+    assert "collection_names" not in contract_keywords
     return function
 
 
@@ -87,26 +123,33 @@ def test_mutating_vectordb_live_tests_use_isolated_backends() -> None:
         _assert_live_test_uses_isolated_vectordb(source, test_name)
 
 
+def test_search_contract_vectordb_fixture_provisions_clean_backend_once() -> None:
+    source = _context_live_source()
+    fixture = _function_def(source, "search_contract_vectordb")
+    argument_names = _argument_names(fixture)
+    call_names = _call_names(fixture)
+
+    assert "shared_context_service" in argument_names
+    assert "session_workroom" in argument_names
+    assert "_create_temp_vectordb" in call_names
+    assert "_safe_delete_vectordb" in _finally_call_names(fixture)
+
+
 @pytest.mark.parametrize(
-    ("test_name", "contract_call_name", "collection_keyword_name"),
+    ("test_name", "contract_call_name"),
     [
-        ("test_context_search_contract", "search", "collection_name"),
-        ("test_context_retrieve_contract", "retrieve", "collection_names"),
-        ("test_context_agentic_search_contract", "agentic_search", "collection_name"),
+        ("test_context_search_contract", "search"),
+        ("test_context_retrieve_contract", "retrieve"),
+        ("test_context_agentic_search_contract", "agentic_search"),
     ],
 )
-def test_search_family_contracts_use_seeded_isolated_collections(
+def test_search_family_contracts_use_clean_isolated_backend(
     test_name: str,
     contract_call_name: str,
-    collection_keyword_name: str,
 ) -> None:
     source = _context_live_source()
-    function = _assert_live_test_uses_isolated_vectordb(
+    _assert_live_test_uses_search_contract_vectordb(
         source,
-        test_name,
+        test_name=test_name,
+        contract_call_name=contract_call_name,
     )
-
-    call_names = _call_names(function)
-    contract_keywords = _call_keyword_names(function, contract_call_name)
-    assert "_seed_searchable_context_collection" in call_names
-    assert collection_keyword_name in contract_keywords

--- a/tests/unit/test_context_live_fixture_isolation.py
+++ b/tests/unit/test_context_live_fixture_isolation.py
@@ -87,40 +87,26 @@ def test_mutating_vectordb_live_tests_use_isolated_backends() -> None:
         _assert_live_test_uses_isolated_vectordb(source, test_name)
 
 
-def test_search_contract_live_test_uses_seeded_isolated_collection() -> None:
+@pytest.mark.parametrize(
+    ("test_name", "contract_call_name", "collection_keyword_name"),
+    [
+        ("test_context_search_contract", "search", "collection_name"),
+        ("test_context_retrieve_contract", "retrieve", "collection_names"),
+        ("test_context_agentic_search_contract", "agentic_search", "collection_name"),
+    ],
+)
+def test_search_family_contracts_use_seeded_isolated_collections(
+    test_name: str,
+    contract_call_name: str,
+    collection_keyword_name: str,
+) -> None:
     source = _context_live_source()
     function = _assert_live_test_uses_isolated_vectordb(
         source,
-        "test_context_search_contract",
+        test_name,
     )
 
     call_names = _call_names(function)
-    search_keywords = _call_keyword_names(function, "search")
+    contract_keywords = _call_keyword_names(function, contract_call_name)
     assert "_seed_searchable_context_collection" in call_names
-    assert "collection_name" in search_keywords
-
-
-def test_retrieve_contract_live_test_uses_seeded_isolated_collection() -> None:
-    source = _context_live_source()
-    function = _assert_live_test_uses_isolated_vectordb(
-        source,
-        "test_context_retrieve_contract",
-    )
-
-    call_names = _call_names(function)
-    retrieve_keywords = _call_keyword_names(function, "retrieve")
-    assert "_seed_searchable_context_collection" in call_names
-    assert "collection_names" in retrieve_keywords
-
-
-def test_agentic_search_contract_live_test_uses_seeded_isolated_collection() -> None:
-    source = _context_live_source()
-    function = _assert_live_test_uses_isolated_vectordb(
-        source,
-        "test_context_agentic_search_contract",
-    )
-
-    call_names = _call_names(function)
-    agentic_keywords = _call_keyword_names(function, "agentic_search")
-    assert "_seed_searchable_context_collection" in call_names
-    assert "collection_name" in agentic_keywords
+    assert collection_keyword_name in contract_keywords

--- a/tests/unit/test_context_live_fixture_isolation.py
+++ b/tests/unit/test_context_live_fixture_isolation.py
@@ -3,30 +3,124 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
+pytestmark = pytest.mark.unit
+
 
 def _context_live_source() -> str:
     tests_root = Path(__file__).resolve().parents[1]
     return (tests_root / "integration" / "test_context_live.py").read_text()
 
 
-def _function_def(source: str, name: str) -> ast.FunctionDef:
+def _function_def(source: str, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
     module = ast.parse(source)
     for node in module.body:
-        if isinstance(node, ast.FunctionDef) and node.name == name:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
             return node
     raise AssertionError(f"{name} not found")
 
 
-def test_vectordb_scale_live_test_uses_an_isolated_backend() -> None:
+def _argument_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    return {
+        argument.arg
+        for argument in [
+            *function.args.posonlyargs,
+            *function.args.args,
+            *function.args.kwonlyargs,
+        ]
+    }
+
+
+def _call_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    calls: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            calls.add(node.func.id)
+        elif isinstance(node.func, ast.Attribute):
+            calls.add(node.func.attr)
+    return calls
+
+
+def _call_keyword_names(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+    call_name: str,
+) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(function):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Name):
+            current_name = node.func.id
+        elif isinstance(node.func, ast.Attribute):
+            current_name = node.func.attr
+        else:
+            continue
+        if current_name != call_name:
+            continue
+        names.update(keyword.arg for keyword in node.keywords if keyword.arg is not None)
+    return names
+
+
+def _assert_live_test_uses_isolated_vectordb(
+    source: str,
+    test_name: str,
+) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    function = _function_def(source, test_name)
+    argument_names = _argument_names(function)
+    call_names = _call_names(function)
+    assert "shared_workroom_vectordb" not in argument_names
+    assert "_create_temp_vectordb" in call_names
+    assert "_safe_delete_vectordb" in call_names
+    return function
+
+
+def test_mutating_vectordb_live_tests_use_isolated_backends() -> None:
     source = _context_live_source()
-    function = _function_def(
-        source,
+
+    for test_name in (
+        "test_context_vectordb_update_accepts_config_and_redacts_public_response",
         "test_context_vectordb_scale_reflects_requested_replicas",
+    ):
+        _assert_live_test_uses_isolated_vectordb(source, test_name)
+
+
+def test_search_contract_live_test_uses_seeded_isolated_collection() -> None:
+    source = _context_live_source()
+    function = _assert_live_test_uses_isolated_vectordb(
+        source,
+        "test_context_search_contract",
     )
 
-    argument_names = {argument.arg for argument in function.args.args}
-    function_source = ast.get_source_segment(source, function) or ""
+    call_names = _call_names(function)
+    search_keywords = _call_keyword_names(function, "search")
+    assert "_seed_searchable_context_collection" in call_names
+    assert "collection_name" in search_keywords
 
-    assert "shared_workroom_vectordb" not in argument_names
-    assert "_create_temp_vectordb" in function_source
-    assert "_safe_delete_vectordb" in function_source
+
+def test_retrieve_contract_live_test_uses_seeded_isolated_collection() -> None:
+    source = _context_live_source()
+    function = _assert_live_test_uses_isolated_vectordb(
+        source,
+        "test_context_retrieve_contract",
+    )
+
+    call_names = _call_names(function)
+    retrieve_keywords = _call_keyword_names(function, "retrieve")
+    assert "_seed_searchable_context_collection" in call_names
+    assert "collection_names" in retrieve_keywords
+
+
+def test_agentic_search_contract_live_test_uses_seeded_isolated_collection() -> None:
+    source = _context_live_source()
+    function = _assert_live_test_uses_isolated_vectordb(
+        source,
+        "test_context_agentic_search_contract",
+    )
+
+    call_names = _call_names(function)
+    agentic_keywords = _call_keyword_names(function, "agentic_search")
+    assert "_seed_searchable_context_collection" in call_names
+    assert "collection_name" in agentic_keywords

--- a/tests/unit/test_context_live_fixture_isolation.py
+++ b/tests/unit/test_context_live_fixture_isolation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _context_live_source() -> str:
+    tests_root = Path(__file__).resolve().parents[1]
+    return (tests_root / "integration" / "test_context_live.py").read_text()
+
+
+def _function_def(source: str, name: str) -> ast.FunctionDef:
+    module = ast.parse(source)
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found")
+
+
+def test_vectordb_scale_live_test_uses_an_isolated_backend() -> None:
+    source = _context_live_source()
+    function = _function_def(
+        source,
+        "test_context_vectordb_scale_reflects_requested_replicas",
+    )
+
+    argument_names = {argument.arg for argument in function.args.args}
+    function_source = ast.get_source_segment(source, function) or ""
+
+    assert "shared_workroom_vectordb" not in argument_names
+    assert "_create_temp_vectordb" in function_source
+    assert "_safe_delete_vectordb" in function_source

--- a/tests/unit/test_context_live_fixture_isolation.py
+++ b/tests/unit/test_context_live_fixture_isolation.py
@@ -35,6 +35,29 @@ def _argument_names(function: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str
     }
 
 
+def _fixture_scope(function: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    for decorator in function.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        if isinstance(decorator.func, ast.Attribute):
+            decorator_name = decorator.func.attr
+        elif isinstance(decorator.func, ast.Name):
+            decorator_name = decorator.func.id
+        else:
+            continue
+        if decorator_name != "fixture":
+            continue
+        for keyword in decorator.keywords:
+            if (
+                keyword.arg == "scope"
+                and isinstance(keyword.value, ast.Constant)
+                and isinstance(keyword.value.value, str)
+            ):
+                return keyword.value.value
+        return None
+    raise AssertionError(f"{function.name} has no pytest.fixture decorator")
+
+
 def _call_names(node: ast.AST) -> set[str]:
     calls: set[str] = set()
     for child in ast.walk(node):
@@ -129,6 +152,7 @@ def test_search_contract_vectordb_fixture_provisions_clean_backend_once() -> Non
     argument_names = _argument_names(fixture)
     call_names = _call_names(fixture)
 
+    assert _fixture_scope(fixture) == "session"
     assert "shared_context_service" in argument_names
     assert "session_workroom" in argument_names
     assert "_create_temp_vectordb" in call_names


### PR DESCRIPTION
## Summary

- Isolates the context VDB update/scale live tests onto temporary workroom-scoped Milvus backends with cleanup in `finally`.
- Keeps the search/retrieve/agentic-search smoke contracts on a single dedicated clean backend so earlier vector insert/query tests cannot turn shape checks into data-search assertions.
- Adds AST regression coverage for fixture isolation, cleanup placement, and the search-family contract calls.

## Why

Refs ENG-8691.

Kajiya exposed repeated context smoke failures around the legacy search/retrieve contract tests. The SDK tests should verify response-shape compatibility for those endpoints without inheriting collections or lifecycle mutations from other live context tests. This PR keeps the live smoke focused on the SDK contract and leaves the separate core search-path defect isolated instead of encoding a brittle cross-service data assertion in the SDK suite.

## Verification

| Check | Result |
| --- | --- |
| SDK PR checks | Passing on `98bfd8145d56cfff250bb6d5cdc67583fb8b25c2` |
| `python -m pytest -q tests/unit/test_context_live_fixture_isolation.py` | `5 passed` |
| `python -m pytest -q tests/unit/test_context_service.py tests/unit/test_context_live_fixture_isolation.py` | `80 passed` |
| `python -m ruff check tests/integration/test_context_live.py tests/unit/test_context_live_fixture_isolation.py` | Passed |
| `python -m ruff format --check tests/integration/test_context_live.py tests/unit/test_context_live_fixture_isolation.py` | Passed |
| `python -m mypy --follow-imports=skip tests/unit/test_context_live_fixture_isolation.py tests/integration/test_context_live.py` | Passed |
| `python -m pytest -q tests/integration/test_context_live.py --collect-only` | `32 tests collected` |
| `git diff --check` | Passed |
| Kajiya Azure Smoke rerun | Passed: https://github.com/kamiwaza-internal/kajiya/actions/runs/29757876135 |

Pinned rerun refs: SDK `98bfd8145d56cfff250bb6d5cdc67583fb8b25c2`, SDK base `e5d0509cd0b9bae232ca8a95a22990f1eb95b683`, kamiwaza `d98a13b462e5551d62652abdb96a6274971df5a1`, deploy `c07e2eb818628fc2411df76d218d926ad1611dac`, containers `f37b5131c41362de930f891a79ae593a6c9e5af1`, operators `cb9eb01036446da491c7324c2ef7d6e04f773102`, kajiya `0613fe6e72d6647b3d43e02062f15802c0bc091b`.
