### PR TITLE
fix(extensions): retag compose image placeholders (ENG-8963)

### DIFF
--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -44,9 +44,13 @@ def _replace_image_tag(image_ref: str, new_tag: str) -> str:
     """
     ref = image_ref.split("@", 1)[0]
     last_slash = ref.rfind("/")
-    last_colon = ref.rfind(":")
-    if last_colon > last_slash:
-        ref = ref[:last_colon]
+    placeholder_tag = ref.find(":${", last_slash + 1)
+    if placeholder_tag >= 0:
+        ref = ref[:placeholder_tag]
+    else:
+        last_colon = ref.rfind(":")
+        if last_colon > last_slash:
+            ref = ref[:last_colon]
     return f"{ref}:{new_tag}"
 
 

--- a/tests/unit/extensions/test_publish_cmd.py
+++ b/tests/unit/extensions/test_publish_cmd.py
@@ -2893,6 +2893,13 @@ class TestReplaceImageTag:
             "localhost:5000/foo:1.0.0", "2.0.0-dev"
         ) == "localhost:5000/foo:2.0.0-dev"
 
+    def test_replaces_compose_default_tag_placeholder(self):
+        from kamiwaza_extensions.compose_transformer import _replace_image_tag
+
+        assert _replace_image_tag(
+            "ghcr.io/my-org/foo:${IMAGE_TAG:-local}", "2.0.0-dev"
+        ) == "ghcr.io/my-org/foo:2.0.0-dev"
+
     def test_strips_digest_before_retagging(self):
         from kamiwaza_extensions.compose_transformer import _replace_image_tag
 


### PR DESCRIPTION
## Summary
- treat a Compose default tag placeholder as one tag before applying the publish revision
- preserve existing literal-tag, registry-port, and digest behavior
- add regression coverage for the Tomo image shape

## Why
Tomo publishes images declared as ghcr.io/.../tomo-api:${TOMO_IMAGE_TAG:-local}. The old last-colon rewrite produced an invalid reference ending in ${TOMO_IMAGE_TAG:develop, so both develop catalog publishes failed after every image built successfully.

## Verification
- uv run ruff check kamiwaza_extensions/compose_transformer.py tests/unit/extensions/test_publish_cmd.py
- uv run pytest tests/unit/extensions/test_publish_cmd.py tests/unit/extensions/test_compose_transformer.py (194 passed)
- Tomo real Compose canonical refs contain no unresolved placeholders and resolve to :develop
- kz-ext validate /home/shkevin/kamiwaza-extensions-tomo

Failed Tomo runs:
- https://github.com/kamiwaza-internal/kamiwaza-extensions-tomo/actions/runs/29862620036
- https://github.com/kamiwaza-internal/kamiwaza-extensions-tomo/actions/runs/29865859495