### PR TITLE
feat(extensions): support co-located service sidecars

### DIFF
--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -95,10 +95,17 @@ def _build_patch_service_specs(payload: Any) -> List[Any]:
     patch_services: List[Any] = []
     for svc in payload.services:
         registry, repository, tag = _split_image_ref(svc.image)
+        _, digest_separator, digest = svc.image.partition("@")
         image_patch = ImagePatch(
             tag=tag,
             registry=registry,
             repository=repository,
+            # The platform rejects an ambiguous update to an existing
+            # digest-pinned service. Preserve a declared pin (external
+            # services such as sandbox-controller) and explicitly clear a
+            # stale pin when dev replaces the service with a newly tagged
+            # build.
+            digest=digest if digest_separator else "",
         )
         spec = PatchServiceSpec(
             name=svc.name,

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -108,23 +108,27 @@ def _build_patch_service_specs(payload: Any) -> List[Any]:
             spec.env = svc.env
         if svc.replicas is not None:
             spec.replicas = svc.replicas
-        svc_extra = svc.model_extra or {}
-        for field in (
-            "healthCheck",
-            "automountServiceAccountToken",
-            "containerSecurityContext",
-        ):
-            if field in svc_extra and svc_extra[field] is not None:
-                setattr(spec, field, svc_extra[field])
-        # Always forward ``volumeMounts`` (even when empty) so removing
-        # a volume from compose clears the stale per-service mount on
-        # the persisted CR; consistent with the top-level ``volumes``
-        # forwarding in ``_build_patch_kwargs``. The operator appends
-        # ``svc.VolumeMounts`` after its own ``tmp``/``data`` mounts, so
-        # an empty list clears only user-declared mounts.
-        spec.volumeMounts = svc_extra.get("volumeMounts") or []
+        _copy_patch_service_overrides(spec, svc)
         patch_services.append(spec)
     return patch_services
+
+
+def _copy_patch_service_overrides(spec: Any, service: Any) -> None:
+    """Carry typed and extra per-service deployment overrides into PATCH."""
+    # Always send the field so removing sidecarOf from Compose clears a stale
+    # co-location relationship on the persisted CR.
+    spec.sidecar_of = service.sidecar_of or ""
+    service_extra = service.model_extra or {}
+    for field in (
+        "healthCheck",
+        "automountServiceAccountToken",
+        "containerSecurityContext",
+    ):
+        if field in service_extra and service_extra[field] is not None:
+            setattr(spec, field, service_extra[field])
+    # Always forward an empty list so removing a compose volume mount clears
+    # the stale user-declared mount without touching operator-managed volumes.
+    spec.volumeMounts = service_extra.get("volumeMounts") or []
 
 
 def _resume_revision(prior_state: Any, rev_tag: str, resumable: bool) -> Optional[str]:

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -353,18 +353,7 @@ class PayloadBuilder:
         service_volume_mounts = service_volume_mounts or {}
         specs: List[ExtensionServiceSpec] = []
 
-        # Determine primary service: prefer "frontend", fall back to first with ports
-        primary_name = None
-        for svc_name, svc in services_dict.items():
-            ports = self._parse_ports(svc.get("ports", []))
-            if svc_name == "frontend" and ports:
-                primary_name = svc_name
-                break
-        if primary_name is None:
-            for svc_name, svc in services_dict.items():
-                if self._parse_ports(svc.get("ports", [])):
-                    primary_name = svc_name
-                    break
+        primary_name = _primary_service_name(services_dict)
 
         for svc_name, svc in services_dict.items():
             ports = self._parse_ports(svc.get("ports", []))
@@ -429,17 +418,8 @@ class PayloadBuilder:
             )
             if health_check:
                 spec_kwargs["healthCheck"] = health_check
-            automount = _service_extension_field(svc, "automountServiceAccountToken")
-            if automount is not None:
-                spec_kwargs["automountServiceAccountToken"] = automount
-            container_security_context = _service_extension_field(
-                svc, "containerSecurityContext"
-            )
-            if container_security_context is not None:
-                spec_kwargs["containerSecurityContext"] = container_security_context
             volume_mounts = service_volume_mounts.get(svc_name)
-            if volume_mounts:
-                spec_kwargs["volumeMounts"] = volume_mounts
+            _apply_service_deployment_overrides(spec_kwargs, svc, volume_mounts)
 
             specs.append(ExtensionServiceSpec(**spec_kwargs))
 
@@ -793,6 +773,41 @@ def _service_extension_field(svc: Dict[str, Any], key: str) -> Optional[Any]:
     if isinstance(x_kamiwaza, dict) and key in x_kamiwaza:
         return x_kamiwaza[key]
     return None
+
+
+def _primary_service_name(services: Dict[str, Any]) -> Optional[str]:
+    """Prefer a port-bearing frontend, then the first non-sidecar service."""
+    if _service_can_be_primary(services.get("frontend")):
+        return "frontend"
+    for service_name, service in services.items():
+        if _service_can_be_primary(service):
+            return service_name
+    return None
+
+
+def _service_can_be_primary(service: Optional[Dict[str, Any]]) -> bool:
+    if not service:
+        return False
+    if _service_extension_field(service, "sidecarOf"):
+        return False
+    return bool(PayloadBuilder._parse_ports(service.get("ports", [])))
+
+
+def _apply_service_deployment_overrides(
+    spec: Dict[str, Any],
+    service: Dict[str, Any],
+    volume_mounts: Optional[List[Dict[str, Any]]],
+) -> None:
+    for field in (
+        "automountServiceAccountToken",
+        "sidecarOf",
+        "containerSecurityContext",
+    ):
+        value = _service_extension_field(service, field)
+        if value is not None:
+            spec[field] = value
+    if volume_mounts:
+        spec["volumeMounts"] = volume_mounts
 
 
 def _metadata_service_field(

--- a/kamiwaza_sdk/schemas/extensions.py
+++ b/kamiwaza_sdk/schemas/extensions.py
@@ -48,7 +48,9 @@ class ResourceSpec(BaseModel):
 class ExtensionServiceSpec(BaseModel):
     """Specification for a single service within an extension."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(
+        extra="allow", populate_by_name=True, serialize_by_alias=True
+    )
 
     name: str = Field(..., description="Service name")
     image: str = Field(..., description="Container image (registry/repo:tag)")
@@ -59,6 +61,11 @@ class ExtensionServiceSpec(BaseModel):
     resources: Optional[ResourceSpec] = None
     command: Optional[List[str]] = None
     args: Optional[List[str]] = None
+    sidecar_of: Optional[str] = Field(
+        default=None,
+        alias="sidecarOf",
+        description="Service whose Pod should host this service as a sidecar",
+    )
 
 
 class KamiwazaIntegrationSpec(BaseModel):
@@ -163,12 +170,15 @@ class ImagePatch(BaseModel):
 class PatchServiceSpec(BaseModel):
     """Partial service update — only name is required (for matching)."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(
+        extra="allow", populate_by_name=True, serialize_by_alias=True
+    )
 
     name: str
     image: Optional[ImagePatch] = None
     env: Optional[List[Dict[str, Any]]] = None
     replicas: Optional[int] = Field(None, ge=0)
+    sidecar_of: Optional[str] = Field(default=None, alias="sidecarOf")
 
 
 class PatchExtension(BaseModel):

--- a/kamiwaza_sdk/schemas/extensions.py
+++ b/kamiwaza_sdk/schemas/extensions.py
@@ -165,6 +165,7 @@ class ImagePatch(BaseModel):
     tag: str
     registry: Optional[str] = None
     repository: Optional[str] = None
+    digest: Optional[str] = None
 
 
 class PatchServiceSpec(BaseModel):

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -807,7 +807,7 @@ class TestBuildPatchKwargsCarriesAnnotations:
                 ),
                 ExtensionServiceSpec(
                     name="sandbox-controller",
-                    image="reg/sc:dev",
+                    image="reg/sc:dev@sha256:" + "a" * 64,
                     automountServiceAccountToken=True,
                     sidecarOf="frontend",
                 ),
@@ -829,7 +829,9 @@ class TestBuildPatchKwargsCarriesAnnotations:
         assert sc_extra["automountServiceAccountToken"] is True
         assert by_name["sandbox-controller"].sidecar_of == "frontend"
         assert by_name["sandbox-controller"].model_dump()["sidecarOf"] == "frontend"
+        assert by_name["sandbox-controller"].image.digest == "sha256:" + "a" * 64
         assert by_name["frontend"].model_dump()["sidecarOf"] == ""
+        assert by_name["frontend"].image.digest == ""
         assert "healthCheck" not in sc_extra
         assert "containerSecurityContext" not in sc_extra
 

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -809,6 +809,7 @@ class TestBuildPatchKwargsCarriesAnnotations:
                     name="sandbox-controller",
                     image="reg/sc:dev",
                     automountServiceAccountToken=True,
+                    sidecarOf="frontend",
                 ),
                 ExtensionServiceSpec(name="frontend", image="reg/fe:dev"),
             ]
@@ -826,6 +827,9 @@ class TestBuildPatchKwargsCarriesAnnotations:
 
         sc_extra = by_name["sandbox-controller"].model_extra or {}
         assert sc_extra["automountServiceAccountToken"] is True
+        assert by_name["sandbox-controller"].sidecar_of == "frontend"
+        assert by_name["sandbox-controller"].model_dump()["sidecarOf"] == "frontend"
+        assert by_name["frontend"].model_dump()["sidecarOf"] == ""
         assert "healthCheck" not in sc_extra
         assert "containerSecurityContext" not in sc_extra
 

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -721,7 +721,10 @@ class TestServiceOverrides:
                 "sandbox-controller": {
                     "image": "reg/sandbox-controller:dev",
                     "ports": ["8085"],
-                    "x-kamiwaza": {"automountServiceAccountToken": True},
+                    "x-kamiwaza": {
+                        "automountServiceAccountToken": True,
+                        "sidecarOf": "postgres",
+                    },
                 },
             },
         }
@@ -736,6 +739,28 @@ class TestServiceOverrides:
         }
         assert services["postgres"]["healthCheck"] == {"tcpSocket": {"port": 5432}}
         assert services["sandbox-controller"]["automountServiceAccountToken"] is True
+        assert services["sandbox-controller"]["sidecarOf"] == "postgres"
+        assert services["sandbox-controller"]["primary"] is False
+
+    def test_sidecar_is_not_selected_as_fallback_primary(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "controller": {
+                    "image": "reg/controller:dev",
+                    "ports": ["8085"],
+                    "x-kamiwaza": {"sidecarOf": "guard"},
+                },
+                "guard": {"image": "reg/guard:dev", "ports": ["8000"]},
+            }
+        }
+
+        payload = builder.build(metadata, transformed, connection, "my-app-dev-abc")
+        services = {service.name: service for service in payload.services}
+
+        assert services["controller"].primary is False
+        assert services["guard"].primary is True
 
     def test_kubernetes_sandbox_controller_emits_sandbox_spec(
         self, builder, metadata, connection


### PR DESCRIPTION
Linear: ENG-8268

## Summary

- add typed sidecarOf support to extension service schemas
- emit sidecar placement, token mount, security context, and volume metadata
- keep primary-service selection stable when a sidecar appears first
- clear stale sidecar relations during extension patching

## Why

This enables the MCP sandbox controller to share the mcp-guard Pod while retaining an independently configured container.

## Validation

- 134 focused unit tests passed
- Ruff passed
- CodeScene staged and branch quality gates passed