### PR TITLE
ENG-9131: inject sandbox hostIP env in extension payloads

### DIFF
--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -50,6 +50,7 @@ ANNOTATION_DEPLOYED_AT = "kamiwaza.io/deployed-at"
 # (different from the ``kamiwaza.io/*`` deploy-metadata namespace
 # above). The operator recognizes both.
 ANNOTATION_SERVICE_REF_REWRITES = "extensions.kamiwaza.io/service-ref-rewrites"
+SANDBOX_HOST_IP_ENV = "SANDBOX_HOST_IP"
 
 
 def _compose_resources_to_k8s(resources: Dict[str, str]) -> Dict[str, str]:
@@ -369,6 +370,8 @@ class PayloadBuilder:
         for svc_name, svc in services_dict.items():
             ports = self._parse_ports(svc.get("ports", []))
             env = self._parse_env(svc.get("environment", []))
+            if _env_entry_value(env, "SANDBOX_BACKEND") == "kubernetes":
+                _ensure_sandbox_host_ip_env(env)
             resources = self._parse_resources(svc)
 
             is_primary = svc_name == primary_name
@@ -839,6 +842,34 @@ def _service_env_map(svc: Dict[str, Any]) -> Dict[str, str]:
                     if value is not None:
                         env[str(key)] = str(value)
     return env
+
+
+def _env_entry_value(env: List[Dict[str, Any]], name: str) -> Optional[str]:
+    for entry in env:
+        if entry.get("name") != name or "value" not in entry:
+            continue
+        return str(entry["value"])
+    return None
+
+
+def _ensure_sandbox_host_ip_env(env: List[Dict[str, Any]]) -> None:
+    for index, entry in enumerate(env):
+        if entry.get("name") != SANDBOX_HOST_IP_ENV:
+            continue
+        if entry.get("valueFrom") is not None:
+            return
+        if str(entry.get("value", "")).strip():
+            return
+        env[index] = _sandbox_host_ip_env()
+        return
+    env.append(_sandbox_host_ip_env())
+
+
+def _sandbox_host_ip_env() -> Dict[str, Any]:
+    return {
+        "name": SANDBOX_HOST_IP_ENV,
+        "valueFrom": {"fieldRef": {"fieldPath": "status.hostIP"}},
+    }
 
 
 def _sandbox_resources_from_env(

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -759,6 +759,10 @@ class TestServiceOverrides:
         }
 
         payload = builder.build(metadata, transformed, connection, "my-app-dev-abc")
+        services = {svc.name: svc.model_dump() for svc in payload.services}
+        sandbox_env = {
+            entry["name"]: entry for entry in services["sandbox-controller"]["env"]
+        }
 
         assert (payload.model_extra or {})["sandbox"] == {
             "enabled": True,
@@ -770,6 +774,54 @@ class TestServiceOverrides:
                 "limits": {"cpu": "2", "memory": "4Gi"},
             },
         }
+        assert sandbox_env["SANDBOX_HOST_IP"] == {
+            "name": "SANDBOX_HOST_IP",
+            "valueFrom": {"fieldRef": {"fieldPath": "status.hostIP"}},
+        }
+
+    @pytest.mark.parametrize(
+        ("host_ip_value", "expected_host_ip_env"),
+        [
+            (
+                None,
+                {
+                    "name": "SANDBOX_HOST_IP",
+                    "valueFrom": {"fieldRef": {"fieldPath": "status.hostIP"}},
+                },
+            ),
+            (
+                "",
+                {
+                    "name": "SANDBOX_HOST_IP",
+                    "valueFrom": {"fieldRef": {"fieldPath": "status.hostIP"}},
+                },
+            ),
+            ("10.0.0.5", {"name": "SANDBOX_HOST_IP", "value": "10.0.0.5"}),
+        ],
+    )
+    def test_kubernetes_sandbox_controller_host_ip_env(
+        self, builder, metadata, connection, host_ip_value, expected_host_ip_env
+    ):
+        environment = {"SANDBOX_BACKEND": "kubernetes"}
+        if host_ip_value is not None:
+            environment["SANDBOX_HOST_IP"] = host_ip_value
+        transformed = {
+            "services": {
+                "sandbox-controller": {
+                    "image": "reg/sandbox-controller:dev",
+                    "ports": ["8085"],
+                    "environment": environment,
+                }
+            },
+        }
+
+        payload = builder.build(metadata, transformed, connection, "my-app-dev-abc")
+
+        services = {svc.name: svc.model_dump() for svc in payload.services}
+        sandbox_env = {
+            entry["name"]: entry for entry in services["sandbox-controller"]["env"]
+        }
+        assert sandbox_env["SANDBOX_HOST_IP"] == expected_host_ip_env
 
     def test_non_kubernetes_backend_emits_no_sandbox_spec(
         self, builder, metadata, connection


### PR DESCRIPTION
## Summary
- inject `SANDBOX_HOST_IP` on Kubernetes sandbox-controller services emitted by the extension payload builder
- use Downward API `status.hostIP` when the env var is missing or blank
- preserve explicit nonblank host IP values and existing `valueFrom` definitions

## Validation
- `uv run pytest tests/unit/extensions/test_payload_builder.py -q`
- `uv run ruff check kamiwaza_extensions/payload_builder.py tests/unit/extensions/test_payload_builder.py`
- `uv run python -m py_compile kamiwaza_extensions/payload_builder.py tests/unit/extensions/test_payload_builder.py`
- `git diff --check`

## Companion PRs
- Kaizen runtime declaration/fallback: https://github.com/kamiwaza-internal/kamiwaza-extensions-kaizen/pull/507
- Core App Garden injection: https://github.com/kamiwaza-internal/kamiwaza/pull/2412

## Linear
- [ENG-9131](https://linear.app/kamiwaza/issue/ENG-9131/t-node-10-kaizen-sandbox-controller-downward-api-statushostip-for-host)