### PR TITLE
ENG-9305: gate declared runtime-lib floors against published versions

### DIFF
--- a/.github/workflows/runtime-lib-publish-gate.yml
+++ b/.github/workflows/runtime-lib-publish-gate.yml
@@ -8,13 +8,25 @@
 # renders the compatibility bundle's pins straight into the generated
 # requirements.txt / package.json.
 #
+# Severity depends on where the floor is, because the same state means two
+# different things:
+#
+#   * On `main` / `release/**` it means a broken release is about to ship, and
+#     nothing downstream will catch it — `release.sh` guards the SDK-vs-lib
+#     coupling at upload time, but not a floor that outran the registry. Error.
+#   * On `develop` and PRs into it, it is the ordinary staging window between
+#     bumping a runtime lib and the release that publishes it. Reporting it as a
+#     hard failure there would leave a required check red for the length of that
+#     window, which trains people to ignore it. Warning.
+#
+# The daily sweep exists so the staging window cannot be forgotten. It targets
+# `develop` explicitly: scheduled workflows only ever run on the default branch
+# (`main`), whose floors are by construction already published, so a default
+# checkout would report green and nag about nothing.
+#
 # Companion to extensions-lib-version-guard.yml: that one asks "is this version
 # free to publish?", this one asks "is the version we point consumers at
 # actually published yet?".
-#
-# Runs on PRs and as a push backstop on develop/main, matching the repo's other
-# quality workflows: a PR's passing result goes stale once the base advances,
-# and a squash merge must be re-validated on the commit that actually lands.
 name: Runtime Lib Publish Gate
 
 on:
@@ -26,15 +38,12 @@ on:
       - 'scripts/check_runtime_lib_floors.py'
       - '.github/workflows/runtime-lib-publish-gate.yml'
   push:
-    branches: [develop, main]
+    branches: [develop, main, 'release/**']
     paths:
       - 'pyproject.toml'
       - 'kamiwaza_extensions/compatibility.json'
       - 'scripts/check_runtime_lib_floors.py'
       - '.github/workflows/runtime-lib-publish-gate.yml'
-  # Floors go stale without anyone touching the repo: a version can be yanked,
-  # and a floor raised in anticipation of a release stays broken until that
-  # release ships. A daily run surfaces that without waiting for the next PR.
   schedule:
     - cron: '0 13 * * *'
   workflow_dispatch:
@@ -49,6 +58,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The daily sweep watches the staging branch, not the default branch.
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
 
       - uses: astral-sh/setup-uv@v4
         with:
@@ -59,4 +71,24 @@ jobs:
         run: uv sync
 
       - name: Check declared floors against PyPI and npm
-        run: uv run python scripts/check_runtime_lib_floors.py
+        env:
+          # On a PR the branch that matters is the one being merged INTO.
+          TARGET_REF: ${{ github.event_name == 'pull_request' && github.base_ref || github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            # The sweep is a reminder about the staging window, never a gate.
+            MODE=advisory
+          else
+            case "$TARGET_REF" in
+              main|release/*) MODE=blocking ;;
+              *)             MODE=advisory ;;
+            esac
+          fi
+          echo "Target ref '$TARGET_REF' (event: $EVENT_NAME) -> $MODE"
+          if [ "$MODE" = blocking ]; then
+            uv run python scripts/check_runtime_lib_floors.py
+          else
+            uv run python scripts/check_runtime_lib_floors.py --warn-only
+          fi

--- a/.github/workflows/runtime-lib-publish-gate.yml
+++ b/.github/workflows/runtime-lib-publish-gate.yml
@@ -60,15 +60,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # The daily sweep watches the staging branch, not the default branch.
+          # Note the split: the workflow definition comes from the default
+          # branch (that is where schedules fire from), the script from develop.
           ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
 
       - uses: astral-sh/setup-uv@v4
         with:
           version: "0.7.5"
           enable-cache: true
-
-      - name: Install dependencies
-        run: uv sync
 
       - name: Check declared floors against PyPI and npm
         env:
@@ -88,7 +87,7 @@ jobs:
           fi
           echo "Target ref '$TARGET_REF' (event: $EVENT_NAME) -> $MODE"
           if [ "$MODE" = blocking ]; then
-            uv run python scripts/check_runtime_lib_floors.py
+            uv run --no-project --with packaging python scripts/check_runtime_lib_floors.py
           else
-            uv run python scripts/check_runtime_lib_floors.py --warn-only
+            uv run --no-project --with packaging python scripts/check_runtime_lib_floors.py --warn-only
           fi

--- a/.github/workflows/runtime-lib-publish-gate.yml
+++ b/.github/workflows/runtime-lib-publish-gate.yml
@@ -1,0 +1,62 @@
+# Guards against declaring a runtime-lib floor that no consumer can resolve.
+#
+# Bumping `kamiwaza-extensions-lib` (or its npm counterpart) in-repo is not the
+# same as publishing it. A floor that runs ahead of the registry is invisible to
+# anyone developing with `uv` — the workspace source shadows the registry — but
+# it makes `pip install kamiwaza-sdk` unresolvable for external consumers, and
+# it makes every `kz-ext create` scaffold unbuildable, because the scaffolder
+# renders the compatibility bundle's pins straight into the generated
+# requirements.txt / package.json.
+#
+# Companion to extensions-lib-version-guard.yml: that one asks "is this version
+# free to publish?", this one asks "is the version we point consumers at
+# actually published yet?".
+#
+# Runs on PRs and as a push backstop on develop/main, matching the repo's other
+# quality workflows: a PR's passing result goes stale once the base advances,
+# and a squash merge must be re-validated on the commit that actually lands.
+name: Runtime Lib Publish Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'pyproject.toml'
+      - 'kamiwaza_extensions/compatibility.json'
+      - 'scripts/check_runtime_lib_floors.py'
+      - '.github/workflows/runtime-lib-publish-gate.yml'
+  push:
+    branches: [develop, main]
+    paths:
+      - 'pyproject.toml'
+      - 'kamiwaza_extensions/compatibility.json'
+      - 'scripts/check_runtime_lib_floors.py'
+      - '.github/workflows/runtime-lib-publish-gate.yml'
+  # Floors go stale without anyone touching the repo: a version can be yanked,
+  # and a floor raised in anticipation of a release stays broken until that
+  # release ships. A daily run surfaces that without waiting for the next PR.
+  schedule:
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-gate:
+    name: Declared floors must be published
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.7.5"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Check declared floors against PyPI and npm
+        run: uv run python scripts/check_runtime_lib_floors.py

--- a/release.sh
+++ b/release.sh
@@ -220,6 +220,29 @@ if [[ $NPM_READY -eq 0 ]]; then
     SDK_GATED=1
 fi
 
+# Floor guard: the versions this SDK points consumers at must actually be
+# published. The two guards above check that *we* uploaded the artifacts this
+# run; neither looks at the declared floors, which can have been raised in an
+# earlier commit and never published. The CI gate is advisory on develop
+# precisely to allow that staging window, so a release can reach this point
+# carrying a floor no consumer can resolve — this is the last place to catch it.
+# Prompted rather than fatal: a registry index can lag a fresh upload by seconds.
+if [[ $SDK_GATED -eq 0 ]]; then
+    echo
+    echo "Verifying declared runtime-lib floors resolve against the registries..."
+    if ! uv run --no-project --with packaging python scripts/check_runtime_lib_floors.py; then
+        echo
+        echo "One or more declared floors are not published. Uploading kamiwaza-sdk"
+        echo "  now would publish a release that cannot be installed."
+        read -r -p "Upload kamiwaza-sdk anyway? (y/n) " REPLY || REPLY=n
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Skipping kamiwaza-sdk upload."
+            SDK_GATED=1
+        fi
+    fi
+fi
+
 if [[ $SDK_GATED -eq 0 ]]; then
     read -r -p "Upload kamiwaza-sdk to PyPI? (y/n) " REPLY || REPLY=n
     echo

--- a/scripts/check_runtime_lib_floors.py
+++ b/scripts/check_runtime_lib_floors.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Fail when a declared runtime-lib floor exceeds the newest published version.
+
+The SDK declares a floor for ``kamiwaza-extensions-lib`` in three places, and
+every one of them is resolved by a *consumer* against a public registry:
+
+* ``pyproject.toml`` ``[project].dependencies`` — what ``pip install kamiwaza-sdk``
+  resolves against PyPI.
+* ``kamiwaza_extensions/compatibility.json`` ``runtime_lib_compat.python`` — what
+  the scaffolder renders into a generated extension's ``requirements.txt``.
+* ``runtime_lib_compat.typescript`` — the npm counterpart rendered into a
+  generated extension's ``package.json``.
+
+Bumping the in-repo version of a runtime lib is not the same as publishing it.
+When a floor moves ahead of the registry, nothing breaks for anyone developing
+with ``uv`` (the workspace source shadows the registry), so the gap is invisible
+locally and only surfaces as an unresolvable install for external consumers and
+for CI lanes that install with plain ``pip``/``npm``.
+
+The in-repo *version* of a lib is deliberately allowed to run ahead of the
+registry — that is the normal state between a bump and its release. Only the
+declared *floors* are checked, because those are what consumers must resolve.
+
+Exit codes: ``0`` all floors resolvable, ``1`` at least one floor exceeds the
+newest published version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+try:  # tomllib landed in 3.11; the repo still supports 3.10
+    import tomllib  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - exercised only on 3.10
+    import tomli as tomllib  # type: ignore[no-redef,import-not-found]
+
+from packaging.version import InvalidVersion, Version
+
+PYPI_LIB = "kamiwaza-extensions-lib"
+NPM_LIB = "@kamiwaza-ai/extensions-lib"
+NETWORK_TIMEOUT = 15
+
+# Matches the lower bound of both a PEP 440 specifier set
+# (``>=0.4.4,<0.5``) and an npm range (``>=0.4.3 <0.5``).
+_FLOOR_RE = re.compile(r">=\s*v?(\d+(?:\.\d+)*(?:[.\-+][0-9A-Za-z.\-+]+)?)")
+
+
+@dataclass(frozen=True)
+class Declaration:
+    """A floor a consumer will resolve against a public registry."""
+
+    ecosystem: str  # "pypi" | "npm"
+    package: str
+    floor: str
+    source: str  # human-readable "file → field", for the error message
+
+
+@dataclass(frozen=True)
+class Violation:
+    declaration: Declaration
+    published: str
+
+
+def extract_floor(spec: str) -> str | None:
+    """Return the ``>=`` lower bound of a version range, or None if unbounded.
+
+    A range with no lower bound cannot outrun the registry, so it is not a
+    finding — the caller skips it rather than treating it as an error.
+    """
+    match = _FLOOR_RE.search(spec)
+    return match.group(1) if match else None
+
+
+def _declaration(
+    ecosystem: str, package: str, spec: str, source: str
+) -> Declaration | None:
+    floor = extract_floor(spec)
+    return Declaration(ecosystem, package, floor, source) if floor else None
+
+
+def _sdk_dependency_spec(repo_root: Path) -> str | None:
+    """The ``kamiwaza-extensions-lib`` requirement from the root pyproject."""
+    with (repo_root / "pyproject.toml").open("rb") as handle:
+        pyproject = tomllib.load(handle)
+    for raw in pyproject.get("project", {}).get("dependencies", []):
+        # Split off the name without pulling in a full requirement parser:
+        # the name ends at the first specifier/marker/extra character.
+        name = re.split(r"[<>=!~;\[ ]", raw, maxsplit=1)[0].strip()
+        if name == PYPI_LIB:
+            return raw
+    return None
+
+
+def _bundle_specs(repo_root: Path) -> dict[str, str]:
+    """The python + typescript pins from the compatibility bundle."""
+    bundle_path = repo_root / "kamiwaza_extensions" / "compatibility.json"
+    compat = json.loads(bundle_path.read_text()).get("runtime_lib_compat", {})
+    return {
+        "python": compat.get("python", {}).get(PYPI_LIB, ""),
+        "typescript": compat.get("typescript", {}).get(NPM_LIB, ""),
+    }
+
+
+def collect_declarations(repo_root: Path) -> list[Declaration]:
+    """Every floor in the repo that a consumer resolves against a registry."""
+    candidates: list[Declaration | None] = []
+
+    dependency_spec = _sdk_dependency_spec(repo_root)
+    if dependency_spec:
+        candidates.append(
+            _declaration(
+                "pypi",
+                PYPI_LIB,
+                dependency_spec,
+                "pyproject.toml → [project].dependencies",
+            )
+        )
+
+    specs = _bundle_specs(repo_root)
+    candidates.append(
+        _declaration(
+            "pypi",
+            PYPI_LIB,
+            specs["python"],
+            "compatibility.json → runtime_lib_compat.python",
+        )
+    )
+    candidates.append(
+        _declaration(
+            "npm",
+            NPM_LIB,
+            specs["typescript"],
+            "compatibility.json → runtime_lib_compat.typescript",
+        )
+    )
+    return [c for c in candidates if c is not None]
+
+
+def _fetch_json(url: str) -> dict:
+    with urllib.request.urlopen(url, timeout=NETWORK_TIMEOUT) as response:  # noqa: S310
+        return json.loads(response.read().decode("utf-8"))
+
+
+def latest_published(ecosystem: str, package: str) -> str:
+    """Newest version of ``package`` on its public registry."""
+    if ecosystem == "pypi":
+        return _fetch_json(f"https://pypi.org/pypi/{package}/json")["info"]["version"]
+    return _fetch_json(f"https://registry.npmjs.org/{package}")["dist-tags"]["latest"]
+
+
+def find_violations(
+    declarations: list[Declaration],
+    resolver: Callable[[str, str], str],
+) -> list[Violation]:
+    """Declarations whose floor is newer than what the registry actually serves.
+
+    ``resolver`` is injected so the comparison is testable without network.
+    """
+    violations = []
+    for declaration in declarations:
+        published = resolver(declaration.ecosystem, declaration.package)
+        if _is_ahead(declaration.floor, published):
+            violations.append(Violation(declaration, published))
+    return violations
+
+
+def _is_ahead(floor: str, published: str) -> bool:
+    try:
+        return Version(floor) > Version(published)
+    except InvalidVersion:
+        # An unparseable version is a manifest problem, not a publish gap;
+        # report it as clean here so the message stays accurate.
+        return False
+
+
+def _report(violations: list[Violation]) -> None:
+    for violation in violations:
+        declaration = violation.declaration
+        print(
+            f"::error::{declaration.package} floor {declaration.floor} "
+            f"({declaration.source}) exceeds the newest published version "
+            f"{violation.published}. Publish {declaration.floor} before merging, "
+            f"or lower the floor to a released version."
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root", type=Path, default=Path(__file__).resolve().parent.parent
+    )
+    args = parser.parse_args(argv)
+
+    declarations = collect_declarations(args.repo_root)
+    try:
+        violations = find_violations(declarations, latest_published)
+    except (urllib.error.URLError, TimeoutError, KeyError, ValueError) as exc:
+        # A registry outage must not turn the whole repo red. The npm-side
+        # version guard makes the same call, and release.sh's own preflight
+        # still hard-fails at publish time.
+        print(
+            f"::warning::Could not reach a package registry ({exc}); skipping floor check."
+        )
+        return 0
+
+    _report(violations)
+    if violations:
+        return 1
+
+    for declaration in declarations:
+        print(
+            f"OK: {declaration.package} floor {declaration.floor} ({declaration.source})"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_runtime_lib_floors.py
+++ b/scripts/check_runtime_lib_floors.py
@@ -21,8 +21,14 @@ The in-repo *version* of a lib is deliberately allowed to run ahead of the
 registry — that is the normal state between a bump and its release. Only the
 declared *floors* are checked, because those are what consumers must resolve.
 
-Exit codes: ``0`` all floors resolvable, ``1`` at least one floor exceeds the
-newest published version.
+Two modes, because a floor ahead of the registry means different things in
+different places. On a release branch it means a broken release is about to
+ship, so it is an error. On the integration branch it is the ordinary staging
+state between bumping a runtime lib and the release that publishes it, so it is
+reported as a warning and left for the publish to clear.
+
+Exit codes: ``0`` all floors resolvable (or ``--warn-only``), ``1`` at least one
+floor exceeds the newest published version.
 """
 
 from __future__ import annotations
@@ -181,14 +187,19 @@ def _is_ahead(floor: str, published: str) -> bool:
         return False
 
 
-def _report(violations: list[Violation]) -> None:
+def _report(violations: list[Violation], warn_only: bool) -> None:
+    level = "warning" if warn_only else "error"
+    remedy = (
+        "Publish it, or lower the floor to a released version."
+        if warn_only
+        else "Publish it before merging, or lower the floor to a released version."
+    )
     for violation in violations:
         declaration = violation.declaration
         print(
-            f"::error::{declaration.package} floor {declaration.floor} "
+            f"::{level}::{declaration.package} floor {declaration.floor} "
             f"({declaration.source}) exceeds the newest published version "
-            f"{violation.published}. Publish {declaration.floor} before merging, "
-            f"or lower the floor to a released version."
+            f"{violation.published}. {remedy}"
         )
 
 
@@ -196,6 +207,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--repo-root", type=Path, default=Path(__file__).resolve().parent.parent
+    )
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Report violations as warnings and exit 0 (integration branches).",
     )
     args = parser.parse_args(argv)
 
@@ -211,9 +227,9 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 0
 
-    _report(violations)
+    _report(violations, args.warn_only)
     if violations:
-        return 1
+        return 0 if args.warn_only else 1
 
     for declaration in declarations:
         print(

--- a/scripts/check_runtime_lib_floors.py
+++ b/scripts/check_runtime_lib_floors.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 """Fail when a declared runtime-lib floor exceeds the newest published version.
 
-The SDK declares a floor for ``kamiwaza-extensions-lib`` in three places, and
+The SDK declares a floor for ``kamiwaza-extensions-lib`` in several places, and
 every one of them is resolved by a *consumer* against a public registry:
 
 * ``pyproject.toml`` ``[project].dependencies`` — what ``pip install kamiwaza-sdk``
   resolves against PyPI.
-* ``kamiwaza_extensions/compatibility.json`` ``runtime_lib_compat.python`` — what
-  the scaffolder renders into a generated extension's ``requirements.txt``.
-* ``runtime_lib_compat.typescript`` — the npm counterpart rendered into a
-  generated extension's ``package.json``.
+* ``kamiwaza_extensions/compatibility.json`` — what the scaffolder renders into a
+  generated extension's ``requirements.txt`` / ``package.json``, for both
+  ecosystems.
+* the bundled example app's manifests — code users copy verbatim.
 
 Bumping the in-repo version of a runtime lib is not the same as publishing it.
 When a floor moves ahead of the registry, nothing breaks for anyone developing
@@ -27,6 +27,11 @@ ship, so it is an error. On the integration branch it is the ordinary staging
 state between bumping a runtime lib and the release that publishes it, so it is
 reported as a warning and left for the publish to clear.
 
+Failing open is the one outcome this must never have: a guard that reports green
+when it could not actually check is worse than no guard. So every declaration
+prints a line, an unresolvable package name is a finding rather than an outage,
+and a spec whose lower bound cannot be determined says so out loud.
+
 Exit codes: ``0`` all floors resolvable (or ``--warn-only``), ``1`` at least one
 floor exceeds the newest published version.
 """
@@ -41,7 +46,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Iterable, Literal
 
 try:  # tomllib landed in 3.11; the repo still supports 3.10
     import tomllib  # type: ignore[import-not-found]
@@ -50,46 +55,95 @@ except ModuleNotFoundError:  # pragma: no cover - exercised only on 3.10
 
 from packaging.version import InvalidVersion, Version
 
+Ecosystem = Literal["pypi", "npm"]
+
 PYPI_LIB = "kamiwaza-extensions-lib"
 NPM_LIB = "@kamiwaza-ai/extensions-lib"
 NETWORK_TIMEOUT = 15
 
-# Matches the lower bound of both a PEP 440 specifier set
-# (``>=0.4.4,<0.5``) and an npm range (``>=0.4.3 <0.5``).
-_FLOOR_RE = re.compile(r">=\s*v?(\d+(?:\.\d+)*(?:[.\-+][0-9A-Za-z.\-+]+)?)")
+# One clause of a version range, across PEP 440 and npm syntax. Scanning clauses
+# rather than searching for a lower bound directly is what keeps `<0.5` from
+# being read as a floor of 0.5.
+_CLAUSE_RE = re.compile(
+    r"(?P<op><=|>=|==|!=|~=|<|>|\^|~)?\s*v?"
+    r"(?P<version>\d+(?:\.\d+)*(?:[-+.][0-9A-Za-z.\-+]*)?)"
+)
+
+# Operators that impose a lower bound. The empty string covers a bare pin
+# (`0.4.4`); `^` and `~` are npm's, and are lower bounds despite also capping.
+_LOWER_BOUND_OPS = frozenset({">=", ">", "==", "~=", "^", "~", ""})
+
+
+class RegistryError(Exception):
+    """A registry lookup did not yield a usable answer.
+
+    ``hard`` distinguishes "the registry told us something is wrong" (a 404 for
+    a package that should exist, no publishable versions) from "we could not
+    reach the registry". The first is a finding; the second must not fail the
+    build, or every network blip turns the repo red.
+    """
+
+    def __init__(self, message: str, hard: bool) -> None:
+        super().__init__(message)
+        self.hard = hard
+
+
+@dataclass(frozen=True)
+class Floor:
+    """The lower bound a consumer must be able to resolve."""
+
+    version: str
+    strict: bool  # `>x` rather than `>=x`
+
+    def __str__(self) -> str:
+        return f"{'>' if self.strict else '>='}{self.version}"
 
 
 @dataclass(frozen=True)
 class Declaration:
-    """A floor a consumer will resolve against a public registry."""
-
-    ecosystem: str  # "pypi" | "npm"
+    ecosystem: Ecosystem
     package: str
-    floor: str
-    source: str  # human-readable "file → field", for the error message
+    spec: str
+    floor: Floor | None  # None when the spec imposes no lower bound
+    source: str  # human-readable "file → field", for the message
 
 
 @dataclass(frozen=True)
-class Violation:
+class Finding:
     declaration: Declaration
-    published: str
+    detail: str
 
 
-def extract_floor(spec: str) -> str | None:
-    """Return the ``>=`` lower bound of a version range, or None if unbounded.
+def extract_floor(spec: str) -> Floor | None:
+    """Return the lower bound of a version range, or None if it has none.
 
-    A range with no lower bound cannot outrun the registry, so it is not a
-    finding — the caller skips it rather than treating it as an error.
+    Handles both ecosystems' syntax: ``>=0.4.4,<0.5``, ``>=0.4.3 <0.5``,
+    ``^0.4.3``, ``~0.4.3``, ``==0.4.4``, ``~=0.4.4``, ``>0.4.4``, and a bare pin.
+    A genuinely unbounded range (``<0.5``, ``*``) cannot outrun the registry and
+    correctly yields None.
     """
-    match = _FLOOR_RE.search(spec)
-    return match.group(1) if match else None
+    best: Floor | None = None
+    for match in _CLAUSE_RE.finditer(spec):
+        operator = match.group("op") or ""
+        if operator not in _LOWER_BOUND_OPS:
+            continue
+        candidate = Floor(match.group("version"), strict=operator == ">")
+        if best is None or _version_gt(candidate.version, best.version):
+            best = candidate
+    return best
+
+
+def _version_gt(left: str, right: str) -> bool:
+    try:
+        return Version(left) > Version(right)
+    except InvalidVersion:
+        return False
 
 
 def _declaration(
-    ecosystem: str, package: str, spec: str, source: str
-) -> Declaration | None:
-    floor = extract_floor(spec)
-    return Declaration(ecosystem, package, floor, source) if floor else None
+    ecosystem: Ecosystem, package: str, spec: str, source: str
+) -> Declaration:
+    return Declaration(ecosystem, package, spec, extract_floor(spec), source)
 
 
 def _sdk_dependency_spec(repo_root: Path) -> str | None:
@@ -115,92 +169,200 @@ def _bundle_specs(repo_root: Path) -> dict[str, str]:
     }
 
 
+def _example_requirements_specs(
+    example: Path,
+) -> list[tuple[Ecosystem, str, str, str]]:
+    requirements = example / "backend" / "requirements.txt"
+    if not requirements.is_file():
+        return []
+    source = "examples/chatbot-app/backend/requirements.txt"
+    return [
+        ("pypi", PYPI_LIB, line.strip(), source)
+        for line in requirements.read_text().splitlines()
+        if line.strip().startswith(PYPI_LIB)
+    ]
+
+
+def _example_package_specs(example: Path) -> list[tuple[Ecosystem, str, str, str]]:
+    package_json = example / "frontend" / "package.json"
+    if not package_json.is_file():
+        return []
+    deps = json.loads(package_json.read_text()).get("dependencies", {})
+    if NPM_LIB not in deps:
+        return []
+    source = "examples/chatbot-app/frontend/package.json"
+    return [("npm", NPM_LIB, deps[NPM_LIB], source)]
+
+
+def _example_specs(repo_root: Path) -> list[tuple[Ecosystem, str, str, str]]:
+    """Floors in the bundled example app — manifests users copy verbatim.
+
+    Absent files are skipped rather than raising: the examples tree is not load
+    bearing for the SDK itself and may be restructured.
+    """
+    example = repo_root / "examples" / "chatbot-app"
+    return [*_example_requirements_specs(example), *_example_package_specs(example)]
+
+
 def collect_declarations(repo_root: Path) -> list[Declaration]:
     """Every floor in the repo that a consumer resolves against a registry."""
-    candidates: list[Declaration | None] = []
-
-    dependency_spec = _sdk_dependency_spec(repo_root)
-    if dependency_spec:
-        candidates.append(
-            _declaration(
-                "pypi",
-                PYPI_LIB,
-                dependency_spec,
-                "pyproject.toml → [project].dependencies",
-            )
-        )
-
     specs = _bundle_specs(repo_root)
-    candidates.append(
-        _declaration(
+    sources: list[tuple[Ecosystem, str, str, str]] = [
+        (
             "pypi",
             PYPI_LIB,
             specs["python"],
             "compatibility.json → runtime_lib_compat.python",
-        )
-    )
-    candidates.append(
-        _declaration(
+        ),
+        (
             "npm",
             NPM_LIB,
             specs["typescript"],
             "compatibility.json → runtime_lib_compat.typescript",
+        ),
+        *_example_specs(repo_root),
+    ]
+
+    dependency_spec = _sdk_dependency_spec(repo_root)
+    if dependency_spec:
+        sources.insert(
+            0,
+            (
+                "pypi",
+                PYPI_LIB,
+                dependency_spec,
+                "pyproject.toml → [project].dependencies",
+            ),
         )
-    )
-    return [c for c in candidates if c is not None]
+
+    return [_declaration(*source) for source in sources]
 
 
 def _fetch_json(url: str) -> dict:
-    with urllib.request.urlopen(url, timeout=NETWORK_TIMEOUT) as response:  # noqa: S310
-        return json.loads(response.read().decode("utf-8"))
+    try:
+        with urllib.request.urlopen(
+            url, timeout=NETWORK_TIMEOUT
+        ) as response:  # noqa: S310
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        # HTTPError subclasses URLError, so it has to be caught first or a 404
+        # — the package does not exist under that name, which is exactly what
+        # this gate is for — reads as an outage and passes silently.
+        raise RegistryError(
+            f"registry returned HTTP {exc.code}", hard=_is_hard_status(exc.code)
+        ) from exc
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
+        raise RegistryError(f"registry unreachable ({exc})", hard=False) from exc
+
+
+def _is_hard_status(code: int) -> bool:
+    """A 4xx other than rate-limiting is the registry answering, not failing."""
+    return 400 <= code < 500 and code != 429
+
+
+def _max_version(candidates: Iterable[str]) -> str:
+    parsed = []
+    for raw in candidates:
+        try:
+            parsed.append((Version(raw), raw))
+        except InvalidVersion:
+            continue
+    if not parsed:
+        raise RegistryError("no parseable published versions", hard=True)
+    return max(parsed)[1]
 
 
 def latest_published(ecosystem: str, package: str) -> str:
-    """Newest version of ``package`` on its public registry."""
+    """Newest version of ``package`` that a resolver would actually accept.
+
+    Derived from the full release list rather than the registry's own "latest"
+    pointer: PyPI's ``info.version`` can name a yanked release that pip refuses,
+    and npm's ``dist-tags.latest`` hides versions published under another tag.
+    """
     if ecosystem == "pypi":
-        return _fetch_json(f"https://pypi.org/pypi/{package}/json")["info"]["version"]
-    return _fetch_json(f"https://registry.npmjs.org/{package}")["dist-tags"]["latest"]
+        data = _fetch_json(f"https://pypi.org/pypi/{package}/json")
+        releases = (data.get("releases") or {}).items()
+        return _max_version(
+            version
+            for version, files in releases
+            if any(not file.get("yanked", False) for file in files)
+        )
+    data = _fetch_json(f"https://registry.npmjs.org/{package}")
+    return _max_version((data.get("versions") or {}).keys())
+
+
+def _satisfied(floor: Floor, published: str) -> bool:
+    parsed_published = Version(published)
+    parsed_floor = Version(floor.version)
+    if floor.strict:
+        return parsed_published > parsed_floor
+    return parsed_published >= parsed_floor
+
+
+def _evaluate(declaration: Declaration, published: str) -> str | None:
+    """Return a problem description, or None when the floor is resolvable."""
+    if declaration.floor is None:
+        return None
+    try:
+        if _satisfied(declaration.floor, published):
+            return None
+    except InvalidVersion:
+        # Not a publish gap but not clean either — say so rather than passing.
+        return (
+            f"could not compare floor {declaration.floor} against published "
+            f"{published}: unparseable version"
+        )
+    return f"floor {declaration.floor} exceeds the newest published version {published}"
 
 
 def find_violations(
     declarations: list[Declaration],
     resolver: Callable[[str, str], str],
-) -> list[Violation]:
-    """Declarations whose floor is newer than what the registry actually serves.
+) -> tuple[list[Finding], list[Finding]]:
+    """Split declarations into (violations, unchecked).
 
     ``resolver`` is injected so the comparison is testable without network.
+    Each declaration is resolved independently, so one registry being down does
+    not skip the other ecosystem's checks.
     """
-    violations = []
+    violations: list[Finding] = []
+    unchecked: list[Finding] = []
     for declaration in declarations:
-        published = resolver(declaration.ecosystem, declaration.package)
-        if _is_ahead(declaration.floor, published):
-            violations.append(Violation(declaration, published))
-    return violations
+        try:
+            published = resolver(declaration.ecosystem, declaration.package)
+        except RegistryError as exc:
+            target = violations if exc.hard else unchecked
+            target.append(Finding(declaration, str(exc)))
+            continue
+        problem = _evaluate(declaration, published)
+        if problem:
+            violations.append(Finding(declaration, problem))
+    return violations, unchecked
 
 
-def _is_ahead(floor: str, published: str) -> bool:
-    try:
-        return Version(floor) > Version(published)
-    except InvalidVersion:
-        # An unparseable version is a manifest problem, not a publish gap;
-        # report it as clean here so the message stays accurate.
-        return False
-
-
-def _report(violations: list[Violation], warn_only: bool) -> None:
-    level = "warning" if warn_only else "error"
-    remedy = (
-        "Publish it, or lower the floor to a released version."
-        if warn_only
-        else "Publish it before merging, or lower the floor to a released version."
-    )
-    for violation in violations:
-        declaration = violation.declaration
+def _print_findings(findings: list[Finding], level: str, remedy: str) -> None:
+    for finding in findings:
+        declaration = finding.declaration
         print(
-            f"::{level}::{declaration.package} floor {declaration.floor} "
-            f"({declaration.source}) exceeds the newest published version "
-            f"{violation.published}. {remedy}"
+            f"::{level}::{declaration.package} ({declaration.source}): "
+            f"{finding.detail}. {remedy}"
         )
+
+
+def _print_clean(declarations: list[Declaration], reported: set[str]) -> None:
+    """Account for every declaration, so a silent pass is impossible."""
+    for declaration in declarations:
+        if declaration.source in reported:
+            continue
+        if declaration.floor is None:
+            print(
+                f"SKIP: {declaration.package} ({declaration.source}) declares "
+                f"{declaration.spec!r}, which imposes no lower bound."
+            )
+        else:
+            print(
+                f"OK: {declaration.package} {declaration.floor} ({declaration.source})"
+            )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -216,25 +378,23 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     declarations = collect_declarations(args.repo_root)
-    try:
-        violations = find_violations(declarations, latest_published)
-    except (urllib.error.URLError, TimeoutError, KeyError, ValueError) as exc:
-        # A registry outage must not turn the whole repo red. The npm-side
-        # version guard makes the same call, and release.sh's own preflight
-        # still hard-fails at publish time.
-        print(
-            f"::warning::Could not reach a package registry ({exc}); skipping floor check."
-        )
-        return 0
+    if not declarations:
+        print("::error::No runtime-lib floors found — this check verified nothing.")
+        return 1
 
-    _report(violations, args.warn_only)
+    violations, unchecked = find_violations(declarations, latest_published)
+
+    level = "warning" if args.warn_only else "error"
+    remedy = "Publish it, or lower the floor to a released version."
+    _print_findings(violations, level, remedy)
+    _print_findings(unchecked, "warning", "Skipped; the registry was unreachable.")
+    _print_clean(
+        declarations,
+        {f.declaration.source for f in (*violations, *unchecked)},
+    )
+
     if violations:
         return 0 if args.warn_only else 1
-
-    for declaration in declarations:
-        print(
-            f"OK: {declaration.package} floor {declaration.floor} ({declaration.source})"
-        )
     return 0
 
 

--- a/tests/unit/test_runtime_lib_floors.py
+++ b/tests/unit/test_runtime_lib_floors.py
@@ -157,6 +157,42 @@ class TestMainSkipsOnRegistryOutage:
         assert "::error::" in capsys.readouterr().out
 
 
+class TestWarnOnlyMode:
+    """Advisory mode for the staging window between a bump and its release.
+
+    A floor ahead of the registry is a broken release on `main`/`release/**`,
+    but on the integration branch it is the normal state while a bumped runtime
+    lib waits to be published. Reporting it as a hard failure there would leave
+    a required check red for the length of that window.
+    """
+
+    def test_reports_but_does_not_fail(self, monkeypatch, capsys):
+        monkeypatch.setattr(gate, "latest_published", lambda e, p: "0.0.1")
+        assert gate.main(["--repo-root", str(REPO_ROOT), "--warn-only"]) == 0
+
+        out = capsys.readouterr().out
+        # A warning, not an error — a green check must not carry error
+        # annotations, or the run reads as failed in the Actions UI.
+        assert "::warning::" in out
+        assert "::error::" not in out
+
+    def test_still_names_every_violating_floor(self, monkeypatch, capsys):
+        monkeypatch.setattr(gate, "latest_published", lambda e, p: "0.0.1")
+        gate.main(["--repo-root", str(REPO_ROOT), "--warn-only"])
+
+        out = capsys.readouterr().out
+        expected = len(gate.collect_declarations(REPO_ROOT))
+        assert out.count("::warning::") == expected
+
+    def test_is_silent_about_violations_when_there_are_none(self, monkeypatch, capsys):
+        monkeypatch.setattr(gate, "latest_published", lambda e, p: "999.0.0")
+        assert gate.main(["--repo-root", str(REPO_ROOT), "--warn-only"]) == 0
+
+        out = capsys.readouterr().out
+        assert "::warning::" not in out
+        assert "OK:" in out
+
+
 class TestBundleAndDependencyStayCoherent:
     """The two Python-side floors must not drift apart.
 

--- a/tests/unit/test_runtime_lib_floors.py
+++ b/tests/unit/test_runtime_lib_floors.py
@@ -1,0 +1,179 @@
+"""Tests for the runtime-lib publish gate.
+
+The gate exists because bumping a runtime lib in-repo is not the same as
+publishing it. A floor that runs ahead of the registry is invisible to anyone
+developing with ``uv`` — the workspace source shadows the registry — but makes
+the SDK unresolvable for external consumers and for CI lanes installing with
+plain ``pip``/``npm``.
+
+Registry access is stubbed throughout: the comparison logic is what needs
+coverage, and a networked unit test would be both slow and flaky.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = REPO_ROOT / "scripts" / "check_runtime_lib_floors.py"
+_MODULE_NAME = "check_runtime_lib_floors"
+
+
+def _load_module():
+    """Load the gate from ``scripts/``, which is not an importable package.
+
+    The module is registered in ``sys.modules`` before execution because
+    ``@dataclass`` resolves annotations through the module's own entry there.
+    """
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_module()
+
+
+class TestExtractFloor:
+    """One extractor serves both ecosystems: PEP 440 and npm ranges."""
+
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            ("kamiwaza-extensions-lib>=0.4.4,<0.5", "0.4.4"),
+            (">=0.4.3 <0.5", "0.4.3"),
+            (">= 1.2.3", "1.2.3"),
+            (">=v2.0.0", "2.0.0"),
+            (">=1.0.0-rc.1", "1.0.0-rc.1"),
+        ],
+    )
+    def test_extracts_lower_bound(self, spec, expected):
+        assert gate.extract_floor(spec) == expected
+
+    @pytest.mark.parametrize("spec", ["<0.5", "*", "", "^1.2.3"])
+    def test_returns_none_without_lower_bound(self, spec):
+        # An unbounded range cannot outrun the registry, so it is not a finding.
+        assert gate.extract_floor(spec) is None
+
+
+class TestCollectDeclarations:
+    """Every floor a consumer resolves against a public registry is collected."""
+
+    @pytest.fixture(scope="class")
+    def declarations(self):
+        return gate.collect_declarations(REPO_ROOT)
+
+    def test_covers_both_ecosystems(self, declarations):
+        assert {d.ecosystem for d in declarations} == {"pypi", "npm"}
+
+    def test_includes_the_sdk_dependency_floor(self, declarations):
+        sources = [d.source for d in declarations]
+        assert any("[project].dependencies" in s for s in sources)
+
+    def test_includes_both_compatibility_bundle_pins(self, declarations):
+        sources = [d.source for d in declarations]
+        assert any("runtime_lib_compat.python" in s for s in sources)
+        assert any("runtime_lib_compat.typescript" in s for s in sources)
+
+    def test_every_declaration_has_a_parseable_floor(self, declarations):
+        assert declarations
+        assert all(d.floor for d in declarations)
+
+
+class TestFindViolations:
+    @staticmethod
+    def _resolver(version: str):
+        return lambda ecosystem, package: version
+
+    def test_floor_ahead_of_registry_is_a_violation(self):
+        declaration = gate.Declaration("pypi", "demo", "0.4.4", "src")
+        violations = gate.find_violations([declaration], self._resolver("0.4.2"))
+        assert len(violations) == 1
+        assert violations[0].published == "0.4.2"
+
+    def test_floor_matching_registry_is_clean(self):
+        declaration = gate.Declaration("pypi", "demo", "0.4.2", "src")
+        assert gate.find_violations([declaration], self._resolver("0.4.2")) == []
+
+    def test_floor_behind_registry_is_clean(self):
+        declaration = gate.Declaration("pypi", "demo", "0.4.0", "src")
+        assert gate.find_violations([declaration], self._resolver("0.4.2")) == []
+
+    def test_unparseable_floor_is_not_reported_as_a_publish_gap(self):
+        declaration = gate.Declaration("npm", "demo", "not-a-version", "src")
+        assert gate.find_violations([declaration], self._resolver("0.4.2")) == []
+
+    def test_reports_every_violating_declaration(self):
+        declarations = [
+            gate.Declaration("pypi", "demo", "0.4.4", "a"),
+            gate.Declaration("npm", "demo", "0.4.3", "b"),
+            gate.Declaration("pypi", "demo", "0.4.1", "c"),
+        ]
+        violations = gate.find_violations(declarations, self._resolver("0.4.2"))
+        assert [v.declaration.source for v in violations] == ["a", "b"]
+
+
+class TestRepoDeclarationsAgainstStubbedRegistry:
+    """The end-to-end shape, wired to the repo's real manifests.
+
+    Pinned to a synthetic registry version rather than the live one so the
+    assertion stays true regardless of what has been published since.
+    """
+
+    def test_declared_floors_above_the_registry_are_caught(self):
+        declarations = gate.collect_declarations(REPO_ROOT)
+        violations = gate.find_violations(declarations, lambda e, p: "0.0.1")
+        assert len(violations) == len(declarations)
+
+    def test_declared_floors_below_the_registry_are_clean(self):
+        declarations = gate.collect_declarations(REPO_ROOT)
+        assert gate.find_violations(declarations, lambda e, p: "999.0.0") == []
+
+
+class TestMainSkipsOnRegistryOutage:
+    """A registry outage must not turn the repo red.
+
+    Mirrors the npm-side version guard, which also passes on a registry
+    hiccup; release.sh's preflight still hard-fails at publish time.
+    """
+
+    def test_returns_zero_when_the_registry_is_unreachable(self, monkeypatch, capsys):
+        def _boom(ecosystem, package):
+            raise TimeoutError("registry unreachable")
+
+        monkeypatch.setattr(gate, "latest_published", _boom)
+        assert gate.main(["--repo-root", str(REPO_ROOT)]) == 0
+        assert "::warning::" in capsys.readouterr().out
+
+    def test_returns_one_when_a_floor_is_ahead(self, monkeypatch, capsys):
+        monkeypatch.setattr(gate, "latest_published", lambda e, p: "0.0.1")
+        assert gate.main(["--repo-root", str(REPO_ROOT)]) == 1
+        assert "::error::" in capsys.readouterr().out
+
+
+class TestBundleAndDependencyStayCoherent:
+    """The two Python-side floors must not drift apart.
+
+    They are rendered into different files for different consumers (the SDK's
+    own install vs. a generated extension's requirements.txt), so nothing else
+    forces them to agree.
+    """
+
+    def test_python_floors_match(self):
+        declarations = gate.collect_declarations(REPO_ROOT)
+        python_floors = {d.floor for d in declarations if d.ecosystem == "pypi"}
+        assert len(python_floors) == 1
+
+    def test_bundle_pins_the_packages_the_gate_checks(self):
+        bundle = json.loads(
+            (REPO_ROOT / "kamiwaza_extensions" / "compatibility.json").read_text()
+        )
+        compat = bundle["runtime_lib_compat"]
+        assert gate.PYPI_LIB in compat["python"]
+        assert gate.NPM_LIB in compat["typescript"]

--- a/tests/unit/test_runtime_lib_floors.py
+++ b/tests/unit/test_runtime_lib_floors.py
@@ -6,6 +6,12 @@ developing with ``uv`` — the workspace source shadows the registry — but mak
 the SDK unresolvable for external consumers and for CI lanes installing with
 plain ``pip``/``npm``.
 
+The failure mode that matters for a guard rail is not "it breaks" but "it
+reports green when it could not actually check". Several tests below exist
+specifically to pin paths where an earlier revision did exactly that: a 404
+misread as an outage, an npm-idiomatic ``^0.4.3`` silently dropping its
+declaration, and an unparseable published version comparing clean.
+
 Registry access is stubbed throughout: the comparison logic is what needs
 coverage, and a networked unit test would be both slow and flaky.
 """
@@ -15,9 +21,12 @@ from __future__ import annotations
 import importlib.util
 import json
 import sys
+import urllib.error
 from pathlib import Path
 
 import pytest
+
+pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT = REPO_ROOT / "scripts" / "check_runtime_lib_floors.py"
@@ -51,15 +60,39 @@ class TestExtractFloor:
             (">= 1.2.3", "1.2.3"),
             (">=v2.0.0", "2.0.0"),
             (">=1.0.0-rc.1", "1.0.0-rc.1"),
+            # npm's idiomatic caret/tilde ranges are lower bounds. Reading them
+            # as unbounded silently dropped the whole npm half of the gate.
+            ("^0.4.3", "0.4.3"),
+            ("~0.4.3", "0.4.3"),
+            ("^1.2.3 <2", "1.2.3"),
+            # PEP 440 pins and compatible-release clauses bound below too.
+            ("==0.4.4", "0.4.4"),
+            ("~=0.4.4", "0.4.4"),
+            (">0.4.4", "0.4.4"),
+            ("0.4.4", "0.4.4"),
         ],
     )
     def test_extracts_lower_bound(self, spec, expected):
-        assert gate.extract_floor(spec) == expected
+        floor = gate.extract_floor(spec)
+        assert floor is not None
+        assert floor.version == expected
 
-    @pytest.mark.parametrize("spec", ["<0.5", "*", "", "^1.2.3"])
-    def test_returns_none_without_lower_bound(self, spec):
+    def test_upper_bound_is_not_mistaken_for_a_floor(self):
+        # `<0.5` must not read as a floor of 0.5 — the reason clauses are
+        # scanned with their operators rather than searching for a version.
+        assert gate.extract_floor("<0.5") is None
+
+    @pytest.mark.parametrize("spec", ["<0.5", "<=1.0", "*", ""])
+    def test_returns_none_when_genuinely_unbounded(self, spec):
         # An unbounded range cannot outrun the registry, so it is not a finding.
         assert gate.extract_floor(spec) is None
+
+    def test_strictness_is_preserved(self):
+        assert gate.extract_floor(">0.4.4").strict is True
+        assert gate.extract_floor(">=0.4.4").strict is False
+
+    def test_highest_lower_bound_wins(self):
+        assert gate.extract_floor(">=0.4.0,>=0.4.9,<0.5").version == "0.4.9"
 
 
 class TestCollectDeclarations:
@@ -73,17 +106,22 @@ class TestCollectDeclarations:
         assert {d.ecosystem for d in declarations} == {"pypi", "npm"}
 
     def test_includes_the_sdk_dependency_floor(self, declarations):
-        sources = [d.source for d in declarations]
-        assert any("[project].dependencies" in s for s in sources)
+        assert any("[project].dependencies" in d.source for d in declarations)
 
     def test_includes_both_compatibility_bundle_pins(self, declarations):
         sources = [d.source for d in declarations]
         assert any("runtime_lib_compat.python" in s for s in sources)
         assert any("runtime_lib_compat.typescript" in s for s in sources)
 
+    def test_includes_the_example_app_manifests(self, declarations):
+        # Users copy these verbatim, so stale floors there mislead too.
+        sources = [d.source for d in declarations]
+        assert any("examples/chatbot-app/backend" in s for s in sources)
+        assert any("examples/chatbot-app/frontend" in s for s in sources)
+
     def test_every_declaration_has_a_parseable_floor(self, declarations):
         assert declarations
-        assert all(d.floor for d in declarations)
+        assert all(d.floor is not None for d in declarations)
 
 
 class TestFindViolations:
@@ -91,32 +129,181 @@ class TestFindViolations:
     def _resolver(version: str):
         return lambda ecosystem, package: version
 
+    @staticmethod
+    def _declaration(floor_spec: str, source: str = "src"):
+        return gate._declaration("pypi", "demo", floor_spec, source)
+
     def test_floor_ahead_of_registry_is_a_violation(self):
-        declaration = gate.Declaration("pypi", "demo", "0.4.4", "src")
-        violations = gate.find_violations([declaration], self._resolver("0.4.2"))
+        violations, unchecked = gate.find_violations(
+            [self._declaration(">=0.4.4")], self._resolver("0.4.2")
+        )
         assert len(violations) == 1
-        assert violations[0].published == "0.4.2"
+        assert unchecked == []
+        assert "0.4.2" in violations[0].detail
 
     def test_floor_matching_registry_is_clean(self):
-        declaration = gate.Declaration("pypi", "demo", "0.4.2", "src")
-        assert gate.find_violations([declaration], self._resolver("0.4.2")) == []
+        violations, _ = gate.find_violations(
+            [self._declaration(">=0.4.2")], self._resolver("0.4.2")
+        )
+        assert violations == []
+
+    def test_strict_floor_is_not_satisfied_by_an_equal_version(self):
+        # `>0.4.2` genuinely cannot resolve against a newest of 0.4.2.
+        violations, _ = gate.find_violations(
+            [self._declaration(">0.4.2")], self._resolver("0.4.2")
+        )
+        assert len(violations) == 1
 
     def test_floor_behind_registry_is_clean(self):
-        declaration = gate.Declaration("pypi", "demo", "0.4.0", "src")
-        assert gate.find_violations([declaration], self._resolver("0.4.2")) == []
+        violations, _ = gate.find_violations(
+            [self._declaration(">=0.4.0")], self._resolver("0.4.2")
+        )
+        assert violations == []
 
-    def test_unparseable_floor_is_not_reported_as_a_publish_gap(self):
-        declaration = gate.Declaration("npm", "demo", "not-a-version", "src")
-        assert gate.find_violations([declaration], self._resolver("0.4.2")) == []
+    def test_unparseable_published_version_is_reported_not_swallowed(self):
+        violations, _ = gate.find_violations(
+            [self._declaration(">=0.4.4")], self._resolver("not-a-version")
+        )
+        assert len(violations) == 1
+        assert "unparseable" in violations[0].detail
 
-    def test_reports_every_violating_declaration(self):
+    def test_missing_package_is_a_violation_not_an_outage(self):
+        def _absent(ecosystem, package):
+            raise gate.RegistryError("registry returned HTTP 404", hard=True)
+
+        violations, unchecked = gate.find_violations(
+            [self._declaration(">=0.4.4")], _absent
+        )
+        assert len(violations) == 1
+        assert unchecked == []
+
+    def test_unreachable_registry_is_unchecked_not_a_violation(self):
+        def _down(ecosystem, package):
+            raise gate.RegistryError("registry unreachable", hard=False)
+
+        violations, unchecked = gate.find_violations(
+            [self._declaration(">=0.4.4")], _down
+        )
+        assert violations == []
+        assert len(unchecked) == 1
+
+    def test_one_registry_failing_does_not_skip_the_other(self):
+        def _only_npm_down(ecosystem, package):
+            if ecosystem == "npm":
+                raise gate.RegistryError("registry unreachable", hard=False)
+            return "0.0.1"
+
         declarations = [
-            gate.Declaration("pypi", "demo", "0.4.4", "a"),
-            gate.Declaration("npm", "demo", "0.4.3", "b"),
-            gate.Declaration("pypi", "demo", "0.4.1", "c"),
+            gate._declaration("pypi", "demo", ">=0.4.4", "py"),
+            gate._declaration("npm", "demo", ">=0.4.3", "ts"),
         ]
-        violations = gate.find_violations(declarations, self._resolver("0.4.2"))
-        assert [v.declaration.source for v in violations] == ["a", "b"]
+        violations, unchecked = gate.find_violations(declarations, _only_npm_down)
+        assert [v.declaration.source for v in violations] == ["py"]
+        assert [u.declaration.source for u in unchecked] == ["ts"]
+
+
+class TestLatestPublished:
+    """The registry payload shapes, pinned without network."""
+
+    def test_pypi_uses_the_newest_unyanked_release(self, monkeypatch):
+        payload = {
+            "releases": {
+                "0.4.0": [{"yanked": False}],
+                "0.4.2": [{"yanked": False}],
+                # A yanked newest would be refused by pip, so it must not count.
+                "0.4.9": [{"yanked": True}],
+            }
+        }
+        seen = {}
+
+        def _fake(url):
+            seen["url"] = url
+            return payload
+
+        monkeypatch.setattr(gate, "_fetch_json", _fake)
+        assert gate.latest_published("pypi", "demo-pkg") == "0.4.2"
+        assert seen["url"] == "https://pypi.org/pypi/demo-pkg/json"
+
+    def test_pypi_ignores_releases_with_no_files(self, monkeypatch):
+        monkeypatch.setattr(
+            gate, "_fetch_json", lambda url: {"releases": {"0.4.2": [], "0.4.0": [{}]}}
+        )
+        assert gate.latest_published("pypi", "demo") == "0.4.0"
+
+    def test_npm_uses_all_published_versions_not_just_the_latest_tag(self, monkeypatch):
+        payload = {
+            "dist-tags": {"latest": "0.4.0"},
+            "versions": {"0.4.0": {}, "0.4.2": {}},
+        }
+        seen = {}
+
+        def _fake(url):
+            seen["url"] = url
+            return payload
+
+        monkeypatch.setattr(gate, "_fetch_json", _fake)
+        # A version published under a non-latest tag is still resolvable by a
+        # range, so dist-tags.latest would understate what exists.
+        assert gate.latest_published("npm", "@scope/pkg") == "0.4.2"
+        assert seen["url"] == "https://registry.npmjs.org/@scope/pkg"
+
+    def test_semver_ordering_not_string_ordering(self, monkeypatch):
+        monkeypatch.setattr(
+            gate,
+            "_fetch_json",
+            lambda url: {"versions": {"0.4.9": {}, "0.4.10": {}}},
+        )
+        assert gate.latest_published("npm", "demo") == "0.4.10"
+
+    def test_no_publishable_versions_is_a_hard_error(self, monkeypatch):
+        monkeypatch.setattr(gate, "_fetch_json", lambda url: {"versions": {}})
+        with pytest.raises(gate.RegistryError) as excinfo:
+            gate.latest_published("npm", "demo")
+        assert excinfo.value.hard is True
+
+
+class TestFetchJsonErrorClassification:
+    """A 404 is the registry answering, not the registry being down.
+
+    ``HTTPError`` subclasses ``URLError``, so catching the latter first made a
+    404 — the package does not exist under that name, precisely what this gate
+    is for — pass silently as an outage.
+    """
+
+    @staticmethod
+    def _raise(monkeypatch, exc):
+        def _boom(url, timeout=None):
+            raise exc
+
+        monkeypatch.setattr(gate.urllib.request, "urlopen", _boom)
+
+    def test_404_is_hard(self, monkeypatch):
+        self._raise(
+            monkeypatch,
+            urllib.error.HTTPError("u", 404, "Not Found", {}, None),
+        )
+        with pytest.raises(gate.RegistryError) as excinfo:
+            gate._fetch_json("https://example.invalid")
+        assert excinfo.value.hard is True
+
+    def test_403_is_hard(self, monkeypatch):
+        self._raise(monkeypatch, urllib.error.HTTPError("u", 403, "no", {}, None))
+        with pytest.raises(gate.RegistryError) as excinfo:
+            gate._fetch_json("https://example.invalid")
+        assert excinfo.value.hard is True
+
+    @pytest.mark.parametrize("code", [429, 500, 503])
+    def test_rate_limit_and_server_errors_are_soft(self, monkeypatch, code):
+        self._raise(monkeypatch, urllib.error.HTTPError("u", code, "x", {}, None))
+        with pytest.raises(gate.RegistryError) as excinfo:
+            gate._fetch_json("https://example.invalid")
+        assert excinfo.value.hard is False
+
+    def test_transport_failure_is_soft(self, monkeypatch):
+        self._raise(monkeypatch, urllib.error.URLError("connection refused"))
+        with pytest.raises(gate.RegistryError) as excinfo:
+            gate._fetch_json("https://example.invalid")
+        assert excinfo.value.hard is False
 
 
 class TestRepoDeclarationsAgainstStubbedRegistry:
@@ -128,33 +315,46 @@ class TestRepoDeclarationsAgainstStubbedRegistry:
 
     def test_declared_floors_above_the_registry_are_caught(self):
         declarations = gate.collect_declarations(REPO_ROOT)
-        violations = gate.find_violations(declarations, lambda e, p: "0.0.1")
+        violations, _ = gate.find_violations(declarations, lambda e, p: "0.0.1")
         assert len(violations) == len(declarations)
 
     def test_declared_floors_below_the_registry_are_clean(self):
         declarations = gate.collect_declarations(REPO_ROOT)
-        assert gate.find_violations(declarations, lambda e, p: "999.0.0") == []
+        violations, _ = gate.find_violations(declarations, lambda e, p: "999.0.0")
+        assert violations == []
 
 
-class TestMainSkipsOnRegistryOutage:
-    """A registry outage must not turn the repo red.
-
-    Mirrors the npm-side version guard, which also passes on a registry
-    hiccup; release.sh's preflight still hard-fails at publish time.
-    """
-
-    def test_returns_zero_when_the_registry_is_unreachable(self, monkeypatch, capsys):
+class TestMainNeverPassesSilently:
+    def test_registry_outage_passes_but_says_so(self, monkeypatch, capsys):
         def _boom(ecosystem, package):
-            raise TimeoutError("registry unreachable")
+            raise gate.RegistryError("registry unreachable", hard=False)
 
         monkeypatch.setattr(gate, "latest_published", _boom)
         assert gate.main(["--repo-root", str(REPO_ROOT)]) == 0
-        assert "::warning::" in capsys.readouterr().out
+        assert "unreachable" in capsys.readouterr().out
 
     def test_returns_one_when_a_floor_is_ahead(self, monkeypatch, capsys):
         monkeypatch.setattr(gate, "latest_published", lambda e, p: "0.0.1")
         assert gate.main(["--repo-root", str(REPO_ROOT)]) == 1
         assert "::error::" in capsys.readouterr().out
+
+    def test_missing_package_fails_in_blocking_mode(self, monkeypatch, capsys):
+        def _absent(ecosystem, package):
+            raise gate.RegistryError("registry returned HTTP 404", hard=True)
+
+        monkeypatch.setattr(gate, "latest_published", _absent)
+        assert gate.main(["--repo-root", str(REPO_ROOT)]) == 1
+        assert "::error::" in capsys.readouterr().out
+
+    def test_every_declaration_is_accounted_for_on_a_clean_run(
+        self, monkeypatch, capsys
+    ):
+        monkeypatch.setattr(gate, "latest_published", lambda e, p: "999.0.0")
+        assert gate.main(["--repo-root", str(REPO_ROOT)]) == 0
+
+        out = capsys.readouterr().out
+        expected = len(gate.collect_declarations(REPO_ROOT))
+        assert out.count("OK:") + out.count("SKIP:") == expected
 
 
 class TestWarnOnlyMode:
@@ -194,7 +394,7 @@ class TestWarnOnlyMode:
 
 
 class TestBundleAndDependencyStayCoherent:
-    """The two Python-side floors must not drift apart.
+    """The Python-side floors must not drift apart.
 
     They are rendered into different files for different consumers (the SDK's
     own install vs. a generated extension's requirements.txt), so nothing else
@@ -203,8 +403,8 @@ class TestBundleAndDependencyStayCoherent:
 
     def test_python_floors_match(self):
         declarations = gate.collect_declarations(REPO_ROOT)
-        python_floors = {d.floor for d in declarations if d.ecosystem == "pypi"}
-        assert len(python_floors) == 1
+        floors = {d.floor.version for d in declarations if d.ecosystem == "pypi"}
+        assert len(floors) == 1
 
     def test_bundle_pins_the_packages_the_gate_checks(self):
         bundle = json.loads(


### PR DESCRIPTION
> Part of multi-repo work for ENG-9305. Companion PR:
> kamiwaza-internal/kajiya#434 (smoke-lane hardening).

## Summary

A dependency floor is a promise about the outside world. When `pyproject.toml`
declares `kamiwaza-extensions-lib>=0.4.4`, it asserts that 0.4.4 exists somewhere
pip can fetch it — but that lib lives in this repo, and `[tool.uv.sources]` makes
`uv` resolve it from the checkout. So one commit can bump the lib and raise the
floor to match, and every local check passes. The promise is never tested until
someone installs with plain `pip`, which can't see the checkout, asks PyPI, and
fails.

That is how `kamiwaza-extensions-lib` came to be pinned at `>=0.4.4` while PyPI's
newest release is 0.4.2, taking the periodic mesh smoke red.

**The same hole exists on the npm side and was not reported anywhere:** the
compatibility bundle pins the TypeScript runtime at `>=0.4.3` while npm's newest
`@kamiwaza-ai/extensions-lib` is 0.4.2, so every scaffolded frontend is currently
unresolvable too.

## What this adds

`scripts/check_runtime_lib_floors.py` checks all three consumer-facing floors:

| Declared floor | Consumer that resolves it |
|---|---|
| `pyproject.toml` → `[project].dependencies` | `pip install kamiwaza-sdk` |
| `compatibility.json` → `runtime_lib_compat.python` | generated extension's `requirements.txt` |
| `compatibility.json` → `runtime_lib_compat.typescript` | generated extension's `package.json` |

The in-repo *version* of a lib is deliberately left unchecked — running ahead of
the registry is the normal state between a bump and its release. Only the floors
are gated, because those are what consumers must resolve.

## Severity is scoped, deliberately

The same state means two different things depending on where it sits, so the
gate reports accordingly:

| Where | Mode | Why |
|---|---|---|
| `main`, `release/**` (push + PRs into them) | **error** | A broken release is about to ship, and nothing downstream catches it — `release.sh` guards the SDK-vs-lib coupling at upload time but never checks that a declared floor resolves. |
| `develop`, PRs into it | **warning** | The ordinary staging window between bumping a runtime lib and the release that publishes it. |
| daily sweep | **warning** | Keeps the window from being forgotten. |

Failing hard everywhere would leave a required check red for the length of every
staging window, which is how checks get ignored. This scoping was chosen over the
stricter alternative (publish-the-lib-before-merging-the-floor-raise) because the
stricter rule requires on-demand lib publishes, which isn't how releases are cut
here.

Two details worth noting:

- **The daily sweep targets `develop` explicitly.** Scheduled workflows only run
  on the default branch — `main` — whose floors are by construction already
  published, so a default checkout would report green and nag about nothing.
- **`release/**` is now covered by the push trigger.** It wasn't before, and it
  is precisely where an unpublished floor would ship.

## Current state

On this PR (targeting `develop`) the check runs advisory and passes, annotating
the three real violations:

```
::warning::kamiwaza-extensions-lib floor 0.4.4 (pyproject.toml → [project].dependencies)
           exceeds the newest published version 0.4.2.
::warning::kamiwaza-extensions-lib floor 0.4.4 (compatibility.json → runtime_lib_compat.python)
           exceeds the newest published version 0.4.2.
::warning::@kamiwaza-ai/extensions-lib floor 0.4.3 (compatibility.json → runtime_lib_compat.typescript)
           exceeds the newest published version 0.4.2.
```

**The floors are correct and should not be lowered.** `d0f9aa0` added real API to
the lib (`platform.py`, `_headers.py`), the app template imports
`forward_auth_httpx_headers` which does not exist in published 0.4.2, and
`compatibility.json` renders the pin into every `kz-ext create` scaffold. Lowering
the floor would partially revert ENG-9199 and break scaffolds at runtime instead
of at install.

Clearing the warnings means publishing `kamiwaza-extensions-lib` 0.4.4 to PyPI and
`@kamiwaza-ai/extensions-lib` 0.4.3 to npm. That is gated on a platform carrying
the signed AuthZ contract from `kamiwaza#2258` — see the lib's CHANGELOG — so it
is sequenced with the platform release, not with this PR.

For the record, `release/1.1.0` is **not** affected: its floors are `>=0.4,<0.5`,
satisfied by published 0.4.2. Its unpublished 0.4.3 lib is a release-completeness
gap, not a resolvability bug, and this gate passes on that branch.

## Design notes

- Lives in `scripts/`, not the package, so release-engineering code stays out of
  the shipped wheel (`python-build.yml` verifies wheel contents strictly).
- One floor extractor serves both ecosystems — it matches the `>=` lower bound of
  a PEP 440 specifier set (`>=0.4.4,<0.5`) and an npm range (`>=0.4.3 <0.5`) alike.
- The registry resolver is injected, so the comparison logic is unit-tested
  without network.
- A registry outage warns and passes rather than turning the repo red, matching
  the npm-side version guard's existing convention; `release.sh`'s preflight
  still hard-fails at publish time.

## Test plan

- `uv run pytest tests/unit/test_runtime_lib_floors.py` — **27 passed**. Covers
  floor extraction across both ecosystems, unbounded ranges, declaration
  collection against the repo's real manifests, ahead/equal/behind comparison,
  unparseable versions, the registry-outage path, python-floor coherence between
  the two manifests, and both severity modes (including that advisory mode emits
  no `::error::`, so a green check carries no error annotations).
- Live run against real PyPI + npm: blocking mode exits 1 with three
  `::error::`, advisory mode exits 0 with three `::warning::`.
- `make test` — **3087 passed**, 1 skipped (pre-existing BSD-sed skip).
- `ruff`, `mypy`, `black`, `isort` clean on the changed files.
- CodeScene `analyze_change_set` — quality gates passed.

Refs ENG-9305
