### PR TITLE
feat(extensions): scope Compose volumes per service and forward persistence [ENG-9604]

### DIFF
--- a/kamiwaza-ai-extensions-lib/package-lock.json
+++ b/kamiwaza-ai-extensions-lib/package-lock.json
@@ -746,6 +746,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -763,6 +766,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -780,6 +786,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -797,6 +806,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -814,6 +826,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -831,6 +846,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -848,6 +866,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -865,6 +886,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -882,6 +906,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -905,6 +932,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -928,6 +958,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -951,6 +984,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -974,6 +1010,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -997,6 +1036,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1020,6 +1062,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1043,6 +1088,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1239,6 +1287,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1256,6 +1307,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1273,6 +1327,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1290,6 +1347,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/kamiwaza-ai-extensions-lib/package-lock.json
+++ b/kamiwaza-ai-extensions-lib/package-lock.json
@@ -746,9 +746,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -766,9 +763,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -786,9 +780,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -806,9 +797,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -826,9 +814,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -846,9 +831,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -866,9 +848,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -886,9 +865,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -906,9 +882,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -932,9 +905,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -958,9 +928,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -984,9 +951,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1010,9 +974,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1036,9 +997,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1062,9 +1020,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1088,9 +1043,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1287,9 +1239,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1307,9 +1256,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1327,9 +1273,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1347,9 +1290,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -96,24 +96,114 @@ def _build_patch_service_specs(
 def _validate_service_filter(
     service: Optional[str], compose_data: Dict[str, Any]
 ) -> None:
-    """Reject a ``--service`` name that no compose service answers to.
+    """Reject a ``--service`` name this run could not actually deploy.
 
-    Without this the filter yields an empty service list, and the failure
-    surfaces at the very end of the run as a raw pydantic ``min_length``
-    error that never mentions ``--service`` — after the whole build phase
-    has already run.
+    Raw Compose keys are the wrong set to check against. A profile-gated
+    service is stripped by the transformer, so the filter yields an empty
+    service list and ``PatchExtension`` raises a bare pydantic ``min_length``
+    error — after the whole build and push phase, naming neither the flag nor
+    the service. A service with no build context is not one ``--service`` can
+    build either: it would warn "No images to build" and PATCH the image the
+    author already declared, a silent no-op deploy.
     """
     if service is None:
         return
-    known = sorted((compose_data.get("services") or {}).keys())
-    if service in known:
-        return
-    console.print(
-        f"[red]Error:[/red] --service '{service}' is not a service in "
-        f"docker-compose.yml."
+    services = compose_data.get("services") or {}
+    if service not in services:
+        _fail_service_filter(
+            service, "is not a service in docker-compose.yml", services
+        )
+    config = services.get(service) or {}
+    if config.get("profiles"):
+        _fail_service_filter(
+            service,
+            "is profile-gated, so it is not part of a cluster deploy",
+            services,
+        )
+    if "build" not in config:
+        _fail_service_filter(
+            service,
+            "has no build context, so there is nothing to build or push for it",
+            services,
+        )
+
+
+def warn_orphaned_persistence(
+    prior_mounts: Dict[str, str], payload: Any
+) -> List[str]:
+    """Warn where a removed persistence block leaves the CR's PVC in place.
+
+    ``get_extension`` returns only ``ExtensionServiceStatus``, so the CR's own
+    spec cannot be read back to clear a block the extension has dropped. The
+    PVC therefore stays mounted while this PATCH sends a Compose emptyDir at
+    the same path: an identical target is a duplicate ``volumeMounts`` entry
+    the K8s API rejects, and a nested one shadows a claim still holding the
+    data the author believes they stopped writing.
+
+    Returns the messages emitted, so callers can assert on them.
+    """
+    warnings: List[str] = []
+    for service in payload.services:
+        prior = prior_mounts.get(service.name)
+        if not prior or service.persistence:
+            continue
+        collisions = [
+            mount["mountPath"]
+            for mount in (service.volume_mounts or [])
+            if _under_mount_path(mount.get("mountPath", ""), prior)
+        ]
+        if not collisions:
+            continue
+        message = (
+            f"Service '{service.name}' no longer declares persistence, but the "
+            f"deployed extension has a volume at '{prior}' that this deploy "
+            f"cannot clear. Compose still mounts {', '.join(collisions)} there, "
+            "which will either be rejected as a duplicate mount or silently "
+            "shadow the existing volume. Remove the Compose volume too, or "
+            "restore the persistence block."
+        )
+        warnings.append(message)
+        console.print(f"  [yellow]Warning:[/yellow] {message}")
+    return warnings
+
+
+def _deployed_persistence_mounts(payload: Any) -> Dict[str, str]:
+    """Per-service persistence mountPath this run is deploying."""
+    mounts: Dict[str, str] = {}
+    for service in payload.services:
+        persistence = service.persistence
+        if isinstance(persistence, dict) and persistence.get("enabled") is True:
+            mount_path = persistence.get("mountPath")
+            if isinstance(mount_path, str) and mount_path:
+                mounts[service.name] = mount_path
+    return mounts
+
+
+def _under_mount_path(target: str, mount_path: str) -> bool:
+    """Is *target* the persistence mountPath, or nested inside it?"""
+    if not target or not mount_path:
+        return False
+    normalized = target.rstrip("/") or "/"
+    base = mount_path.rstrip("/") or "/"
+    return normalized == base or normalized.startswith(base + "/")
+
+
+def _deployable_service_names(services: Dict[str, Any]) -> List[str]:
+    """Services ``--service`` can name: buildable and not profile-gated."""
+    return sorted(
+        name
+        for name, config in services.items()
+        if isinstance(config, dict) and "build" in config and not config.get("profiles")
     )
-    if known:
-        console.print(f"  [dim]Available: {', '.join(known)}[/dim]")
+
+
+def _fail_service_filter(
+    service: str, reason: str, services: Dict[str, Any]
+) -> None:
+    console.print(f"[red]Error:[/red] --service '{service}' {reason}.")
+    deployable = _deployable_service_names(services)
+    if deployable:
+        console.print(f"  [dim]Available: {', '.join(deployable)}[/dim]")
     raise typer.Exit(code=1)
 
 
@@ -964,6 +1054,10 @@ def run_dev_remote(
         console.print(f"[red]Error:[/red] invalid extension definition: {exc}")
         raise typer.Exit(code=1) from exc
 
+    warn_orphaned_persistence(
+        getattr(prior_state, "last_persistence_mounts", None) or {}, payload
+    )
+
     def _record(step: str) -> None:
         try:
             mark_step(
@@ -983,6 +1077,7 @@ def run_dev_remote(
                 registry=registry,
                 push_registry=push_registry,
                 image_basename=info.image_basename,
+                persistence_mounts=_deployed_persistence_mounts(payload),
                 build_engine=build_engine if step == "build" else "",
             )
         except OSError as state_exc:

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
 import typer
+from pydantic import ValidationError as PydanticValidationError
 from rich.console import Console
 
 console = Console(stderr=True)
@@ -66,7 +67,6 @@ def _build_patch_kwargs(
 def _build_patch_service_specs(
     payload: Any,
     service_filter: Optional[str] = None,
-    clear_persistence_for: Optional[frozenset] = None,
 ) -> List[Any]:
     """Build the per-service ``PatchServiceSpec`` list from a
     ``CreateExtension`` payload, forwarding the new ``x-kamiwaza``
@@ -86,39 +86,11 @@ def _build_patch_service_specs(
     leave the CR's image field at the original repository and produce
     ``ImagePullBackOff`` on the next pull.
     """
-    clear = clear_persistence_for or frozenset()
     return [
-        _build_patch_service_spec(service, clear_persistence=service.name in clear)
+        _build_patch_service_spec(service)
         for service in payload.services
         if service_filter is None or service.name == service_filter
     ]
-
-
-def persistent_service_names(extension: Any) -> frozenset:
-    """Names of services whose *current* CR has persistence enabled.
-
-    Used to decide where a removed compose persistence block must be
-    explicitly cleared. Sending a blanket disable to every service instead
-    would aim a PVC-affecting write at services that never asked for one.
-    """
-    services = getattr(getattr(extension, "spec", None), "services", None)
-    if services is None:
-        services = getattr(extension, "services", None) or []
-    return frozenset(
-        name
-        for service in services
-        if _persistence_is_enabled(service)
-        for name in [getattr(service, "name", None)]
-        if name
-    )
-
-
-def _persistence_is_enabled(service: Any) -> bool:
-    """True when a CR service carries persistence, dict- or model-shaped."""
-    persistence = getattr(service, "persistence", None)
-    if isinstance(persistence, dict):
-        return persistence.get("enabled") is True
-    return getattr(persistence, "enabled", False) is True
 
 
 def _validate_service_filter(
@@ -145,14 +117,7 @@ def _validate_service_filter(
     raise typer.Exit(code=1)
 
 
-def _patch_persistence(service: Any, clear: bool) -> Optional[dict]:
-    """Persistence value for one PATCH: declared, cleared, or untouched."""
-    if service.persistence:
-        return service.persistence
-    return {"enabled": False} if clear else None
-
-
-def _build_patch_service_spec(service: Any, *, clear_persistence: bool = False) -> Any:
+def _build_patch_service_spec(service: Any) -> Any:
     """Translate one create service into its complete PATCH contract."""
     from kamiwaza_extensions.compose_transformer import _split_image_ref
     from kamiwaza_sdk.schemas.extensions import ImagePatch, PatchServiceSpec
@@ -169,14 +134,12 @@ def _build_patch_service_spec(service: Any, *, clear_persistence: bool = False) 
         ),
         env=service.env or None,
         replicas=service.replicas,
-        # Removing an ``x-kamiwaza.persistence`` block must clear the PVC
-        # config on the CR: ``patch_extension`` dumps with
-        # ``exclude_none=True``, so None omits the field and leaves the old
-        # mount able to collide with a Compose volume reintroduced at the
-        # same path. The explicit disable goes *only* to services whose
-        # current CR actually has persistence on — a blanket disable would
-        # aim a PVC-affecting write at services that never requested one.
-        persistence=_patch_persistence(service, clear_persistence),
+        # Sent only when the extension declares it. Clearing a block the
+        # extension removed would need the CR's current spec, and
+        # ``get_extension`` returns a status projection
+        # (``ExtensionServiceStatus``) carrying no persistence — so a removed
+        # block stays on the CR rather than being silently mis-cleared.
+        persistence=service.persistence,
         # Volumes are service-scoped: every service owns a pod template.
         # Empty lists deliberately clear stale Compose volumes on PATCH.
         volumes=service.volumes or [],
@@ -985,14 +948,21 @@ def run_dev_remote(
         info.name, user_id=extract_user_id(token.access_token)
     )
     deployer_email = _decode_email(token.access_token)
-    payload = payload_builder.build(
-        metadata=info.metadata,
-        transformed_compose=transformed,
-        connection=connection,
-        dev_name=dev_name,
-        deployer=deployer_email,
-        revision=rev_tag,
-    )
+    try:
+        payload = payload_builder.build(
+            metadata=info.metadata,
+            transformed_compose=transformed,
+            connection=connection,
+            dev_name=dev_name,
+            deployer=deployer_email,
+            revision=rev_tag,
+        )
+    except (ValueError, PydanticValidationError) as exc:
+        # A malformed persistence or volume declaration would otherwise raise
+        # a raw traceback here — after the whole build and push phase has
+        # already run, with nothing naming the field at fault.
+        console.print(f"[red]Error:[/red] invalid extension definition: {exc}")
+        raise typer.Exit(code=1) from exc
 
     def _record(step: str) -> None:
         try:
@@ -1043,18 +1013,14 @@ def run_dev_remote(
         from kamiwaza_sdk.schemas.extensions import PatchExtension
 
         try:
-            # Check if extension already exists. The response is also the
-            # only view of which services currently hold a PVC, which is
-            # what decides where a removed persistence block gets cleared.
-            existing = client.extensions.get_extension(dev_name)
+            # Check if extension already exists
+            client.extensions.get_extension(dev_name)
 
             # Build patch from payload — extract image, env, replicas
             # plus the x-kamiwaza per-service overrides forwarded via
             # ``extra="allow"`` (jxstanford PR #97 review H2).
             patch_services = _build_patch_service_specs(
-                payload,
-                service_filter=service,
-                clear_persistence_for=persistent_service_names(existing),
+                payload, service_filter=service
             )
             # Carries the deployer/revision/deployed-at annotations on
             # every PATCH so `kz-ext status` reflects the current

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -64,7 +64,9 @@ def _build_patch_kwargs(
 
 
 def _build_patch_service_specs(
-    payload: Any, service_filter: Optional[str] = None
+    payload: Any,
+    service_filter: Optional[str] = None,
+    clear_persistence_for: Optional[frozenset] = None,
 ) -> List[Any]:
     """Build the per-service ``PatchServiceSpec`` list from a
     ``CreateExtension`` payload, forwarding the new ``x-kamiwaza``
@@ -84,14 +86,73 @@ def _build_patch_service_specs(
     leave the CR's image field at the original repository and produce
     ``ImagePullBackOff`` on the next pull.
     """
+    clear = clear_persistence_for or frozenset()
     return [
-        _build_patch_service_spec(service)
+        _build_patch_service_spec(service, clear_persistence=service.name in clear)
         for service in payload.services
         if service_filter is None or service.name == service_filter
     ]
 
 
-def _build_patch_service_spec(service: Any) -> Any:
+def persistent_service_names(extension: Any) -> frozenset:
+    """Names of services whose *current* CR has persistence enabled.
+
+    Used to decide where a removed compose persistence block must be
+    explicitly cleared. Sending a blanket disable to every service instead
+    would aim a PVC-affecting write at services that never asked for one.
+    """
+    services = getattr(getattr(extension, "spec", None), "services", None)
+    if services is None:
+        services = getattr(extension, "services", None) or []
+    return frozenset(
+        name
+        for service in services
+        if _persistence_is_enabled(service)
+        for name in [getattr(service, "name", None)]
+        if name
+    )
+
+
+def _persistence_is_enabled(service: Any) -> bool:
+    """True when a CR service carries persistence, dict- or model-shaped."""
+    persistence = getattr(service, "persistence", None)
+    if isinstance(persistence, dict):
+        return persistence.get("enabled") is True
+    return getattr(persistence, "enabled", False) is True
+
+
+def _validate_service_filter(
+    service: Optional[str], compose_data: Dict[str, Any]
+) -> None:
+    """Reject a ``--service`` name that no compose service answers to.
+
+    Without this the filter yields an empty service list, and the failure
+    surfaces at the very end of the run as a raw pydantic ``min_length``
+    error that never mentions ``--service`` — after the whole build phase
+    has already run.
+    """
+    if service is None:
+        return
+    known = sorted((compose_data.get("services") or {}).keys())
+    if service in known:
+        return
+    console.print(
+        f"[red]Error:[/red] --service '{service}' is not a service in "
+        f"docker-compose.yml."
+    )
+    if known:
+        console.print(f"  [dim]Available: {', '.join(known)}[/dim]")
+    raise typer.Exit(code=1)
+
+
+def _patch_persistence(service: Any, clear: bool) -> Optional[dict]:
+    """Persistence value for one PATCH: declared, cleared, or untouched."""
+    if service.persistence:
+        return service.persistence
+    return {"enabled": False} if clear else None
+
+
+def _build_patch_service_spec(service: Any, *, clear_persistence: bool = False) -> Any:
     """Translate one create service into its complete PATCH contract."""
     from kamiwaza_extensions.compose_transformer import _split_image_ref
     from kamiwaza_sdk.schemas.extensions import ImagePatch, PatchServiceSpec
@@ -109,11 +170,13 @@ def _build_patch_service_spec(service: Any) -> Any:
         env=service.env or None,
         replicas=service.replicas,
         # Removing an ``x-kamiwaza.persistence`` block must clear the PVC
-        # config on the CR. ``patch_extension`` dumps with
-        # ``exclude_none=True``, so sending None would omit the field and
-        # leave the old mount in place — able to collide with a Compose
-        # volume reintroduced at the same path. Send an explicit disable.
-        persistence=service.persistence or {"enabled": False},
+        # config on the CR: ``patch_extension`` dumps with
+        # ``exclude_none=True``, so None omits the field and leaves the old
+        # mount able to collide with a Compose volume reintroduced at the
+        # same path. The explicit disable goes *only* to services whose
+        # current CR actually has persistence on — a blanket disable would
+        # aim a PVC-affecting write at services that never requested one.
+        persistence=_patch_persistence(service, clear_persistence),
         # Volumes are service-scoped: every service owns a pod template.
         # Empty lists deliberately clear stale Compose volumes on PATCH.
         volumes=service.volumes or [],
@@ -411,6 +474,8 @@ def run_dev_remote(
     if info.compose_data is None:
         console.print("[red]Error:[/red] No docker-compose.yml found.")
         raise typer.Exit(code=1)
+
+    _validate_service_filter(service, info.compose_data)
 
     # 2. Resolve connection + auth
     conn_mgr = ConnectionManager()
@@ -978,13 +1043,19 @@ def run_dev_remote(
         from kamiwaza_sdk.schemas.extensions import PatchExtension
 
         try:
-            # Check if extension already exists
-            client.extensions.get_extension(dev_name)
+            # Check if extension already exists. The response is also the
+            # only view of which services currently hold a PVC, which is
+            # what decides where a removed persistence block gets cleared.
+            existing = client.extensions.get_extension(dev_name)
 
             # Build patch from payload — extract image, env, replicas
             # plus the x-kamiwaza per-service overrides forwarded via
             # ``extra="allow"`` (jxstanford PR #97 review H2).
-            patch_services = _build_patch_service_specs(payload, service_filter=service)
+            patch_services = _build_patch_service_specs(
+                payload,
+                service_filter=service,
+                clear_persistence_for=persistent_service_names(existing),
+            )
             # Carries the deployer/revision/deployed-at annotations on
             # every PATCH so `kz-ext status` reflects the current
             # redeploy (review re-review PR #84 H1).

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -60,25 +60,20 @@ def _build_patch_kwargs(
     sandbox = extra.get("sandbox")
     if sandbox:
         kwargs["sandbox"] = sandbox
-    # Always forward ``volumes`` (even when empty) so removing a named
-    # volume from compose actually clears the stale top-level volume on
-    # the persisted CR. Same iterative-dev contract that drives the
-    # ``kamiwaza``/annotations forwarding above.
-    #
-    # Safe against operator-managed mounts: the kamiwaza-extension-
-    # operator rebuilds each Deployment's volume list every reconcile as
-    # ``[tmp emptyDir] + (data PVC if persistence) + svc.Volumes``. The
-    # ``tmp``/``data`` volumes are injected at reconcile time and are
-    # never stored in ``svc.Volumes``, so PATCHing ``volumes: []`` clears
-    # only user-declared volumes and cannot wipe operator-managed ones.
-    kwargs["volumes"] = extra.get("volumes") or []
     return kwargs
 
 
-def _build_patch_service_specs(payload: Any) -> List[Any]:
+def _build_patch_service_specs(
+    payload: Any, service_filter: Optional[str] = None
+) -> List[Any]:
     """Build the per-service ``PatchServiceSpec`` list from a
     ``CreateExtension`` payload, forwarding the new ``x-kamiwaza``
     per-service overrides via ``extra="allow"``.
+
+    When ``--service`` is active, only that service is included. The
+    transformer assigns the new revision to every build-context service, but
+    only the selected image is built and pushed; PATCHing the siblings would
+    roll them to nonexistent tags and produce ``ImagePullBackOff``.
 
     The PATCH carries the full ``(registry, repository, tag)`` triple
     from the canonical image ref. The operator reconstructs the CR's
@@ -89,42 +84,45 @@ def _build_patch_service_specs(payload: Any) -> List[Any]:
     leave the CR's image field at the original repository and produce
     ``ImagePullBackOff`` on the next pull.
     """
+    return [
+        _build_patch_service_spec(service)
+        for service in payload.services
+        if service_filter is None or service.name == service_filter
+    ]
+
+
+def _build_patch_service_spec(service: Any) -> Any:
+    """Translate one create service into its complete PATCH contract."""
     from kamiwaza_extensions.compose_transformer import _split_image_ref
     from kamiwaza_sdk.schemas.extensions import ImagePatch, PatchServiceSpec
 
-    patch_services: List[Any] = []
-    for svc in payload.services:
-        registry, repository, tag = _split_image_ref(svc.image)
-        image_patch = ImagePatch(
+    registry, repository, tag = _split_image_ref(service.image)
+    _image_without_digest, separator, digest = service.image.partition("@")
+    spec = PatchServiceSpec(
+        name=service.name,
+        image=ImagePatch(
             tag=tag,
             registry=registry,
             repository=repository,
-        )
-        spec = PatchServiceSpec(
-            name=svc.name,
-            image=image_patch,
-        )
-        if svc.env:
-            spec.env = svc.env
-        if svc.replicas is not None:
-            spec.replicas = svc.replicas
-        svc_extra = svc.model_extra or {}
-        for field in (
-            "healthCheck",
-            "automountServiceAccountToken",
-            "containerSecurityContext",
-        ):
-            if field in svc_extra and svc_extra[field] is not None:
-                setattr(spec, field, svc_extra[field])
-        # Always forward ``volumeMounts`` (even when empty) so removing
-        # a volume from compose clears the stale per-service mount on
-        # the persisted CR; consistent with the top-level ``volumes``
-        # forwarding in ``_build_patch_kwargs``. The operator appends
-        # ``svc.VolumeMounts`` after its own ``tmp``/``data`` mounts, so
-        # an empty list clears only user-declared mounts.
-        spec.volumeMounts = svc_extra.get("volumeMounts") or []
-        patch_services.append(spec)
-    return patch_services
+            digest=digest if separator else None,
+        ),
+        env=service.env or None,
+        replicas=service.replicas,
+        persistence=service.persistence,
+        # Volumes are service-scoped: every service owns a pod template.
+        # Empty lists deliberately clear stale Compose volumes on PATCH.
+        volumes=service.volumes or [],
+        volumeMounts=service.volume_mounts or [],
+    )
+    for field in (
+        "healthCheck",
+        "automountServiceAccountToken",
+        "containerSecurityContext",
+    ):
+        value = (service.model_extra or {}).get(field)
+        if value is not None:
+            setattr(spec, field, value)
+    return spec
 
 
 def _resume_revision(prior_state: Any, rev_tag: str, resumable: bool) -> Optional[str]:
@@ -981,7 +979,7 @@ def run_dev_remote(
             # Build patch from payload — extract image, env, replicas
             # plus the x-kamiwaza per-service overrides forwarded via
             # ``extra="allow"`` (jxstanford PR #97 review H2).
-            patch_services = _build_patch_service_specs(payload)
+            patch_services = _build_patch_service_specs(payload, service_filter=service)
             # Carries the deployer/revision/deployed-at annotations on
             # every PATCH so `kz-ext status` reflects the current
             # redeploy (review re-review PR #84 H1).
@@ -1299,7 +1297,9 @@ def run_dev_unload() -> None:
             "(the template had no upstream catalog entry)."
         )
     else:
-        console.print(f"  [green]✓[/green] Removed overlay for [bold]{info.name}[/bold].")
+        console.print(
+            f"  [green]✓[/green] Removed overlay for [bold]{info.name}[/bold]."
+        )
     console.print(
         "  [dim]The running dev extension instance is unaffected — only new "
         "workroom launches change.[/dim]"

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -167,10 +167,19 @@ def warn_orphaned_persistence(
     return warnings
 
 
-def _deployed_persistence_mounts(payload: Any) -> Dict[str, str]:
-    """Per-service persistence mountPath this run is deploying."""
+def _deployed_persistence_mounts(
+    payload: Any, service_filter: Optional[str] = None
+) -> Dict[str, str]:
+    """Per-service persistence mountPath this run applied to the CR.
+
+    Only services this run actually PATCHed are reported: under ``--service``
+    the siblings were never sent, so recording their layout as deployed would
+    claim something this run did not do.
+    """
     mounts: Dict[str, str] = {}
     for service in payload.services:
+        if service_filter is not None and service.name != service_filter:
+            continue
         persistence = service.persistence
         if isinstance(persistence, dict) and persistence.get("enabled") is True:
             mount_path = persistence.get("mountPath")
@@ -1077,7 +1086,7 @@ def run_dev_remote(
                 registry=registry,
                 push_registry=push_registry,
                 image_basename=info.image_basename,
-                persistence_mounts=_deployed_persistence_mounts(payload),
+                persistence_mounts=_deployed_persistence_mounts(payload, service),
                 build_engine=build_engine if step == "build" else "",
             )
         except OSError as state_exc:

--- a/kamiwaza_extensions/commands/dev.py
+++ b/kamiwaza_extensions/commands/dev.py
@@ -108,7 +108,12 @@ def _build_patch_service_spec(service: Any) -> Any:
         ),
         env=service.env or None,
         replicas=service.replicas,
-        persistence=service.persistence,
+        # Removing an ``x-kamiwaza.persistence`` block must clear the PVC
+        # config on the CR. ``patch_extension`` dumps with
+        # ``exclude_none=True``, so sending None would omit the field and
+        # leave the old mount in place — able to collide with a Compose
+        # volume reintroduced at the same path. Send an explicit disable.
+        persistence=service.persistence or {"enabled": False},
         # Volumes are service-scoped: every service owns a pod template.
         # Empty lists deliberately clear stale Compose volumes on PATCH.
         volumes=service.volumes or [],

--- a/kamiwaza_extensions/compose_volumes.py
+++ b/kamiwaza_extensions/compose_volumes.py
@@ -1,0 +1,151 @@
+"""Translate Docker Compose named volumes to extension service pod specs."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from kamiwaza_extensions.volume_utils import looks_like_host_path
+
+_DNS_LABEL_RE = re.compile(r"[^a-z0-9-]+")
+_OPERATOR_VOLUME_NAMES = frozenset({"tmp", "data"})
+
+
+@dataclass(frozen=True)
+class ServiceVolumeSpec:
+    """Volumes and mounts owned by one service pod template."""
+
+    volumes: List[Dict[str, Any]]
+    mounts: List[Dict[str, Any]]
+
+
+def build_service_volume_specs(
+    transformed: Dict[str, Any],
+) -> Dict[str, ServiceVolumeSpec]:
+    """Build service-scoped K8s volume specs from transformed Compose."""
+    specs: Dict[str, ServiceVolumeSpec] = {}
+    for service_name, service in (transformed.get("services") or {}).items():
+        if not isinstance(service, dict):
+            continue
+        spec = _build_service_volume_spec(service)
+        if spec.volumes or spec.mounts:
+            specs[service_name] = spec
+    return specs
+
+
+def _build_service_volume_spec(service: Dict[str, Any]) -> ServiceVolumeSpec:
+    volumes: List[Dict[str, Any]] = []
+    mounts: List[Dict[str, Any]] = []
+    source_to_name: Dict[str, str] = {}
+    used_names = set(_OPERATOR_VOLUME_NAMES)
+    persistence_mount = _persistence_mount_path(service)
+
+    for raw_volume in service.get("volumes", []) or []:
+        parsed = _parse_named_volume_mount(raw_volume)
+        if parsed is None:
+            continue
+        source, target, read_only = parsed
+        if target.rstrip("/") == persistence_mount:
+            continue
+
+        volume_name = source_to_name.get(source)
+        if volume_name is None:
+            volume_name = _unique_k8s_volume_name(source, used_names)
+            source_to_name[source] = volume_name
+            volumes.append({"name": volume_name, "emptyDir": {}})
+        mounts.append(_volume_mount(volume_name, target, read_only))
+
+    return ServiceVolumeSpec(volumes=volumes, mounts=mounts)
+
+
+def _persistence_mount_path(service: Dict[str, Any]) -> str:
+    extension = service.get("x-kamiwaza")
+    if not isinstance(extension, dict):
+        return ""
+    persistence = extension.get("persistence")
+    if not isinstance(persistence, dict) or persistence.get("enabled") is not True:
+        return ""
+    return str(persistence.get("mountPath", "")).rstrip("/")
+
+
+def _volume_mount(name: str, target: str, read_only: bool) -> Dict[str, Any]:
+    mount: Dict[str, Any] = {"name": name, "mountPath": target}
+    if read_only:
+        mount["readOnly"] = True
+    return mount
+
+
+def _parse_named_volume_mount(raw_volume: Any) -> Optional[tuple[str, str, bool]]:
+    """Return ``(source, target, read_only)`` for a named Compose volume."""
+    if isinstance(raw_volume, dict):
+        return _parse_long_volume_mount(raw_volume)
+    return _parse_short_volume_mount(raw_volume)
+
+
+def _parse_short_volume_mount(
+    raw_volume: Any,
+) -> Optional[tuple[str, str, bool]]:
+    if not isinstance(raw_volume, str):
+        return None
+    parts = raw_volume.split(":")
+    if len(parts) < 2:
+        return None
+    source, target = parts[0], parts[1]
+    if not _valid_named_mount(source, target):
+        return None
+    return source, target, _short_mount_is_read_only(parts)
+
+
+def _short_mount_is_read_only(parts: List[str]) -> bool:
+    modes = ",".join(parts[2:]).split(",") if len(parts) > 2 else []
+    return any(mode.strip().lower() == "ro" for mode in modes)
+
+
+def _parse_long_volume_mount(
+    raw_volume: Dict[str, Any],
+) -> Optional[tuple[str, str, bool]]:
+    values = _long_volume_values(raw_volume)
+    if values is None:
+        return None
+
+    source_str, target_str = values
+    if not _valid_named_mount(source_str, target_str):
+        return None
+    read_only = bool(raw_volume.get("read_only") or raw_volume.get("readOnly"))
+    return source_str, target_str, read_only
+
+
+def _long_volume_values(
+    raw_volume: Dict[str, Any],
+) -> Optional[tuple[str, str]]:
+    if raw_volume.get("type", "volume") != "volume":
+        return None
+    source = _first_value(raw_volume, "source", "src")
+    target = _first_value(raw_volume, "target", "destination", "dst")
+    if source is None or target is None:
+        return None
+    return str(source), str(target)
+
+
+def _first_value(values: Dict[str, Any], *keys: str) -> Any:
+    return next((values[key] for key in keys if values.get(key)), None)
+
+
+def _valid_named_mount(source: str, target: str) -> bool:
+    if not source or not target.startswith("/"):
+        return False
+    return not looks_like_host_path(source)
+
+
+def _unique_k8s_volume_name(source: str, used_names: set[str]) -> str:
+    base = _DNS_LABEL_RE.sub("-", source.lower()).strip("-")
+    base = base[:63].strip("-") or "volume"
+    name = base
+    counter = 2
+    while name in used_names:
+        suffix = f"-{counter}"
+        name = f"{base[: 63 - len(suffix)].rstrip('-')}{suffix}"
+        counter += 1
+    used_names.add(name)
+    return name

--- a/kamiwaza_extensions/compose_volumes.py
+++ b/kamiwaza_extensions/compose_volumes.py
@@ -90,11 +90,24 @@ def _persistence_mount_path(service: Dict[str, Any]) -> str:
     persistence = extension.get("persistence")
     if not isinstance(persistence, dict) or persistence.get("enabled") is not True:
         return ""
-    mount_path = str(persistence.get("mountPath", "")).strip().rstrip("/")
+
+    raw = persistence.get("mountPath")
+    # ``mountPath:`` with no value parses to None. Stringifying first would
+    # yield the truthy "None" and sail past every check below, so reject it
+    # before it can become a string.
+    mount_path = raw.strip().rstrip("/") if isinstance(raw, str) else ""
     if not mount_path:
         raise ValueError(
             "x-kamiwaza.persistence.enabled is true but mountPath is missing. "
-            "Set mountPath to the directory the PVC should back."
+            "Set mountPath to the absolute directory the PVC should back."
+        )
+    # Compose targets are absolute, so a relative mountPath can never match
+    # one — the guard would silently pass and an emptyDir would land on top
+    # of the PVC. That is the failure this module exists to prevent.
+    if not mount_path.startswith("/"):
+        raise ValueError(
+            "x-kamiwaza.persistence.mountPath must be an absolute path, "
+            f"got {mount_path!r}."
         )
     return mount_path
 

--- a/kamiwaza_extensions/compose_volumes.py
+++ b/kamiwaza_extensions/compose_volumes.py
@@ -95,7 +95,7 @@ def persistence_mount_path(persistence: Any) -> str:
             so the guard would pass silently and an emptyDir would land on the
             path the PVC is meant to back.
     """
-    if not isinstance(persistence, dict) or persistence.get("enabled") is not True:
+    if not isinstance(persistence, dict) or not _persistence_enabled(persistence):
         return ""
 
     raw = persistence.get("mountPath")
@@ -114,6 +114,26 @@ def persistence_mount_path(persistence: Any) -> str:
             f"got {mount_path!r}."
         )
     return mount_path
+
+
+def _persistence_enabled(persistence: Dict[str, Any]) -> bool:
+    """Is persistence switched on? Absent means no; non-bool is an error.
+
+    A truthy string would disarm the volume guard here while the platform
+    coerces it and provisions the PVC anyway, putting an emptyDir over the
+    claim. The sibling SANDBOX_PERSISTENCE flag does accept "true"/"1"/"yes",
+    so this is a shape an author can reach honestly — say so rather than
+    silently ignore it.
+    """
+    enabled = persistence.get("enabled")
+    if enabled is None:
+        return False
+    if not isinstance(enabled, bool):
+        raise ValueError(
+            "persistence.enabled must be a boolean (true/false, unquoted), "
+            f"got {enabled!r}."
+        )
+    return enabled
 
 
 def _volume_mount(name: str, target: str, read_only: bool) -> Dict[str, Any]:

--- a/kamiwaza_extensions/compose_volumes.py
+++ b/kamiwaza_extensions/compose_volumes.py
@@ -46,7 +46,7 @@ def _build_service_volume_spec(service: Dict[str, Any]) -> ServiceVolumeSpec:
         if parsed is None:
             continue
         source, target, read_only = parsed
-        if target.rstrip("/") == persistence_mount:
+        if _covered_by_persistence(target, persistence_mount):
             continue
 
         volume_name = source_to_name.get(source)
@@ -59,14 +59,44 @@ def _build_service_volume_spec(service: Dict[str, Any]) -> ServiceVolumeSpec:
     return ServiceVolumeSpec(volumes=volumes, mounts=mounts)
 
 
+def _covered_by_persistence(target: str, persistence_mount: str) -> bool:
+    """Is this Compose target already served by the service's PVC mount?
+
+    Exact equality is not enough: the stock Postgres layout declares
+    ``pgdata:/var/lib/postgresql/data`` under a ``/var/lib/postgresql``
+    persistence mount, and an emptyDir at the nested path would shadow the
+    PVC subtree the volume exists to persist.
+    """
+    if not persistence_mount:
+        return False
+    normalized = target.rstrip("/") or "/"
+    return normalized == persistence_mount or normalized.startswith(
+        persistence_mount + "/"
+    )
+
+
 def _persistence_mount_path(service: Dict[str, Any]) -> str:
+    """Return the service's declared persistence mountPath, if it has one.
+
+    Raises:
+        ValueError: When persistence is enabled without a mountPath. The
+            operator provisions the PVC but mounts it nowhere, so translating
+            the Compose volumes would emit an emptyDir at the path the author
+            meant to persist — silently, and with the PVC left dangling.
+    """
     extension = service.get("x-kamiwaza")
     if not isinstance(extension, dict):
         return ""
     persistence = extension.get("persistence")
     if not isinstance(persistence, dict) or persistence.get("enabled") is not True:
         return ""
-    return str(persistence.get("mountPath", "")).rstrip("/")
+    mount_path = str(persistence.get("mountPath", "")).strip().rstrip("/")
+    if not mount_path:
+        raise ValueError(
+            "x-kamiwaza.persistence.enabled is true but mountPath is missing. "
+            "Set mountPath to the directory the PVC should back."
+        )
+    return mount_path
 
 
 def _volume_mount(name: str, target: str, read_only: bool) -> Dict[str, Any]:

--- a/kamiwaza_extensions/compose_volumes.py
+++ b/kamiwaza_extensions/compose_volumes.py
@@ -22,24 +22,35 @@ class ServiceVolumeSpec:
 
 def build_service_volume_specs(
     transformed: Dict[str, Any],
+    persistence_by_service: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, ServiceVolumeSpec]:
-    """Build service-scoped K8s volume specs from transformed Compose."""
+    """Build service-scoped K8s volume specs from transformed Compose.
+
+    ``persistence_by_service`` carries the persistence block already resolved
+    by the caller, which is what decides whether a Compose volume is left to
+    the PVC. Resolving it here instead would read Compose only, and a
+    persistence block declared in ``kamiwaza.json`` would arm no guard — the
+    service would ship a PVC and an emptyDir over the same path.
+    """
+    resolved = persistence_by_service or {}
     specs: Dict[str, ServiceVolumeSpec] = {}
     for service_name, service in (transformed.get("services") or {}).items():
         if not isinstance(service, dict):
             continue
-        spec = _build_service_volume_spec(service)
+        spec = _build_service_volume_spec(service, resolved.get(service_name))
         if spec.volumes or spec.mounts:
             specs[service_name] = spec
     return specs
 
 
-def _build_service_volume_spec(service: Dict[str, Any]) -> ServiceVolumeSpec:
+def _build_service_volume_spec(
+    service: Dict[str, Any], persistence: Any = None
+) -> ServiceVolumeSpec:
     volumes: List[Dict[str, Any]] = []
     mounts: List[Dict[str, Any]] = []
     source_to_name: Dict[str, str] = {}
     used_names = set(_OPERATOR_VOLUME_NAMES)
-    persistence_mount = _persistence_mount_path(service)
+    persistence_mount = persistence_mount_path(persistence)
 
     for raw_volume in service.get("volumes", []) or []:
         parsed = _parse_named_volume_mount(raw_volume)
@@ -75,19 +86,15 @@ def _covered_by_persistence(target: str, persistence_mount: str) -> bool:
     )
 
 
-def _persistence_mount_path(service: Dict[str, Any]) -> str:
-    """Return the service's declared persistence mountPath, if it has one.
+def persistence_mount_path(persistence: Any) -> str:
+    """Return the mountPath an already-resolved persistence block requests.
 
     Raises:
-        ValueError: When persistence is enabled without a mountPath. The
-            operator provisions the PVC but mounts it nowhere, so translating
-            the Compose volumes would emit an emptyDir at the path the author
-            meant to persist — silently, and with the PVC left dangling.
+        ValueError: When persistence is enabled but the mountPath is missing
+            or not absolute. Either way it can never match a Compose target,
+            so the guard would pass silently and an emptyDir would land on the
+            path the PVC is meant to back.
     """
-    extension = service.get("x-kamiwaza")
-    if not isinstance(extension, dict):
-        return ""
-    persistence = extension.get("persistence")
     if not isinstance(persistence, dict) or persistence.get("enabled") is not True:
         return ""
 
@@ -98,15 +105,12 @@ def _persistence_mount_path(service: Dict[str, Any]) -> str:
     mount_path = raw.strip().rstrip("/") if isinstance(raw, str) else ""
     if not mount_path:
         raise ValueError(
-            "x-kamiwaza.persistence.enabled is true but mountPath is missing. "
+            "persistence.enabled is true but mountPath is missing. "
             "Set mountPath to the absolute directory the PVC should back."
         )
-    # Compose targets are absolute, so a relative mountPath can never match
-    # one — the guard would silently pass and an emptyDir would land on top
-    # of the PVC. That is the failure this module exists to prevent.
     if not mount_path.startswith("/"):
         raise ValueError(
-            "x-kamiwaza.persistence.mountPath must be an absolute path, "
+            "persistence.mountPath must be an absolute path, "
             f"got {mount_path!r}."
         )
     return mount_path

--- a/kamiwaza_extensions/dev_state.py
+++ b/kamiwaza_extensions/dev_state.py
@@ -203,8 +203,15 @@ def mark_step(
     state.last_registry = registry
     state.last_push_registry = push_registry or registry
     state.last_image_basename = image_basename
-    if persistence_mounts is not None:
-        state.last_persistence_mounts = persistence_mounts
+    # Only the apply step knows the CR moved, and the record is sticky: a
+    # service that stopped declaring persistence keeps its entry, because the
+    # PATCH cannot clear the CR's block and the warning must keep firing. A
+    # ``--service`` run touches only the service it patched.
+    if persistence_mounts is not None and step == "apply":
+        state.last_persistence_mounts = {
+            **state.last_persistence_mounts,
+            **persistence_mounts,
+        }
     # Only overwrite ``last_build_engine`` on the build step; later steps
     # leave the recorded engine alone so a resume sees the engine that
     # actually built the image, not whichever one happened to push.

--- a/kamiwaza_extensions/dev_state.py
+++ b/kamiwaza_extensions/dev_state.py
@@ -15,10 +15,10 @@ from __future__ import annotations
 
 import json
 import os
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 DEV_STATE_DIR = ".kz-ext"
 DEV_STATE_FILE = "dev-state.json"
@@ -53,6 +53,12 @@ class DevState:
     # `--revision` must invalidate resume — otherwise we'd skip
     # build/push and deploy an image ref that was never built or pushed.
     last_image_basename: Optional[str] = None
+    # Per-service persistence mountPath deployed on the last run. The CR keeps
+    # a persistence block the extension has since removed — ``get_extension``
+    # returns only status, so the CR's own spec is unreadable from here — and
+    # the next PATCH would send a Compose emptyDir at the same path. This
+    # records enough to warn about that collision.
+    last_persistence_mounts: Dict[str, str] = field(default_factory=dict)
     # Engine ("docker" / "podman") used by the prior build. Docker and
     # Podman keep separate image stores, so a ``--no-build`` resume that
     # would push with a different engine would call `podman tag <image>`
@@ -164,6 +170,7 @@ def mark_step(
     push_registry: str = "",
     image_basename: Optional[str] = None,
     build_engine: str = "",
+    persistence_mounts: Optional[Dict[str, str]] = None,
 ) -> DevState:
     """Update the dev-state to record completion of ``step``.
 
@@ -196,6 +203,8 @@ def mark_step(
     state.last_registry = registry
     state.last_push_registry = push_registry or registry
     state.last_image_basename = image_basename
+    if persistence_mounts is not None:
+        state.last_persistence_mounts = persistence_mounts
     # Only overwrite ``last_build_engine`` on the build step; later steps
     # leave the recorded engine alone so a resume sees the engine that
     # actually built the image, not whichever one happened to push.

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -288,6 +288,7 @@ class PayloadBuilder:
                 spec_kwargs,
                 svc,
                 service_volume_specs.get(svc_name),
+                _resolve_persistence(metadata, svc_name, svc),
             )
 
             specs.append(ExtensionServiceSpec(**spec_kwargs))
@@ -679,22 +680,41 @@ def _add_service_overrides(
     spec: Dict[str, Any],
     service: Dict[str, Any],
     volume_spec: Optional[ServiceVolumeSpec],
+    persistence: Optional[Any] = None,
 ) -> None:
     """Add operator-owned per-service fields to one service payload."""
     for field in (
         "automountServiceAccountToken",
         "containerSecurityContext",
-        "persistence",
     ):
         value = _service_extension_field(service, field)
         if value is not None:
             spec[field] = value
+    if persistence is not None:
+        spec["persistence"] = persistence
     if volume_spec is None:
         return
     if volume_spec.volumes:
         spec["volumes"] = volume_spec.volumes
     if volume_spec.mounts:
         spec["volumeMounts"] = volume_spec.mounts
+
+
+def _resolve_persistence(
+    metadata: Optional[Dict[str, Any]],
+    svc_name: str,
+    service: Dict[str, Any],
+) -> Optional[Any]:
+    """Persistence for one service, kamiwaza.json ahead of compose.
+
+    Mirrors the healthCheck precedence (ENG-4832) so an extension can declare
+    its PVC in the file that is already the source of catalog truth, without
+    the compose-only path overriding it on every redeploy.
+    """
+    from_metadata = _metadata_service_field(metadata, svc_name, "persistence")
+    if from_metadata is not None:
+        return from_metadata
+    return _service_extension_field(service, "persistence")
 
 
 def _metadata_service_field(

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -24,9 +24,12 @@ from kamiwaza_sdk.schemas.extensions import (
 )
 
 from kamiwaza_extensions.compose_transformer import detect_service_url_rewrites
+from kamiwaza_extensions.compose_volumes import (
+    ServiceVolumeSpec,
+    build_service_volume_specs,
+)
 from kamiwaza_extensions.connections import ConnectionInfo
 from kamiwaza_extensions.validators.compose import INVALID_DEPLOY_REQUESTS_TEXT
-from kamiwaza_extensions.volume_utils import looks_like_host_path
 
 # CRD annotation keys — namespace is ``kamiwaza.io/*`` (NOT ``kamiwaza.ai/*``).
 # The platform's annotation persister filters incoming Extension CR annotations
@@ -72,104 +75,6 @@ def _compose_resources_to_k8s(resources: Dict[str, str]) -> Dict[str, str]:
     return out
 
 
-_DNS_LABEL_RE = re.compile(r"[^a-z0-9-]+")
-
-
-def _build_volume_specs(
-    transformed: Dict[str, Any],
-) -> tuple[List[Dict[str, Any]], Dict[str, List[Dict[str, Any]]]]:
-    """Translate named compose volumes to K8s emptyDir volumes and mounts."""
-    volumes: List[Dict[str, Any]] = []
-    mounts_by_service: Dict[str, List[Dict[str, Any]]] = {}
-    source_to_name: Dict[str, str] = {}
-    # Pre-reserve the operator-injected volume names. The kamiwaza-
-    # extension-operator rebuilds each Deployment's volume list as
-    # ``[tmp emptyDir] + (data PVC if persistence) + svc.Volumes``; if a
-    # user's compose volume normalizes to ``tmp`` or ``data``, the
-    # reconciled pod would carry duplicate volume names and the K8s API
-    # would reject the spec. Seeding the set forces such a volume to a
-    # collision-suffixed name (``tmp-2``/``data-2``).
-    used_names: set[str] = {"tmp", "data"}
-
-    for svc_name, svc in (transformed.get("services") or {}).items():
-        if not isinstance(svc, dict):
-            continue
-        mounts: List[Dict[str, Any]] = []
-        for raw_volume in svc.get("volumes", []) or []:
-            parsed = _parse_named_volume_mount(raw_volume)
-            if not parsed:
-                continue
-            source, target, read_only = parsed
-            if source not in source_to_name:
-                name = _unique_k8s_volume_name(source, used_names)
-                source_to_name[source] = name
-                volumes.append({"name": name, "emptyDir": {}})
-
-            mount: Dict[str, Any] = {
-                "name": source_to_name[source],
-                "mountPath": target,
-            }
-            if read_only:
-                mount["readOnly"] = True
-            mounts.append(mount)
-        if mounts:
-            mounts_by_service[svc_name] = mounts
-
-    return volumes, mounts_by_service
-
-
-def _parse_named_volume_mount(raw_volume: Any) -> Optional[tuple[str, str, bool]]:
-    """Return ``(source, target, read_only)`` for named compose volumes."""
-    if isinstance(raw_volume, dict):
-        volume_type = raw_volume.get("type", "volume")
-        source = raw_volume.get("source") or raw_volume.get("src")
-        target = (
-            raw_volume.get("target")
-            or raw_volume.get("destination")
-            or raw_volume.get("dst")
-        )
-        if volume_type != "volume" or not source or not target:
-            return None
-        source_str = str(source)
-        target_str = str(target)
-        if looks_like_host_path(source_str) or not target_str.startswith("/"):
-            return None
-        read_only = bool(raw_volume.get("read_only") or raw_volume.get("readOnly"))
-        return source_str, target_str, read_only
-
-    if not isinstance(raw_volume, str):
-        return None
-
-    parts = raw_volume.split(":")
-    if len(parts) < 2:
-        return None
-    source, target = parts[0], parts[1]
-    if not source or not target or not target.startswith("/"):
-        return None
-    if looks_like_host_path(source):
-        return None
-
-    modes = ",".join(parts[2:]).split(",") if len(parts) > 2 else []
-    read_only = any(mode.strip().lower() == "ro" for mode in modes)
-    return source, target, read_only
-
-
-def _unique_k8s_volume_name(source: str, used_names: set[str]) -> str:
-    base = _DNS_LABEL_RE.sub("-", source.lower()).strip("-")
-    if not base:
-        base = "volume"
-    base = base[:63].strip("-") or "volume"
-    name = base
-    counter = 2
-    while name in used_names:
-        suffix = f"-{counter}"
-        prefix_len = 63 - len(suffix)
-        name = f"{base[:prefix_len].rstrip('-')}{suffix}"
-        counter += 1
-    used_names.add(name)
-    return name
-
-
 class PayloadBuilder:
     """Build a ``CreateExtension`` request from extension metadata and
     a transformed compose dict."""
@@ -197,15 +102,12 @@ class PayloadBuilder:
         # ``tlsRejectUnauthorized`` spec field so the deployed
         # extension's in-cluster callbacks match the developer's intent.
         verify_ssl = connection.effective_verify_ssl()
-        volumes, service_volume_mounts = _build_volume_specs(transformed_compose)
-
         services = self._build_services(
             transformed_compose,
             app_path=app_path,
             verify_ssl=verify_ssl,
             extension_type=ext_type,
             metadata=metadata,
-            service_volume_mounts=service_volume_mounts,
         )
         origin = connection.url.removesuffix("/api")
         tls_reject = "0" if not verify_ssl else "1"
@@ -232,8 +134,6 @@ class PayloadBuilder:
         sandbox = self._build_sandbox_spec(metadata, transformed_compose)
         if sandbox:
             kwargs["sandbox"] = sandbox
-        if volumes:
-            kwargs["volumes"] = volumes
 
         annotations = self.build_annotations(deployer=deployer, revision=revision)
 
@@ -347,24 +247,12 @@ class PayloadBuilder:
         verify_ssl: bool = True,
         extension_type: str = "app",
         metadata: Optional[Dict[str, Any]] = None,
-        service_volume_mounts: Optional[Dict[str, List[Dict[str, Any]]]] = None,
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
-        service_volume_mounts = service_volume_mounts or {}
+        service_volume_specs = build_service_volume_specs(transformed)
         specs: List[ExtensionServiceSpec] = []
 
-        # Determine primary service: prefer "frontend", fall back to first with ports
-        primary_name = None
-        for svc_name, svc in services_dict.items():
-            ports = self._parse_ports(svc.get("ports", []))
-            if svc_name == "frontend" and ports:
-                primary_name = svc_name
-                break
-        if primary_name is None:
-            for svc_name, svc in services_dict.items():
-                if self._parse_ports(svc.get("ports", [])):
-                    primary_name = svc_name
-                    break
+        primary_name = self._find_primary_service(services_dict)
 
         for svc_name, svc in services_dict.items():
             ports = self._parse_ports(svc.get("ports", []))
@@ -372,51 +260,18 @@ class PayloadBuilder:
             resources = self._parse_resources(svc)
 
             is_primary = svc_name == primary_name
-
-            # Inject platform env vars
-            if is_primary and app_path:
-                env.append({"name": "KAMIWAZA_APP_PATH", "value": app_path})
-            if not verify_ssl:
-                # K8s rule: explicit ``env`` wins over ``envFrom``
-                # (ConfigMap injection). Inject BOTH conventional
-                # variables explicitly so the deployed pod sees the
-                # relaxed setting regardless of what the operator
-                # writes into ``KAMIWAZA_TLS_REJECT_UNAUTHORIZED`` in
-                # the configmap. Mirrors what the legacy ``make
-                # kamiwaza-push`` flow did — that CR was the empirical
-                # proof point that explicit env beats configmap-via-spec
-                # round-trip and is the reliable mechanism.
-                #
-                # - ``KAMIWAZA_VERIFY_SSL=false`` for the Python SDK
-                #   client (``_verify_ssl_disabled_from_env``).
-                # - ``KAMIWAZA_TLS_REJECT_UNAUTHORIZED=0`` for code that
-                #   reads the Node.js convention (frontend proxy + many
-                #   backend HTTP clients that prefer this var).
-                env.append({"name": "KAMIWAZA_VERIFY_SSL", "value": "false"})
-                env.append({"name": "KAMIWAZA_TLS_REJECT_UNAUTHORIZED", "value": "0"})
-
-            # Health-check precedence (ENG-4832):
-            # 1. ``kamiwaza.json`` → ``services.<svc_name>.healthCheck`` —
-            #    the user-facing escape hatch for any tool/service extension
-            #    whose primary doesn't serve ``/sse`` (FastMCP feature-flagged
-            #    off, REST-only, gRPC-only). Lives in the metadata file
-            #    rather than compose so kamiwaza.json stays the single
-            #    source of catalog truth.
-            # 2. Compose ``x-kamiwaza.healthCheck`` — pre-existing override
-            #    path for compose-authored extensions.
-            # 3. ``_default_health_check`` heuristics — back-compat default
-            #    when neither override is set.
-            health_check = _metadata_service_field(metadata, svc_name, "healthCheck")
-            if not health_check:
-                health_check = _service_extension_field(svc, "healthCheck")
-            if not health_check:
-                health_check = self._default_health_check(
+            self._append_platform_env(env, is_primary, app_path, verify_ssl)
+            health_check = (
+                _metadata_service_field(metadata, svc_name, "healthCheck")
+                or _service_extension_field(svc, "healthCheck")
+                or self._default_health_check(
                     svc_name,
                     svc,
                     ports,
                     extension_type=extension_type,
                     is_primary=is_primary,
                 )
+            )
 
             spec_kwargs: Dict[str, Any] = dict(
                 name=svc_name,
@@ -429,21 +284,48 @@ class PayloadBuilder:
             )
             if health_check:
                 spec_kwargs["healthCheck"] = health_check
-            automount = _service_extension_field(svc, "automountServiceAccountToken")
-            if automount is not None:
-                spec_kwargs["automountServiceAccountToken"] = automount
-            container_security_context = _service_extension_field(
-                svc, "containerSecurityContext"
+            _add_service_overrides(
+                spec_kwargs,
+                svc,
+                service_volume_specs.get(svc_name),
             )
-            if container_security_context is not None:
-                spec_kwargs["containerSecurityContext"] = container_security_context
-            volume_mounts = service_volume_mounts.get(svc_name)
-            if volume_mounts:
-                spec_kwargs["volumeMounts"] = volume_mounts
 
             specs.append(ExtensionServiceSpec(**spec_kwargs))
 
         return specs
+
+    def _find_primary_service(self, services: Dict[str, Any]) -> Optional[str]:
+        frontend = services.get("frontend")
+        if isinstance(frontend, dict) and self._parse_ports(frontend.get("ports", [])):
+            return "frontend"
+        return next(
+            (
+                service_name
+                for service_name, service in services.items()
+                if self._parse_ports(service.get("ports", []))
+            ),
+            None,
+        )
+
+    @staticmethod
+    def _append_platform_env(
+        env: List[Dict[str, str]],
+        is_primary: bool,
+        app_path: str,
+        verify_ssl: bool,
+    ) -> None:
+        if is_primary and app_path:
+            env.append({"name": "KAMIWAZA_APP_PATH", "value": app_path})
+        if verify_ssl:
+            return
+        # Explicit env wins over ConfigMap envFrom. Emit both Python and Node
+        # conventions so every extension runtime receives one TLS policy.
+        env.extend(
+            [
+                {"name": "KAMIWAZA_VERIFY_SSL", "value": "false"},
+                {"name": "KAMIWAZA_TLS_REJECT_UNAUTHORIZED", "value": "0"},
+            ]
+        )
 
     @staticmethod
     def _parse_ports(ports: List[Any]) -> List[ExtensionPort]:
@@ -517,9 +399,7 @@ class PayloadBuilder:
         # protocol-aware default as short-form, so a non-HTTP backend that
         # adopts long-form syntax for unrelated reasons (e.g. adding
         # ``protocol: tcp``) isn't mislabeled ``http`` and broken on istio.
-        name = port.get("name") or default_service_port_name(
-            container_port, is_primary
-        )
+        name = port.get("name") or default_service_port_name(container_port, is_primary)
 
         # Prefer the compose-spec ``app_protocol`` key; fall back to the
         # k8s-shaped ``appProtocol`` only when the spec key is absent.
@@ -793,6 +673,28 @@ def _service_extension_field(svc: Dict[str, Any], key: str) -> Optional[Any]:
     if isinstance(x_kamiwaza, dict) and key in x_kamiwaza:
         return x_kamiwaza[key]
     return None
+
+
+def _add_service_overrides(
+    spec: Dict[str, Any],
+    service: Dict[str, Any],
+    volume_spec: Optional[ServiceVolumeSpec],
+) -> None:
+    """Add operator-owned per-service fields to one service payload."""
+    for field in (
+        "automountServiceAccountToken",
+        "containerSecurityContext",
+        "persistence",
+    ):
+        value = _service_extension_field(service, field)
+        if value is not None:
+            spec[field] = value
+    if volume_spec is None:
+        return
+    if volume_spec.volumes:
+        spec["volumes"] = volume_spec.volumes
+    if volume_spec.mounts:
+        spec["volumeMounts"] = volume_spec.mounts
 
 
 def _metadata_service_field(

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -249,7 +249,17 @@ class PayloadBuilder:
         metadata: Optional[Dict[str, Any]] = None,
     ) -> List[ExtensionServiceSpec]:
         services_dict = transformed.get("services") or {}
-        service_volume_specs = build_service_volume_specs(transformed)
+        # Resolve persistence once, before volumes: it is what decides whether
+        # a Compose volume is left to the PVC, and resolving it twice let the
+        # kamiwaza.json path arm no guard.
+        persistence_by_service = {
+            svc_name: _resolve_persistence(metadata, svc_name, svc)
+            for svc_name, svc in services_dict.items()
+            if isinstance(svc, dict)
+        }
+        service_volume_specs = build_service_volume_specs(
+            transformed, persistence_by_service
+        )
         specs: List[ExtensionServiceSpec] = []
 
         primary_name = self._find_primary_service(services_dict)
@@ -288,7 +298,7 @@ class PayloadBuilder:
                 spec_kwargs,
                 svc,
                 service_volume_specs.get(svc_name),
-                _resolve_persistence(metadata, svc_name, svc),
+                persistence_by_service.get(svc_name),
             )
 
             specs.append(ExtensionServiceSpec(**spec_kwargs))

--- a/kamiwaza_sdk/schemas/extensions.py
+++ b/kamiwaza_sdk/schemas/extensions.py
@@ -186,9 +186,6 @@ class PatchServiceSpec(BaseModel):
         default=None,
         alias="volumeMounts",
     )
-    allow_empty_persistence_initialization: bool = Field(
-        default=False, alias="allowEmptyPersistenceInitialization"
-    )
 
 
 class PatchExtension(BaseModel):

--- a/kamiwaza_sdk/schemas/extensions.py
+++ b/kamiwaza_sdk/schemas/extensions.py
@@ -48,7 +48,9 @@ class ResourceSpec(BaseModel):
 class ExtensionServiceSpec(BaseModel):
     """Specification for a single service within an extension."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(
+        extra="allow", populate_by_name=True, serialize_by_alias=True
+    )
 
     name: str = Field(..., description="Service name")
     image: str = Field(..., description="Container image (registry/repo:tag)")
@@ -59,6 +61,12 @@ class ExtensionServiceSpec(BaseModel):
     resources: Optional[ResourceSpec] = None
     command: Optional[List[str]] = None
     args: Optional[List[str]] = None
+    persistence: Optional[Dict[str, Any]] = None
+    volumes: Optional[List[Dict[str, Any]]] = None
+    volume_mounts: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        alias="volumeMounts",
+    )
 
 
 class KamiwazaIntegrationSpec(BaseModel):
@@ -158,17 +166,29 @@ class ImagePatch(BaseModel):
     tag: str
     registry: Optional[str] = None
     repository: Optional[str] = None
+    digest: Optional[str] = None
 
 
 class PatchServiceSpec(BaseModel):
     """Partial service update — only name is required (for matching)."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(
+        extra="allow", populate_by_name=True, serialize_by_alias=True
+    )
 
     name: str
     image: Optional[ImagePatch] = None
     env: Optional[List[Dict[str, Any]]] = None
     replicas: Optional[int] = Field(None, ge=0)
+    persistence: Optional[Dict[str, Any]] = None
+    volumes: Optional[List[Dict[str, Any]]] = None
+    volume_mounts: Optional[List[Dict[str, Any]]] = Field(
+        default=None,
+        alias="volumeMounts",
+    )
+    allow_empty_persistence_initialization: bool = Field(
+        default=False, alias="allowEmptyPersistenceInitialization"
+    )
 
 
 class PatchExtension(BaseModel):

--- a/tests/unit/extensions/test_compose_volumes.py
+++ b/tests/unit/extensions/test_compose_volumes.py
@@ -1,0 +1,150 @@
+"""Direct coverage for Compose named-volume translation.
+
+The module decides whether a Compose volume becomes a pod emptyDir or is left
+to the operator's PVC. Getting that wrong is silent data loss, so the parsing
+branches are pinned here rather than only through the payload builder.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kamiwaza_extensions.compose_volumes import build_service_volume_specs
+
+
+def _spec(service: dict) -> object:
+    return build_service_volume_specs({"services": {"svc": service}}).get("svc")
+
+
+def test_named_volume_becomes_emptydir_with_mount() -> None:
+    spec = _spec({"volumes": ["cache:/var/cache"]})
+
+    assert spec.volumes == [{"name": "cache", "emptyDir": {}}]
+    assert spec.mounts == [{"name": "cache", "mountPath": "/var/cache"}]
+
+
+def test_repeated_source_reuses_one_volume() -> None:
+    spec = _spec({"volumes": ["shared:/a", "shared:/b"]})
+
+    assert spec.volumes == [{"name": "shared", "emptyDir": {}}]
+    assert [mount["mountPath"] for mount in spec.mounts] == ["/a", "/b"]
+
+
+@pytest.mark.parametrize(
+    "volume",
+    [
+        "./host/path:/in/container",
+        "/abs/host:/in/container",
+        "../up:/in/container",
+        {"type": "bind", "source": "./host", "target": "/in/container"},
+    ],
+)
+def test_host_paths_and_binds_are_not_translated(volume) -> None:
+    assert _spec({"volumes": [volume]}) is None
+
+
+@pytest.mark.parametrize(
+    "volume",
+    [
+        "cache:/data:ro",
+        {"source": "cache", "target": "/data", "read_only": True},
+        {"source": "cache", "target": "/data", "readOnly": True},
+    ],
+)
+def test_read_only_is_preserved_in_every_spelling(volume) -> None:
+    assert _spec({"volumes": [volume]}).mounts == [
+        {"name": "cache", "mountPath": "/data", "readOnly": True}
+    ]
+
+
+@pytest.mark.parametrize(
+    ("source_key", "target_key"),
+    [("source", "target"), ("src", "destination"), ("src", "dst")],
+)
+def test_long_form_key_aliases(source_key: str, target_key: str) -> None:
+    volume = {source_key: "cache", target_key: "/data"}
+
+    assert _spec({"volumes": [volume]}).mounts == [
+        {"name": "cache", "mountPath": "/data"}
+    ]
+
+
+@pytest.mark.parametrize("volume", [None, 42, ["nested"], "no-colon", "cache:rel"])
+def test_malformed_entries_are_skipped(volume) -> None:
+    assert _spec({"volumes": [volume]}) is None
+
+
+def test_operator_names_are_reserved_with_collision_counter() -> None:
+    spec = _spec({"volumes": ["tmp:/one", "data:/two"]})
+
+    assert [volume["name"] for volume in spec.volumes] == ["tmp-2", "data-2"]
+
+
+def test_long_source_name_is_truncated_to_a_dns_label() -> None:
+    spec = _spec({"volumes": [f"{'v' * 80}:/data"]})
+
+    name = spec.volumes[0]["name"]
+    assert len(name) == 63
+    assert not name.endswith("-")
+
+
+class TestPersistenceInteraction:
+    """A service with a PVC must never get an emptyDir over that subtree."""
+
+    @staticmethod
+    def _service(mount_path: str, volumes: list) -> dict:
+        return {
+            "volumes": volumes,
+            "x-kamiwaza": {
+                "persistence": {"enabled": True, "mountPath": mount_path}
+            },
+        }
+
+    def test_exact_persistence_target_is_left_to_the_pvc(self) -> None:
+        service = self._service("/var/lib/postgresql/data", ["pg:/var/lib/postgresql/data"])
+
+        assert _spec(service) is None
+
+    def test_nested_persistence_target_is_left_to_the_pvc(self) -> None:
+        """The stock Postgres layout: PGDATA nested under the mountPath."""
+        service = self._service("/var/lib/postgresql", ["pg:/var/lib/postgresql/data"])
+
+        assert _spec(service) is None
+
+    def test_trailing_slash_does_not_defeat_the_guard(self) -> None:
+        service = self._service("/var/lib/postgresql", ["pg:/var/lib/postgresql/"])
+
+        assert _spec(service) is None
+
+    def test_sibling_prefix_is_still_translated(self) -> None:
+        """``/var/lib/postgresql-backup`` is not inside ``/var/lib/postgresql``."""
+        service = self._service(
+            "/var/lib/postgresql", ["backup:/var/lib/postgresql-backup"]
+        )
+
+        assert _spec(service).mounts == [
+            {"name": "backup", "mountPath": "/var/lib/postgresql-backup"}
+        ]
+
+    def test_unrelated_volume_is_still_translated(self) -> None:
+        service = self._service("/var/lib/postgresql", ["cache:/var/cache"])
+
+        assert _spec(service).mounts == [{"name": "cache", "mountPath": "/var/cache"}]
+
+    def test_disabled_persistence_does_not_suppress_translation(self) -> None:
+        service = {
+            "volumes": ["pg:/data"],
+            "x-kamiwaza": {"persistence": {"enabled": False, "mountPath": "/data"}},
+        }
+
+        assert _spec(service).mounts == [{"name": "pg", "mountPath": "/data"}]
+
+    def test_enabled_without_mount_path_is_rejected(self) -> None:
+        """The operator would provision the PVC and mount it nowhere."""
+        service = {
+            "volumes": ["cache:/data"],
+            "x-kamiwaza": {"persistence": {"enabled": True, "size": "5Gi"}},
+        }
+
+        with pytest.raises(ValueError, match="mountPath is missing"):
+            _spec(service)

--- a/tests/unit/extensions/test_compose_volumes.py
+++ b/tests/unit/extensions/test_compose_volumes.py
@@ -215,3 +215,46 @@ def test_no_resolved_persistence_translates_every_volume() -> None:
     assert specs["postgres"].mounts == [
         {"name": "pg", "mountPath": "/var/lib/postgresql/data"}
     ]
+
+
+class TestPersistenceEnabledMustBeBoolean:
+    """A truthy string disarms the guard here while the platform coerces it and
+    provisions the PVC anyway — an emptyDir lands on top of the claim."""
+
+    @staticmethod
+    def _persistence(enabled) -> dict:
+        return {"enabled": enabled, "mountPath": "/var/lib/postgresql"}
+
+    @pytest.mark.parametrize("enabled", ["true", "True", "1", "yes", "on", 1])
+    def test_truthy_non_bool_is_rejected(self, enabled) -> None:
+        service = {"volumes": ["pg:/var/lib/postgresql/data"]}
+
+        with pytest.raises(ValueError, match="must be a boolean"):
+            build_service_volume_specs(
+                {"services": {"pg": service}}, {"pg": self._persistence(enabled)}
+            )
+
+    @pytest.mark.parametrize("enabled", ["false", "no", 0])
+    def test_falsy_non_bool_is_also_rejected(self, enabled) -> None:
+        with pytest.raises(ValueError, match="must be a boolean"):
+            build_service_volume_specs(
+                {"services": {"pg": {"volumes": ["pg:/data"]}}},
+                {"pg": self._persistence(enabled)},
+            )
+
+    def test_real_booleans_are_accepted(self) -> None:
+        service = {"volumes": ["pg:/var/lib/postgresql/data"]}
+
+        specs = build_service_volume_specs(
+            {"services": {"pg": service}}, {"pg": self._persistence(True)}
+        )
+
+        assert specs.get("pg") is None
+
+    def test_absent_enabled_declares_no_persistence(self) -> None:
+        specs = build_service_volume_specs(
+            {"services": {"pg": {"volumes": ["pg:/data"]}}},
+            {"pg": {"mountPath": "/data"}},
+        )
+
+        assert specs["pg"].mounts == [{"name": "pg", "mountPath": "/data"}]

--- a/tests/unit/extensions/test_compose_volumes.py
+++ b/tests/unit/extensions/test_compose_volumes.py
@@ -12,8 +12,17 @@ import pytest
 from kamiwaza_extensions.compose_volumes import build_service_volume_specs
 
 
-def _spec(service: dict) -> object:
-    return build_service_volume_specs({"services": {"svc": service}}).get("svc")
+def _spec(service: dict, persistence: object = None) -> object:
+    """Build the spec for one service.
+
+    ``persistence`` defaults to whatever the service declares under
+    ``x-kamiwaza``, matching how the payload builder resolves it.
+    """
+    if persistence is None:
+        persistence = (service.get("x-kamiwaza") or {}).get("persistence")
+    return build_service_volume_specs(
+        {"services": {"svc": service}}, {"svc": persistence}
+    ).get("svc")
 
 
 def test_named_volume_becomes_emptydir_with_mount() -> None:
@@ -179,3 +188,30 @@ class TestPersistenceMountPathValidation:
 
     def test_absolute_mount_path_is_accepted(self) -> None:
         assert _spec(self._service("/var/lib/postgresql")) is None
+
+
+def test_persistence_from_metadata_arms_the_guard() -> None:
+    """The caller resolves persistence (kamiwaza.json ahead of compose) and
+    passes it in. Re-reading compose here would leave a metadata-declared PVC
+    unguarded — a PVC and an emptyDir over the same path."""
+    service = {"volumes": ["pg:/var/lib/postgresql/data"]}
+
+    specs = build_service_volume_specs(
+        {"services": {"postgres": service}},
+        {"postgres": {"enabled": True, "mountPath": "/var/lib/postgresql"}},
+    )
+
+    assert specs.get("postgres") is None
+
+
+def test_no_resolved_persistence_translates_every_volume() -> None:
+    service = {
+        "volumes": ["pg:/var/lib/postgresql/data"],
+        "x-kamiwaza": {"persistence": {"enabled": True, "mountPath": "/ignored"}},
+    }
+
+    specs = build_service_volume_specs({"services": {"postgres": service}}, {})
+
+    assert specs["postgres"].mounts == [
+        {"name": "pg", "mountPath": "/var/lib/postgresql/data"}
+    ]

--- a/tests/unit/extensions/test_compose_volumes.py
+++ b/tests/unit/extensions/test_compose_volumes.py
@@ -148,3 +148,34 @@ class TestPersistenceInteraction:
 
         with pytest.raises(ValueError, match="mountPath is missing"):
             _spec(service)
+
+
+class TestPersistenceMountPathValidation:
+    """A mountPath that can never match a Compose target is worse than an
+    error: the guard passes and an emptyDir lands on top of the PVC."""
+
+    @staticmethod
+    def _service(mount_path) -> dict:
+        return {
+            "volumes": ["pg:/var/lib/postgresql/data"],
+            "x-kamiwaza": {
+                "persistence": {"enabled": True, "mountPath": mount_path}
+            },
+        }
+
+    @pytest.mark.parametrize(
+        "mount_path", ["var/lib/postgresql", "data", "./data", "postgresql/data"]
+    )
+    def test_relative_mount_path_is_rejected(self, mount_path: str) -> None:
+        with pytest.raises(ValueError, match="absolute path"):
+            _spec(self._service(mount_path))
+
+    @pytest.mark.parametrize("mount_path", [None, 42, {"path": "/data"}, ["/data"]])
+    def test_non_string_mount_path_is_rejected(self, mount_path) -> None:
+        """``mountPath:`` with no value parses to None; stringifying it would
+        yield a truthy "None" that sails past every check."""
+        with pytest.raises(ValueError, match="mountPath is missing"):
+            _spec(self._service(mount_path))
+
+    def test_absolute_mount_path_is_accepted(self) -> None:
+        assert _spec(self._service("/var/lib/postgresql")) is None

--- a/tests/unit/extensions/test_dev_patch.py
+++ b/tests/unit/extensions/test_dev_patch.py
@@ -438,3 +438,42 @@ class TestOrphanedPersistenceWarning:
         from kamiwaza_extensions.commands.dev import _deployed_persistence_mounts
 
         assert _deployed_persistence_mounts(self._payload({"enabled": False})) == {}
+
+
+class TestDeployedPersistenceIsScopedToTheFilter:
+    @staticmethod
+    def _payload():
+        from kamiwaza_sdk.schemas.extensions import CreateExtension, ExtensionServiceSpec
+
+        return CreateExtension(
+            name="ext",
+            type="app",
+            version="1.0.0",
+            services=[
+                ExtensionServiceSpec(
+                    name="postgres",
+                    image="ghcr.io/o/pg:1",
+                    persistence={"enabled": True, "mountPath": "/data"},
+                ),
+                ExtensionServiceSpec(
+                    name="seaweedfs",
+                    image="ghcr.io/o/sw:1",
+                    persistence={"enabled": True, "mountPath": "/store"},
+                ),
+            ],
+        )
+
+    def test_unfiltered_run_records_every_service(self):
+        from kamiwaza_extensions.commands.dev import _deployed_persistence_mounts
+
+        assert _deployed_persistence_mounts(self._payload()) == {
+            "postgres": "/data",
+            "seaweedfs": "/store",
+        }
+
+    def test_service_filtered_run_records_only_what_it_patched(self):
+        from kamiwaza_extensions.commands.dev import _deployed_persistence_mounts
+
+        assert _deployed_persistence_mounts(self._payload(), "postgres") == {
+            "postgres": "/data"
+        }

--- a/tests/unit/extensions/test_dev_patch.py
+++ b/tests/unit/extensions/test_dev_patch.py
@@ -83,10 +83,12 @@ class TestDeployPatchLogic:
             for svc in payload.services:
                 parts = svc.image.rsplit(":", 1)
                 tag = parts[1] if len(parts) > 1 else "latest"
-                patch_services.append(PatchServiceSpec(
-                    name=svc.name,
-                    image=ImagePatch(tag=tag),
-                ))
+                patch_services.append(
+                    PatchServiceSpec(
+                        name=svc.name,
+                        image=ImagePatch(tag=tag),
+                    )
+                )
             patch = PatchExtension(services=patch_services)
             ext = client.extensions.patch_extension("myapp-dev-abc123", patch)
         except NotFoundError:
@@ -134,12 +136,14 @@ class TestDeployPatchLogic:
         ]
         for image, expected_tag in test_cases:
             slash_pos = image.rfind("/")
-            after_slash = image[slash_pos + 1:] if slash_pos >= 0 else image
+            after_slash = image[slash_pos + 1 :] if slash_pos >= 0 else image
             if ":" in after_slash:
                 tag = after_slash.rsplit(":", 1)[1]
             else:
                 tag = "latest"
-            assert tag == expected_tag, f"For image '{image}' expected '{expected_tag}' got '{tag}'"
+            assert tag == expected_tag, (
+                f"For image '{image}' expected '{expected_tag}' got '{tag}'"
+            )
 
 
 class TestBuildPatchServiceSpecs:
@@ -157,7 +161,9 @@ class TestBuildPatchServiceSpecs:
             type="app",
             version="1.0.0",
             services=[
-                ExtensionServiceSpec(name="backend", image=image, primary=True, ports=[]),
+                ExtensionServiceSpec(
+                    name="backend", image=image, primary=True, ports=[]
+                ),
             ],
         )
 
@@ -205,12 +211,49 @@ class TestBuildPatchServiceSpecs:
         # which was never pushed.
         from kamiwaza_extensions.commands.dev import _build_patch_service_specs
 
-        payload = self._payload(
-            "ghcr.io/kamiwaza-internal/foo/images/omniparse:v2"
-        )
+        payload = self._payload("ghcr.io/kamiwaza-internal/foo/images/omniparse:v2")
         img = _build_patch_service_specs(payload)[0].image
         # The patch carries the new repository, not just a new tag —
         # the operator will rewrite the CR's image field accordingly.
         assert img.registry == "ghcr.io"
         assert img.repository == "kamiwaza-internal/foo/images/omniparse"
         assert img.tag == "v2"
+
+    def test_digest_pinned_ref_preserves_pin_on_patch(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        digest = "sha256:" + "a" * 64
+        payload = self._payload(f"ghcr.io/org/controller:develop@{digest}")
+
+        img = _build_patch_service_specs(payload)[0].image
+
+        assert img.registry == "ghcr.io"
+        assert img.repository == "org/controller"
+        assert img.tag == "develop"
+        assert img.digest == digest
+
+    def test_persistence_override_flows_through_patch(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        payload = self._payload("registry.test/postgres:17")
+        payload.services[0].persistence = {
+            "enabled": True,
+            "size": "10Gi",
+            "mountPath": "/var/lib/postgresql",
+        }
+
+        spec = _build_patch_service_specs(payload)[0]
+        assert spec.persistence == {
+            "enabled": True,
+            "size": "10Gi",
+            "mountPath": "/var/lib/postgresql",
+        }
+
+    def test_service_filter_excludes_unbuilt_sibling_images(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        payload = _make_payload()
+        specs = _build_patch_service_specs(payload, service_filter="frontend")
+
+        assert [spec.name for spec in specs] == ["frontend"]
+        assert specs[0].image.repository == "myapp-frontend"

--- a/tests/unit/extensions/test_dev_patch.py
+++ b/tests/unit/extensions/test_dev_patch.py
@@ -259,93 +259,6 @@ class TestBuildPatchServiceSpecs:
         assert specs[0].image.repository == "myapp-frontend"
 
 
-class TestPersistenceClearingIsTargeted:
-    """A blanket disable would aim a PVC-affecting write at services that
-    never requested one; the clear must follow the CR's actual state."""
-
-    @staticmethod
-    def _payload(*names):
-        from kamiwaza_sdk.schemas.extensions import CreateExtension, ExtensionServiceSpec
-
-        return CreateExtension(
-            name="ext",
-            type="app",
-            version="1.0.0",
-            services=[
-                ExtensionServiceSpec(name=n, image=f"ghcr.io/o/{n}:1") for n in names
-            ],
-        )
-
-    def test_service_without_persistence_is_left_untouched(self):
-        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
-
-        specs = _build_patch_service_specs(self._payload("backend", "frontend"))
-
-        for spec in specs:
-            assert spec.model_dump(exclude_none=True).get("persistence") is None
-
-    def test_service_losing_persistence_is_explicitly_disabled(self):
-        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
-
-        specs = _build_patch_service_specs(
-            self._payload("postgres", "backend"),
-            clear_persistence_for=frozenset({"postgres"}),
-        )
-        by_name = {s.name: s for s in specs}
-
-        assert by_name["postgres"].persistence == {"enabled": False}
-        assert by_name["backend"].persistence is None
-
-    def test_declared_persistence_wins_over_clearing(self):
-        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
-        from kamiwaza_sdk.schemas.extensions import CreateExtension, ExtensionServiceSpec
-
-        payload = CreateExtension(
-            name="ext",
-            type="app",
-            version="1.0.0",
-            services=[
-                ExtensionServiceSpec(
-                    name="postgres",
-                    image="ghcr.io/o/pg:1",
-                    persistence={"enabled": True, "mountPath": "/data"},
-                )
-            ],
-        )
-
-        specs = _build_patch_service_specs(
-            payload, clear_persistence_for=frozenset({"postgres"})
-        )
-
-        assert specs[0].persistence == {"enabled": True, "mountPath": "/data"}
-
-
-class TestPersistentServiceNames:
-    def test_reads_enabled_services_from_the_current_cr(self):
-        from types import SimpleNamespace
-
-        from kamiwaza_extensions.commands.dev import persistent_service_names
-
-        extension = SimpleNamespace(
-            spec=SimpleNamespace(
-                services=[
-                    SimpleNamespace(name="postgres", persistence={"enabled": True}),
-                    SimpleNamespace(name="cache", persistence={"enabled": False}),
-                    SimpleNamespace(name="backend", persistence=None),
-                ]
-            )
-        )
-
-        assert persistent_service_names(extension) == frozenset({"postgres"})
-
-    def test_missing_services_yields_empty_set(self):
-        from types import SimpleNamespace
-
-        from kamiwaza_extensions.commands.dev import persistent_service_names
-
-        assert persistent_service_names(SimpleNamespace()) == frozenset()
-
-
 class TestServiceFilterValidation:
     def test_unknown_service_exits_with_a_message_naming_the_flag(self, capsys):
         import typer
@@ -366,3 +279,40 @@ class TestServiceFilterValidation:
         from kamiwaza_extensions.commands.dev import _validate_service_filter
 
         _validate_service_filter(None, {"services": {}})
+
+
+class TestPatchPersistenceIsDeclarationOnly:
+    """Clearing a removed block would need the CR's spec, which
+    ``get_extension`` does not return — so the PATCH only ever asserts what
+    the extension declares."""
+
+    @staticmethod
+    def _payload(persistence=None):
+        from kamiwaza_sdk.schemas.extensions import CreateExtension, ExtensionServiceSpec
+
+        kwargs = {"persistence": persistence} if persistence is not None else {}
+        return CreateExtension(
+            name="ext",
+            type="app",
+            version="1.0.0",
+            services=[
+                ExtensionServiceSpec(
+                    name="postgres", image="ghcr.io/o/pg:1", **kwargs
+                )
+            ],
+        )
+
+    def test_declared_persistence_is_sent(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        declared = {"enabled": True, "mountPath": "/data"}
+        specs = _build_patch_service_specs(self._payload(declared))
+
+        assert specs[0].persistence == declared
+
+    def test_undeclared_persistence_is_omitted(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        specs = _build_patch_service_specs(self._payload())
+
+        assert specs[0].model_dump(exclude_none=True).get("persistence") is None

--- a/tests/unit/extensions/test_dev_patch.py
+++ b/tests/unit/extensions/test_dev_patch.py
@@ -257,3 +257,112 @@ class TestBuildPatchServiceSpecs:
 
         assert [spec.name for spec in specs] == ["frontend"]
         assert specs[0].image.repository == "myapp-frontend"
+
+
+class TestPersistenceClearingIsTargeted:
+    """A blanket disable would aim a PVC-affecting write at services that
+    never requested one; the clear must follow the CR's actual state."""
+
+    @staticmethod
+    def _payload(*names):
+        from kamiwaza_sdk.schemas.extensions import CreateExtension, ExtensionServiceSpec
+
+        return CreateExtension(
+            name="ext",
+            type="app",
+            version="1.0.0",
+            services=[
+                ExtensionServiceSpec(name=n, image=f"ghcr.io/o/{n}:1") for n in names
+            ],
+        )
+
+    def test_service_without_persistence_is_left_untouched(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        specs = _build_patch_service_specs(self._payload("backend", "frontend"))
+
+        for spec in specs:
+            assert spec.model_dump(exclude_none=True).get("persistence") is None
+
+    def test_service_losing_persistence_is_explicitly_disabled(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+
+        specs = _build_patch_service_specs(
+            self._payload("postgres", "backend"),
+            clear_persistence_for=frozenset({"postgres"}),
+        )
+        by_name = {s.name: s for s in specs}
+
+        assert by_name["postgres"].persistence == {"enabled": False}
+        assert by_name["backend"].persistence is None
+
+    def test_declared_persistence_wins_over_clearing(self):
+        from kamiwaza_extensions.commands.dev import _build_patch_service_specs
+        from kamiwaza_sdk.schemas.extensions import CreateExtension, ExtensionServiceSpec
+
+        payload = CreateExtension(
+            name="ext",
+            type="app",
+            version="1.0.0",
+            services=[
+                ExtensionServiceSpec(
+                    name="postgres",
+                    image="ghcr.io/o/pg:1",
+                    persistence={"enabled": True, "mountPath": "/data"},
+                )
+            ],
+        )
+
+        specs = _build_patch_service_specs(
+            payload, clear_persistence_for=frozenset({"postgres"})
+        )
+
+        assert specs[0].persistence == {"enabled": True, "mountPath": "/data"}
+
+
+class TestPersistentServiceNames:
+    def test_reads_enabled_services_from_the_current_cr(self):
+        from types import SimpleNamespace
+
+        from kamiwaza_extensions.commands.dev import persistent_service_names
+
+        extension = SimpleNamespace(
+            spec=SimpleNamespace(
+                services=[
+                    SimpleNamespace(name="postgres", persistence={"enabled": True}),
+                    SimpleNamespace(name="cache", persistence={"enabled": False}),
+                    SimpleNamespace(name="backend", persistence=None),
+                ]
+            )
+        )
+
+        assert persistent_service_names(extension) == frozenset({"postgres"})
+
+    def test_missing_services_yields_empty_set(self):
+        from types import SimpleNamespace
+
+        from kamiwaza_extensions.commands.dev import persistent_service_names
+
+        assert persistent_service_names(SimpleNamespace()) == frozenset()
+
+
+class TestServiceFilterValidation:
+    def test_unknown_service_exits_with_a_message_naming_the_flag(self, capsys):
+        import typer
+
+        from kamiwaza_extensions.commands.dev import _validate_service_filter
+
+        with pytest.raises(typer.Exit):
+            _validate_service_filter(
+                "backnd", {"services": {"backend": {}, "frontend": {}}}
+            )
+
+    def test_known_service_passes(self):
+        from kamiwaza_extensions.commands.dev import _validate_service_filter
+
+        _validate_service_filter("backend", {"services": {"backend": {}}})
+
+    def test_none_filter_passes(self):
+        from kamiwaza_extensions.commands.dev import _validate_service_filter
+
+        _validate_service_filter(None, {"services": {}})

--- a/tests/unit/extensions/test_dev_patch.py
+++ b/tests/unit/extensions/test_dev_patch.py
@@ -260,20 +260,56 @@ class TestBuildPatchServiceSpecs:
 
 
 class TestServiceFilterValidation:
-    def test_unknown_service_exits_with_a_message_naming_the_flag(self, capsys):
+    """Raw Compose keys are the wrong set: a profile-gated or image-only
+    service passes that check and then fails late, after build and push."""
+
+    COMPOSE = {
+        "services": {
+            "backend": {"build": "./backend"},
+            "frontend": {"build": "./frontend"},
+            "agent": {"build": "./agent", "profiles": ["local"]},
+            "redis": {"image": "redis:7"},
+        }
+    }
+
+    def _reject(self, name: str, match: str, capsys) -> None:
         import typer
 
         from kamiwaza_extensions.commands.dev import _validate_service_filter
 
         with pytest.raises(typer.Exit):
-            _validate_service_filter(
-                "backnd", {"services": {"backend": {}, "frontend": {}}}
-            )
+            _validate_service_filter(name, self.COMPOSE)
+        err = capsys.readouterr().err
+        assert "--service" in err
+        assert match in err
 
-    def test_known_service_passes(self):
+    def test_unknown_service_is_rejected(self, capsys):
+        self._reject("backnd", "not a service", capsys)
+
+    def test_profile_gated_service_is_rejected(self, capsys):
+        """The transformer strips it, so the PATCH list would come back empty."""
+        self._reject("agent", "profile-gated", capsys)
+
+    def test_image_only_service_is_rejected(self, capsys):
+        """Nothing to build or push — the deploy would be a silent no-op."""
+        self._reject("redis", "no build context", capsys)
+
+    def test_rejection_lists_only_deployable_services(self, capsys):
+        import typer
+
         from kamiwaza_extensions.commands.dev import _validate_service_filter
 
-        _validate_service_filter("backend", {"services": {"backend": {}}})
+        with pytest.raises(typer.Exit):
+            _validate_service_filter("nope", self.COMPOSE)
+
+        err = capsys.readouterr().err
+        assert "backend" in err and "frontend" in err
+        assert "agent" not in err and "redis" not in err
+
+    def test_deployable_service_passes(self):
+        from kamiwaza_extensions.commands.dev import _validate_service_filter
+
+        _validate_service_filter("backend", self.COMPOSE)
 
     def test_none_filter_passes(self):
         from kamiwaza_extensions.commands.dev import _validate_service_filter
@@ -316,3 +352,89 @@ class TestPatchPersistenceIsDeclarationOnly:
         specs = _build_patch_service_specs(self._payload())
 
         assert specs[0].model_dump(exclude_none=True).get("persistence") is None
+
+
+class TestOrphanedPersistenceWarning:
+    """The CR keeps a persistence block the extension has dropped —
+    ``get_extension`` returns only status, so it cannot be cleared from here."""
+
+    @staticmethod
+    def _payload(persistence=None, mounts=None):
+        from kamiwaza_sdk.schemas.extensions import CreateExtension, ExtensionServiceSpec
+
+        kwargs = {}
+        if persistence is not None:
+            kwargs["persistence"] = persistence
+        if mounts is not None:
+            kwargs["volumeMounts"] = mounts
+        return CreateExtension(
+            name="ext",
+            type="app",
+            version="1.0.0",
+            services=[
+                ExtensionServiceSpec(name="postgres", image="ghcr.io/o/pg:1", **kwargs)
+            ],
+        )
+
+    def test_warns_when_a_volume_reclaims_the_old_mount_path(self):
+        from kamiwaza_extensions.commands.dev import warn_orphaned_persistence
+
+        payload = self._payload(
+            mounts=[{"name": "pg", "mountPath": "/var/lib/postgresql/data"}]
+        )
+
+        warnings = warn_orphaned_persistence(
+            {"postgres": "/var/lib/postgresql/data"}, payload
+        )
+
+        assert len(warnings) == 1
+        assert "/var/lib/postgresql/data" in warnings[0]
+
+    def test_warns_on_a_nested_target_that_would_shadow_the_claim(self):
+        from kamiwaza_extensions.commands.dev import warn_orphaned_persistence
+
+        payload = self._payload(
+            mounts=[{"name": "pg", "mountPath": "/var/lib/postgresql/data"}]
+        )
+
+        assert warn_orphaned_persistence({"postgres": "/var/lib/postgresql"}, payload)
+
+    def test_silent_when_persistence_is_still_declared(self):
+        from kamiwaza_extensions.commands.dev import warn_orphaned_persistence
+
+        payload = self._payload(
+            persistence={"enabled": True, "mountPath": "/var/lib/postgresql/data"},
+            mounts=[{"name": "other", "mountPath": "/tmp/x"}],
+        )
+
+        assert warn_orphaned_persistence({"postgres": "/var/lib/postgresql"}, payload) == []
+
+    def test_silent_when_the_volume_is_elsewhere(self):
+        from kamiwaza_extensions.commands.dev import warn_orphaned_persistence
+
+        payload = self._payload(mounts=[{"name": "cache", "mountPath": "/var/cache"}])
+
+        assert warn_orphaned_persistence({"postgres": "/var/lib/postgresql"}, payload) == []
+
+    def test_silent_with_no_prior_state(self):
+        from kamiwaza_extensions.commands.dev import warn_orphaned_persistence
+
+        payload = self._payload(mounts=[{"name": "pg", "mountPath": "/data"}])
+
+        assert warn_orphaned_persistence({}, payload) == []
+
+    def test_records_what_this_run_deploys(self):
+        from kamiwaza_extensions.commands.dev import _deployed_persistence_mounts
+
+        payload = self._payload(
+            persistence={"enabled": True, "mountPath": "/var/lib/postgresql/data"}
+        )
+
+        assert _deployed_persistence_mounts(payload) == {
+            "postgres": "/var/lib/postgresql/data"
+        }
+
+    def test_disabled_persistence_is_not_recorded(self):
+        from kamiwaza_extensions.commands.dev import _deployed_persistence_mounts
+
+        assert _deployed_persistence_mounts(self._payload({"enabled": False})) == {}

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -752,9 +752,8 @@ class TestBuildPatchKwargsCarriesAnnotations:
         )
         assert "sandbox" not in kwargs
 
-    def test_carries_volumes_so_patch_refreshes_mount_contract(self):
-        """ENG-4834: existing dev CRs are updated by PATCH after first
-        create, so top-level volume declarations must ride PATCH too."""
+    def test_drops_invalid_top_level_volumes(self):
+        """CRD volumes belong to services, never the extension root."""
         from kamiwaza_extensions.commands.dev import _build_patch_kwargs
 
         volumes = [{"name": "omniparse-data", "emptyDir": {}}]
@@ -764,27 +763,22 @@ class TestBuildPatchKwargsCarriesAnnotations:
             kamiwaza = None
 
         kwargs = _build_patch_kwargs(patch_services=["svc"], payload=_FakePayload())
-        assert kwargs["volumes"] == volumes
+        assert "volumes" not in kwargs
 
-    def test_patchextension_accepts_volumes_via_extra_allow(self):
-        """Sanity: PatchExtension must accept top-level volumes via
-        ``extra="allow"``."""
-        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
-        from kamiwaza_sdk.schemas.extensions import PatchExtension, PatchServiceSpec
+    def test_patch_service_serializes_volume_aliases(self):
+        from kamiwaza_sdk.schemas.extensions import PatchServiceSpec
 
+        volume_mounts = [{"name": "data", "mountPath": "/data"}]
         volumes = [{"name": "data", "emptyDir": {}}]
-
-        class _FakePayload:
-            model_extra = {"volumes": volumes}
-            kamiwaza = None
-
-        kwargs = _build_patch_kwargs(
-            patch_services=[PatchServiceSpec(name="x")],
-            payload=_FakePayload(),
+        patch_service = PatchServiceSpec(
+            name="x",
+            volumes=volumes,
+            volumeMounts=volume_mounts,
         )
-        patch = PatchExtension(**kwargs)
-        assert (patch.model_extra or {}).get("volumes") == volumes
-        assert patch.model_dump()["volumes"] == volumes
+
+        serialized = patch_service.model_dump()
+        assert serialized["volumes"] == volumes
+        assert serialized["volumeMounts"] == volume_mounts
 
     def test_patch_service_specs_forwards_x_kamiwaza_overrides(self):
         """jxstanford PR #97 review H2: per-service overrides
@@ -853,43 +847,32 @@ class TestBuildPatchKwargsCarriesAnnotations:
         specs = _build_patch_service_specs(_FakePayload())
         assert (specs[0].model_extra or {})["automountServiceAccountToken"] is False
 
-    def test_patch_service_specs_forwards_volume_mounts(self):
-        """ENG-4834: service-level mounts must also refresh on PATCH."""
+    def test_patch_service_specs_forwards_volumes_and_mounts(self):
+        """ENG-4834: service pod-volume contract must refresh on PATCH."""
         from kamiwaza_extensions.commands.dev import _build_patch_service_specs
         from kamiwaza_sdk.schemas.extensions import ExtensionServiceSpec
 
         volume_mounts = [{"name": "data", "mountPath": "/data"}]
+        volumes = [{"name": "data", "emptyDir": {}}]
 
         class _FakePayload:
             services = [
                 ExtensionServiceSpec(
                     name="tool",
                     image="reg/tool:dev",
+                    volumes=volumes,
                     volumeMounts=volume_mounts,
                 ),
             ]
 
         specs = _build_patch_service_specs(_FakePayload())
-        assert (specs[0].model_extra or {})["volumeMounts"] == volume_mounts
+        assert specs[0].volumes == volumes
+        assert specs[0].volume_mounts == volume_mounts
+        assert specs[0].model_dump()["volumes"] == volumes
         assert specs[0].model_dump()["volumeMounts"] == volume_mounts
 
-    def test_volumes_cleared_when_payload_has_none(self):
-        """ENG-4834 follow-up: removing a named volume from compose
-        must clear the stale top-level volume on the persisted CR.
-        Omitting the field on PATCH leaves the operator with no signal
-        to clear, so always send an explicit (possibly empty) list."""
-        from kamiwaza_extensions.commands.dev import _build_patch_kwargs
-
-        kwargs = _build_patch_kwargs(
-            patch_services=["svc"],
-            payload=self._payload_with_annotations(None),
-        )
-        assert kwargs["volumes"] == []
-
-    def test_volume_mounts_cleared_when_svc_has_none(self):
-        """ENG-4834 follow-up: per-service mounts must also clear on
-        PATCH when removed from compose. Mirrors the top-level clear
-        behavior in ``_build_patch_kwargs``."""
+    def test_service_volumes_and_mounts_clear_when_removed(self):
+        """Removing compose volumes sends empty service-scoped lists."""
         from kamiwaza_extensions.commands.dev import _build_patch_service_specs
         from kamiwaza_sdk.schemas.extensions import ExtensionServiceSpec
 
@@ -899,7 +882,8 @@ class TestBuildPatchKwargsCarriesAnnotations:
             ]
 
         specs = _build_patch_service_specs(_FakePayload())
-        assert (specs[0].model_extra or {}).get("volumeMounts") == []
+        assert specs[0].volumes == []
+        assert specs[0].volume_mounts == []
 
     def test_patchextension_accepts_sandbox_via_extra_allow(self):
         """Sanity: PatchExtension must accept the sandbox kwarg via

--- a/tests/unit/extensions/test_dev_state.py
+++ b/tests/unit/extensions/test_dev_state.py
@@ -904,3 +904,55 @@ class TestBuildPatchKwargsCarriesAnnotations:
             "enabled": True,
             "service_name": "sc",
         }
+
+
+class TestPersistenceMountRecording:
+    """Recorded state must describe what the CR has, not what a run intended:
+    written only on apply, sticky, and scoped to the services actually sent."""
+
+    @staticmethod
+    def _apply(tmp_path, mounts, step="apply"):
+        from kamiwaza_extensions.dev_state import mark_step
+
+        return mark_step(
+            tmp_path,
+            step,
+            revision="r1",
+            dev_name="ext-dev",
+            cluster="https://c",
+            extension_name="ext",
+            deployer="d",
+            persistence_mounts=mounts,
+        )
+
+    def test_recorded_on_apply(self, tmp_path):
+        state = self._apply(tmp_path, {"pg": "/data"})
+
+        assert state.last_persistence_mounts == {"pg": "/data"}
+
+    @pytest.mark.parametrize("step", ["build", "push", "poll"])
+    def test_not_recorded_before_the_cr_moves(self, tmp_path, step: str):
+        """A run that stops after build would otherwise record a layout that
+        was never applied."""
+        state = self._apply(tmp_path, {"pg": "/data"}, step=step)
+
+        assert state.last_persistence_mounts == {}
+
+    def test_entry_survives_a_later_run_that_drops_persistence(self, tmp_path):
+        """The PATCH cannot clear the CR's block, so the warning has to keep
+        firing — erasing the memory made it one-shot."""
+        self._apply(tmp_path, {"pg": "/data"})
+
+        state = self._apply(tmp_path, {})
+
+        assert state.last_persistence_mounts == {"pg": "/data"}
+
+    def test_service_scoped_run_leaves_siblings_alone(self, tmp_path):
+        self._apply(tmp_path, {"pg": "/data", "cache": "/var/cache"})
+
+        state = self._apply(tmp_path, {"pg": "/data2"})
+
+        assert state.last_persistence_mounts == {
+            "pg": "/data2",
+            "cache": "/var/cache",
+        }

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -543,17 +543,15 @@ class TestComposeVolumes:
         payload = builder.build(metadata, transformed, connection, "tool-dev-abc")
         tool = payload.services[0].model_dump()
 
-        assert (payload.model_extra or {})["volumes"] == [
-            {"name": "omniparse-data", "emptyDir": {}}
-        ]
-        assert payload.model_dump()["volumes"] == [
-            {"name": "omniparse-data", "emptyDir": {}}
-        ]
+        assert "volumes" not in (payload.model_extra or {})
+        assert tool["volumes"] == [{"name": "omniparse-data", "emptyDir": {}}]
         assert tool["volumeMounts"] == [
             {"name": "omniparse-data", "mountPath": "/data"}
         ]
 
-    def test_shared_named_volume_is_declared_once(self, builder, metadata, connection):
+    def test_shared_named_volume_is_declared_in_each_service(
+        self, builder, metadata, connection
+    ):
         transformed = {
             "services": {
                 "api": {
@@ -571,15 +569,77 @@ class TestComposeVolumes:
         payload = builder.build(metadata, transformed, connection, "app-dev-abc")
         services = {svc.name: svc.model_dump() for svc in payload.services}
 
-        assert (payload.model_extra or {})["volumes"] == [
-            {"name": "shared-data", "emptyDir": {}}
-        ]
+        expected_volume = [{"name": "shared-data", "emptyDir": {}}]
+        assert services["api"]["volumes"] == expected_volume
+        assert services["worker"]["volumes"] == expected_volume
         assert services["api"]["volumeMounts"] == [
             {"name": "shared-data", "mountPath": "/cache"}
         ]
         assert services["worker"]["volumeMounts"] == [
             {"name": "shared-data", "mountPath": "/cache"}
         ]
+
+    def test_explicit_persistence_replaces_matching_empty_dir(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "postgres": {
+                    "image": "postgres:17",
+                    "ports": ["5432"],
+                    "volumes": ["postgres-data:/var/lib/postgresql"],
+                    "x-kamiwaza": {
+                        "persistence": {
+                            "enabled": True,
+                            "size": "10Gi",
+                            "mountPath": "/var/lib/postgresql",
+                        }
+                    },
+                }
+            },
+            "volumes": {"postgres-data": None},
+        }
+
+        payload = builder.build(metadata, transformed, connection, "app-dev-abc")
+        postgres = payload.services[0].model_dump(exclude_none=True)
+
+        assert "volumes" not in postgres
+        assert "volumeMounts" not in postgres
+        assert postgres["persistence"] == {
+            "enabled": True,
+            "size": "10Gi",
+            "mountPath": "/var/lib/postgresql",
+        }
+
+    def test_disabled_persistence_keeps_matching_empty_dir(
+        self, builder, metadata, connection
+    ):
+        transformed = {
+            "services": {
+                "postgres": {
+                    "image": "postgres:17",
+                    "ports": ["5432"],
+                    "volumes": ["postgres-data:/var/lib/postgresql"],
+                    "x-kamiwaza": {
+                        "persistence": {
+                            "enabled": False,
+                            "size": "10Gi",
+                            "mountPath": "/var/lib/postgresql",
+                        }
+                    },
+                }
+            },
+            "volumes": {"postgres-data": None},
+        }
+
+        payload = builder.build(metadata, transformed, connection, "app-dev-abc")
+        postgres = payload.services[0].model_dump()
+
+        assert postgres["volumes"] == [{"name": "postgres-data", "emptyDir": {}}]
+        assert postgres["volumeMounts"] == [
+            {"name": "postgres-data", "mountPath": "/var/lib/postgresql"}
+        ]
+        assert postgres["persistence"]["enabled"] is False
 
     def test_long_form_volume_is_supported_and_read_only(
         self, builder, metadata, connection
@@ -604,9 +664,7 @@ class TestComposeVolumes:
         payload = builder.build(metadata, transformed, connection, "app-dev-abc")
         backend = payload.services[0].model_dump()
 
-        assert (payload.model_extra or {})["volumes"] == [
-            {"name": "backend-data", "emptyDir": {}}
-        ]
+        assert backend["volumes"] == [{"name": "backend-data", "emptyDir": {}}]
         assert backend["volumeMounts"] == [
             {
                 "name": "backend-data",
@@ -622,9 +680,9 @@ class TestComposeVolumes:
             metadata, transformed_compose, connection, "app-dev-abc"
         )
 
-        assert "volumes" not in (payload.model_extra or {})
         assert all(
-            "volumeMounts" not in (svc.model_extra or {}) for svc in payload.services
+            svc.volumes is None and svc.volume_mounts is None
+            for svc in payload.services
         )
 
     def test_interpolated_host_path_is_not_emitted_as_empty_dir(
@@ -649,9 +707,9 @@ class TestComposeVolumes:
         }
 
         payload = builder.build(metadata, transformed, connection, "tool-dev-abc")
-        tool = payload.services[0].model_dump()
+        tool = payload.services[0].model_dump(exclude_none=True)
 
-        assert "volumes" not in (payload.model_extra or {})
+        assert "volumes" not in tool
         assert "volumeMounts" not in tool
 
     def test_user_volume_named_tmp_avoids_operator_collision(
@@ -674,7 +732,7 @@ class TestComposeVolumes:
         payload = builder.build(metadata, transformed, connection, "tool-dev-abc")
         tool = payload.services[0].model_dump()
 
-        emitted = {v["name"] for v in (payload.model_extra or {})["volumes"]}
+        emitted = {v["name"] for v in tool["volumes"]}
         assert emitted.isdisjoint({"tmp", "data"})
         mount_names = {m["name"] for m in tool["volumeMounts"]}
         # Mounts must reference the renamed volumes, not the reserved ones.


### PR DESCRIPTION
## Summary

Compose named volumes were translated into a single extension-level list of emptyDir volumes, with mounts distributed to services. Every service owns its own pod template, so that list belongs on the service.

The consequence was worse than a modelling wart: a service declaring persistence got an emptyDir mounted over its PVC path. The PVC was provisioned and bound, and nothing was ever written to it. Postgres in a Compose-authored extension came up green on an empty ephemeral volume and lost its data on every pod restart.

## What changed

- New `kamiwaza_extensions/compose_volumes.py` builds volumes and mounts per service. A Compose volume whose target matches the service's `x-kamiwaza.persistence` mountPath is skipped, leaving the operator's PVC mount in place. The operator-injected `tmp` and `data` names stay reserved so a user volume normalizing to either gets a collision suffix instead of producing a duplicate-name pod spec the API would reject.
- `persistence` is forwarded from `x-kamiwaza` to the CR alongside `volumes` and `volumeMounts`, so a Compose-authored extension can request a PVC. The operator has supported `PersistenceSpec` since its initial commit; the SDK simply never emitted it.
- `ExtensionServiceSpec` and `PatchServiceSpec` gain `persistence` / `volumes` / `volume_mounts` and serialize by alias, so `volumeMounts` survives the round-trip.

Two deploy-path fixes rode along, both in `commands/dev.py`:

- `--service` now filters the PATCH to the built service. The transformer assigns the new revision to every build-context service, but only the selected image is built and pushed, so PATCHing the siblings rolled them to nonexistent tags and produced `ImagePullBackOff`.
- The image PATCH carries a digest when the ref has one.

## Testing

`145 passed` across `test_payload_builder.py`, `test_dev_patch.py`, `test_dev_state.py`. `ruff` and `mypy` clean on the changed modules.

Verified end to end on a dev cluster: postgres and seaweedfs both reconcile with bound PVCs (40Gi / 30Gi, `ceph-block`) and the live pod spec shows `data` backed by the PVC rather than an emptyDir.

## Note

`payload_builder.py` shows -170/+72 because the volume helpers moved out to the new module. The remaining delta there is extraction of `_find_primary_service` and `_append_platform_env` from a function that had grown past readable size.
