### PR TITLE
feat(extensions): add object-storage client and real SSO catalog credentials [ENG-9605]

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,14 @@ When your extension is ready for release:
 
 Publish profiles support multiple environments (dev/staging/prod) and CI via env var overrides (`KZ_PUBLISH_REGISTRY`, `KZ_PUBLISH_CATALOG_ENDPOINT`, etc.).
 
+Catalog credentials are selected explicitly. Existing `env` and
+`aws-profile:<name>` profiles retain boto3's standard behavior. Use `sso` (or
+`client:sso`) for bucket-scoped Cloudflare broker credentials, `client:static`
+for the canonical client's AWS/R2 static credential chain, or `client:auto` for
+automatic static-then-SSO resolution. See the
+[object-storage client guide](docs/extensions/object-storage-client.md) for the
+public client/resource API, multi-bucket mode, and authentication controls.
+
 ### Converting Existing Apps
 
 ```bash

--- a/docs/extensions/developer-guide.md
+++ b/docs/extensions/developer-guide.md
@@ -157,6 +157,8 @@ kz-ext publish --profile internal-develop --revision $(git rev-parse --short HEA
 Publishing does not deploy. After `kz-ext publish` succeeds, anyone in
 your tenant with App Garden access can install your extension from the
 catalog — that install is what creates the runtime CR on their cluster.
+For static, profile, and broker-backed SSO credential modes, see the
+[object-storage client guide](object-storage-client.md).
 
 ## `kz-ext doctor` — pre-flight checks
 

--- a/docs/extensions/object-storage-client.md
+++ b/docs/extensions/object-storage-client.md
@@ -1,0 +1,66 @@
+# Object-storage client
+
+`kamiwaza_extensions.client` is the canonical SDK client for S3-compatible
+object storage and is used by `kz-ext publish` for broker-backed catalog access.
+It provides complete client, resource, credential-provider, and multi-bucket
+behavior under a provider-neutral namespace.
+
+The storage API is boto3-compatible. Cloudflare R2 and its credential broker
+are supported capabilities, not assumptions imposed on every catalog.
+
+## Public API
+
+```python
+from kamiwaza_extensions.client import CredentialProvider, get_client, get_resource
+
+# Automatic resolution: explicit credentials, AWS profile, AWS/R2 environment,
+# then broker-backed SSO.
+s3 = get_client(auth_mode="auto")
+
+# Deterministic broker authentication for one bucket.
+catalog = get_client(bucket="extensions-dev", auth_mode="sso")
+
+# The boto3 resource API remains available.
+resource = get_resource(auth_mode="static")
+
+# Raw credentials remain available for other adapters.
+credentials = CredentialProvider(
+    auth_mode="sso", bucket="extensions-dev"
+).get_credentials()
+```
+
+With `auth_mode="sso"` and no bucket, `get_client()` retains the lazy
+multi-bucket proxy. It requests and refreshes credentials independently for
+each bucket. `kz-ext publish` intentionally uses the single-bucket form because
+one publish profile owns one catalog bucket.
+
+## Publish profiles
+
+Credential specifications are explicit so ambient developer credentials do
+not silently redirect a publish:
+
+| Specification | Behavior |
+|---|---|
+| `env` | Existing boto3 environment/session chain |
+| `aws-profile:<name>` | Existing named boto3 profile |
+| `sso` or `client:sso` | Forced broker-backed SSO for the profile bucket |
+| `client:static` | Canonical static chain; fails if credentials are absent |
+| `client:auto` | Automatic static resolution followed by broker-backed SSO |
+
+```sh
+kz-ext config publish-profile dev \
+  --registry ghcr.io/my-org \
+  --catalog-endpoint https://ACCOUNT.r2.cloudflarestorage.com \
+  --catalog-bucket extensions-dev \
+  --catalog-credentials sso
+```
+
+`R2_BROKER_URL` configures the broker. If a valid token is not cached, the CLI
+prints a login URL and waits for a loopback callback. Set
+`R2_AUTH_NON_INTERACTIVE=true` in CI so missing credentials fail immediately.
+`R2_AUTH_CALLBACK_TIMEOUT_SECONDS` controls the interactive callback timeout.
+
+The `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ENDPOINT_URL`,
+`R2_ACCOUNT_ID`, `AWS_*`, and `KAMIWAZA_REGISTRY_*` inputs remain supported by
+the reusable client. Existing `kz-ext` profiles using `env` or
+`aws-profile:<name>` are unchanged.

--- a/kamiwaza-ai-extensions-lib/package-lock.json
+++ b/kamiwaza-ai-extensions-lib/package-lock.json
@@ -746,6 +746,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -763,6 +766,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -780,6 +786,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -797,6 +806,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -814,6 +826,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -831,6 +846,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -848,6 +866,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -865,6 +886,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -882,6 +906,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -905,6 +932,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -928,6 +958,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -951,6 +984,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -974,6 +1010,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -997,6 +1036,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1020,6 +1062,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1043,6 +1088,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1239,6 +1287,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1256,6 +1307,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1273,6 +1327,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1290,6 +1347,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/kamiwaza-ai-extensions-lib/package-lock.json
+++ b/kamiwaza-ai-extensions-lib/package-lock.json
@@ -746,9 +746,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -766,9 +763,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -786,9 +780,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -806,9 +797,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -826,9 +814,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -846,9 +831,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -866,9 +848,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -886,9 +865,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "LGPL-3.0-or-later",
             "optional": true,
             "os": [
@@ -906,9 +882,6 @@
                 "arm"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -932,9 +905,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -958,9 +928,6 @@
                 "ppc64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -984,9 +951,6 @@
                 "riscv64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1010,9 +974,6 @@
                 "s390x"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1036,9 +997,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1062,9 +1020,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1088,9 +1043,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "Apache-2.0",
             "optional": true,
             "os": [
@@ -1287,9 +1239,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1307,9 +1256,6 @@
                 "arm64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1327,9 +1273,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1347,9 +1290,6 @@
                 "x64"
             ],
             "dev": true,
-            "libc": [
-                "musl"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [

--- a/kamiwaza_extensions/catalog_publisher.py
+++ b/kamiwaza_extensions/catalog_publisher.py
@@ -682,6 +682,7 @@ class CatalogPublisher:
         elif creds in {"sso", "client:sso", "client:auto", "client:static"}:
             from kamiwaza_extensions.client import get_client
             from kamiwaza_extensions.client.auth.chain import AuthMode
+            from kamiwaza_extensions.client.options import ClientOptions
 
             auth_modes: Dict[str, AuthMode] = {
                 "sso": "sso",
@@ -691,9 +692,11 @@ class CatalogPublisher:
             }
             try:
                 return get_client(
-                    endpoint_url=profile.catalog_endpoint,
-                    bucket=profile.catalog_bucket,
-                    auth_mode=auth_modes[creds],
+                    options=ClientOptions(
+                        endpoint_url=profile.catalog_endpoint,
+                        bucket=profile.catalog_bucket,
+                        auth_mode=auth_modes[creds],
+                    )
                 )
             except Exception as exc:
                 raise CatalogPublishError(

--- a/kamiwaza_extensions/catalog_publisher.py
+++ b/kamiwaza_extensions/catalog_publisher.py
@@ -181,8 +181,8 @@ class CatalogPublisher:
                 f"Supported values: {sorted(SUPPORTED_CATALOG_SCHEMAS)}."
             )
         try:
-            import boto3
-            from botocore.exceptions import ClientError
+            import boto3  # type: ignore[import-untyped]
+            from botocore.exceptions import ClientError  # type: ignore[import-untyped]
         except ImportError:
             raise ImportError(
                 "boto3 is required for catalog publishing. "
@@ -679,16 +679,31 @@ class CatalogPublisher:
             session = self._boto3.Session(profile_name=profile_name)
         elif creds == "env":
             session = self._boto3.Session()
-        elif creds == "sso":
-            raise NotImplementedError(
-                "SSO credential flow is not yet supported. "
-                "Use 'aws-profile:<name>' with an SSO-configured profile, "
-                "or 'env' with exported credentials instead."
-            )
+        elif creds in {"sso", "client:sso", "client:auto", "client:static"}:
+            from kamiwaza_extensions.client import get_client
+            from kamiwaza_extensions.client.auth.chain import AuthMode
+
+            auth_modes: Dict[str, AuthMode] = {
+                "sso": "sso",
+                "client:sso": "sso",
+                "client:auto": "auto",
+                "client:static": "static",
+            }
+            try:
+                return get_client(
+                    endpoint_url=profile.catalog_endpoint,
+                    bucket=profile.catalog_bucket,
+                    auth_mode=auth_modes[creds],
+                )
+            except Exception as exc:
+                raise CatalogPublishError(
+                    f"Failed to initialize catalog storage client: {exc}"
+                ) from exc
         else:
             raise ValueError(
                 f"Unknown credential spec '{creds}'. "
-                "Expected 'aws-profile:<name>', 'env', or 'sso'."
+                "Expected 'aws-profile:<name>', 'env', 'sso', "
+                "'client:auto', 'client:static', or 'client:sso'."
             )
 
         return session.client("s3", endpoint_url=profile.catalog_endpoint)

--- a/kamiwaza_extensions/client/__init__.py
+++ b/kamiwaza_extensions/client/__init__.py
@@ -1,0 +1,11 @@
+"""Canonical SDK client for S3-compatible object storage.
+
+The public API supports boto3 clients and resources, static credentials,
+bucket-scoped broker authentication, and lazy multi-bucket access.
+"""
+
+from kamiwaza_extensions.client.auth.credentials import Credentials
+from kamiwaza_extensions.client.auth.provider import CredentialProvider
+from kamiwaza_extensions.client.client import get_client, get_resource
+
+__all__ = ["Credentials", "CredentialProvider", "get_client", "get_resource"]

--- a/kamiwaza_extensions/client/__init__.py
+++ b/kamiwaza_extensions/client/__init__.py
@@ -7,5 +7,13 @@ bucket-scoped broker authentication, and lazy multi-bucket access.
 from kamiwaza_extensions.client.auth.credentials import Credentials
 from kamiwaza_extensions.client.auth.provider import CredentialProvider
 from kamiwaza_extensions.client.client import get_client, get_resource
+from kamiwaza_extensions.client.options import ClientOptions, ExplicitCredentials
 
-__all__ = ["Credentials", "CredentialProvider", "get_client", "get_resource"]
+__all__ = [
+    "ClientOptions",
+    "Credentials",
+    "CredentialProvider",
+    "ExplicitCredentials",
+    "get_client",
+    "get_resource",
+]

--- a/kamiwaza_extensions/client/adapters/__init__.py
+++ b/kamiwaza_extensions/client/adapters/__init__.py
@@ -1,0 +1,7 @@
+"""CLI and SDK adapters for the object-storage client."""
+
+from kamiwaza_extensions.client.adapters.base import BaseAdapter
+from kamiwaza_extensions.client.adapters.boto3 import Boto3Adapter
+from kamiwaza_extensions.client.auth.credentials import Credentials
+
+__all__ = ["BaseAdapter", "Boto3Adapter", "Credentials"]

--- a/kamiwaza_extensions/client/adapters/base.py
+++ b/kamiwaza_extensions/client/adapters/base.py
@@ -1,0 +1,30 @@
+"""Abstract adapter interface for credential consumers.
+
+Adapters consume Credentials from CredentialProvider and produce output
+in their native format (boto3 client, rclone config, env vars, etc.).
+
+To add a new adapter (e.g., rclone):
+  1. Create CredentialProvider(config=..., **cred_kwargs)
+  2. Call provider.get_credentials() to get Credentials
+  3. Transform into your format (config file, env vars, etc.)
+"""
+
+from __future__ import annotations
+
+from kamiwaza_extensions.client.auth.credentials import Credentials
+from kamiwaza_extensions.client.auth.provider import CredentialProvider
+
+
+class BaseAdapter:
+    """Abstract base for CLI/SDK adapters.
+
+    Each adapter uses a CredentialProvider and produces output
+    in its native format (e.g., boto3 client, rclone config path).
+    """
+
+    def __init__(self, credential_provider: CredentialProvider) -> None:
+        self._credential_provider = credential_provider
+
+    def get_credentials(self) -> Credentials:
+        """Return raw credentials. Override if adapter needs custom logic."""
+        return self._credential_provider.get_credentials()

--- a/kamiwaza_extensions/client/adapters/boto3.py
+++ b/kamiwaza_extensions/client/adapters/boto3.py
@@ -1,0 +1,241 @@
+"""boto3 S3 client adapter — primary adapter for R2."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import boto3  # type: ignore[import-untyped]
+import botocore.session  # type: ignore[import-untyped]
+
+from kamiwaza_extensions.client.auth.chain import AuthMode, resolve_credentials
+from kamiwaza_extensions.client.auth.credentials import Credentials
+from kamiwaza_extensions.client.auth.provider import CredentialProvider
+from kamiwaza_extensions.client.auth.static import StaticCredentials
+from kamiwaza_extensions.client.config import Config
+
+
+def _refreshable_session(
+    provider: CredentialProvider, bucket: str | None = None
+) -> boto3.Session:
+    """Create a boto3 session backed by refreshable broker credentials."""
+    core_session = botocore.session.get_session()
+    core_session._credentials = provider.to_refreshable_credentials(bucket)  # type: ignore[attr-defined]
+    return boto3.Session(botocore_session=core_session)
+
+
+def _extract_bucket_from_kwargs(_operation: str, kwargs: dict[str, Any]) -> str | None:
+    """Extract bucket name from S3 operation kwargs.
+
+    Most operations use 'Bucket'. copy_object uses 'Bucket' for destination.
+    list_buckets has no bucket. Returns None when bucket cannot be determined.
+    """
+    if "Bucket" in kwargs:
+        return cast(str, kwargs["Bucket"])
+    # CopySource can be 'bucket/key' or {'Bucket': 'x', 'Key': 'y'}
+    copy_source = kwargs.get("CopySource")
+    if isinstance(copy_source, dict) and "Bucket" in copy_source:
+        return cast(str, copy_source["Bucket"])
+    if isinstance(copy_source, str) and "/" in copy_source:
+        return copy_source.split("/", 1)[0]
+    return None
+
+
+class _MultiBucketClient:
+    """Proxy S3 client that lazily fetches credentials per bucket.
+
+    Intercepts calls, extracts the bucket from kwargs, and delegates to a
+    boto3 client created with credentials for that bucket. Browser login
+    happens at most once (JWT cached); per-bucket credential fetches use
+    the cached JWT.
+    """
+
+    def __init__(
+        self,
+        credential_provider: CredentialProvider,
+        endpoint: str | None,
+        region: str,
+    ) -> None:
+        self._provider = credential_provider
+        self._endpoint = endpoint
+        self._region = region
+        self._clients: dict[str, Any] = {}
+
+    def _get_client_for_bucket(self, bucket: str) -> Any:
+        if bucket not in self._clients:
+            client_kwargs: dict[str, Any] = {
+                "service_name": "s3",
+                "region_name": self._region,
+            }
+            if self._endpoint:
+                client_kwargs["endpoint_url"] = self._endpoint
+            session = _refreshable_session(self._provider, bucket)
+            self._clients[bucket] = session.client(**client_kwargs)
+        return self._clients[bucket]
+
+    def _delegate(self, operation: str, kwargs: dict[str, Any]) -> Any:
+        bucket = _extract_bucket_from_kwargs(operation, kwargs)
+        if bucket is None:
+            # list_buckets etc. - use default creds (broker with no bucket)
+            bucket = "default"
+        client = self._get_client_for_bucket(bucket)
+        method = getattr(client, operation)
+        return method(**kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate attribute access. Operations become wrapped calls; meta/paginators use default client."""
+        if name.startswith("_"):
+            raise AttributeError(name)
+        # meta, get_paginator, get_waiter - proxy to default client
+        if name in ("meta", "get_paginator", "get_waiter"):
+            return getattr(self._get_client_for_bucket("default"), name)
+
+        def _wrapped(*_args: Any, **kwargs: Any) -> Any:
+            return self._delegate(name, kwargs)
+
+        return _wrapped
+
+
+class Boto3Adapter:
+    """Creates boto3 S3 client/resource for R2 with auth resolution.
+
+    Implements the adapter pattern: consumes CredentialProvider and produces
+    boto3 clients and resources.
+    """
+
+    def __init__(
+        self,
+        config: Config | None = None,
+        *,
+        endpoint_url: str | None = None,
+        region_name: str | None = None,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        session_token: str | None = None,
+        bucket: str | None = None,
+        auth_mode: AuthMode = "auto",
+    ) -> None:
+        self._config = config or Config.load()
+        self._access_key_id = access_key_id
+        self._secret_access_key = secret_access_key
+        self._session_token = session_token
+        self._bucket = bucket
+        self._credential_provider = CredentialProvider(
+            config=self._config,
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+            bucket=bucket,
+            auth_mode=auth_mode,
+        )
+        self._endpoint_url = endpoint_url
+        self._region_name = region_name
+        self._auth_mode = auth_mode
+
+    def get_credentials(self) -> Credentials:
+        """Return raw credentials (for other adapters or direct use)."""
+        return self._credential_provider.get_credentials()
+
+    def get_client(self) -> Any:
+        """Return boto3 S3 client or multi-bucket proxy.
+
+        With static credentials: returns a real boto3 client.
+        With SSO and no bucket: returns MultiBucketClient (lazily fetches creds per bucket).
+        With SSO and bucket set: returns a single-bucket boto3 client.
+        """
+        static, method = resolve_credentials(
+            access_key_id=self._access_key_id,
+            secret_access_key=self._secret_access_key,
+            session_token=self._session_token,
+            auth_mode=self._auth_mode,
+        )
+
+        endpoint = self._config.get_endpoint_url(self._endpoint_url)
+        region = self._region_name or self._config.defaults.region
+
+        if method == "static" and static is not None:
+            return self._create_static_client(static, endpoint, region)
+        if method == "sso" and self._bucket is None:
+            return _MultiBucketClient(
+                credential_provider=self._credential_provider,
+                endpoint=endpoint,
+                region=region,
+            )
+        return self._create_sso_client(endpoint, region)
+
+    def _create_static_client(
+        self,
+        creds: StaticCredentials,
+        endpoint: str | None,
+        region: str,
+    ) -> Any:
+        """Create boto3 client with static credentials."""
+        client_kwargs: dict[str, Any] = {
+            "service_name": "s3",
+            "region_name": region,
+            "aws_access_key_id": creds.access_key_id,
+            "aws_secret_access_key": creds.secret_access_key,
+        }
+        if creds.session_token:
+            client_kwargs["aws_session_token"] = creds.session_token
+        if endpoint:
+            client_kwargs["endpoint_url"] = endpoint
+
+        return boto3.client(**client_kwargs)
+
+    def _create_sso_client(self, endpoint: str | None, region: str) -> Any:
+        """Create boto3 client with broker temp credentials (R2 direct)."""
+        client_kwargs: dict[str, Any] = {
+            "service_name": "s3",
+            "region_name": region,
+        }
+        if endpoint:
+            client_kwargs["endpoint_url"] = endpoint
+        session = _refreshable_session(self._credential_provider)
+        return session.client(**client_kwargs)
+
+    def get_resource(self) -> Any:
+        """Return a boto3 S3 resource (not a wrapper)."""
+        static, method = resolve_credentials(
+            access_key_id=self._access_key_id,
+            secret_access_key=self._secret_access_key,
+            session_token=self._session_token,
+            auth_mode=self._auth_mode,
+        )
+
+        endpoint = self._config.get_endpoint_url(self._endpoint_url)
+        region = self._region_name or self._config.defaults.region
+
+        if method == "static" and static is not None:
+            return self._create_static_resource(static, endpoint, region)
+        return self._create_sso_resource(endpoint, region)
+
+    def _create_static_resource(
+        self,
+        creds: StaticCredentials,
+        endpoint: str | None,
+        region: str,
+    ) -> Any:
+        """Create boto3 resource with static credentials."""
+        resource_kwargs: dict[str, Any] = {
+            "service_name": "s3",
+            "region_name": region,
+            "aws_access_key_id": creds.access_key_id,
+            "aws_secret_access_key": creds.secret_access_key,
+        }
+        if creds.session_token:
+            resource_kwargs["aws_session_token"] = creds.session_token
+        if endpoint:
+            resource_kwargs["endpoint_url"] = endpoint
+
+        return boto3.resource(**resource_kwargs)
+
+    def _create_sso_resource(self, endpoint: str | None, region: str) -> Any:
+        """Create boto3 resource with broker temp credentials (R2 direct)."""
+        resource_kwargs: dict[str, Any] = {
+            "service_name": "s3",
+            "region_name": region,
+        }
+        if endpoint:
+            resource_kwargs["endpoint_url"] = endpoint
+        session = _refreshable_session(self._credential_provider)
+        return session.resource(**resource_kwargs)

--- a/kamiwaza_extensions/client/adapters/boto3.py
+++ b/kamiwaza_extensions/client/adapters/boto3.py
@@ -7,11 +7,19 @@ from typing import Any, cast
 import boto3  # type: ignore[import-untyped]
 import botocore.session  # type: ignore[import-untyped]
 
-from kamiwaza_extensions.client.auth.chain import AuthMode, resolve_credentials
 from kamiwaza_extensions.client.auth.credentials import Credentials
 from kamiwaza_extensions.client.auth.provider import CredentialProvider
 from kamiwaza_extensions.client.auth.static import StaticCredentials
 from kamiwaza_extensions.client.config import Config
+from kamiwaza_extensions.client.options import ClientOptions, ExplicitCredentials
+
+
+def _s3_kwargs(endpoint: str | None, region: str) -> dict[str, Any]:
+    """Base kwargs shared by every boto3 S3 client and resource we build."""
+    kwargs: dict[str, Any] = {"service_name": "s3", "region_name": region}
+    if endpoint:
+        kwargs["endpoint_url"] = endpoint
+    return kwargs
 
 
 def _refreshable_session(
@@ -62,14 +70,10 @@ class _MultiBucketClient:
 
     def _get_client_for_bucket(self, bucket: str) -> Any:
         if bucket not in self._clients:
-            client_kwargs: dict[str, Any] = {
-                "service_name": "s3",
-                "region_name": self._region,
-            }
-            if self._endpoint:
-                client_kwargs["endpoint_url"] = self._endpoint
             session = _refreshable_session(self._provider, bucket)
-            self._clients[bucket] = session.client(**client_kwargs)
+            self._clients[bucket] = session.client(
+                **_s3_kwargs(self._endpoint, self._region)
+            )
         return self._clients[bucket]
 
     def _delegate(self, operation: str, kwargs: dict[str, Any]) -> Any:
@@ -106,34 +110,27 @@ class Boto3Adapter:
         self,
         config: Config | None = None,
         *,
-        endpoint_url: str | None = None,
-        region_name: str | None = None,
-        access_key_id: str | None = None,
-        secret_access_key: str | None = None,
-        session_token: str | None = None,
-        bucket: str | None = None,
-        auth_mode: AuthMode = "auto",
+        options: ClientOptions | None = None,
+        explicit: ExplicitCredentials | None = None,
     ) -> None:
         self._config = config or Config.load()
-        self._access_key_id = access_key_id
-        self._secret_access_key = secret_access_key
-        self._session_token = session_token
-        self._bucket = bucket
+        self._options = options or ClientOptions()
         self._credential_provider = CredentialProvider(
             config=self._config,
-            access_key_id=access_key_id,
-            secret_access_key=secret_access_key,
-            session_token=session_token,
-            bucket=bucket,
-            auth_mode=auth_mode,
+            explicit=explicit,
+            bucket=self._options.bucket,
+            auth_mode=self._options.auth_mode,
         )
-        self._endpoint_url = endpoint_url
-        self._region_name = region_name
-        self._auth_mode = auth_mode
 
     def get_credentials(self) -> Credentials:
         """Return raw credentials (for other adapters or direct use)."""
         return self._credential_provider.get_credentials()
+
+    def _connection(self) -> tuple[str | None, str]:
+        """Resolve the endpoint and region this adapter will connect with."""
+        endpoint = self._config.get_endpoint_url(self._options.endpoint_url)
+        region = self._options.region_name or self._config.defaults.region
+        return endpoint, region
 
     def get_client(self) -> Any:
         """Return boto3 S3 client or multi-bucket proxy.
@@ -142,100 +139,44 @@ class Boto3Adapter:
         With SSO and no bucket: returns MultiBucketClient (lazily fetches creds per bucket).
         With SSO and bucket set: returns a single-bucket boto3 client.
         """
-        static, method = resolve_credentials(
-            access_key_id=self._access_key_id,
-            secret_access_key=self._secret_access_key,
-            session_token=self._session_token,
-            auth_mode=self._auth_mode,
-        )
-
-        endpoint = self._config.get_endpoint_url(self._endpoint_url)
-        region = self._region_name or self._config.defaults.region
+        static, method = self._credential_provider.resolve_static()
+        endpoint, region = self._connection()
 
         if method == "static" and static is not None:
-            return self._create_static_client(static, endpoint, region)
-        if method == "sso" and self._bucket is None:
+            return self._static_factory("client", static, endpoint, region)
+        if method == "sso" and self._options.bucket is None:
             return _MultiBucketClient(
                 credential_provider=self._credential_provider,
                 endpoint=endpoint,
                 region=region,
             )
-        return self._create_sso_client(endpoint, region)
-
-    def _create_static_client(
-        self,
-        creds: StaticCredentials,
-        endpoint: str | None,
-        region: str,
-    ) -> Any:
-        """Create boto3 client with static credentials."""
-        client_kwargs: dict[str, Any] = {
-            "service_name": "s3",
-            "region_name": region,
-            "aws_access_key_id": creds.access_key_id,
-            "aws_secret_access_key": creds.secret_access_key,
-        }
-        if creds.session_token:
-            client_kwargs["aws_session_token"] = creds.session_token
-        if endpoint:
-            client_kwargs["endpoint_url"] = endpoint
-
-        return boto3.client(**client_kwargs)
-
-    def _create_sso_client(self, endpoint: str | None, region: str) -> Any:
-        """Create boto3 client with broker temp credentials (R2 direct)."""
-        client_kwargs: dict[str, Any] = {
-            "service_name": "s3",
-            "region_name": region,
-        }
-        if endpoint:
-            client_kwargs["endpoint_url"] = endpoint
-        session = _refreshable_session(self._credential_provider)
-        return session.client(**client_kwargs)
+        return self._sso_factory("client", endpoint, region)
 
     def get_resource(self) -> Any:
         """Return a boto3 S3 resource (not a wrapper)."""
-        static, method = resolve_credentials(
-            access_key_id=self._access_key_id,
-            secret_access_key=self._secret_access_key,
-            session_token=self._session_token,
-            auth_mode=self._auth_mode,
-        )
-
-        endpoint = self._config.get_endpoint_url(self._endpoint_url)
-        region = self._region_name or self._config.defaults.region
+        static, method = self._credential_provider.resolve_static()
+        endpoint, region = self._connection()
 
         if method == "static" and static is not None:
-            return self._create_static_resource(static, endpoint, region)
-        return self._create_sso_resource(endpoint, region)
+            return self._static_factory("resource", static, endpoint, region)
+        return self._sso_factory("resource", endpoint, region)
 
-    def _create_static_resource(
-        self,
+    @staticmethod
+    def _static_factory(
+        kind: str,
         creds: StaticCredentials,
         endpoint: str | None,
         region: str,
     ) -> Any:
-        """Create boto3 resource with static credentials."""
-        resource_kwargs: dict[str, Any] = {
-            "service_name": "s3",
-            "region_name": region,
-            "aws_access_key_id": creds.access_key_id,
-            "aws_secret_access_key": creds.secret_access_key,
-        }
+        """Build a boto3 client or resource from static credentials."""
+        kwargs = _s3_kwargs(endpoint, region)
+        kwargs["aws_access_key_id"] = creds.access_key_id
+        kwargs["aws_secret_access_key"] = creds.secret_access_key
         if creds.session_token:
-            resource_kwargs["aws_session_token"] = creds.session_token
-        if endpoint:
-            resource_kwargs["endpoint_url"] = endpoint
+            kwargs["aws_session_token"] = creds.session_token
+        return getattr(boto3, kind)(**kwargs)
 
-        return boto3.resource(**resource_kwargs)
-
-    def _create_sso_resource(self, endpoint: str | None, region: str) -> Any:
-        """Create boto3 resource with broker temp credentials (R2 direct)."""
-        resource_kwargs: dict[str, Any] = {
-            "service_name": "s3",
-            "region_name": region,
-        }
-        if endpoint:
-            resource_kwargs["endpoint_url"] = endpoint
+    def _sso_factory(self, kind: str, endpoint: str | None, region: str) -> Any:
+        """Build a boto3 client or resource from broker temp credentials."""
         session = _refreshable_session(self._credential_provider)
-        return session.resource(**resource_kwargs)
+        return getattr(session, kind)(**_s3_kwargs(endpoint, region))

--- a/kamiwaza_extensions/client/auth/__init__.py
+++ b/kamiwaza_extensions/client/auth/__init__.py
@@ -1,0 +1,13 @@
+"""Authentication resolution for the object-storage client."""
+
+from kamiwaza_extensions.client.auth.chain import resolve_credentials
+from kamiwaza_extensions.client.auth.credentials import Credentials
+from kamiwaza_extensions.client.auth.provider import CredentialProvider
+from kamiwaza_extensions.client.auth.static import StaticCredentialProvider
+
+__all__ = [
+    "Credentials",
+    "CredentialProvider",
+    "resolve_credentials",
+    "StaticCredentialProvider",
+]

--- a/kamiwaza_extensions/client/auth/base.py
+++ b/kamiwaza_extensions/client/auth/base.py
@@ -1,0 +1,31 @@
+"""Base types for authentication."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class Credentials:
+    """Credentials tuple for adapters."""
+
+    access_key_id: str
+    secret_access_key: str
+    session_token: str | None
+    expiry: datetime | None
+
+
+class CredentialProvider(ABC):
+    """Abstract base for credential providers."""
+
+    @abstractmethod
+    def can_provide(self) -> bool:
+        """Return True if this provider can supply credentials."""
+        ...
+
+    @abstractmethod
+    def get_credentials(self) -> Credentials | None:
+        """Return credentials or None."""
+        ...

--- a/kamiwaza_extensions/client/auth/chain.py
+++ b/kamiwaza_extensions/client/auth/chain.py
@@ -1,0 +1,51 @@
+"""Auth resolution chain.
+
+Priority:
+  1. Explicit credentials (pass-thru)
+  2. ~/.aws/credentials (pass-thru)
+  3. AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from env (pass-thru)
+  4. R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY from env (pass-thru)
+  5. Cloudflare SSO via broker (refreshable)
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from kamiwaza_extensions.client.auth.static import (
+    StaticCredentials,
+    get_static_credentials,
+)
+
+AuthMode = Literal["auto", "static", "sso"]
+AuthMethod = Literal["static", "sso"]
+
+
+def resolve_credentials(
+    access_key_id: str | None = None,
+    secret_access_key: str | None = None,
+    session_token: str | None = None,
+    auth_mode: AuthMode = "auto",
+) -> tuple[StaticCredentials | None, AuthMethod]:
+    """Resolve credentials via the auth chain.
+
+    Returns (credentials, method) where method is "static" or "sso".
+    For static, credentials may be None if neither explicit nor env are set.
+    """
+    if auth_mode not in {"auto", "static", "sso"}:
+        raise ValueError(f"Unknown authentication mode: {auth_mode}")
+    if auth_mode == "sso":
+        return None, "sso"
+
+    static = get_static_credentials(
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        session_token=session_token,
+    )
+    if static is not None:
+        return static, "static"
+    if auth_mode == "static":
+        raise RuntimeError(
+            "Static object-storage credentials were requested but none were found"
+        )
+    return None, "sso"

--- a/kamiwaza_extensions/client/auth/credentials.py
+++ b/kamiwaza_extensions/client/auth/credentials.py
@@ -1,0 +1,23 @@
+"""Canonical credentials type for adapters.
+
+All adapters (boto3, rclone, aws-cli, etc.) consume this format.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass
+class Credentials:
+    """Raw credentials for S3-compatible storage.
+
+    Adapters consume this and provide it in their native format
+    (e.g., boto3 client, rclone config, env vars for aws cli).
+    """
+
+    access_key_id: str
+    secret_access_key: str
+    session_token: str | None = None
+    expiry: datetime | None = None

--- a/kamiwaza_extensions/client/auth/provider.py
+++ b/kamiwaza_extensions/client/auth/provider.py
@@ -15,6 +15,7 @@ from kamiwaza_extensions.client.auth.sso import (
 )
 from kamiwaza_extensions.client.auth.static import StaticCredentials
 from kamiwaza_extensions.client.config import Config
+from kamiwaza_extensions.client.options import ExplicitCredentials
 
 # Refresh R2 creds when they have less than this many seconds left
 _REFRESH_BUFFER_SECONDS = 60
@@ -35,28 +36,28 @@ class CredentialProvider:
         self,
         config: Config | None = None,
         *,
-        access_key_id: str | None = None,
-        secret_access_key: str | None = None,
-        session_token: str | None = None,
+        explicit: ExplicitCredentials | None = None,
         bucket: str | None = None,
         auth_mode: AuthMode = "auto",
     ) -> None:
         self._config = config or Config.load()
-        self._access_key_id = access_key_id
-        self._secret_access_key = secret_access_key
-        self._session_token = session_token
+        self._explicit = explicit or ExplicitCredentials()
         self._bucket = bucket
         self._auth_mode = auth_mode
         self._sso_cache: dict[str, Credentials] = {}  # keyed by bucket or "default"
 
-    def get_credentials(self) -> Credentials:
-        """Return credentials (static or SSO). Handles refresh for SSO."""
-        static, method = resolve_credentials(
-            access_key_id=self._access_key_id,
-            secret_access_key=self._secret_access_key,
-            session_token=self._session_token,
+    def resolve_static(self) -> tuple[StaticCredentials | None, str]:
+        """Resolve the caller-supplied credentials against the auth mode."""
+        return resolve_credentials(
+            access_key_id=self._explicit.access_key_id,
+            secret_access_key=self._explicit.secret_access_key,
+            session_token=self._explicit.session_token,
             auth_mode=self._auth_mode,
         )
+
+    def get_credentials(self) -> Credentials:
+        """Return credentials (static or SSO). Handles refresh for SSO."""
+        static, method = self.resolve_static()
 
         if method == "static" and static is not None:
             return self._static_to_credentials(static)
@@ -73,12 +74,7 @@ class CredentialProvider:
         Raises:
             RuntimeError: When using static credentials (bucket-specific not supported).
         """
-        static, method = resolve_credentials(
-            access_key_id=self._access_key_id,
-            secret_access_key=self._secret_access_key,
-            session_token=self._session_token,
-            auth_mode=self._auth_mode,
-        )
+        static, method = self.resolve_static()
         if method == "static" and static is not None:
             raise RuntimeError(
                 "get_credentials_for_bucket is only for SSO flow. "
@@ -104,12 +100,8 @@ class CredentialProvider:
         """Get SSO credentials for a bucket (cached or fresh from broker)."""
         cache_key = bucket_or_default
         now = datetime.now(timezone.utc)
-        cached = self._sso_cache.get(cache_key)
-        if (
-            cached
-            and cached.expiry
-            and cached.expiry > now + timedelta(seconds=_REFRESH_BUFFER_SECONDS)
-        ):
+        cached = self._cached_if_fresh(cache_key, now)
+        if cached is not None:
             return cached
 
         broker_url = self._config.r2.broker_url
@@ -121,7 +113,25 @@ class CredentialProvider:
         bucket_param = None if cache_key == "default" else cache_key
         token = get_cloudflare_token(self._config, bucket=bucket_param)
         result = exchange_token_for_credentials(token, broker_url, bucket=bucket_param)
-        expiration = result.get("expiration")
+        creds = Credentials(
+            access_key_id=result["access_key_id"],
+            secret_access_key=result["secret_access_key"],
+            session_token=result.get("session_token"),
+            expiry=self._resolve_expiry(result.get("expiration"), now),
+        )
+        self._sso_cache[cache_key] = creds
+        return creds
+
+    def _cached_if_fresh(self, cache_key: str, now: datetime) -> Credentials | None:
+        """Return the cached credentials while they remain outside the buffer."""
+        cached = self._sso_cache.get(cache_key)
+        if not cached or not cached.expiry:
+            return None
+        buffer = timedelta(seconds=_REFRESH_BUFFER_SECONDS)
+        return cached if cached.expiry > now + buffer else None
+
+    def _resolve_expiry(self, expiration: Any, now: datetime) -> datetime:
+        """Validate the broker expiry, falling back to the configured TTL."""
         expiry = _parse_expiry(expiration)
         if expiration is not None and expiry is None:
             raise RuntimeError("Credential broker returned an invalid expiration")
@@ -131,14 +141,7 @@ class CredentialProvider:
             )
         if expiry <= now:
             raise RuntimeError("Credential broker returned expired credentials")
-        creds = Credentials(
-            access_key_id=result["access_key_id"],
-            secret_access_key=result["secret_access_key"],
-            session_token=result.get("session_token"),
-            expiry=expiry,
-        )
-        self._sso_cache[cache_key] = creds
-        return creds
+        return expiry
 
     def to_refreshable_credentials(
         self, bucket: str | None = None

--- a/kamiwaza_extensions/client/auth/provider.py
+++ b/kamiwaza_extensions/client/auth/provider.py
@@ -1,0 +1,190 @@
+"""Credential provider — yields raw credentials for any adapter."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from botocore.credentials import RefreshableCredentials  # type: ignore[import-untyped]
+
+from kamiwaza_extensions.client.auth.chain import AuthMode, resolve_credentials
+from kamiwaza_extensions.client.auth.credentials import Credentials
+from kamiwaza_extensions.client.auth.sso import (
+    exchange_token_for_credentials,
+    get_cloudflare_token,
+)
+from kamiwaza_extensions.client.auth.static import StaticCredentials
+from kamiwaza_extensions.client.config import Config
+
+# Refresh R2 creds when they have less than this many seconds left
+_REFRESH_BUFFER_SECONDS = 60
+
+
+class CredentialProvider:
+    """Provides raw credentials for any adapter (boto3, rclone, aws-cli, etc.).
+
+    Handles both static and SSO flows. Adapters call get_credentials() and
+    receive Credentials in a format they can consume.
+
+    When bucket is set, SSO credentials are requested for that bucket.
+    Useful when the user is in multiple groups and the default role-based
+    bucket would be prod; pass bucket='dev-kevin-test' to get dev creds.
+    """
+
+    def __init__(
+        self,
+        config: Config | None = None,
+        *,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        session_token: str | None = None,
+        bucket: str | None = None,
+        auth_mode: AuthMode = "auto",
+    ) -> None:
+        self._config = config or Config.load()
+        self._access_key_id = access_key_id
+        self._secret_access_key = secret_access_key
+        self._session_token = session_token
+        self._bucket = bucket
+        self._auth_mode = auth_mode
+        self._sso_cache: dict[str, Credentials] = {}  # keyed by bucket or "default"
+
+    def get_credentials(self) -> Credentials:
+        """Return credentials (static or SSO). Handles refresh for SSO."""
+        static, method = resolve_credentials(
+            access_key_id=self._access_key_id,
+            secret_access_key=self._secret_access_key,
+            session_token=self._session_token,
+            auth_mode=self._auth_mode,
+        )
+
+        if method == "static" and static is not None:
+            return self._static_to_credentials(static)
+
+        return self._get_sso_credentials()
+
+    def get_credentials_for_bucket(self, bucket: str) -> Credentials:
+        """Return credentials for a specific bucket (SSO only).
+
+        Use when managing multiple buckets: fetches or returns cached creds
+        for the given bucket. Browser login happens once (JWT cached); per-bucket
+        credential fetches use the cached JWT.
+
+        Raises:
+            RuntimeError: When using static credentials (bucket-specific not supported).
+        """
+        static, method = resolve_credentials(
+            access_key_id=self._access_key_id,
+            secret_access_key=self._secret_access_key,
+            session_token=self._session_token,
+            auth_mode=self._auth_mode,
+        )
+        if method == "static" and static is not None:
+            raise RuntimeError(
+                "get_credentials_for_bucket is only for SSO flow. "
+                "With static credentials, use a single client."
+            )
+        return self._get_sso_credentials_for_bucket(bucket)
+
+    def _static_to_credentials(self, static: StaticCredentials) -> Credentials:
+        """Convert static credentials to Credentials."""
+        return Credentials(
+            access_key_id=static.access_key_id,
+            secret_access_key=static.secret_access_key,
+            session_token=static.session_token,
+            expiry=None,
+        )
+
+    def _get_sso_credentials(self) -> Credentials:
+        """Get SSO credentials (cached or fresh from broker)."""
+        cache_key = self._bucket or "default"
+        return self._get_sso_credentials_for_bucket(cache_key)
+
+    def _get_sso_credentials_for_bucket(self, bucket_or_default: str) -> Credentials:
+        """Get SSO credentials for a bucket (cached or fresh from broker)."""
+        cache_key = bucket_or_default
+        now = datetime.now(timezone.utc)
+        cached = self._sso_cache.get(cache_key)
+        if (
+            cached
+            and cached.expiry
+            and cached.expiry > now + timedelta(seconds=_REFRESH_BUFFER_SECONDS)
+        ):
+            return cached
+
+        broker_url = self._config.r2.broker_url
+        if not broker_url:
+            raise RuntimeError(
+                "Broker URL not configured. Set R2_BROKER_URL in your environment."
+            )
+
+        bucket_param = None if cache_key == "default" else cache_key
+        token = get_cloudflare_token(self._config, bucket=bucket_param)
+        result = exchange_token_for_credentials(token, broker_url, bucket=bucket_param)
+        expiration = result.get("expiration")
+        expiry = _parse_expiry(expiration)
+        if expiration is not None and expiry is None:
+            raise RuntimeError("Credential broker returned an invalid expiration")
+        if expiry is None:
+            expiry = now + timedelta(
+                seconds=self._config.defaults.credential_ttl_seconds
+            )
+        if expiry <= now:
+            raise RuntimeError("Credential broker returned expired credentials")
+        creds = Credentials(
+            access_key_id=result["access_key_id"],
+            secret_access_key=result["secret_access_key"],
+            session_token=result.get("session_token"),
+            expiry=expiry,
+        )
+        self._sso_cache[cache_key] = creds
+        return creds
+
+    def to_refreshable_credentials(
+        self, bucket: str | None = None
+    ) -> RefreshableCredentials:
+        """Wrap temporary credentials for botocore automatic refresh."""
+
+        def get_current() -> Credentials:
+            if bucket is None:
+                return self.get_credentials()
+            return self.get_credentials_for_bucket(bucket)
+
+        creds = get_current()
+        if creds.expiry is None:
+            raise RuntimeError("Static credentials cannot be made refreshable")
+
+        def refresh() -> dict[str, Any]:
+            c = get_current()
+            if c.expiry is None:
+                raise RuntimeError("Credential broker returned no expiration")
+            return {
+                "access_key": c.access_key_id,
+                "secret_key": c.secret_access_key,
+                "token": c.session_token,
+                "expiry_time": c.expiry.isoformat(),
+            }
+
+        return RefreshableCredentials(
+            access_key=creds.access_key_id,
+            secret_key=creds.secret_access_key,
+            token=creds.session_token,
+            expiry_time=creds.expiry,
+            refresh_using=refresh,
+            method="r2-sso",
+            advisory_timeout=_REFRESH_BUFFER_SECONDS,
+            mandatory_timeout=10,
+        )
+
+
+def _parse_expiry(value: str | None) -> datetime | None:
+    """Parse ISO expiration string to datetime."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except (ValueError, TypeError):
+        return None

--- a/kamiwaza_extensions/client/auth/sso.py
+++ b/kamiwaza_extensions/client/auth/sso.py
@@ -1,0 +1,415 @@
+"""Cloudflare auth + credential broker exchange.
+
+Uses Cloudflare for authentication (Google SSO is integrated in Cloudflare).
+Prints login URL; user opens it in browser and logs in via Cloudflare.
+Uses authorization code flow with PKCE (OAuth 2.0 best practice).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import html
+import json
+import os
+import secrets
+import stat
+import tempfile
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from importlib import resources
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import requests  # type: ignore[import-untyped]
+
+from kamiwaza_extensions.client.config import DEFAULT_CONFIG_DIR, Config
+
+
+def _load_template(name: str) -> str:
+    """Load HTML template from package templates directory."""
+    path = resources.files("kamiwaza_extensions.client.auth") / "templates" / name
+    return path.read_text(encoding="utf-8")
+
+
+def _generate_pkce_pair() -> tuple[str, str]:
+    """Generate PKCE code_verifier and code_challenge (S256).
+
+    Returns:
+        (code_verifier, code_challenge)
+    """
+    code_verifier = (
+        base64.urlsafe_b64encode(secrets.token_bytes(32)).decode().rstrip("=")
+    )
+    digest = hashlib.sha256(code_verifier.encode()).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).decode().rstrip("=")
+    return code_verifier, code_challenge
+
+
+def get_cloudflare_token(config: Config, bucket: str | None = None) -> str:
+    """Obtain Cloudflare auth token (cached or via browser login).
+
+    When no valid cached token exists, prints the broker login URL. The user
+    opens it and logs in via Cloudflare; the broker redirects back with a code.
+
+    Args:
+        config: R2 client config.
+        bucket: Optional bucket name; when provided, shown on success/error pages.
+
+    Raises:
+        RuntimeError: If no valid token can be obtained.
+    """
+    token_path = Path(config.auth.token_cache_path).expanduser()
+    _ensure_private_directory(token_path.parent)
+
+    # Try cached token first
+    cached = _load_cached_token(token_path)
+    if (
+        cached
+        and isinstance(cached.get("token"), str)
+        and not _is_token_expired(cached)
+    ):
+        return cast(str, cached["token"])
+
+    if config.auth.non_interactive:
+        raise RuntimeError(
+            "Interactive Cloudflare login is disabled and no valid cached token exists"
+        )
+
+    # Cloudflare login via broker.
+    token = _run_cloudflare_login(config, token_path, bucket=bucket)
+    return token
+
+
+def _load_cached_token(path: Path) -> dict[str, Any] | None:
+    """Load cached token from disk."""
+    if not path.exists():
+        return None
+    if path.is_symlink() or not path.is_file():
+        raise RuntimeError(f"Token cache must be a regular file: {path}")
+    try:
+        path.chmod(0o600)
+        with path.open(encoding="utf-8") as f:
+            cached = json.load(f)
+        if not isinstance(cached, dict):
+            return None
+        return cast(dict[str, Any], cached)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _is_token_expired(cached: dict[str, Any]) -> bool:
+    """Check if cached token is expired (best-effort).
+
+    Uses expires_at from cache, or decodes JWT exp claim if present.
+    Expiry is dictated by the Cloudflare Access application's session config.
+    """
+    expiry = cached.get("expires_at")
+    if expiry:
+        try:
+            from datetime import datetime, timezone
+
+            exp = datetime.fromisoformat(expiry.replace("Z", "+00:00"))
+            return datetime.now(timezone.utc) >= exp
+        except (ValueError, TypeError):
+            pass
+    # Fallback: decode JWT exp claim (Cloudflare Access dictates session lifetime)
+    token = cached.get("token")
+    if token:
+        exp_ts = _jwt_exp_claim(token)
+        if exp_ts is not None:
+            import time
+
+            return time.time() >= exp_ts
+    return False
+
+
+def _jwt_exp_claim(token: str) -> int | None:
+    """Extract exp (expiration) claim from JWT payload without verification."""
+    try:
+        import base64
+
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        payload = parts[1]
+        # base64url: replace - with +, _ with /
+        padding = 4 - len(payload) % 4
+        if padding != 4:
+            payload += "=" * padding
+        payload = payload.replace("-", "+").replace("_", "/")
+        data = json.loads(base64.b64decode(payload).decode())
+        exp = data.get("exp")
+        if isinstance(exp, int) and not isinstance(exp, bool):
+            return exp
+        return None
+    except (ValueError, KeyError, TypeError, UnicodeError):
+        return None
+
+
+def _run_cloudflare_login(
+    config: Config, token_path: Path, bucket: str | None = None
+) -> str:
+    """Open browser to broker login; receive code via localhost callback; exchange for token."""
+    broker_url = config.r2.broker_url
+    if not broker_url:
+        raise RuntimeError(
+            "Broker URL not configured. Set R2_BROKER_URL in your environment. "
+            "This is typically set by your organization for Cloudflare R2 access."
+        )
+    _validate_broker_url(broker_url)
+
+    code_verifier, code_challenge = _generate_pkce_pair()
+    expected_state = secrets.token_urlsafe(32)
+
+    code_received: list[str] = []
+    error_received: list[str] = []
+    bucket_received: list[str] = []
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path == "/callback":
+                params = parse_qs(parsed.query)
+                received_state = params.get("state", [""])[0]
+                if not secrets.compare_digest(received_state, expected_state):
+                    error_received.append("Invalid login callback state")
+                elif "code" in params:
+                    code_received.append(params["code"][0])
+                elif "error" in params:
+                    error_received.append(params["error"][0])
+                if "bucket" in params:
+                    bucket_received.append(params["bucket"][0])
+            self._send_response()
+
+        def _send_response(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            display_bucket = bucket_received[0] if bucket_received else bucket
+            bucket_label = (
+                f" for {html.escape(display_bucket)}" if display_bucket else ""
+            )
+            if code_received:
+                body = _load_template("callback_success.html").replace(
+                    "{{bucket_label}}", bucket_label
+                )
+            elif error_received:
+                body = (
+                    _load_template("callback_error.html")
+                    .replace("{{error}}", html.escape(error_received[0]))
+                    .replace("{{bucket_label}}", bucket_label)
+                )
+            else:
+                body = _load_template("callback_no_code.html").replace(
+                    "{{bucket_label}}", bucket_label
+                )
+            self.wfile.write(body.encode())
+
+        def log_message(self, format: str, *args: Any) -> None:
+            pass  # Suppress server logs
+
+    with HTTPServer(("127.0.0.1", 0), CallbackHandler) as httpd:
+        port = cast(int, httpd.server_address[1])
+        callback_params = {"state": expected_state}
+        if bucket:
+            callback_params["bucket"] = bucket
+        redirect_uri = f"http://127.0.0.1:{port}/callback?{urlencode(callback_params)}"
+        login_params = {
+            "redirect_uri": redirect_uri,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        login_url = f"{broker_url.rstrip('/')}/login?{urlencode(login_params)}"
+        sep = "=" * 72
+        print(
+            f"\n{sep}\n"
+            f"  CLOUDFLARE LOGIN REQUIRED\n"
+            f"  Open this URL in your browser to authenticate:\n"
+            f"\n  {login_url}\n"
+            f"{sep}\n",
+            flush=True,
+        )
+
+        deadline = time.monotonic() + config.auth.callback_timeout_seconds
+        while not code_received and not error_received:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            httpd.timeout = remaining
+            httpd.handle_request()
+
+    if error_received:
+        raise RuntimeError(f"Cloudflare login failed: {error_received[0]}")
+
+    if not code_received:
+        raise RuntimeError(
+            "Cloudflare login did not complete before the callback timeout. "
+            "Please try again."
+        )
+
+    token = _exchange_code_for_token(
+        code=code_received[0],
+        code_verifier=code_verifier,
+        redirect_uri=redirect_uri,
+        broker_url=broker_url,
+    )
+    _save_token(token_path, token, config.defaults.credential_ttl_seconds)
+    return token
+
+
+def _exchange_code_for_token(
+    code: str,
+    code_verifier: str,
+    redirect_uri: str,
+    broker_url: str,
+) -> str:
+    """Exchange authorization code for JWT (PKCE flow)."""
+    _validate_broker_url(broker_url)
+    resp = requests.post(
+        broker_url.rstrip("/") + "/token",
+        json={
+            "code": code,
+            "code_verifier": code_verifier,
+            "redirect_uri": redirect_uri,
+        },
+        headers={"Content-Type": "application/json"},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    try:
+        data = resp.json()
+    except requests.exceptions.JSONDecodeError as e:
+        raise RuntimeError(
+            f"Broker /token returned non-JSON (status {resp.status_code}). "
+            "Ensure Cloudflare Access permits the token exchange endpoint."
+        ) from e
+    if not isinstance(data, dict):
+        raise RuntimeError("Broker /token response must be a JSON object")
+    token = data.get("token")
+    if not isinstance(token, str) or not token:
+        raise RuntimeError("Broker did not return a token")
+    return cast(str, token)
+
+
+def _save_token(path: Path, token: str, fallback_ttl_seconds: int = 900) -> None:
+    """Save token to disk with secure permissions.
+
+    Expiry is dictated by the Cloudflare Access JWT exp claim when decodable;
+    otherwise falls back to fallback_ttl_seconds.
+    """
+    from datetime import datetime, timezone
+
+    _ensure_private_directory(path.parent)
+    exp_ts = _jwt_exp_claim(token)
+    if exp_ts is not None:
+        expires_at = datetime.fromtimestamp(exp_ts, tz=timezone.utc).isoformat()
+    else:
+        from datetime import timedelta
+
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=fallback_ttl_seconds)
+        ).isoformat()
+    data = {"token": token, "expires_at": expires_at}
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as token_file:
+            json.dump(data, token_file, indent=2)
+        temp_path.replace(path)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _ensure_private_directory(path: Path) -> None:
+    """Create or tighten a directory used to store authentication state."""
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if path.stat().st_uid != os.getuid():
+        raise RuntimeError(f"Token directory is not owned by the current user: {path}")
+    permissions = stat.S_IMODE(path.stat().st_mode)
+    if permissions & 0o077 and path != DEFAULT_CONFIG_DIR.expanduser():
+        raise RuntimeError(f"Token directory permissions are too broad: {path}")
+    try:
+        path.chmod(0o700)
+    except OSError as exc:
+        raise RuntimeError(f"Could not secure token directory: {path}") from exc
+
+
+def _validate_broker_url(broker_url: str) -> None:
+    """Require a trustworthy HTTP origin for credential-broker requests."""
+    parsed = urlparse(broker_url)
+    if parsed.username or parsed.password:
+        raise RuntimeError("Credential broker URL must not contain user information")
+    if parsed.scheme == "https" and parsed.hostname:
+        return
+    if parsed.scheme == "http" and parsed.hostname in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+    }:
+        return
+    raise RuntimeError(
+        "Credential broker URL must use HTTPS (HTTP is allowed only for localhost)"
+    )
+
+
+def exchange_token_for_credentials(
+    token: str,
+    broker_url: str,
+    *,
+    bucket: str | None = None,
+) -> dict[str, Any]:
+    """Exchange Cloudflare auth token for temporary R2 credentials.
+
+    When bucket is provided, requests credentials for that bucket. Useful when
+    the user is in multiple groups (e.g. developer + ops) and the default
+    role-based bucket would be prod; pass bucket='dev-kevin-test' to get
+    dev credentials instead.
+
+    Returns:
+        Dict with access_key_id, secret_access_key, session_token, expiration.
+    """
+    _validate_broker_url(broker_url)
+    payload: dict[str, Any] = {"token": token}
+    if bucket:
+        payload["bucket"] = bucket
+    resp = requests.post(
+        broker_url.rstrip("/") + "/credentials",
+        json=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+    try:
+        response_data = resp.json()
+    except requests.exceptions.JSONDecodeError as exc:
+        raise RuntimeError("Credential broker returned a non-JSON response") from exc
+    if not isinstance(response_data, dict):
+        raise RuntimeError("Credential broker response must be a JSON object")
+    data = cast(dict[str, Any], response_data)
+    missing = [
+        field
+        for field in ("access_key_id", "secret_access_key")
+        if not isinstance(data.get(field), str) or not data[field]
+    ]
+    if missing:
+        raise RuntimeError(
+            "Credential broker response omitted required fields: " + ", ".join(missing)
+        )
+    session_token = data.get("session_token")
+    if session_token is not None and not isinstance(session_token, str):
+        raise RuntimeError("Credential broker returned an invalid session_token")
+    expiration = data.get("expiration")
+    if expiration is not None and not isinstance(expiration, str):
+        raise RuntimeError("Credential broker returned an invalid expiration")
+    return data

--- a/kamiwaza_extensions/client/auth/sso.py
+++ b/kamiwaza_extensions/client/auth/sso.py
@@ -16,6 +16,8 @@ import secrets
 import stat
 import tempfile
 import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from importlib import resources
 from pathlib import Path
@@ -25,6 +27,10 @@ from urllib.parse import parse_qs, urlencode, urlparse
 import requests  # type: ignore[import-untyped]
 
 from kamiwaza_extensions.client.config import DEFAULT_CONFIG_DIR, Config
+
+_LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+_REQUIRED_CREDENTIAL_FIELDS = ("access_key_id", "secret_access_key")
+_OPTIONAL_CREDENTIAL_FIELDS = ("session_token", "expiration")
 
 
 def _load_template(name: str) -> str:
@@ -63,23 +69,27 @@ def get_cloudflare_token(config: Config, bucket: str | None = None) -> str:
     token_path = Path(config.auth.token_cache_path).expanduser()
     _ensure_private_directory(token_path.parent)
 
-    # Try cached token first
-    cached = _load_cached_token(token_path)
-    if (
-        cached
-        and isinstance(cached.get("token"), str)
-        and not _is_token_expired(cached)
-    ):
-        return cast(str, cached["token"])
+    cached_token = _valid_cached_token(token_path)
+    if cached_token is not None:
+        return cached_token
 
     if config.auth.non_interactive:
         raise RuntimeError(
             "Interactive Cloudflare login is disabled and no valid cached token exists"
         )
 
-    # Cloudflare login via broker.
-    token = _run_cloudflare_login(config, token_path, bucket=bucket)
-    return token
+    return _run_cloudflare_login(config, token_path, bucket=bucket)
+
+
+def _valid_cached_token(token_path: Path) -> str | None:
+    """Return the cached token when one is present and still valid."""
+    cached = _load_cached_token(token_path)
+    if not cached:
+        return None
+    token = cached.get("token")
+    if not isinstance(token, str):
+        return None
+    return None if _is_token_expired(cached) else token
 
 
 def _load_cached_token(path: Path) -> dict[str, Any] | None:
@@ -105,41 +115,33 @@ def _is_token_expired(cached: dict[str, Any]) -> bool:
     Uses expires_at from cache, or decodes JWT exp claim if present.
     Expiry is dictated by the Cloudflare Access application's session config.
     """
-    expiry = cached.get("expires_at")
-    if expiry:
-        try:
-            from datetime import datetime, timezone
+    declared_expiry = _parse_iso_expiry(cached.get("expires_at"))
+    if declared_expiry is not None:
+        return datetime.now(timezone.utc) >= declared_expiry
 
-            exp = datetime.fromisoformat(expiry.replace("Z", "+00:00"))
-            return datetime.now(timezone.utc) >= exp
-        except (ValueError, TypeError):
-            pass
     # Fallback: decode JWT exp claim (Cloudflare Access dictates session lifetime)
     token = cached.get("token")
-    if token:
-        exp_ts = _jwt_exp_claim(token)
-        if exp_ts is not None:
-            import time
+    exp_ts = _jwt_exp_claim(token) if token else None
+    return exp_ts is not None and time.time() >= exp_ts
 
-            return time.time() >= exp_ts
-    return False
+
+def _parse_iso_expiry(expiry: Any) -> datetime | None:
+    """Parse a cached ISO-8601 expiry, tolerating a trailing ``Z``."""
+    if not expiry:
+        return None
+    try:
+        return datetime.fromisoformat(str(expiry).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
 
 
 def _jwt_exp_claim(token: str) -> int | None:
     """Extract exp (expiration) claim from JWT payload without verification."""
     try:
-        import base64
-
         parts = token.split(".")
         if len(parts) != 3:
             return None
-        payload = parts[1]
-        # base64url: replace - with +, _ with /
-        padding = 4 - len(payload) % 4
-        if padding != 4:
-            payload += "=" * padding
-        payload = payload.replace("-", "+").replace("_", "/")
-        data = json.loads(base64.b64decode(payload).decode())
+        data = json.loads(_decode_jwt_segment(parts[1]))
         exp = data.get("exp")
         if isinstance(exp, int) and not isinstance(exp, bool):
             return exp
@@ -148,10 +150,123 @@ def _jwt_exp_claim(token: str) -> int | None:
         return None
 
 
+def _decode_jwt_segment(payload: str) -> str:
+    """Decode one base64url JWT segment to text."""
+    padding = 4 - len(payload) % 4
+    if padding != 4:
+        payload += "=" * padding
+    payload = payload.replace("-", "+").replace("_", "/")
+    return base64.b64decode(payload).decode()
+
+
+@dataclass
+class _CallbackResult:
+    """What the local callback server captured from the broker redirect."""
+
+    codes: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    buckets: list[str] = field(default_factory=list)
+
+    @property
+    def settled(self) -> bool:
+        return bool(self.codes or self.errors)
+
+
+def _callback_handler_class(
+    result: _CallbackResult,
+    expected_state: str,
+    bucket: str | None,
+) -> type[BaseHTTPRequestHandler]:
+    """Build the one-shot callback handler bound to this login attempt."""
+
+    class CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            parsed = urlparse(self.path)
+            if parsed.path == "/callback":
+                _record_callback_params(
+                    result, parse_qs(parsed.query), expected_state
+                )
+            self._send_response()
+
+        def _send_response(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(_callback_body(result, bucket).encode())
+
+        def log_message(self, format: str, *args: Any) -> None:
+            pass  # Suppress server logs
+
+    return CallbackHandler
+
+
+def _record_callback_params(
+    result: _CallbackResult,
+    params: dict[str, list[str]],
+    expected_state: str,
+) -> None:
+    """Record the redirect outcome, rejecting a mismatched state."""
+    received_state = params.get("state", [""])[0]
+    if not secrets.compare_digest(received_state, expected_state):
+        result.errors.append("Invalid login callback state")
+    elif "code" in params:
+        result.codes.append(params["code"][0])
+    elif "error" in params:
+        result.errors.append(params["error"][0])
+    if "bucket" in params:
+        result.buckets.append(params["bucket"][0])
+
+
+def _callback_body(result: _CallbackResult, bucket: str | None) -> str:
+    """Render the browser-facing page for the completed redirect."""
+    display_bucket = result.buckets[0] if result.buckets else bucket
+    bucket_label = f" for {html.escape(display_bucket)}" if display_bucket else ""
+    if result.codes:
+        return _load_template("callback_success.html").replace(
+            "{{bucket_label}}", bucket_label
+        )
+    if result.errors:
+        return (
+            _load_template("callback_error.html")
+            .replace("{{error}}", html.escape(result.errors[0]))
+            .replace("{{bucket_label}}", bucket_label)
+        )
+    return _load_template("callback_no_code.html").replace(
+        "{{bucket_label}}", bucket_label
+    )
+
+
 def _run_cloudflare_login(
     config: Config, token_path: Path, bucket: str | None = None
 ) -> str:
     """Open browser to broker login; receive code via localhost callback; exchange for token."""
+    broker_url = _require_broker_url(config)
+    code_verifier, code_challenge = _generate_pkce_pair()
+    expected_state = secrets.token_urlsafe(32)
+    result = _CallbackResult()
+
+    handler = _callback_handler_class(result, expected_state, bucket)
+    with HTTPServer(("127.0.0.1", 0), handler) as httpd:
+        port = cast(int, httpd.server_address[1])
+        redirect_uri = _build_redirect_uri(port, expected_state, bucket)
+        _print_login_prompt(
+            _build_login_url(broker_url, redirect_uri, code_challenge)
+        )
+        _await_callback(httpd, result, config.auth.callback_timeout_seconds)
+
+    code = _require_callback_code(result)
+    token = _exchange_code_for_token(
+        code=code,
+        code_verifier=code_verifier,
+        redirect_uri=redirect_uri,
+        broker_url=broker_url,
+    )
+    _save_token(token_path, token, config.defaults.credential_ttl_seconds)
+    return token
+
+
+def _require_broker_url(config: Config) -> str:
+    """Return the configured broker URL, or explain how to set it."""
     broker_url = config.r2.broker_url
     if not broker_url:
         raise RuntimeError(
@@ -159,104 +274,60 @@ def _run_cloudflare_login(
             "This is typically set by your organization for Cloudflare R2 access."
         )
     _validate_broker_url(broker_url)
+    return broker_url
 
-    code_verifier, code_challenge = _generate_pkce_pair()
-    expected_state = secrets.token_urlsafe(32)
 
-    code_received: list[str] = []
-    error_received: list[str] = []
-    bucket_received: list[str] = []
+def _build_redirect_uri(port: int, expected_state: str, bucket: str | None) -> str:
+    callback_params = {"state": expected_state}
+    if bucket:
+        callback_params["bucket"] = bucket
+    return f"http://127.0.0.1:{port}/callback?{urlencode(callback_params)}"
 
-    class CallbackHandler(BaseHTTPRequestHandler):
-        def do_GET(self) -> None:
-            parsed = urlparse(self.path)
-            if parsed.path == "/callback":
-                params = parse_qs(parsed.query)
-                received_state = params.get("state", [""])[0]
-                if not secrets.compare_digest(received_state, expected_state):
-                    error_received.append("Invalid login callback state")
-                elif "code" in params:
-                    code_received.append(params["code"][0])
-                elif "error" in params:
-                    error_received.append(params["error"][0])
-                if "bucket" in params:
-                    bucket_received.append(params["bucket"][0])
-            self._send_response()
 
-        def _send_response(self) -> None:
-            self.send_response(200)
-            self.send_header("Content-Type", "text/html")
-            self.end_headers()
-            display_bucket = bucket_received[0] if bucket_received else bucket
-            bucket_label = (
-                f" for {html.escape(display_bucket)}" if display_bucket else ""
-            )
-            if code_received:
-                body = _load_template("callback_success.html").replace(
-                    "{{bucket_label}}", bucket_label
-                )
-            elif error_received:
-                body = (
-                    _load_template("callback_error.html")
-                    .replace("{{error}}", html.escape(error_received[0]))
-                    .replace("{{bucket_label}}", bucket_label)
-                )
-            else:
-                body = _load_template("callback_no_code.html").replace(
-                    "{{bucket_label}}", bucket_label
-                )
-            self.wfile.write(body.encode())
+def _build_login_url(broker_url: str, redirect_uri: str, code_challenge: str) -> str:
+    login_params = {
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    return f"{broker_url.rstrip('/')}/login?{urlencode(login_params)}"
 
-        def log_message(self, format: str, *args: Any) -> None:
-            pass  # Suppress server logs
 
-    with HTTPServer(("127.0.0.1", 0), CallbackHandler) as httpd:
-        port = cast(int, httpd.server_address[1])
-        callback_params = {"state": expected_state}
-        if bucket:
-            callback_params["bucket"] = bucket
-        redirect_uri = f"http://127.0.0.1:{port}/callback?{urlencode(callback_params)}"
-        login_params = {
-            "redirect_uri": redirect_uri,
-            "code_challenge": code_challenge,
-            "code_challenge_method": "S256",
-        }
-        login_url = f"{broker_url.rstrip('/')}/login?{urlencode(login_params)}"
-        sep = "=" * 72
-        print(
-            f"\n{sep}\n"
-            f"  CLOUDFLARE LOGIN REQUIRED\n"
-            f"  Open this URL in your browser to authenticate:\n"
-            f"\n  {login_url}\n"
-            f"{sep}\n",
-            flush=True,
-        )
+def _print_login_prompt(login_url: str) -> None:
+    sep = "=" * 72
+    print(
+        f"\n{sep}\n"
+        f"  CLOUDFLARE LOGIN REQUIRED\n"
+        f"  Open this URL in your browser to authenticate:\n"
+        f"\n  {login_url}\n"
+        f"{sep}\n",
+        flush=True,
+    )
 
-        deadline = time.monotonic() + config.auth.callback_timeout_seconds
-        while not code_received and not error_received:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                break
-            httpd.timeout = remaining
-            httpd.handle_request()
 
-    if error_received:
-        raise RuntimeError(f"Cloudflare login failed: {error_received[0]}")
+def _await_callback(
+    httpd: HTTPServer, result: _CallbackResult, timeout_seconds: float
+) -> None:
+    """Serve requests until the redirect arrives or the deadline passes."""
+    deadline = time.monotonic() + timeout_seconds
+    while not result.settled:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        httpd.timeout = remaining
+        httpd.handle_request()
 
-    if not code_received:
+
+def _require_callback_code(result: _CallbackResult) -> str:
+    """Return the authorization code, or raise the reason there is none."""
+    if result.errors:
+        raise RuntimeError(f"Cloudflare login failed: {result.errors[0]}")
+    if not result.codes:
         raise RuntimeError(
             "Cloudflare login did not complete before the callback timeout. "
             "Please try again."
         )
-
-    token = _exchange_code_for_token(
-        code=code_received[0],
-        code_verifier=code_verifier,
-        redirect_uri=redirect_uri,
-        broker_url=broker_url,
-    )
-    _save_token(token_path, token, config.defaults.credential_ttl_seconds)
-    return token
+    return result.codes[0]
 
 
 def _exchange_code_for_token(
@@ -278,19 +349,31 @@ def _exchange_code_for_token(
         timeout=30,
     )
     resp.raise_for_status()
-    try:
-        data = resp.json()
-    except requests.exceptions.JSONDecodeError as e:
-        raise RuntimeError(
+    data = _broker_json_object(
+        resp,
+        non_json_message=(
             f"Broker /token returned non-JSON (status {resp.status_code}). "
             "Ensure Cloudflare Access permits the token exchange endpoint."
-        ) from e
-    if not isinstance(data, dict):
-        raise RuntimeError("Broker /token response must be a JSON object")
+        ),
+        non_object_message="Broker /token response must be a JSON object",
+    )
     token = data.get("token")
     if not isinstance(token, str) or not token:
         raise RuntimeError("Broker did not return a token")
-    return cast(str, token)
+    return token
+
+
+def _broker_json_object(
+    resp: Any, *, non_json_message: str, non_object_message: str
+) -> dict[str, Any]:
+    """Decode a broker response body that must be a JSON object."""
+    try:
+        payload = resp.json()
+    except requests.exceptions.JSONDecodeError as exc:
+        raise RuntimeError(non_json_message) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(non_object_message)
+    return cast(dict[str, Any], payload)
 
 
 def _save_token(path: Path, token: str, fallback_ttl_seconds: int = 900) -> None:
@@ -299,19 +382,23 @@ def _save_token(path: Path, token: str, fallback_ttl_seconds: int = 900) -> None
     Expiry is dictated by the Cloudflare Access JWT exp claim when decodable;
     otherwise falls back to fallback_ttl_seconds.
     """
-    from datetime import datetime, timezone
-
     _ensure_private_directory(path.parent)
+    data = {"token": token, "expires_at": _token_expiry(token, fallback_ttl_seconds)}
+    _write_private_json(path, data)
+
+
+def _token_expiry(token: str, fallback_ttl_seconds: int) -> str:
+    """Prefer the JWT's own exp claim; fall back to a fixed TTL."""
     exp_ts = _jwt_exp_claim(token)
     if exp_ts is not None:
-        expires_at = datetime.fromtimestamp(exp_ts, tz=timezone.utc).isoformat()
-    else:
-        from datetime import timedelta
+        return datetime.fromtimestamp(exp_ts, tz=timezone.utc).isoformat()
+    return (
+        datetime.now(timezone.utc) + timedelta(seconds=fallback_ttl_seconds)
+    ).isoformat()
 
-        expires_at = (
-            datetime.now(timezone.utc) + timedelta(seconds=fallback_ttl_seconds)
-        ).isoformat()
-    data = {"token": token, "expires_at": expires_at}
+
+def _write_private_json(path: Path, data: dict[str, Any]) -> None:
+    """Atomically write owner-only JSON to path."""
     fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     temp_path = Path(temp_name)
     try:
@@ -347,17 +434,18 @@ def _validate_broker_url(broker_url: str) -> None:
     parsed = urlparse(broker_url)
     if parsed.username or parsed.password:
         raise RuntimeError("Credential broker URL must not contain user information")
-    if parsed.scheme == "https" and parsed.hostname:
-        return
-    if parsed.scheme == "http" and parsed.hostname in {
-        "localhost",
-        "127.0.0.1",
-        "::1",
-    }:
-        return
-    raise RuntimeError(
-        "Credential broker URL must use HTTPS (HTTP is allowed only for localhost)"
-    )
+    if not _is_trusted_origin(parsed.scheme, parsed.hostname):
+        raise RuntimeError(
+            "Credential broker URL must use HTTPS (HTTP is allowed only for localhost)"
+        )
+
+
+def _is_trusted_origin(scheme: str, hostname: str | None) -> bool:
+    if not hostname:
+        return False
+    if scheme == "https":
+        return True
+    return scheme == "http" and hostname in _LOCAL_HOSTS
 
 
 def exchange_token_for_credentials(
@@ -390,26 +478,41 @@ def exchange_token_for_credentials(
         timeout=30,
     )
     resp.raise_for_status()
-    try:
-        response_data = resp.json()
-    except requests.exceptions.JSONDecodeError as exc:
-        raise RuntimeError("Credential broker returned a non-JSON response") from exc
-    if not isinstance(response_data, dict):
-        raise RuntimeError("Credential broker response must be a JSON object")
-    data = cast(dict[str, Any], response_data)
+    data = _broker_json_object(
+        resp,
+        non_json_message="Credential broker returned a non-JSON response",
+        non_object_message="Credential broker response must be a JSON object",
+    )
+    _validate_credentials_payload(data)
+    return data
+
+
+def _is_non_empty_str(value: Any) -> bool:
+    return isinstance(value, str) and bool(value)
+
+
+def _validate_credentials_payload(data: dict[str, Any]) -> None:
+    """Reject a credential payload missing or mistyping any documented field."""
+    _require_credential_fields(data)
+    _reject_mistyped_optional_fields(data)
+
+
+def _require_credential_fields(data: dict[str, Any]) -> None:
+    """Every credential set must carry a usable key pair."""
     missing = [
-        field
-        for field in ("access_key_id", "secret_access_key")
-        if not isinstance(data.get(field), str) or not data[field]
+        name
+        for name in _REQUIRED_CREDENTIAL_FIELDS
+        if not _is_non_empty_str(data.get(name))
     ]
     if missing:
         raise RuntimeError(
             "Credential broker response omitted required fields: " + ", ".join(missing)
         )
-    session_token = data.get("session_token")
-    if session_token is not None and not isinstance(session_token, str):
-        raise RuntimeError("Credential broker returned an invalid session_token")
-    expiration = data.get("expiration")
-    if expiration is not None and not isinstance(expiration, str):
-        raise RuntimeError("Credential broker returned an invalid expiration")
-    return data
+
+
+def _reject_mistyped_optional_fields(data: dict[str, Any]) -> None:
+    """Optional fields may be absent, but never the wrong type."""
+    for name in _OPTIONAL_CREDENTIAL_FIELDS:
+        value = data.get(name)
+        if value is not None and not isinstance(value, str):
+            raise RuntimeError(f"Credential broker returned an invalid {name}")

--- a/kamiwaza_extensions/client/auth/static.py
+++ b/kamiwaza_extensions/client/auth/static.py
@@ -64,15 +64,12 @@ def _load_aws_credentials_file(profile: str) -> StaticCredentials | None:
         return None
 
 
-def get_static_credentials(
-    access_key_id: str | None = None,
-    secret_access_key: str | None = None,
-    session_token: str | None = None,
-) -> StaticCredentials | None:
-    """Resolve static credentials from explicit args, environment, or ~/.aws/credentials.
-
-    Returns None if no static credentials are available.
-    """
+def _validate_explicit(
+    access_key_id: str | None,
+    secret_access_key: str | None,
+    session_token: str | None,
+) -> None:
+    """Reject a partially supplied explicit credential triple."""
     if bool(access_key_id) != bool(secret_access_key):
         raise ValueError(
             "access_key_id and secret_access_key must be provided together"
@@ -80,7 +77,35 @@ def get_static_credentials(
     if session_token and not access_key_id:
         raise ValueError("session_token requires explicit access and secret keys")
 
-    # Priority 1: Explicit credentials
+
+def _from_env_pair(
+    access_var: str, secret_var: str, token_var: str
+) -> StaticCredentials | None:
+    """Build credentials from a matched environment variable pair."""
+    access = os.environ.get(access_var)
+    secret = os.environ.get(secret_var)
+    if not access or not secret:
+        return None
+    return StaticCredentials(
+        access_key_id=access,
+        secret_access_key=secret,
+        session_token=os.environ.get(token_var),
+    )
+
+
+def get_static_credentials(
+    access_key_id: str | None = None,
+    secret_access_key: str | None = None,
+    session_token: str | None = None,
+) -> StaticCredentials | None:
+    """Resolve static credentials from explicit args, environment, or ~/.aws/credentials.
+
+    Sources are tried in the documented priority order and the first that
+    yields a complete pair wins. Returns None if no static credentials are
+    available.
+    """
+    _validate_explicit(access_key_id, secret_access_key, session_token)
+
     if access_key_id and secret_access_key:
         return StaticCredentials(
             access_key_id=access_key_id,
@@ -88,32 +113,21 @@ def get_static_credentials(
             session_token=session_token,
         )
 
-    # Priority 2: ~/.aws/credentials (use existing service/user tokens)
-    profile = os.environ.get(ENV_AWS_PROFILE, "default")
-    file_creds = _load_aws_credentials_file(profile)
-    if file_creds is not None:
-        return file_creds
-
-    # Priority 3: AWS environment variables
-    aws_access = os.environ.get(ENV_AWS_ACCESS_KEY_ID)
-    aws_secret = os.environ.get(ENV_AWS_SECRET_ACCESS_KEY)
-    if aws_access and aws_secret:
-        return StaticCredentials(
-            access_key_id=aws_access,
-            secret_access_key=aws_secret,
-            session_token=os.environ.get(ENV_AWS_SESSION_TOKEN),
-        )
-
-    # Priority 4: R2 environment variables
-    env_access = os.environ.get(ENV_ACCESS_KEY_ID)
-    env_secret = os.environ.get(ENV_SECRET_ACCESS_KEY)
-    if env_access and env_secret:
-        return StaticCredentials(
-            access_key_id=env_access,
-            secret_access_key=env_secret,
-            session_token=os.environ.get("R2_SESSION_TOKEN"),
-        )
-
+    sources = (
+        lambda: _load_aws_credentials_file(
+            os.environ.get(ENV_AWS_PROFILE, "default")
+        ),
+        lambda: _from_env_pair(
+            ENV_AWS_ACCESS_KEY_ID, ENV_AWS_SECRET_ACCESS_KEY, ENV_AWS_SESSION_TOKEN
+        ),
+        lambda: _from_env_pair(
+            ENV_ACCESS_KEY_ID, ENV_SECRET_ACCESS_KEY, "R2_SESSION_TOKEN"
+        ),
+    )
+    for source in sources:
+        creds = source()
+        if creds is not None:
+            return creds
     return None
 
 

--- a/kamiwaza_extensions/client/auth/static.py
+++ b/kamiwaza_extensions/client/auth/static.py
@@ -1,0 +1,141 @@
+"""Static credential provider (explicit + AWS credentials file + environment).
+
+Priority 1: Explicit credentials passed to constructor
+Priority 2: ~/.aws/credentials (profile from AWS_PROFILE, default "default")
+Priority 3: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from environment
+Priority 4: R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY from environment
+"""
+
+from __future__ import annotations
+
+import os
+from configparser import ConfigParser
+from dataclasses import dataclass
+from pathlib import Path
+
+from kamiwaza_extensions.client.config import ENV_ACCESS_KEY_ID, ENV_SECRET_ACCESS_KEY
+
+# AWS credential file location (AWS_SHARED_CREDENTIALS_FILE or ~/.aws/credentials)
+ENV_AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
+ENV_AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
+ENV_AWS_SESSION_TOKEN = "AWS_SESSION_TOKEN"
+ENV_AWS_PROFILE = "AWS_PROFILE"
+ENV_AWS_SHARED_CREDENTIALS_FILE = "AWS_SHARED_CREDENTIALS_FILE"
+
+DEFAULT_AWS_CREDENTIALS_PATH = Path.home() / ".aws" / "credentials"
+
+
+@dataclass
+class StaticCredentials:
+    """Static (non-refreshable) credentials."""
+
+    access_key_id: str
+    secret_access_key: str
+    session_token: str | None = None
+    expiry: None = None  # Static creds don't expire
+
+
+def _load_aws_credentials_file(profile: str) -> StaticCredentials | None:
+    """Load credentials from ~/.aws/credentials for the given profile."""
+    path = Path(
+        os.environ.get(
+            ENV_AWS_SHARED_CREDENTIALS_FILE, str(DEFAULT_AWS_CREDENTIALS_PATH)
+        )
+    ).expanduser()
+    if not path.exists():
+        return None
+    try:
+        parser = ConfigParser()
+        parser.read(path)
+        if profile not in parser:
+            return None
+        section = parser[profile]
+        access_key = section.get("aws_access_key_id", "").strip()
+        secret_key = section.get("aws_secret_access_key", "").strip()
+        if not access_key or not secret_key:
+            return None
+        session_token = section.get("aws_session_token", "").strip() or None
+        return StaticCredentials(
+            access_key_id=access_key,
+            secret_access_key=secret_key,
+            session_token=session_token,
+        )
+    except (OSError, KeyError):
+        return None
+
+
+def get_static_credentials(
+    access_key_id: str | None = None,
+    secret_access_key: str | None = None,
+    session_token: str | None = None,
+) -> StaticCredentials | None:
+    """Resolve static credentials from explicit args, environment, or ~/.aws/credentials.
+
+    Returns None if no static credentials are available.
+    """
+    if bool(access_key_id) != bool(secret_access_key):
+        raise ValueError(
+            "access_key_id and secret_access_key must be provided together"
+        )
+    if session_token and not access_key_id:
+        raise ValueError("session_token requires explicit access and secret keys")
+
+    # Priority 1: Explicit credentials
+    if access_key_id and secret_access_key:
+        return StaticCredentials(
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+        )
+
+    # Priority 2: ~/.aws/credentials (use existing service/user tokens)
+    profile = os.environ.get(ENV_AWS_PROFILE, "default")
+    file_creds = _load_aws_credentials_file(profile)
+    if file_creds is not None:
+        return file_creds
+
+    # Priority 3: AWS environment variables
+    aws_access = os.environ.get(ENV_AWS_ACCESS_KEY_ID)
+    aws_secret = os.environ.get(ENV_AWS_SECRET_ACCESS_KEY)
+    if aws_access and aws_secret:
+        return StaticCredentials(
+            access_key_id=aws_access,
+            secret_access_key=aws_secret,
+            session_token=os.environ.get(ENV_AWS_SESSION_TOKEN),
+        )
+
+    # Priority 4: R2 environment variables
+    env_access = os.environ.get(ENV_ACCESS_KEY_ID)
+    env_secret = os.environ.get(ENV_SECRET_ACCESS_KEY)
+    if env_access and env_secret:
+        return StaticCredentials(
+            access_key_id=env_access,
+            secret_access_key=env_secret,
+            session_token=os.environ.get("R2_SESSION_TOKEN"),
+        )
+
+    return None
+
+
+class StaticCredentialProvider:
+    """Provides static credentials for pass-through to boto3."""
+
+    def __init__(
+        self,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        session_token: str | None = None,
+    ) -> None:
+        self._creds = get_static_credentials(
+            access_key_id=access_key_id,
+            secret_access_key=secret_access_key,
+            session_token=session_token,
+        )
+
+    def can_provide(self) -> bool:
+        """Check if static credentials are available."""
+        return self._creds is not None
+
+    def get_credentials(self) -> StaticCredentials | None:
+        """Get static credentials if available."""
+        return self._creds

--- a/kamiwaza_extensions/client/auth/templates/callback_error.html
+++ b/kamiwaza_extensions/client/auth/templates/callback_error.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login failed</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0a0f1a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+    }
+    .card {
+      background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 2.5rem;
+      max-width: 420px;
+      text-align: center;
+    }
+    .logo { height: 32px; margin-bottom: 1.5rem; }
+    .icon { color: #ef4444; font-size: 2.5rem; margin-bottom: 1rem; }
+    h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem; }
+    p { color: #94a3b8; font-size: 0.9375rem; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <img class="logo" src="https://www.kamiwaza.ai/hubfs/logo-light.svg" alt="Kamiwaza">
+    <div class="icon">✕</div>
+    <h1>Login failed{{bucket_label}}</h1>
+    <p>{{error}}</p>
+  </div>
+</body>
+</html>

--- a/kamiwaza_extensions/client/auth/templates/callback_no_code.html
+++ b/kamiwaza_extensions/client/auth/templates/callback_no_code.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login incomplete</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0a0f1a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+    }
+    .card {
+      background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 2.5rem;
+      max-width: 420px;
+      text-align: center;
+    }
+    .logo { height: 32px; margin-bottom: 1.5rem; }
+    .icon { color: #94a3b8; font-size: 2.5rem; margin-bottom: 1rem; }
+    h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem; }
+    p { color: #94a3b8; font-size: 0.9375rem; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <img class="logo" src="https://www.kamiwaza.ai/hubfs/logo-light.svg" alt="Kamiwaza">
+    <div class="icon">○</div>
+    <h1>No authorization code received{{bucket_label}}</h1>
+    <p>You can close this window and try again.</p>
+  </div>
+</body>
+</html>

--- a/kamiwaza_extensions/client/auth/templates/callback_success.html
+++ b/kamiwaza_extensions/client/auth/templates/callback_success.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login successful</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #0a0f1a;
+      color: #e2e8f0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+    }
+    .card {
+      background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+      border: 1px solid #334155;
+      border-radius: 12px;
+      padding: 2.5rem;
+      max-width: 420px;
+      text-align: center;
+    }
+    .logo { height: 32px; margin-bottom: 1.5rem; }
+    .icon { color: #06b6d4; font-size: 2.5rem; margin-bottom: 1rem; }
+    h1 { font-size: 1.25rem; font-weight: 600; margin-bottom: 0.5rem; }
+    p { color: #94a3b8; font-size: 0.9375rem; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <img class="logo" src="https://www.kamiwaza.ai/hubfs/logo-light.svg" alt="Kamiwaza">
+    <div class="icon">✓</div>
+    <h1>Login successful{{bucket_label}}</h1>
+    <p>You can close this window and return to your terminal.</p>
+  </div>
+</body>
+</html>

--- a/kamiwaza_extensions/client/client.py
+++ b/kamiwaza_extensions/client/client.py
@@ -5,20 +5,16 @@ from __future__ import annotations
 from typing import Any
 
 from kamiwaza_extensions.client.adapters.boto3 import Boto3Adapter
-from kamiwaza_extensions.client.auth.chain import AuthMode
 from kamiwaza_extensions.client.config import Config
+from kamiwaza_extensions.client.options import ClientOptions, ExplicitCredentials
+
 
 
 def get_client(
     *,
-    endpoint_url: str | None = None,
-    region_name: str | None = None,
-    access_key_id: str | None = None,
-    secret_access_key: str | None = None,
-    session_token: str | None = None,
-    bucket: str | None = None,
+    options: ClientOptions | None = None,
+    explicit: ExplicitCredentials | None = None,
     config: Config | None = None,
-    auth_mode: AuthMode = "auto",
 ) -> Any:
     """Get a boto3 S3 client for Cloudflare R2.
 
@@ -26,13 +22,13 @@ def get_client(
     returns a multi-bucket client that lazily fetches credentials per bucket.
 
     Auth resolution (in order):
-      1. Explicit access_key_id + secret_access_key (no broker call)
+      1. ``explicit`` access_key_id + secret_access_key (no broker call)
       2. ~/.aws/credentials (profile from AWS_PROFILE, default "default")
       3. AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY from env (no broker call)
       4. R2_ACCESS_KEY_ID + R2_SECRET_ACCESS_KEY from env (no broker call)
       5. Cloudflare auth via credential broker (browser login if needed)
 
-    Multi-bucket mode (SSO, bucket=None):
+    Multi-bucket mode (SSO, ``options.bucket`` is None):
       Use one client for multiple buckets. Credentials are fetched on first
       access to each bucket. Browser login happens at most once (JWT cached);
       per-bucket credential fetches use the cached JWT.
@@ -42,74 +38,41 @@ def get_client(
         s3.list_objects_v2(Bucket='dev-kevin-test', MaxKeys=5)   # dev creds
         s3.put_object(Bucket='stage-kevin-test', Key='x', Body=b'')  # stage creds
 
-    Single-bucket mode (SSO, bucket='dev-kevin-test'):
+    Single-bucket mode (SSO, ``options.bucket`` set):
       Returns a real boto3 client with credentials for that bucket. Use when
       you need get_paginator or other features that require a fixed client.
 
     Args:
-        endpoint_url: R2 endpoint (default from config/env)
-        region_name: Region (default "auto" for R2)
-        access_key_id: Explicit access key (skips SSO)
-        secret_access_key: Explicit secret key (skips SSO)
-        session_token: Optional session token for temp creds
-        bucket: When using SSO: None = multi-bucket client; str = single-bucket client.
+        options: Endpoint, region, bucket, and auth mode. See ClientOptions.
+        explicit: Caller-supplied static credentials, skipping SSO.
         config: Optional config override (default: load from file/env)
-        auth_mode: ``auto`` selects static credentials when available and SSO
-            otherwise; ``static`` or ``sso`` selects a strategy explicitly.
 
     Returns:
         boto3 S3 client or multi-bucket proxy
     """
-    adapter = Boto3Adapter(
-        config=config,
-        endpoint_url=endpoint_url,
-        region_name=region_name,
-        access_key_id=access_key_id,
-        secret_access_key=secret_access_key,
-        session_token=session_token,
-        bucket=bucket,
-        auth_mode=auth_mode,
-    )
+    adapter = Boto3Adapter(config=config, options=options, explicit=explicit)
     return adapter.get_client()
 
 
 def get_resource(
     *,
-    endpoint_url: str | None = None,
-    region_name: str | None = None,
-    access_key_id: str | None = None,
-    secret_access_key: str | None = None,
-    session_token: str | None = None,
-    bucket: str | None = None,
+    options: ClientOptions | None = None,
+    explicit: ExplicitCredentials | None = None,
     config: Config | None = None,
-    auth_mode: AuthMode = "auto",
 ) -> Any:
     """Get a boto3 S3 resource for Cloudflare R2.
 
-    Same auth resolution as get_client(). Returns a real boto3 S3 resource.
+    Same auth resolution as get_client(). Returns a real boto3 S3 resource;
+    there is no multi-bucket resource proxy, so ``options.bucket`` selects the
+    bucket whose credentials are requested.
 
     Args:
-        endpoint_url: R2 endpoint (default from config/env)
-        region_name: Region (default "auto" for R2)
-        access_key_id: Explicit access key (skips SSO)
-        secret_access_key: Explicit secret key (skips SSO)
-        session_token: Optional session token for temp creds
-        bucket: When using SSO, request credentials for this bucket (see get_client)
+        options: Endpoint, region, bucket, and auth mode. See ClientOptions.
+        explicit: Caller-supplied static credentials, skipping SSO.
         config: Optional config override
-        auth_mode: ``auto`` selects static credentials when available and SSO
-            otherwise; ``static`` or ``sso`` selects a strategy explicitly.
 
     Returns:
         boto3 S3 resource instance
     """
-    adapter = Boto3Adapter(
-        config=config,
-        endpoint_url=endpoint_url,
-        region_name=region_name,
-        access_key_id=access_key_id,
-        secret_access_key=secret_access_key,
-        session_token=session_token,
-        bucket=bucket,
-        auth_mode=auth_mode,
-    )
+    adapter = Boto3Adapter(config=config, options=options, explicit=explicit)
     return adapter.get_resource()

--- a/kamiwaza_extensions/client/client.py
+++ b/kamiwaza_extensions/client/client.py
@@ -1,0 +1,115 @@
+"""Public API for the S3-compatible object-storage client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kamiwaza_extensions.client.adapters.boto3 import Boto3Adapter
+from kamiwaza_extensions.client.auth.chain import AuthMode
+from kamiwaza_extensions.client.config import Config
+
+
+def get_client(
+    *,
+    endpoint_url: str | None = None,
+    region_name: str | None = None,
+    access_key_id: str | None = None,
+    secret_access_key: str | None = None,
+    session_token: str | None = None,
+    bucket: str | None = None,
+    config: Config | None = None,
+    auth_mode: AuthMode = "auto",
+) -> Any:
+    """Get a boto3 S3 client for Cloudflare R2.
+
+    This is the SDK's boto3-compatible entry point. With SSO and no bucket, it
+    returns a multi-bucket client that lazily fetches credentials per bucket.
+
+    Auth resolution (in order):
+      1. Explicit access_key_id + secret_access_key (no broker call)
+      2. ~/.aws/credentials (profile from AWS_PROFILE, default "default")
+      3. AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY from env (no broker call)
+      4. R2_ACCESS_KEY_ID + R2_SECRET_ACCESS_KEY from env (no broker call)
+      5. Cloudflare auth via credential broker (browser login if needed)
+
+    Multi-bucket mode (SSO, bucket=None):
+      Use one client for multiple buckets. Credentials are fetched on first
+      access to each bucket. Browser login happens at most once (JWT cached);
+      per-bucket credential fetches use the cached JWT.
+
+      Example:
+        s3 = get_client()
+        s3.list_objects_v2(Bucket='dev-kevin-test', MaxKeys=5)   # dev creds
+        s3.put_object(Bucket='stage-kevin-test', Key='x', Body=b'')  # stage creds
+
+    Single-bucket mode (SSO, bucket='dev-kevin-test'):
+      Returns a real boto3 client with credentials for that bucket. Use when
+      you need get_paginator or other features that require a fixed client.
+
+    Args:
+        endpoint_url: R2 endpoint (default from config/env)
+        region_name: Region (default "auto" for R2)
+        access_key_id: Explicit access key (skips SSO)
+        secret_access_key: Explicit secret key (skips SSO)
+        session_token: Optional session token for temp creds
+        bucket: When using SSO: None = multi-bucket client; str = single-bucket client.
+        config: Optional config override (default: load from file/env)
+        auth_mode: ``auto`` selects static credentials when available and SSO
+            otherwise; ``static`` or ``sso`` selects a strategy explicitly.
+
+    Returns:
+        boto3 S3 client or multi-bucket proxy
+    """
+    adapter = Boto3Adapter(
+        config=config,
+        endpoint_url=endpoint_url,
+        region_name=region_name,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        session_token=session_token,
+        bucket=bucket,
+        auth_mode=auth_mode,
+    )
+    return adapter.get_client()
+
+
+def get_resource(
+    *,
+    endpoint_url: str | None = None,
+    region_name: str | None = None,
+    access_key_id: str | None = None,
+    secret_access_key: str | None = None,
+    session_token: str | None = None,
+    bucket: str | None = None,
+    config: Config | None = None,
+    auth_mode: AuthMode = "auto",
+) -> Any:
+    """Get a boto3 S3 resource for Cloudflare R2.
+
+    Same auth resolution as get_client(). Returns a real boto3 S3 resource.
+
+    Args:
+        endpoint_url: R2 endpoint (default from config/env)
+        region_name: Region (default "auto" for R2)
+        access_key_id: Explicit access key (skips SSO)
+        secret_access_key: Explicit secret key (skips SSO)
+        session_token: Optional session token for temp creds
+        bucket: When using SSO, request credentials for this bucket (see get_client)
+        config: Optional config override
+        auth_mode: ``auto`` selects static credentials when available and SSO
+            otherwise; ``static`` or ``sso`` selects a strategy explicitly.
+
+    Returns:
+        boto3 S3 resource instance
+    """
+    adapter = Boto3Adapter(
+        config=config,
+        endpoint_url=endpoint_url,
+        region_name=region_name,
+        access_key_id=access_key_id,
+        secret_access_key=secret_access_key,
+        session_token=session_token,
+        bucket=bucket,
+        auth_mode=auth_mode,
+    )
+    return adapter.get_resource()

--- a/kamiwaza_extensions/client/config.py
+++ b/kamiwaza_extensions/client/config.py
@@ -28,6 +28,19 @@ ENV_AUTH_CALLBACK_TIMEOUT = "R2_AUTH_CALLBACK_TIMEOUT_SECONDS"
 ENV_KAMIWAZA_REGISTRY_ENDPOINT = "KAMIWAZA_REGISTRY_ENDPOINT"
 ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID = "KAMIWAZA_REGISTRY_ACCOUNT_ID"
 
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def _positive_float(raw: str, var_name: str) -> float:
+    """Parse a strictly positive float from an environment variable."""
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(f"{var_name} must be a number") from exc
+    if value <= 0:
+        raise ValueError(f"{var_name} must be greater than zero")
+    return value
+
 
 @dataclass
 class R2Config:
@@ -77,6 +90,11 @@ class Config:
 
     def _apply_env(self) -> None:
         """Apply environment variable configuration."""
+        self._apply_r2_env()
+        self._apply_auth_env()
+
+    def _apply_r2_env(self) -> None:
+        """Resolve account, endpoint, and broker from the environment."""
         if account_id := os.environ.get(ENV_ACCOUNT_ID):
             self.r2.account_id = account_id
 
@@ -85,33 +103,24 @@ class Config:
         )
         if endpoint:
             self.r2.endpoint_url = endpoint
-        elif account_id := os.environ.get(ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID):
-            self.r2.endpoint_url = f"https://{account_id}.r2.cloudflarestorage.com"
-            self.r2.account_id = account_id
+        elif registry_account := os.environ.get(ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID):
+            self.r2.endpoint_url = (
+                f"https://{registry_account}.r2.cloudflarestorage.com"
+            )
+            self.r2.account_id = registry_account
 
         if broker_url := os.environ.get(ENV_BROKER_URL):
             self.r2.broker_url = broker_url.rstrip("/")
 
+    def _apply_auth_env(self) -> None:
+        """Resolve interactive-login behavior from the environment."""
         if non_interactive := os.environ.get(ENV_AUTH_NON_INTERACTIVE):
-            self.auth.non_interactive = non_interactive.lower() in {
-                "1",
-                "true",
-                "yes",
-                "on",
-            }
+            self.auth.non_interactive = non_interactive.lower() in _TRUTHY
 
         if callback_timeout := os.environ.get(ENV_AUTH_CALLBACK_TIMEOUT):
-            try:
-                parsed_timeout = float(callback_timeout)
-            except ValueError as exc:
-                raise ValueError(
-                    f"{ENV_AUTH_CALLBACK_TIMEOUT} must be a number"
-                ) from exc
-            if parsed_timeout <= 0:
-                raise ValueError(
-                    f"{ENV_AUTH_CALLBACK_TIMEOUT} must be greater than zero"
-                )
-            self.auth.callback_timeout_seconds = parsed_timeout
+            self.auth.callback_timeout_seconds = _positive_float(
+                callback_timeout, ENV_AUTH_CALLBACK_TIMEOUT
+            )
 
     def get_endpoint_url(self, override: str | None = None) -> str | None:
         """Get R2 endpoint URL with optional override."""

--- a/kamiwaza_extensions/client/config.py
+++ b/kamiwaza_extensions/client/config.py
@@ -1,0 +1,124 @@
+"""Configuration for the reusable S3-compatible object-storage client.
+
+Environment variables only — no config file required.
+Precedence: Constructor args > Environment variables > Defaults
+
+Kamiwaza registry aliases are supported through KAMIWAZA_REGISTRY_* vars.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DEFAULT_CONFIG_DIR = Path.home() / ".config" / "kamiwaza" / "client"
+DEFAULT_TOKEN_PATH = DEFAULT_CONFIG_DIR / "token.json"
+
+# Environment variable names
+ENV_ACCESS_KEY_ID = "R2_ACCESS_KEY_ID"
+ENV_SECRET_ACCESS_KEY = "R2_SECRET_ACCESS_KEY"
+ENV_ENDPOINT_URL = "R2_ENDPOINT_URL"
+ENV_BROKER_URL = "R2_BROKER_URL"
+ENV_ACCOUNT_ID = "R2_ACCOUNT_ID"
+ENV_AUTH_NON_INTERACTIVE = "R2_AUTH_NON_INTERACTIVE"
+ENV_AUTH_CALLBACK_TIMEOUT = "R2_AUTH_CALLBACK_TIMEOUT_SECONDS"
+
+# Kamiwaza registry aliases
+ENV_KAMIWAZA_REGISTRY_ENDPOINT = "KAMIWAZA_REGISTRY_ENDPOINT"
+ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID = "KAMIWAZA_REGISTRY_ACCOUNT_ID"
+
+
+@dataclass
+class R2Config:
+    """R2 connection configuration."""
+
+    account_id: str | None = None
+    endpoint_url: str | None = None
+    broker_url: str | None = None
+
+
+@dataclass
+class AuthConfig:
+    """Authentication and local callback configuration."""
+
+    token_cache_path: str | Path = field(
+        default_factory=lambda: str(DEFAULT_TOKEN_PATH)
+    )
+    non_interactive: bool = False
+    callback_timeout_seconds: float = 180.0
+
+
+@dataclass
+class DefaultsConfig:
+    """Default values for client creation."""
+
+    region: str = "auto"
+    credential_ttl_seconds: int = 900
+
+
+@dataclass
+class Config:
+    """Full object-storage client configuration.
+
+    Loaded from environment variables only. No config file required.
+    """
+
+    r2: R2Config = field(default_factory=R2Config)
+    auth: AuthConfig = field(default_factory=AuthConfig)
+    defaults: DefaultsConfig = field(default_factory=DefaultsConfig)
+
+    @classmethod
+    def load(cls) -> Config:
+        """Load configuration from environment variables."""
+        config = cls()
+        config._apply_env()
+        return config
+
+    def _apply_env(self) -> None:
+        """Apply environment variable configuration."""
+        if account_id := os.environ.get(ENV_ACCOUNT_ID):
+            self.r2.account_id = account_id
+
+        endpoint = os.environ.get(ENV_ENDPOINT_URL) or os.environ.get(
+            ENV_KAMIWAZA_REGISTRY_ENDPOINT
+        )
+        if endpoint:
+            self.r2.endpoint_url = endpoint
+        elif account_id := os.environ.get(ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID):
+            self.r2.endpoint_url = f"https://{account_id}.r2.cloudflarestorage.com"
+            self.r2.account_id = account_id
+
+        if broker_url := os.environ.get(ENV_BROKER_URL):
+            self.r2.broker_url = broker_url.rstrip("/")
+
+        if non_interactive := os.environ.get(ENV_AUTH_NON_INTERACTIVE):
+            self.auth.non_interactive = non_interactive.lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+
+        if callback_timeout := os.environ.get(ENV_AUTH_CALLBACK_TIMEOUT):
+            try:
+                parsed_timeout = float(callback_timeout)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{ENV_AUTH_CALLBACK_TIMEOUT} must be a number"
+                ) from exc
+            if parsed_timeout <= 0:
+                raise ValueError(
+                    f"{ENV_AUTH_CALLBACK_TIMEOUT} must be greater than zero"
+                )
+            self.auth.callback_timeout_seconds = parsed_timeout
+
+    def get_endpoint_url(self, override: str | None = None) -> str | None:
+        """Get R2 endpoint URL with optional override."""
+        if override:
+            return override
+        if self.r2.endpoint_url:
+            return self.r2.endpoint_url
+        if self.r2.account_id:
+            return f"https://{self.r2.account_id}.r2.cloudflarestorage.com"
+        return None

--- a/kamiwaza_extensions/client/options.py
+++ b/kamiwaza_extensions/client/options.py
@@ -1,0 +1,41 @@
+"""Grouped inputs for object-storage client construction.
+
+The client takes two kinds of input: where to connect and how to authenticate.
+Keeping them as two objects rather than a flat keyword list means the adapter,
+the credential provider, and the public entry points all pass the same shapes
+around instead of re-threading six positional concerns each.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from kamiwaza_extensions.client.auth.chain import AuthMode
+
+
+@dataclass(frozen=True)
+class ExplicitCredentials:
+    """Caller-supplied static credentials.
+
+    All three fields empty means "resolve from the environment"; supplying a
+    key requires supplying its secret.
+    """
+
+    access_key_id: str | None = None
+    secret_access_key: str | None = None
+    session_token: str | None = None
+
+
+@dataclass(frozen=True)
+class ClientOptions:
+    """Where to connect and which auth strategy to use.
+
+    ``bucket`` is only meaningful for SSO: ``None`` yields a multi-bucket
+    client that resolves credentials per bucket, a name yields a single-bucket
+    client.
+    """
+
+    endpoint_url: str | None = None
+    region_name: str | None = None
+    bucket: str | None = None
+    auth_mode: AuthMode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ exclude = ["tests*", "examples*", "kamiwaza_extensions_lib*"]
 [tool.setuptools.package-data]
 kamiwaza_sdk = ["py.typed"]
 kamiwaza_extensions = ["templates/**/*", "templates/**/.*", "compatibility.json", "agent_guidance.md"]
+"kamiwaza_extensions.client.auth" = ["templates/*.html"]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/unit/extensions/client/conftest.py
+++ b/tests/unit/extensions/client/conftest.py
@@ -1,0 +1,42 @@
+"""Pytest fixtures for object-storage client tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kamiwaza_extensions.client.config import (
+    AuthConfig,
+    Config,
+    DefaultsConfig,
+    R2Config,
+)
+
+
+@pytest.fixture
+def config_dir(tmp_path: Path) -> Path:
+    """Temporary config directory."""
+    return tmp_path / "config"
+
+
+@pytest.fixture
+def static_env(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Set static credentials in environment."""
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test-access-key")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test-secret-key")
+    return {"access_key_id": "test-access-key", "secret_access_key": "test-secret-key"}
+
+
+@pytest.fixture
+def minimal_config() -> Config:
+    """Minimal config for testing."""
+    return Config(
+        r2=R2Config(
+            account_id="test-account-id",
+            endpoint_url="https://test-account-id.r2.cloudflarestorage.com",
+            broker_url="https://broker.example.com/credentials",
+        ),
+        auth=AuthConfig(token_cache_path="/tmp/object-storage-client-test/token.json"),
+        defaults=DefaultsConfig(region="auto"),
+    )

--- a/tests/unit/extensions/client/test_auth_static.py
+++ b/tests/unit/extensions/client/test_auth_static.py
@@ -94,83 +94,89 @@ def test_get_static_credentials_aws_env(monkeypatch: pytest.MonkeyPatch) -> None
     assert creds.secret_access_key == "aws-env-secret"
 
 
-def test_get_static_credentials_aws_file(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def aws_credentials_file(monkeypatch: pytest.MonkeyPatch):
+    """Write an AWS credentials file and clear every competing env source."""
+    created: list[str] = []
+
+    def _write(contents: str) -> str:
+        for var in (
+            ENV_ACCESS_KEY_ID,
+            ENV_SECRET_ACCESS_KEY,
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".ini", delete=False
+        ) as handle:
+            handle.write(contents)
+            created.append(handle.name)
+        monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, created[-1])
+        return created[-1]
+
+    yield _write
+
+    for name in created:
+        Path(name).unlink(missing_ok=True)
+
+
+_DEFAULT_PROFILE = (
+    "[default]\n"
+    "aws_access_key_id = file-key\n"
+    "aws_secret_access_key = file-secret\n"
+)
+
+
+def test_get_static_credentials_aws_file(aws_credentials_file) -> None:
     """Credentials loaded from ~/.aws/credentials when R2 and AWS env not set."""
-    monkeypatch.delenv(ENV_ACCESS_KEY_ID, raising=False)
-    monkeypatch.delenv(ENV_SECRET_ACCESS_KEY, raising=False)
-    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
-    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
-        f.write(
-            "[default]\n"
-            "aws_access_key_id = file-key\n"
-            "aws_secret_access_key = file-secret\n"
-        )
-        creds_path = f.name
-    try:
-        monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, creds_path)
-        creds = get_static_credentials()
-        assert creds is not None
-        assert creds.access_key_id == "file-key"
-        assert creds.secret_access_key == "file-secret"
-    finally:
-        Path(creds_path).unlink(missing_ok=True)
+    aws_credentials_file(_DEFAULT_PROFILE)
+
+    creds = get_static_credentials()
+
+    assert creds is not None
+    assert (creds.access_key_id, creds.secret_access_key) == (
+        "file-key",
+        "file-secret",
+    )
 
 
 def test_get_static_credentials_aws_file_overrides_r2_env(
-    monkeypatch: pytest.MonkeyPatch,
+    aws_credentials_file, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """~/.aws/credentials takes precedence over R2_* env vars."""
-    monkeypatch.delenv(ENV_ACCESS_KEY_ID, raising=False)
-    monkeypatch.delenv(ENV_SECRET_ACCESS_KEY, raising=False)
-    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
-    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
-        f.write(
-            "[default]\n"
-            "aws_access_key_id = file-key\n"
-            "aws_secret_access_key = file-secret\n"
-        )
-        creds_path = f.name
-    try:
-        monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, creds_path)
-        monkeypatch.setenv(ENV_ACCESS_KEY_ID, "r2-env-key")
-        monkeypatch.setenv(ENV_SECRET_ACCESS_KEY, "r2-env-secret")
-        creds = get_static_credentials()
-        assert creds is not None
-        assert creds.access_key_id == "file-key"
-        assert creds.secret_access_key == "file-secret"
-    finally:
-        Path(creds_path).unlink(missing_ok=True)
+    aws_credentials_file(_DEFAULT_PROFILE)
+    monkeypatch.setenv(ENV_ACCESS_KEY_ID, "r2-env-key")
+    monkeypatch.setenv(ENV_SECRET_ACCESS_KEY, "r2-env-secret")
+
+    creds = get_static_credentials()
+
+    assert creds is not None
+    assert (creds.access_key_id, creds.secret_access_key) == (
+        "file-key",
+        "file-secret",
+    )
 
 
 def test_get_static_credentials_aws_file_profile(
-    monkeypatch: pytest.MonkeyPatch,
+    aws_credentials_file, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """AWS_PROFILE selects which profile to use from credentials file."""
-    monkeypatch.delenv(ENV_ACCESS_KEY_ID, raising=False)
-    monkeypatch.delenv(ENV_SECRET_ACCESS_KEY, raising=False)
-    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
-    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
-        f.write(
-            "[default]\n"
-            "aws_access_key_id = default-key\n"
-            "aws_secret_access_key = default-secret\n"
-            "[r2-dev]\n"
-            "aws_access_key_id = dev-key\n"
-            "aws_secret_access_key = dev-secret\n"
-        )
-        creds_path = f.name
-    try:
-        monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, creds_path)
-        monkeypatch.setenv(ENV_AWS_PROFILE, "r2-dev")
-        creds = get_static_credentials()
-        assert creds is not None
-        assert creds.access_key_id == "dev-key"
-        assert creds.secret_access_key == "dev-secret"
-    finally:
-        Path(creds_path).unlink(missing_ok=True)
+    aws_credentials_file(
+        _DEFAULT_PROFILE
+        + "[r2-dev]\n"
+        "aws_access_key_id = dev-key\n"
+        "aws_secret_access_key = dev-secret\n"
+    )
+    monkeypatch.setenv(ENV_AWS_PROFILE, "r2-dev")
+
+    creds = get_static_credentials()
+
+    assert creds is not None
+    assert (creds.access_key_id, creds.secret_access_key) == (
+        "dev-key",
+        "dev-secret",
+    )
 
 
 def test_load_aws_credentials_file_missing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/extensions/client/test_auth_static.py
+++ b/tests/unit/extensions/client/test_auth_static.py
@@ -1,0 +1,225 @@
+"""Tests for static credential resolution."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from kamiwaza_extensions.client.auth.chain import resolve_credentials
+from kamiwaza_extensions.client.auth.static import (
+    ENV_AWS_PROFILE,
+    ENV_AWS_SHARED_CREDENTIALS_FILE,
+    _load_aws_credentials_file,
+    get_static_credentials,
+)
+from kamiwaza_extensions.client.config import ENV_ACCESS_KEY_ID, ENV_SECRET_ACCESS_KEY
+
+
+def test_get_static_credentials_explicit() -> None:
+    """Explicit credentials are returned when provided."""
+    creds = get_static_credentials(
+        access_key_id="explicit-key",
+        secret_access_key="explicit-secret",
+    )
+    assert creds is not None
+    assert creds.access_key_id == "explicit-key"
+    assert creds.secret_access_key == "explicit-secret"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"access_key_id": "key"},
+        {"secret_access_key": "secret"},
+        {"session_token": "token"},
+    ],
+)
+def test_get_static_credentials_rejects_partial_explicit_credentials(
+    kwargs: dict[str, str],
+) -> None:
+    with pytest.raises(ValueError, match="must be provided together|requires explicit"):
+        get_static_credentials(**kwargs)
+
+
+def test_get_static_credentials_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """R2 environment variables provide credentials when no explicit or AWS file."""
+    monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, "/nonexistent")  # skip AWS file
+    monkeypatch.setenv(ENV_ACCESS_KEY_ID, "env-key")
+    monkeypatch.setenv(ENV_SECRET_ACCESS_KEY, "env-secret")
+
+    creds = get_static_credentials()
+    assert creds is not None
+    assert creds.access_key_id == "env-key"
+    assert creds.secret_access_key == "env-secret"
+
+
+def test_get_static_credentials_explicit_overrides_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit credentials override environment."""
+    monkeypatch.setenv(ENV_ACCESS_KEY_ID, "env-key")
+    monkeypatch.setenv(ENV_SECRET_ACCESS_KEY, "env-secret")
+
+    creds = get_static_credentials(
+        access_key_id="explicit-key",
+        secret_access_key="explicit-secret",
+    )
+    assert creds is not None
+    assert creds.access_key_id == "explicit-key"
+
+
+def test_get_static_credentials_none_when_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Returns None when no credentials available."""
+    # Point to non-existent file so we don't pick up real ~/.aws/credentials
+    monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, "/nonexistent/aws/credentials")
+    creds = get_static_credentials()
+    assert creds is None
+
+
+def test_get_static_credentials_aws_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from env provide credentials."""
+    monkeypatch.delenv(ENV_ACCESS_KEY_ID, raising=False)
+    monkeypatch.delenv(ENV_SECRET_ACCESS_KEY, raising=False)
+    monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, "/nonexistent")  # skip file
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "aws-env-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "aws-env-secret")
+
+    creds = get_static_credentials()
+    assert creds is not None
+    assert creds.access_key_id == "aws-env-key"
+    assert creds.secret_access_key == "aws-env-secret"
+
+
+def test_get_static_credentials_aws_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Credentials loaded from ~/.aws/credentials when R2 and AWS env not set."""
+    monkeypatch.delenv(ENV_ACCESS_KEY_ID, raising=False)
+    monkeypatch.delenv(ENV_SECRET_ACCESS_KEY, raising=False)
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+        f.write(
+            "[default]\n"
+            "aws_access_key_id = file-key\n"
+            "aws_secret_access_key = file-secret\n"
+        )
+        creds_path = f.name
+    try:
+        monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, creds_path)
+        creds = get_static_credentials()
+        assert creds is not None
+        assert creds.access_key_id == "file-key"
+        assert creds.secret_access_key == "file-secret"
+    finally:
+        Path(creds_path).unlink(missing_ok=True)
+
+
+def test_get_static_credentials_aws_file_overrides_r2_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """~/.aws/credentials takes precedence over R2_* env vars."""
+    monkeypatch.delenv(ENV_ACCESS_KEY_ID, raising=False)
+    monkeypatch.delenv(ENV_SECRET_ACCESS_KEY, raising=False)
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+        f.write(
+            "[default]\n"
+            "aws_access_key_id = file-key\n"
+            "aws_secret_access_key = file-secret\n"
+        )
+        creds_path = f.name
+    try:
+        monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, creds_path)
+        monkeypatch.setenv(ENV_ACCESS_KEY_ID, "r2-env-key")
+        monkeypatch.setenv(ENV_SECRET_ACCESS_KEY, "r2-env-secret")
+        creds = get_static_credentials()
+        assert creds is not None
+        assert creds.access_key_id == "file-key"
+        assert creds.secret_access_key == "file-secret"
+    finally:
+        Path(creds_path).unlink(missing_ok=True)
+
+
+def test_get_static_credentials_aws_file_profile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AWS_PROFILE selects which profile to use from credentials file."""
+    monkeypatch.delenv(ENV_ACCESS_KEY_ID, raising=False)
+    monkeypatch.delenv(ENV_SECRET_ACCESS_KEY, raising=False)
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+        f.write(
+            "[default]\n"
+            "aws_access_key_id = default-key\n"
+            "aws_secret_access_key = default-secret\n"
+            "[r2-dev]\n"
+            "aws_access_key_id = dev-key\n"
+            "aws_secret_access_key = dev-secret\n"
+        )
+        creds_path = f.name
+    try:
+        monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, creds_path)
+        monkeypatch.setenv(ENV_AWS_PROFILE, "r2-dev")
+        creds = get_static_credentials()
+        assert creds is not None
+        assert creds.access_key_id == "dev-key"
+        assert creds.secret_access_key == "dev-secret"
+    finally:
+        Path(creds_path).unlink(missing_ok=True)
+
+
+def test_load_aws_credentials_file_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_load_aws_credentials_file returns None when file does not exist."""
+    monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, "/nonexistent/aws/credentials")
+    assert _load_aws_credentials_file("default") is None
+
+
+def test_resolve_credentials_returns_static() -> None:
+    """resolve_credentials returns static when explicit creds provided."""
+    creds, method = resolve_credentials(
+        access_key_id="key",
+        secret_access_key="secret",
+    )
+    assert creds is not None
+    assert method == "static"
+
+
+def test_resolve_credentials_returns_sso_when_no_static(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """resolve_credentials returns sso when no static creds."""
+    monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, "/nonexistent/aws/credentials")
+    creds, method = resolve_credentials()
+    assert creds is None
+    assert method == "sso"
+
+
+def test_resolve_credentials_forced_sso_ignores_static_credentials() -> None:
+    """An explicit SSO profile cannot be redirected by ambient credentials."""
+    creds, method = resolve_credentials(
+        access_key_id="ambient-key",
+        secret_access_key="ambient-secret",
+        auth_mode="sso",
+    )
+    assert creds is None
+    assert method == "sso"
+
+
+def test_resolve_credentials_forced_static_fails_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Static mode fails closed instead of falling through to browser auth."""
+    monkeypatch.setenv(ENV_AWS_SHARED_CREDENTIALS_FILE, "/nonexistent/credentials")
+    with pytest.raises(RuntimeError, match="Static object-storage credentials"):
+        resolve_credentials(auth_mode="static")
+
+
+def test_resolve_credentials_rejects_unknown_mode() -> None:
+    """Invalid runtime values are rejected even when callers bypass typing."""
+    with pytest.raises(ValueError, match="Unknown authentication mode"):
+        resolve_credentials(auth_mode="invalid")  # type: ignore[arg-type]

--- a/tests/unit/extensions/client/test_client.py
+++ b/tests/unit/extensions/client/test_client.py
@@ -1,0 +1,166 @@
+"""Tests for public client API."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from kamiwaza_extensions.client.client import get_client, get_resource
+from kamiwaza_extensions.client.config import (
+    AuthConfig,
+    Config,
+    DefaultsConfig,
+    R2Config,
+)
+
+
+@pytest.fixture
+def mock_config() -> Config:
+    """Config with static credentials for testing."""
+    return Config(
+        r2=R2Config(endpoint_url="https://test.r2.cloudflarestorage.com"),
+        auth=AuthConfig(token_cache_path="/tmp/test-token.json"),
+        defaults=DefaultsConfig(region="auto"),
+    )
+
+
+def test_get_client_with_static_creds(mock_config: Config) -> None:
+    """get_client returns boto3 client with static credentials."""
+    client = get_client(
+        access_key_id="test-key",
+        secret_access_key="test-secret",
+        config=mock_config,
+    )
+    assert client is not None
+    assert hasattr(client, "list_objects_v2")
+    assert hasattr(client, "get_object")
+    assert hasattr(client, "put_object")
+    # Verify it's a real boto3 client
+    assert client.meta.service_model.service_name == "s3"
+
+
+def test_get_client_with_env_creds(
+    monkeypatch: pytest.MonkeyPatch, mock_config: Config
+) -> None:
+    """get_client uses env vars when no explicit creds."""
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "env-key")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "env-secret")
+
+    client = get_client(config=mock_config)
+    assert client is not None
+    assert client.meta.service_model.service_name == "s3"
+
+
+def test_get_resource_with_static_creds(mock_config: Config) -> None:
+    """get_resource returns boto3 resource with static credentials."""
+    resource = get_resource(
+        access_key_id="test-key",
+        secret_access_key="test-secret",
+        config=mock_config,
+    )
+    assert resource is not None
+    assert hasattr(resource, "Bucket")
+    assert resource.meta.service_name == "s3"
+
+
+def test_get_client_passes_endpoint(mock_config: Config) -> None:
+    """Endpoint URL is passed to boto3 client."""
+    client = get_client(
+        access_key_id="k",
+        secret_access_key="s",
+        config=mock_config,
+    )
+    assert client.meta.endpoint_url is not None
+    assert "r2.cloudflarestorage.com" in str(client.meta.endpoint_url)
+
+
+@patch("kamiwaza_extensions.client.client.Boto3Adapter")
+def test_public_api_forwards_explicit_auth_mode(mock_adapter) -> None:
+    """The public facade exposes deterministic auth selection."""
+    get_client(bucket="catalog", auth_mode="sso")
+
+    mock_adapter.assert_called_once_with(
+        config=None,
+        endpoint_url=None,
+        region_name=None,
+        access_key_id=None,
+        secret_access_key=None,
+        session_token=None,
+        bucket="catalog",
+        auth_mode="sso",
+    )
+
+
+def test_sso_without_bucket_uses_multi_bucket_mode(mock_config: Config) -> None:
+    """The canonical client supports lazy per-bucket routing."""
+    client = get_client(config=mock_config, auth_mode="sso")
+
+    assert client.__class__.__name__ == "_MultiBucketClient"
+
+
+@patch("kamiwaza_extensions.client.adapters.boto3._refreshable_session")
+def test_sso_with_bucket_returns_refreshable_boto3_client(
+    mock_refreshable_session, mock_config: Config
+) -> None:
+    expected = mock_refreshable_session.return_value.client.return_value
+
+    actual = get_client(
+        config=mock_config,
+        bucket="catalog-dev",
+        auth_mode="sso",
+    )
+
+    assert actual is expected
+    mock_refreshable_session.return_value.client.assert_called_once_with(
+        service_name="s3",
+        region_name="auto",
+        endpoint_url="https://test.r2.cloudflarestorage.com",
+    )
+
+
+@patch("kamiwaza_extensions.client.adapters.boto3._refreshable_session")
+def test_sso_resource_uses_refreshable_session(
+    mock_refreshable_session, mock_config: Config
+) -> None:
+    expected = mock_refreshable_session.return_value.resource.return_value
+
+    actual = get_resource(
+        config=mock_config,
+        bucket="catalog-dev",
+        auth_mode="sso",
+    )
+
+    assert actual is expected
+    mock_refreshable_session.return_value.resource.assert_called_once_with(
+        service_name="s3",
+        region_name="auto",
+        endpoint_url="https://test.r2.cloudflarestorage.com",
+    )
+
+
+def test_multi_bucket_client_caches_one_refreshable_client_per_bucket() -> None:
+    from kamiwaza_extensions.client.adapters.boto3 import _MultiBucketClient
+
+    provider = MagicMock()
+    first_session = MagicMock()
+    second_session = MagicMock()
+    first_client = first_session.client.return_value
+    second_client = second_session.client.return_value
+    first_client.get_object.return_value = {"Body": b"first"}
+    second_client.put_object.return_value = {"ETag": "second"}
+
+    with patch(
+        "kamiwaza_extensions.client.adapters.boto3._refreshable_session",
+        side_effect=[first_session, second_session],
+    ) as mock_session:
+        client = _MultiBucketClient(provider, "https://objects.example", "auto")
+        assert client.get_object(Bucket="first", Key="entry") == {"Body": b"first"}
+        assert client.get_object(Bucket="first", Key="again") == {"Body": b"first"}
+        assert client.put_object(Bucket="second", Key="entry", Body=b"x") == {
+            "ETag": "second"
+        }
+
+    assert mock_session.call_count == 2
+    mock_session.assert_any_call(provider, "first")
+    mock_session.assert_any_call(provider, "second")

--- a/tests/unit/extensions/client/test_client.py
+++ b/tests/unit/extensions/client/test_client.py
@@ -13,13 +13,19 @@ from kamiwaza_extensions.client.config import (
     DefaultsConfig,
     R2Config,
 )
+from kamiwaza_extensions.client.options import ClientOptions, ExplicitCredentials
+
+_TEST_ENDPOINT = "https://test.r2.cloudflarestorage.com"
+_STATIC = ExplicitCredentials(
+    access_key_id="test-key", secret_access_key="test-secret"
+)
 
 
 @pytest.fixture
 def mock_config() -> Config:
     """Config with static credentials for testing."""
     return Config(
-        r2=R2Config(endpoint_url="https://test.r2.cloudflarestorage.com"),
+        r2=R2Config(endpoint_url=_TEST_ENDPOINT),
         auth=AuthConfig(token_cache_path="/tmp/test-token.json"),
         defaults=DefaultsConfig(region="auto"),
     )
@@ -27,11 +33,7 @@ def mock_config() -> Config:
 
 def test_get_client_with_static_creds(mock_config: Config) -> None:
     """get_client returns boto3 client with static credentials."""
-    client = get_client(
-        access_key_id="test-key",
-        secret_access_key="test-secret",
-        config=mock_config,
-    )
+    client = get_client(explicit=_STATIC, config=mock_config)
     assert client is not None
     assert hasattr(client, "list_objects_v2")
     assert hasattr(client, "get_object")
@@ -54,11 +56,7 @@ def test_get_client_with_env_creds(
 
 def test_get_resource_with_static_creds(mock_config: Config) -> None:
     """get_resource returns boto3 resource with static credentials."""
-    resource = get_resource(
-        access_key_id="test-key",
-        secret_access_key="test-secret",
-        config=mock_config,
-    )
+    resource = get_resource(explicit=_STATIC, config=mock_config)
     assert resource is not None
     assert hasattr(resource, "Bucket")
     assert resource.meta.service_name == "s3"
@@ -66,11 +64,7 @@ def test_get_resource_with_static_creds(mock_config: Config) -> None:
 
 def test_get_client_passes_endpoint(mock_config: Config) -> None:
     """Endpoint URL is passed to boto3 client."""
-    client = get_client(
-        access_key_id="k",
-        secret_access_key="s",
-        config=mock_config,
-    )
+    client = get_client(explicit=_STATIC, config=mock_config)
     assert client.meta.endpoint_url is not None
     assert "r2.cloudflarestorage.com" in str(client.meta.endpoint_url)
 
@@ -78,64 +72,41 @@ def test_get_client_passes_endpoint(mock_config: Config) -> None:
 @patch("kamiwaza_extensions.client.client.Boto3Adapter")
 def test_public_api_forwards_explicit_auth_mode(mock_adapter) -> None:
     """The public facade exposes deterministic auth selection."""
-    get_client(bucket="catalog", auth_mode="sso")
+    options = ClientOptions(bucket="catalog", auth_mode="sso")
+
+    get_client(options=options)
 
     mock_adapter.assert_called_once_with(
-        config=None,
-        endpoint_url=None,
-        region_name=None,
-        access_key_id=None,
-        secret_access_key=None,
-        session_token=None,
-        bucket="catalog",
-        auth_mode="sso",
+        config=None, options=options, explicit=None
     )
 
 
 def test_sso_without_bucket_uses_multi_bucket_mode(mock_config: Config) -> None:
     """The canonical client supports lazy per-bucket routing."""
-    client = get_client(config=mock_config, auth_mode="sso")
+    client = get_client(config=mock_config, options=ClientOptions(auth_mode="sso"))
 
     assert client.__class__.__name__ == "_MultiBucketClient"
 
 
+@pytest.mark.parametrize("kind", ["client", "resource"])
 @patch("kamiwaza_extensions.client.adapters.boto3._refreshable_session")
-def test_sso_with_bucket_returns_refreshable_boto3_client(
-    mock_refreshable_session, mock_config: Config
+def test_sso_with_bucket_uses_refreshable_session(
+    mock_refreshable_session, kind: str, mock_config: Config
 ) -> None:
-    expected = mock_refreshable_session.return_value.client.return_value
+    """Both entry points build from the same refreshable broker session."""
+    factory = getattr(mock_refreshable_session.return_value, kind)
+    entry_point = get_client if kind == "client" else get_resource
 
-    actual = get_client(
+    actual = entry_point(
         config=mock_config,
-        bucket="catalog-dev",
-        auth_mode="sso",
+        options=ClientOptions(bucket="catalog-dev", auth_mode="sso"),
     )
 
-    assert actual is expected
-    mock_refreshable_session.return_value.client.assert_called_once_with(
+    assert actual is factory.return_value
+    factory.assert_called_once_with(
         service_name="s3",
         region_name="auto",
-        endpoint_url="https://test.r2.cloudflarestorage.com",
-    )
-
-
-@patch("kamiwaza_extensions.client.adapters.boto3._refreshable_session")
-def test_sso_resource_uses_refreshable_session(
-    mock_refreshable_session, mock_config: Config
-) -> None:
-    expected = mock_refreshable_session.return_value.resource.return_value
-
-    actual = get_resource(
-        config=mock_config,
-        bucket="catalog-dev",
-        auth_mode="sso",
-    )
-
-    assert actual is expected
-    mock_refreshable_session.return_value.resource.assert_called_once_with(
-        service_name="s3",
-        region_name="auto",
-        endpoint_url="https://test.r2.cloudflarestorage.com",
+        endpoint_url=_TEST_ENDPOINT,
     )
 
 

--- a/tests/unit/extensions/client/test_config.py
+++ b/tests/unit/extensions/client/test_config.py
@@ -53,26 +53,40 @@ def test_config_load_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.r2.broker_url == "https://env-broker.com/creds"
 
 
-def test_config_load_kamiwaza_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
-    """KAMIWAZA_REGISTRY_ENDPOINT is used when R2_ENDPOINT_URL not set."""
-    monkeypatch.delenv(ENV_ENDPOINT_URL, raising=False)
-    monkeypatch.delenv(ENV_ACCOUNT_ID, raising=False)
-    monkeypatch.delenv(ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID, raising=False)
-    monkeypatch.setenv(
-        ENV_KAMIWAZA_REGISTRY_ENDPOINT, "https://kamiwaza.r2.cloudflarestorage.com"
-    )
-    config = Config.load()
-    assert config.r2.endpoint_url == "https://kamiwaza.r2.cloudflarestorage.com"
+@pytest.mark.parametrize(
+    ("set_var", "value", "expected_endpoint"),
+    [
+        (
+            ENV_KAMIWAZA_REGISTRY_ENDPOINT,
+            "https://kamiwaza.r2.cloudflarestorage.com",
+            "https://kamiwaza.r2.cloudflarestorage.com",
+        ),
+        (
+            ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID,
+            "deadbeef123",
+            "https://deadbeef123.r2.cloudflarestorage.com",
+        ),
+    ],
+)
+def test_config_load_kamiwaza_registry_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+    set_var: str,
+    value: str,
+    expected_endpoint: str,
+) -> None:
+    """Either registry alias resolves an endpoint when the R2 vars are absent."""
+    for var in (
+        ENV_ENDPOINT_URL,
+        ENV_ACCOUNT_ID,
+        ENV_KAMIWAZA_REGISTRY_ENDPOINT,
+        ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID,
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv(set_var, value)
 
-
-def test_config_load_kamiwaza_account_id(monkeypatch: pytest.MonkeyPatch) -> None:
-    """KAMIWAZA_REGISTRY_ACCOUNT_ID constructs endpoint when others not set."""
-    monkeypatch.delenv(ENV_ENDPOINT_URL, raising=False)
-    monkeypatch.delenv(ENV_ACCOUNT_ID, raising=False)
-    monkeypatch.delenv(ENV_KAMIWAZA_REGISTRY_ENDPOINT, raising=False)
-    monkeypatch.setenv(ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID, "deadbeef123")
     config = Config.load()
-    assert config.r2.endpoint_url == "https://deadbeef123.r2.cloudflarestorage.com"
+
+    assert config.r2.endpoint_url == expected_endpoint
 
 
 def test_config_load_auth_controls(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/extensions/client/test_config.py
+++ b/tests/unit/extensions/client/test_config.py
@@ -1,0 +1,96 @@
+"""Tests for config module."""
+
+from __future__ import annotations
+
+import pytest
+
+from kamiwaza_extensions.client.config import (
+    ENV_ACCOUNT_ID,
+    ENV_AUTH_CALLBACK_TIMEOUT,
+    ENV_AUTH_NON_INTERACTIVE,
+    ENV_BROKER_URL,
+    ENV_ENDPOINT_URL,
+    ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID,
+    ENV_KAMIWAZA_REGISTRY_ENDPOINT,
+    Config,
+    R2Config,
+)
+
+
+def test_config_get_endpoint_url_from_account_id() -> None:
+    """Endpoint URL is constructed from account_id when not set."""
+    config = Config(r2=R2Config(account_id="abc123"))
+    assert config.get_endpoint_url() == "https://abc123.r2.cloudflarestorage.com"
+
+
+def test_config_get_endpoint_url_explicit() -> None:
+    """Explicit endpoint_url is used when set."""
+    config = Config(r2=R2Config(endpoint_url="https://custom.endpoint.com"))
+    assert config.get_endpoint_url() == "https://custom.endpoint.com"
+
+
+def test_config_get_endpoint_url_override() -> None:
+    """Override takes precedence."""
+    config = Config(r2=R2Config(endpoint_url="https://config.endpoint.com"))
+    assert config.get_endpoint_url("https://override.com") == "https://override.com"
+
+
+def test_config_get_endpoint_url_none_when_empty() -> None:
+    """Returns None when no endpoint configured."""
+    config = Config()
+    assert config.get_endpoint_url() is None
+
+
+def test_config_load_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Environment variables configure client."""
+    monkeypatch.setenv(ENV_ACCOUNT_ID, "env-account")
+    monkeypatch.setenv(ENV_ENDPOINT_URL, "https://env.endpoint.com")
+    monkeypatch.setenv(ENV_BROKER_URL, "https://env-broker.com/creds")
+
+    config = Config.load()
+    assert config.r2.account_id == "env-account"
+    assert config.r2.endpoint_url == "https://env.endpoint.com"
+    assert config.r2.broker_url == "https://env-broker.com/creds"
+
+
+def test_config_load_kamiwaza_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """KAMIWAZA_REGISTRY_ENDPOINT is used when R2_ENDPOINT_URL not set."""
+    monkeypatch.delenv(ENV_ENDPOINT_URL, raising=False)
+    monkeypatch.delenv(ENV_ACCOUNT_ID, raising=False)
+    monkeypatch.delenv(ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID, raising=False)
+    monkeypatch.setenv(
+        ENV_KAMIWAZA_REGISTRY_ENDPOINT, "https://kamiwaza.r2.cloudflarestorage.com"
+    )
+    config = Config.load()
+    assert config.r2.endpoint_url == "https://kamiwaza.r2.cloudflarestorage.com"
+
+
+def test_config_load_kamiwaza_account_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """KAMIWAZA_REGISTRY_ACCOUNT_ID constructs endpoint when others not set."""
+    monkeypatch.delenv(ENV_ENDPOINT_URL, raising=False)
+    monkeypatch.delenv(ENV_ACCOUNT_ID, raising=False)
+    monkeypatch.delenv(ENV_KAMIWAZA_REGISTRY_ENDPOINT, raising=False)
+    monkeypatch.setenv(ENV_KAMIWAZA_REGISTRY_ACCOUNT_ID, "deadbeef123")
+    config = Config.load()
+    assert config.r2.endpoint_url == "https://deadbeef123.r2.cloudflarestorage.com"
+
+
+def test_config_load_auth_controls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Interactive login controls are configurable for CLI and CI callers."""
+    monkeypatch.setenv(ENV_AUTH_NON_INTERACTIVE, "true")
+    monkeypatch.setenv(ENV_AUTH_CALLBACK_TIMEOUT, "12.5")
+
+    config = Config.load()
+
+    assert config.auth.non_interactive is True
+    assert config.auth.callback_timeout_seconds == 12.5
+
+
+@pytest.mark.parametrize("value", ["zero", "0", "-1"])
+def test_config_rejects_invalid_callback_timeout(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(ENV_AUTH_CALLBACK_TIMEOUT, value)
+
+    with pytest.raises(ValueError, match=ENV_AUTH_CALLBACK_TIMEOUT):
+        Config.load()

--- a/tests/unit/extensions/client/test_provider.py
+++ b/tests/unit/extensions/client/test_provider.py
@@ -14,6 +14,7 @@ from kamiwaza_extensions.client.config import (
     DefaultsConfig,
     R2Config,
 )
+from kamiwaza_extensions.client.options import ExplicitCredentials
 
 
 @pytest.fixture
@@ -33,8 +34,9 @@ def test_credential_provider_static_returns_credentials(minimal_config: Config) 
     """CredentialProvider returns Credentials for static creds."""
     provider = CredentialProvider(
         config=minimal_config,
-        access_key_id="key",
-        secret_access_key="secret",
+        explicit=ExplicitCredentials(
+            access_key_id="key", secret_access_key="secret"
+        ),
     )
     creds = provider.get_credentials()
     assert isinstance(creds, Credentials)
@@ -62,8 +64,7 @@ def test_boto3_adapter_get_credentials(minimal_config: Config) -> None:
 
     adapter = Boto3Adapter(
         config=minimal_config,
-        access_key_id="k",
-        secret_access_key="s",
+        explicit=ExplicitCredentials(access_key_id="k", secret_access_key="s"),
     )
     creds = adapter.get_credentials()
     assert isinstance(creds, Credentials)
@@ -128,8 +129,9 @@ def test_refreshable_credentials_return_botocore_metadata(
 def test_static_credentials_are_not_refreshable(minimal_config: Config) -> None:
     provider = CredentialProvider(
         config=minimal_config,
-        access_key_id="key",
-        secret_access_key="secret",
+        explicit=ExplicitCredentials(
+            access_key_id="key", secret_access_key="secret"
+        ),
         auth_mode="static",
     )
 

--- a/tests/unit/extensions/client/test_provider.py
+++ b/tests/unit/extensions/client/test_provider.py
@@ -1,0 +1,165 @@
+"""Tests for CredentialProvider (extensibility)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from kamiwaza_extensions.client.auth.credentials import Credentials
+from kamiwaza_extensions.client.auth.provider import CredentialProvider, _parse_expiry
+from kamiwaza_extensions.client.config import (
+    AuthConfig,
+    Config,
+    DefaultsConfig,
+    R2Config,
+)
+
+
+@pytest.fixture
+def minimal_config() -> Config:
+    """Minimal config for testing."""
+    return Config(
+        r2=R2Config(
+            endpoint_url="https://test.r2.cloudflarestorage.com",
+            broker_url="https://broker.example.com",
+        ),
+        auth=AuthConfig(token_cache_path="/tmp/test-token.json"),
+        defaults=DefaultsConfig(region="auto"),
+    )
+
+
+def test_credential_provider_static_returns_credentials(minimal_config: Config) -> None:
+    """CredentialProvider returns Credentials for static creds."""
+    provider = CredentialProvider(
+        config=minimal_config,
+        access_key_id="key",
+        secret_access_key="secret",
+    )
+    creds = provider.get_credentials()
+    assert isinstance(creds, Credentials)
+    assert creds.access_key_id == "key"
+    assert creds.secret_access_key == "secret"
+    assert creds.expiry is None
+
+
+def test_credential_provider_env_creds(
+    monkeypatch: pytest.MonkeyPatch, minimal_config: Config
+) -> None:
+    """CredentialProvider uses env vars when no explicit creds."""
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "env-key")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "env-secret")
+
+    provider = CredentialProvider(config=minimal_config)
+    creds = provider.get_credentials()
+    assert creds.access_key_id == "env-key"
+    assert creds.secret_access_key == "env-secret"
+
+
+def test_boto3_adapter_get_credentials(minimal_config: Config) -> None:
+    """Boto3Adapter.get_credentials() returns raw Credentials for extensibility."""
+    from kamiwaza_extensions.client.adapters.boto3 import Boto3Adapter
+
+    adapter = Boto3Adapter(
+        config=minimal_config,
+        access_key_id="k",
+        secret_access_key="s",
+    )
+    creds = adapter.get_credentials()
+    assert isinstance(creds, Credentials)
+    assert creds.access_key_id == "k"
+
+
+def test_forced_sso_ignores_ambient_static_credentials(
+    monkeypatch: pytest.MonkeyPatch, minimal_config: Config
+) -> None:
+    """Explicit SSO mode always obtains bucket-scoped broker credentials."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "ambient-key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ambient-secret")
+    monkeypatch.setattr(
+        "kamiwaza_extensions.client.auth.provider.get_cloudflare_token",
+        lambda config, bucket=None: "token",
+    )
+    monkeypatch.setattr(
+        "kamiwaza_extensions.client.auth.provider.exchange_token_for_credentials",
+        lambda token, broker_url, bucket=None: {
+            "access_key_id": "broker-key",
+            "secret_access_key": "broker-secret",
+            "session_token": "broker-session",
+            "expiration": "2035-01-01T00:00:00Z",
+        },
+    )
+    provider = CredentialProvider(
+        config=minimal_config,
+        bucket="catalog-dev",
+        auth_mode="sso",
+    )
+
+    creds = provider.get_credentials()
+
+    assert creds.access_key_id == "broker-key"
+    assert creds.session_token == "broker-session"
+
+
+def test_refreshable_credentials_return_botocore_metadata(
+    monkeypatch: pytest.MonkeyPatch, minimal_config: Config
+) -> None:
+    monkeypatch.setattr(
+        "kamiwaza_extensions.client.auth.provider.get_cloudflare_token",
+        lambda config, bucket=None: "token",
+    )
+    monkeypatch.setattr(
+        "kamiwaza_extensions.client.auth.provider.exchange_token_for_credentials",
+        lambda token, broker_url, bucket=None: {
+            "access_key_id": "broker-key",
+            "secret_access_key": "broker-secret",
+            "expiration": "2035-01-01T00:00:00Z",
+        },
+    )
+    provider = CredentialProvider(config=minimal_config, auth_mode="sso")
+
+    refreshable = provider.to_refreshable_credentials()
+    refreshed = refreshable._refresh_using()
+
+    assert refreshable._expiry_time == datetime(2035, 1, 1, tzinfo=timezone.utc)
+    assert refreshed["expiry_time"] == "2035-01-01T00:00:00+00:00"
+
+
+def test_static_credentials_are_not_refreshable(minimal_config: Config) -> None:
+    provider = CredentialProvider(
+        config=minimal_config,
+        access_key_id="key",
+        secret_access_key="secret",
+        auth_mode="static",
+    )
+
+    with pytest.raises(RuntimeError, match="Static credentials"):
+        provider.to_refreshable_credentials()
+
+
+def test_parse_expiry_normalizes_naive_timestamp_to_utc() -> None:
+    assert _parse_expiry("2035-01-01T00:00:00") == datetime(
+        2035, 1, 1, tzinfo=timezone.utc
+    )
+
+
+def test_provider_rejects_malformed_broker_expiration(
+    monkeypatch: pytest.MonkeyPatch, minimal_config: Config
+) -> None:
+    monkeypatch.setattr(
+        "kamiwaza_extensions.client.auth.provider.get_cloudflare_token",
+        lambda config, bucket=None: "token",
+    )
+    monkeypatch.setattr(
+        "kamiwaza_extensions.client.auth.provider.exchange_token_for_credentials",
+        lambda token, broker_url, bucket=None: {
+            "access_key_id": "broker-key",
+            "secret_access_key": "broker-secret",
+            "expiration": "not-a-timestamp",
+        },
+    )
+
+    provider = CredentialProvider(config=minimal_config, auth_mode="sso")
+
+    with pytest.raises(RuntimeError, match="invalid expiration"):
+        provider.get_credentials()

--- a/tests/unit/extensions/client/test_sso.py
+++ b/tests/unit/extensions/client/test_sso.py
@@ -174,33 +174,11 @@ def test_login_callback_times_out(
         sso._run_cloudflare_login(config, tmp_path / "token.json")
 
 
-def test_credential_exchange_requires_key_pair(monkeypatch: pytest.MonkeyPatch) -> None:
-    response = MagicMock()
-    response.json.return_value = {"access_key_id": "only-one"}
-    monkeypatch.setattr(sso.requests, "post", MagicMock(return_value=response))
-
-    with pytest.raises(RuntimeError, match="secret_access_key"):
-        sso.exchange_token_for_credentials(
-            "opaque-token", "https://broker.example.com", bucket="catalog"
-        )
-
-
-def test_credential_exchange_requires_json_object(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    response = MagicMock()
-    response.json.return_value = []
-    monkeypatch.setattr(sso.requests, "post", MagicMock(return_value=response))
-
-    with pytest.raises(RuntimeError, match="JSON object"):
-        sso.exchange_token_for_credentials(
-            "opaque-token", "https://broker.example.com", bucket="catalog"
-        )
-
-
 @pytest.mark.parametrize(
     ("payload", "message"),
     [
+        ({"access_key_id": "only-one"}, "secret_access_key"),
+        ([], "JSON object"),
         (
             {"access_key_id": "key", "secret_access_key": "secret", "session_token": 1},
             "session_token",
@@ -211,9 +189,10 @@ def test_credential_exchange_requires_json_object(
         ),
     ],
 )
-def test_credential_exchange_rejects_invalid_optional_fields(
-    monkeypatch: pytest.MonkeyPatch, payload: dict[str, object], message: str
+def test_credential_exchange_rejects_malformed_payloads(
+    monkeypatch: pytest.MonkeyPatch, payload: object, message: str
 ) -> None:
+    """Any payload that is not a complete, well-typed credential set is refused."""
     response = MagicMock()
     response.json.return_value = payload
     monkeypatch.setattr(sso.requests, "post", MagicMock(return_value=response))

--- a/tests/unit/extensions/client/test_sso.py
+++ b/tests/unit/extensions/client/test_sso.py
@@ -1,0 +1,224 @@
+"""Security and compatibility tests for broker-backed authentication."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from kamiwaza_extensions.client.auth import sso
+from kamiwaza_extensions.client.config import AuthConfig, Config, R2Config
+
+
+def _config(token_path: Path, **auth_overrides: object) -> Config:
+    auth = AuthConfig(token_cache_path=token_path, **auth_overrides)
+    return Config(
+        r2=R2Config(broker_url="https://broker.example.com"),
+        auth=auth,
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://broker.example.com",
+        "http://localhost:8787",
+        "http://127.0.0.1:8787",
+    ],
+)
+def test_validate_broker_url_accepts_secure_or_loopback_origins(url: str) -> None:
+    sso._validate_broker_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://broker.example.com",
+        "file:///tmp/broker",
+        "https://user:secret@broker.example.com",
+    ],
+)
+def test_validate_broker_url_rejects_unsafe_origins(url: str) -> None:
+    with pytest.raises(RuntimeError, match="broker URL|Broker URL"):
+        sso._validate_broker_url(url)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["callback_success.html", "callback_error.html", "callback_no_code.html"],
+)
+def test_callback_templates_are_package_resources(name: str) -> None:
+    assert "<!DOCTYPE html>" in sso._load_template(name)
+
+
+def test_save_token_is_atomic_and_private(tmp_path: Path) -> None:
+    token_path = tmp_path / "auth" / "token.json"
+
+    sso._save_token(token_path, "opaque-token", fallback_ttl_seconds=60)
+
+    assert json.loads(token_path.read_text())["token"] == "opaque-token"
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(token_path.parent.stat().st_mode) == 0o700
+    assert list(token_path.parent.glob(f".{token_path.name}.*")) == []
+
+
+def test_non_interactive_mode_requires_cached_token(tmp_path: Path) -> None:
+    config = _config(tmp_path / "token.json", non_interactive=True)
+
+    with pytest.raises(RuntimeError, match="Interactive Cloudflare login is disabled"):
+        sso.get_cloudflare_token(config)
+
+
+def test_custom_token_directory_must_already_be_private(tmp_path: Path) -> None:
+    shared = tmp_path / "shared"
+    shared.mkdir(mode=0o755)
+    config = _config(shared / "token.json", non_interactive=True)
+
+    with pytest.raises(RuntimeError, match="permissions are too broad"):
+        sso.get_cloudflare_token(config)
+
+
+def test_non_interactive_mode_accepts_cached_token(tmp_path: Path) -> None:
+    token_path = tmp_path / "token.json"
+    token_path.write_text(json.dumps({"token": "cached"}))
+    config = _config(token_path, non_interactive=True)
+
+    assert sso.get_cloudflare_token(config) == "cached"
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+
+
+def test_non_interactive_mode_ignores_non_object_cache(tmp_path: Path) -> None:
+    token_path = tmp_path / "token.json"
+    token_path.write_text("[]")
+    config = _config(token_path, non_interactive=True)
+
+    with pytest.raises(RuntimeError, match="Interactive Cloudflare login is disabled"):
+        sso.get_cloudflare_token(config)
+
+
+def test_login_callback_binds_state_bucket_and_redirect(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FakeServer:
+        def __init__(self, address, handler_class):
+            assert address == ("127.0.0.1", 0)
+            self.server_address = ("127.0.0.1", 43123)
+            self.handler_class = handler_class
+            self.timeout = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def handle_request(self):
+            handler = self.handler_class.__new__(self.handler_class)
+            handler.path = (
+                "/callback?state=fixed-state&bucket=catalog-dev&code=auth-code"
+            )
+            handler._send_response = lambda: None
+            handler.do_GET()
+
+    exchange = MagicMock(return_value="jwt-token")
+    save = MagicMock()
+    monkeypatch.setattr(sso, "HTTPServer", FakeServer)
+    monkeypatch.setattr(sso.secrets, "token_urlsafe", lambda _size: "fixed-state")
+    monkeypatch.setattr(sso, "_exchange_code_for_token", exchange)
+    monkeypatch.setattr(sso, "_save_token", save)
+    config = _config(tmp_path / "token.json", callback_timeout_seconds=5)
+
+    token = sso._run_cloudflare_login(config, tmp_path / "token.json", "catalog-dev")
+
+    assert token == "jwt-token"
+    call = exchange.call_args.kwargs
+    assert call["code"] == "auth-code"
+    redirect = urlparse(call["redirect_uri"])
+    assert redirect.hostname == "127.0.0.1"
+    assert redirect.port == 43123
+    assert parse_qs(redirect.query) == {
+        "state": ["fixed-state"],
+        "bucket": ["catalog-dev"],
+    }
+    save.assert_called_once_with(tmp_path / "token.json", "jwt-token", 900)
+
+
+def test_login_callback_times_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FakeServer:
+        server_address = ("127.0.0.1", 43123)
+
+        def __init__(self, _address, _handler_class):
+            self.timeout = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def handle_request(self):
+            raise AssertionError("expired callback should not handle a request")
+
+    monkeypatch.setattr(sso, "HTTPServer", FakeServer)
+    monotonic = iter([0.0, 1.0])
+    monkeypatch.setattr(sso.time, "monotonic", lambda: next(monotonic))
+    config = _config(tmp_path / "token.json", callback_timeout_seconds=0.1)
+
+    with pytest.raises(RuntimeError, match="callback timeout"):
+        sso._run_cloudflare_login(config, tmp_path / "token.json")
+
+
+def test_credential_exchange_requires_key_pair(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = MagicMock()
+    response.json.return_value = {"access_key_id": "only-one"}
+    monkeypatch.setattr(sso.requests, "post", MagicMock(return_value=response))
+
+    with pytest.raises(RuntimeError, match="secret_access_key"):
+        sso.exchange_token_for_credentials(
+            "opaque-token", "https://broker.example.com", bucket="catalog"
+        )
+
+
+def test_credential_exchange_requires_json_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    response = MagicMock()
+    response.json.return_value = []
+    monkeypatch.setattr(sso.requests, "post", MagicMock(return_value=response))
+
+    with pytest.raises(RuntimeError, match="JSON object"):
+        sso.exchange_token_for_credentials(
+            "opaque-token", "https://broker.example.com", bucket="catalog"
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        (
+            {"access_key_id": "key", "secret_access_key": "secret", "session_token": 1},
+            "session_token",
+        ),
+        (
+            {"access_key_id": "key", "secret_access_key": "secret", "expiration": 1},
+            "expiration",
+        ),
+    ],
+)
+def test_credential_exchange_rejects_invalid_optional_fields(
+    monkeypatch: pytest.MonkeyPatch, payload: dict[str, object], message: str
+) -> None:
+    response = MagicMock()
+    response.json.return_value = payload
+    monkeypatch.setattr(sso.requests, "post", MagicMock(return_value=response))
+
+    with pytest.raises(RuntimeError, match=message):
+        sso.exchange_token_for_credentials(
+            "opaque-token", "https://broker.example.com", bucket="catalog"
+        )

--- a/tests/unit/extensions/test_catalog_publisher.py
+++ b/tests/unit/extensions/test_catalog_publisher.py
@@ -393,40 +393,32 @@ class TestCredentialResolution:
 
         mock_session_cls.assert_called_once_with()
 
-    @patch("kamiwaza_extensions.client.get_client")
-    def test_sso_credentials_use_bucket_scoped_client(self, mock_get_client):
-        from kamiwaza_extensions.catalog_publisher import CatalogPublisher
-
-        profile = _make_profile(catalog_credentials="sso")
-        CatalogPublisher(profile)
-
-        mock_get_client.assert_called_once_with(
-            endpoint_url="https://s3.example.com",
-            bucket="my-catalog",
-            auth_mode="sso",
-        )
-
     @pytest.mark.parametrize(
         ("credential_spec", "auth_mode"),
         [
+            ("sso", "sso"),
             ("client:auto", "auto"),
             ("client:static", "static"),
             ("client:sso", "sso"),
         ],
     )
     @patch("kamiwaza_extensions.client.get_client")
-    def test_client_credential_modes(
+    def test_client_credential_modes_are_bucket_scoped(
         self, mock_get_client, credential_spec, auth_mode
     ):
+        """Every client-backed spec resolves to a bucket-scoped client."""
         from kamiwaza_extensions.catalog_publisher import CatalogPublisher
+        from kamiwaza_extensions.client.options import ClientOptions
 
         profile = _make_profile(catalog_credentials=credential_spec)
         CatalogPublisher(profile)
 
         mock_get_client.assert_called_once_with(
-            endpoint_url="https://s3.example.com",
-            bucket="my-catalog",
-            auth_mode=auth_mode,
+            options=ClientOptions(
+                endpoint_url="https://s3.example.com",
+                bucket="my-catalog",
+                auth_mode=auth_mode,
+            )
         )
 
     @patch(

--- a/tests/unit/extensions/test_catalog_publisher.py
+++ b/tests/unit/extensions/test_catalog_publisher.py
@@ -393,11 +393,55 @@ class TestCredentialResolution:
 
         mock_session_cls.assert_called_once_with()
 
-    def test_sso_credentials_not_implemented(self):
+    @patch("kamiwaza_extensions.client.get_client")
+    def test_sso_credentials_use_bucket_scoped_client(self, mock_get_client):
         from kamiwaza_extensions.catalog_publisher import CatalogPublisher
 
         profile = _make_profile(catalog_credentials="sso")
-        with pytest.raises(NotImplementedError, match="SSO"):
+        CatalogPublisher(profile)
+
+        mock_get_client.assert_called_once_with(
+            endpoint_url="https://s3.example.com",
+            bucket="my-catalog",
+            auth_mode="sso",
+        )
+
+    @pytest.mark.parametrize(
+        ("credential_spec", "auth_mode"),
+        [
+            ("client:auto", "auto"),
+            ("client:static", "static"),
+            ("client:sso", "sso"),
+        ],
+    )
+    @patch("kamiwaza_extensions.client.get_client")
+    def test_client_credential_modes(
+        self, mock_get_client, credential_spec, auth_mode
+    ):
+        from kamiwaza_extensions.catalog_publisher import CatalogPublisher
+
+        profile = _make_profile(catalog_credentials=credential_spec)
+        CatalogPublisher(profile)
+
+        mock_get_client.assert_called_once_with(
+            endpoint_url="https://s3.example.com",
+            bucket="my-catalog",
+            auth_mode=auth_mode,
+        )
+
+    @patch(
+        "kamiwaza_extensions.client.get_client",
+        side_effect=RuntimeError("broker unavailable"),
+    )
+    def test_client_initialization_error_is_normalized(self, _mock_get_client):
+        from kamiwaza_extensions.catalog_publisher import (
+            CatalogPublishError,
+            CatalogPublisher,
+        )
+
+        profile = _make_profile(catalog_credentials="sso")
+
+        with pytest.raises(CatalogPublishError, match="broker unavailable"):
             CatalogPublisher(profile)
 
     def test_unknown_credentials_raises(self):


### PR DESCRIPTION
## Summary

Catalog publishing supported `env` and `aws-profile:<name>`. Asking for `sso` raised `NotImplementedError` with a message pointing back at the two modes that already worked, so a catalog bucket reachable only through the Cloudflare broker had no supported publish path at all.

## What changed

New `kamiwaza_extensions.client` package — an object-storage client with a pluggable auth chain:

- `auth/static.py` — the canonical AWS/R2 static credential chain
- `auth/sso.py` — bucket-scoped broker credentials, completing in the browser against local callback templates
- `auth/chain.py` — automatic static-then-SSO resolution
- `adapters/boto3.py` — the storage adapter, behind a `base` interface so it is not the only possible backend
- `config.py` — bucket-scoped configuration, including multi-bucket mode

`--catalog-creds` now accepts `sso`, `client:sso`, `client:static`, and `client:auto`. The existing `env` and `aws-profile:<name>` modes are untouched and retain boto3's standard behavior, so no current publish workflow changes.

Documented in `docs/extensions/object-storage-client.md`, linked from the README and the developer guide.

## Testing

`172 passed`. New suites cover the client, config, provider, SSO flow, and static auth (`tests/unit/extensions/client/`), plus extended `test_catalog_publisher.py`. `ruff` clean.

## Note

The two `# type: ignore[import-untyped]` markers on the boto3 imports in `catalog_publisher.py` are required — botocore ships no stubs and mypy is configured strict here.
