### PR TITLE
[ENG-9625] Harden SDK nightly model and session resilience

### DIFF
--- a/docs/services/auth/README.md
+++ b/docs/services/auth/README.md
@@ -52,11 +52,13 @@ token is close to expiring, keeps the refresh token, and falls back to a passwor
 grant if the refresh is rejected.
 
 If a selected workroom is deleted while a password-authenticated session is still
-scoped to it, `client.workrooms.leave()` clears the stale cached credentials and
-retries once with a fresh password grant. PAT and API-key credentials are fixed:
-the SDK never clears or retries them as refreshable sessions. Custom authenticators
-may opt into the same bounded recovery by implementing
-`invalidate_session(session) -> True` after clearing their cached credentials.
+scoped to it, `client.workrooms.leave()` clears the stale in-memory credentials and
+session access-token state, then retries once with a fresh password grant. The shared
+on-disk token remains available until the successful grant replaces it. PAT and
+API-key credentials are fixed: the SDK never clears or retries them as refreshable
+sessions. Custom authenticators may opt into the same bounded recovery by returning
+`True` from `invalidate_session(session) -> bool` after invalidating their session
+credentials.
 
 ## Personal Access Tokens
 

--- a/docs/services/auth/README.md
+++ b/docs/services/auth/README.md
@@ -51,6 +51,13 @@ print(logout.front_channel_logout_url)
 token is close to expiring, keeps the refresh token, and falls back to a password
 grant if the refresh is rejected.
 
+If a selected workroom is deleted while a password-authenticated session is still
+scoped to it, `client.workrooms.leave()` clears the stale cached credentials and
+retries once with a fresh password grant. PAT and API-key credentials are fixed:
+the SDK never clears or retries them as refreshable sessions. Custom authenticators
+may opt into the same bounded recovery by implementing
+`invalidate_session(session) -> True` after clearing their cached credentials.
+
 ## Personal Access Tokens
 
 ```python

--- a/docs/services/auth/README.md
+++ b/docs/services/auth/README.md
@@ -54,11 +54,11 @@ grant if the refresh is rejected.
 If a selected workroom is deleted while a password-authenticated session is still
 scoped to it, `client.workrooms.leave()` clears the stale in-memory credentials and
 session access-token state, then retries once with a fresh password grant. The shared
-on-disk token remains available until the successful grant replaces it. PAT and
-API-key credentials are fixed: the SDK never clears or retries them as refreshable
-sessions. Custom authenticators may opt into the same bounded recovery by returning
-`True` from `invalidate_session(session) -> bool` after invalidating their session
-credentials.
+on-disk token remains available during that attempt; a successful grant replaces it,
+while an exhausted grant clears the stale scoped token. PAT and API-key credentials
+are fixed: the SDK never clears or retries them as refreshable sessions. Custom
+authenticators may opt into the same bounded recovery by returning `True` from
+`invalidate_session(session) -> bool` after invalidating their session credentials.
 
 ## Personal Access Tokens
 

--- a/kamiwaza_sdk/authentication.py
+++ b/kamiwaza_sdk/authentication.py
@@ -133,6 +133,7 @@ class UserPasswordAuthenticator(Authenticator):
                 errors.append(str(exc))
                 if self._session_invalidated and self.token_store:
                     self.token_store.clear()
+                    self._session_invalidated = False
                 raise AuthenticationError(
                     f"Failed to obtain access token ({'; '.join(errors)})"
                 ) from exc

--- a/kamiwaza_sdk/authentication.py
+++ b/kamiwaza_sdk/authentication.py
@@ -92,6 +92,7 @@ class UserPasswordAuthenticator(Authenticator):
         self.token_expiry: Optional[datetime] = None
         self.refresh_token_value: Optional[str] = None
         self.token_store = token_store or FileTokenStore()
+        self._session_invalidated = False
         self._load_cached_token()
 
     def authenticate(self, session: requests.Session) -> None:
@@ -130,6 +131,8 @@ class UserPasswordAuthenticator(Authenticator):
                 LOGGER.debug("Performed password grant for new access token")
             except Exception as exc:  # pylint: disable=broad-except
                 errors.append(str(exc))
+                if self._session_invalidated and self.token_store:
+                    self.token_store.clear()
                 raise AuthenticationError(
                     f"Failed to obtain access token ({'; '.join(errors)})"
                 ) from exc
@@ -152,6 +155,7 @@ class UserPasswordAuthenticator(Authenticator):
         self.token = None
         self.token_expiry = None
         self.refresh_token_value = None
+        self._session_invalidated = True
         session.headers.pop("Authorization", None)
         for cookie in list(session.cookies):
             if cookie.name == "access_token":
@@ -175,6 +179,7 @@ class UserPasswordAuthenticator(Authenticator):
         )
         if self.token_store:
             self.token_store.save(stored)
+        self._session_invalidated = False
 
     def _load_cached_token(self) -> None:
         if not self.token_store:

--- a/kamiwaza_sdk/authentication.py
+++ b/kamiwaza_sdk/authentication.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
-import time
 from typing import Optional
 
 import requests  # type: ignore[import-untyped]
@@ -152,10 +152,14 @@ class UserPasswordAuthenticator(Authenticator):
         self.token = None
         self.token_expiry = None
         self.refresh_token_value = None
-        if self.token_store:
-            self.token_store.clear()
         session.headers.pop("Authorization", None)
-        session.cookies.clear()
+        for cookie in list(session.cookies):
+            if cookie.name == "access_token":
+                session.cookies.clear(
+                    domain=cookie.domain,
+                    path=cookie.path,
+                    name=cookie.name,
+                )
         return True
 
     def _store_token_response(self, token_response: TokenResponse) -> None:

--- a/kamiwaza_sdk/authentication.py
+++ b/kamiwaza_sdk/authentication.py
@@ -45,6 +45,14 @@ class Authenticator(ABC):
         """
         return True
 
+    def invalidate_session(self, session: requests.Session) -> bool:
+        """Invalidate cached session credentials when fresh login can recover.
+
+        Returns ``False`` by default so fixed credentials such as PATs are
+        never cleared or retried as though they were refreshable sessions.
+        """
+        return False
+
 
 class ApiKeyAuthenticator(Authenticator):
     """Simple bearer token authenticator backed by a PAT/API key."""
@@ -138,6 +146,17 @@ class UserPasswordAuthenticator(Authenticator):
         ):
             self.refresh_token(session)
         return self.token
+
+    def invalidate_session(self, session: requests.Session) -> bool:
+        """Discard a stale scoped session so the next request logs in afresh."""
+        self.token = None
+        self.token_expiry = None
+        self.refresh_token_value = None
+        if self.token_store:
+            self.token_store.clear()
+        session.headers.pop("Authorization", None)
+        session.cookies.clear()
+        return True
 
     def _store_token_response(self, token_response: TokenResponse) -> None:
         self.token = token_response.access_token

--- a/kamiwaza_sdk/authentication.py
+++ b/kamiwaza_sdk/authentication.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 import time
 from typing import Optional
 
-import requests
+import requests  # type: ignore[import-untyped]
 
 from .exceptions import AuthenticationError
 from .schemas.auth import TokenResponse

--- a/kamiwaza_sdk/schemas/serving/serving.py
+++ b/kamiwaza_sdk/schemas/serving/serving.py
@@ -127,6 +127,12 @@ class ActiveModelDeployment(BaseModel):
     m_id: UUID = Field(description="The UUID of the model")
     m_name: str = Field(description="Name of the model")
     status: str = Field(description="Status of the deployment")
+    engine_name: Optional[str] = Field(
+        default=None, description="Inference engine used by the deployment"
+    )
+    m_file_id: Optional[UUID] = Field(
+        default=None, description="Selected model weights file"
+    )
     instances: List[ModelInstance] = Field(description="List of active instances")
     lb_port: int = Field(description="Load balancer port for the deployment")
     endpoint: Optional[str] = Field(

--- a/kamiwaza_sdk/services/serving.py
+++ b/kamiwaza_sdk/services/serving.py
@@ -188,6 +188,8 @@ class ServingService(BaseService):
                     m_id=deployment.m_id,
                     m_name=deployment.m_name or "",
                     status=deployment.status,
+                    engine_name=deployment.engine_name,
+                    m_file_id=deployment.m_file_id,
                     instances=[i for i in deployment.instances if i.status == 'DEPLOYED'],
                     lb_port=deployment.lb_port,
                     endpoint=endpoint

--- a/kamiwaza_sdk/services/workrooms.py
+++ b/kamiwaza_sdk/services/workrooms.py
@@ -18,6 +18,9 @@ from .base_service import BaseService
 
 _UNSET = object()
 _EXPORT_CHUNK_SIZE = 64 * 1024
+# Must match the backend's deleted-workroom scope denial contract. Other 403s
+# remain fail-closed and are never retried.
+_DELETED_SCOPE_DENIAL_DETAIL = "Workroom access denied"
 
 
 def _is_deleted_scope_denial(error: APIError) -> bool:
@@ -25,7 +28,7 @@ def _is_deleted_scope_denial(error: APIError) -> bool:
         return False
     payload = error.response_data
     detail = payload.get("detail") if isinstance(payload, dict) else None
-    return detail == "Workroom access denied"
+    return detail == _DELETED_SCOPE_DENIAL_DETAIL
 
 
 class WorkroomService(BaseService):

--- a/kamiwaza_sdk/services/workrooms.py
+++ b/kamiwaza_sdk/services/workrooms.py
@@ -18,18 +18,18 @@ from .base_service import BaseService
 
 _UNSET = object()
 _EXPORT_CHUNK_SIZE = 64 * 1024
-# Must match the backend's deleted-workroom scope denial contract in
-# kamiwaza/services/auth/api.py (forward-auth/workroom scope checks). Other
-# 403s remain fail-closed and are never retried. Unit tests pin the payload.
-_DELETED_SCOPE_DENIAL_DETAIL = "Workroom access denied"
+# Must match the backend's generic workroom-scope denial contract in
+# kamiwaza/services/auth/api.py (forward-auth/workroom scope checks). Recovery
+# is limited to the bodyless leave request; other 403s remain fail-closed.
+_WORKROOM_SCOPE_DENIAL_DETAIL = "Workroom access denied"
 
 
-def _is_deleted_scope_denial(error: APIError) -> bool:
+def _is_workroom_scope_denial(error: APIError) -> bool:
     if error.status_code != 403:
         return False
     payload = error.response_data
     detail = payload.get("detail") if isinstance(payload, dict) else None
-    return detail == _DELETED_SCOPE_DENIAL_DETAIL
+    return detail == _WORKROOM_SCOPE_DENIAL_DETAIL
 
 
 class WorkroomService(BaseService):
@@ -45,11 +45,11 @@ class WorkroomService(BaseService):
         self.logger = logging.getLogger(__name__)
 
     def _request_with_scope_recovery(self, request: Callable[[], Any]) -> Any:
-        """Retry once with fresh password credentials after a deleted-room 403."""
+        """Retry a bodyless leave once after a stale workroom-scope 403."""
         try:
             return request()
         except APIError as error:
-            if not _is_deleted_scope_denial(error):
+            if not _is_workroom_scope_denial(error):
                 raise
             authenticator = getattr(self.client, "authenticator", None)
             invalidate = getattr(authenticator, "invalidate_session", None)

--- a/kamiwaza_sdk/services/workrooms.py
+++ b/kamiwaza_sdk/services/workrooms.py
@@ -18,8 +18,9 @@ from .base_service import BaseService
 
 _UNSET = object()
 _EXPORT_CHUNK_SIZE = 64 * 1024
-# Must match the backend's deleted-workroom scope denial contract. Other 403s
-# remain fail-closed and are never retried.
+# Must match the backend's deleted-workroom scope denial contract in
+# kamiwaza/services/auth/api.py (forward-auth/workroom scope checks). Other
+# 403s remain fail-closed and are never retried. Unit tests pin the payload.
 _DELETED_SCOPE_DENIAL_DETAIL = "Workroom access denied"
 
 

--- a/kamiwaza_sdk/services/workrooms.py
+++ b/kamiwaza_sdk/services/workrooms.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any, BinaryIO, List, Optional, Union
+from typing import Any, BinaryIO, Callable, List, Optional, Union
 from uuid import UUID
 
 from ..exceptions import APIError, NotFoundError
@@ -20,6 +20,14 @@ _UNSET = object()
 _EXPORT_CHUNK_SIZE = 64 * 1024
 
 
+def _is_deleted_scope_denial(error: APIError) -> bool:
+    if error.status_code != 403:
+        return False
+    payload = error.response_data
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    return detail == "Workroom access denied"
+
+
 class WorkroomService(BaseService):
     """Service for managing workrooms in the Kamiwaza platform.
 
@@ -31,6 +39,19 @@ class WorkroomService(BaseService):
     def __init__(self, client):
         super().__init__(client)
         self.logger = logging.getLogger(__name__)
+
+    def _request_with_scope_recovery(self, request: Callable[[], Any]) -> Any:
+        """Retry once with fresh password credentials after a deleted-room 403."""
+        try:
+            return request()
+        except APIError as error:
+            if not _is_deleted_scope_denial(error):
+                raise
+            authenticator = getattr(self.client, "authenticator", None)
+            invalidate = getattr(authenticator, "invalidate_session", None)
+            if not callable(invalidate) or not invalidate(self.client.session):
+                raise
+            return request()
 
     # -------------------------------------------------------------------------
     # User CRUD
@@ -247,9 +268,12 @@ class WorkroomService(BaseService):
         """Call the backend workroom-leave endpoint and return its response.
 
         Returned token fields are exposed for callers that manage tokens
-        themselves; this method does not mutate the SDK authenticator.
+        themselves. If a password-authenticated session is still scoped to a
+        deleted workroom, clear its cached credentials and retry once.
         """
-        response = self.client.post("/workrooms/leave")
+        response = self._request_with_scope_recovery(
+            lambda: self.client.post("/workrooms/leave")
+        )
         return LeaveWorkroomResponse.model_validate(response)
 
     # -------------------------------------------------------------------------

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,10 +34,21 @@ pytest -m "integration and live" --live-base-url https://localhost/api --live-us
 
 Some live integration tests exercise admin-only mutation paths. For those tests, prefer supplying an admin-scoped PAT via `KAMIWAZA_API_KEY` instead of relying on the default session PAT minted from username/password bootstrap.
 
+The inference tests choose one model/engine/quantization target from the live
+cluster inventory. NVIDIA selects vLLM, complete Apple Silicon inventory selects
+MLX, and CPU-only, mixed, or incomplete inventory selects llamacpp/GGUF. Override
+the shared repositories with `KAMIWAZA_TEST_MLX_LLM_REPO`,
+`KAMIWAZA_TEST_VLLM_LLM_REPO`, or `KAMIWAZA_TEST_GGUF_LLM_REPO`. Context tests
+also accept `KAMIWAZA_CONTEXT_LLM_REPO`, `KAMIWAZA_CONTEXT_LLM_ENGINE`, and
+`KAMIWAZA_CONTEXT_LLM_QUANTIZATION`; the latter defaults to `q6_k` for an
+explicit context repository and otherwise inherits the shared target.
+
 ## Shared Fixtures
 - `dummy_client` – lightweight HTTP stub for unit tests (records calls, replays canned responses).
 - `client_factory` – builds real `KamiwazaClient` instances with consistent defaults.
-- `qwen_model_id` – canonical `mlx-community/Qwen3-4B-4bit` identifier for download/deploy tests; keep plumbing ready for a GGUF mirror.
+- `deployable_model_target` – platform-compatible, overrideable model repository,
+  engine, and quantization used by the deployability probe, serving workflow,
+  and CLI deployment test.
 - `ingestion_environment` – spins up the MinIO docker stack and seeds sample parquet data for ingest/retrieval tests.
 - `live_kamiwaza_client` – asserts a live server is reachable (`/ping`), then authenticates using either `KAMIWAZA_API_KEY` or username/password credentials.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,13 +14,6 @@ def project_root() -> Path:
 
 
 @pytest.fixture(scope="session")
-def qwen_model_id() -> str:
-    """Canonical downloadable/deployable model ID for tests."""
-
-    return "mlx-community/Qwen3-4B-4bit"
-
-
-@pytest.fixture(scope="session")
 def artifact_cache_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Workspace for test artifacts (model downloads, temp datasets, etc.)."""
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -14,6 +14,10 @@ contributor PRs without a live cluster don't see false reds.
 | `KAMIWAZA_VERIFY_SSL` | Set `false` for self-signed certs in dev | `true` |
 | `KAMIWAZA_PEER_BASE_URL` | Federation peer cluster base URL (ENG-5784) | unset |
 | `KAMIWAZA_PEER_API_KEY` | API key on the peer cluster (ENG-5784) | unset |
+
+Live model tests select vLLM for NVIDIA clusters, MLX only when every reported
+platform is Apple Silicon, and the GGUF/llama.cpp target otherwise.
+
 | `KAMIWAZA_TEST_MLX_LLM_REPO` | MLX model used by live model tests (`KAMIWAZA_CONTEXT_MLX_LLM_REPO` is the legacy alias) | `mlx-community/Qwen3-4B-4bit` |
 | `KAMIWAZA_TEST_VLLM_LLM_REPO` | vLLM model used by live model tests (`KAMIWAZA_CONTEXT_VLLM_LLM_REPO` is the legacy alias) | `Qwen/Qwen3-0.6B` |
 | `KAMIWAZA_TEST_GGUF_LLM_REPO` | llama.cpp model used by live model tests (`KAMIWAZA_CONTEXT_GGUF_LLM_REPO` is the legacy alias) | `unsloth/Qwen3-4B-Thinking-2507-GGUF` |

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -16,7 +16,10 @@ contributor PRs without a live cluster don't see false reds.
 | `KAMIWAZA_PEER_API_KEY` | API key on the peer cluster (ENG-5784) | unset |
 | `KAMIWAZA_TEST_MLX_LLM_REPO` | MLX model used by live model tests (`KAMIWAZA_CONTEXT_MLX_LLM_REPO` is the legacy alias) | `mlx-community/Qwen3-4B-4bit` |
 | `KAMIWAZA_TEST_VLLM_LLM_REPO` | vLLM model used by live model tests (`KAMIWAZA_CONTEXT_VLLM_LLM_REPO` is the legacy alias) | `Qwen/Qwen3-0.6B` |
-| `KAMIWAZA_TEST_GGUF_LLM_REPO` | llama.cpp model used by live model tests (`KAMIWAZA_CONTEXT_GGUF_LLM_REPO` is the legacy alias) | `unsloth/Qwen3-4B-Thinking-2507-GGUF` |
+| `KAMIWAZA_TEST_GGUF_LLM_REPO` | llama.cpp model used by live model tests; it must provide `q4_k` weights (`KAMIWAZA_CONTEXT_GGUF_LLM_REPO` is the legacy alias) | `unsloth/Qwen3-4B-Thinking-2507-GGUF` |
+| `KAMIWAZA_CONTEXT_LLM_REPO` | Higher-precedence model override for context tests | shared platform target |
+| `KAMIWAZA_CONTEXT_LLM_ENGINE` | Higher-precedence engine override for context tests | shared platform target |
+| `KAMIWAZA_CONTEXT_LLM_QUANTIZATION` | Quantization override for context tests | shared target, or `q6_k` with an explicit context repo |
 
 Live model tests select vLLM for NVIDIA clusters, MLX only when every reported
 platform is Apple Silicon, and the GGUF/llama.cpp target otherwise.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -14,6 +14,9 @@ contributor PRs without a live cluster don't see false reds.
 | `KAMIWAZA_VERIFY_SSL` | Set `false` for self-signed certs in dev | `true` |
 | `KAMIWAZA_PEER_BASE_URL` | Federation peer cluster base URL (ENG-5784) | unset |
 | `KAMIWAZA_PEER_API_KEY` | API key on the peer cluster (ENG-5784) | unset |
+| `KAMIWAZA_TEST_MLX_LLM_REPO` | MLX model used by live model tests (`KAMIWAZA_CONTEXT_MLX_LLM_REPO` is the legacy alias) | `mlx-community/Qwen3-4B-4bit` |
+| `KAMIWAZA_TEST_VLLM_LLM_REPO` | vLLM model used by live model tests (`KAMIWAZA_CONTEXT_VLLM_LLM_REPO` is the legacy alias) | `Qwen/Qwen3-0.6B` |
+| `KAMIWAZA_TEST_GGUF_LLM_REPO` | llama.cpp model used by live model tests (`KAMIWAZA_CONTEXT_GGUF_LLM_REPO` is the legacy alias) | `unsloth/Qwen3-4B-Thinking-2507-GGUF` |
 
 ### Brokering env vars (capabilities probe + federated job tests)
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -14,13 +14,12 @@ contributor PRs without a live cluster don't see false reds.
 | `KAMIWAZA_VERIFY_SSL` | Set `false` for self-signed certs in dev | `true` |
 | `KAMIWAZA_PEER_BASE_URL` | Federation peer cluster base URL (ENG-5784) | unset |
 | `KAMIWAZA_PEER_API_KEY` | API key on the peer cluster (ENG-5784) | unset |
-
-Live model tests select vLLM for NVIDIA clusters, MLX only when every reported
-platform is Apple Silicon, and the GGUF/llama.cpp target otherwise.
-
 | `KAMIWAZA_TEST_MLX_LLM_REPO` | MLX model used by live model tests (`KAMIWAZA_CONTEXT_MLX_LLM_REPO` is the legacy alias) | `mlx-community/Qwen3-4B-4bit` |
 | `KAMIWAZA_TEST_VLLM_LLM_REPO` | vLLM model used by live model tests (`KAMIWAZA_CONTEXT_VLLM_LLM_REPO` is the legacy alias) | `Qwen/Qwen3-0.6B` |
 | `KAMIWAZA_TEST_GGUF_LLM_REPO` | llama.cpp model used by live model tests (`KAMIWAZA_CONTEXT_GGUF_LLM_REPO` is the legacy alias) | `unsloth/Qwen3-4B-Thinking-2507-GGUF` |
+
+Live model tests select vLLM for NVIDIA clusters, MLX only when every reported
+platform is Apple Silicon, and the GGUF/llama.cpp target otherwise.
 
 ### Brokering env vars (capabilities probe + federated job tests)
 

--- a/tests/integration/capability_markers.py
+++ b/tests/integration/capability_markers.py
@@ -42,6 +42,18 @@ class ClusterCapabilitySnapshot:
     gpu_vendors: frozenset[str] = frozenset()
     mig_supported: Optional[bool] = None  # None => undeterminable
     node_count: int = 0
+    os_names: frozenset[str] = frozenset()
+    platforms: frozenset[str] = frozenset()
+
+    @property
+    def is_apple_silicon(self) -> bool:
+        """Whether trusted hardware inventory identifies Apple Silicon."""
+        if "darwin" not in self.os_names:
+            return False
+        arm_hints = ("arm64", "aarch64", "arm-64")
+        return any(
+            hint in platform for platform in self.platforms for hint in arm_hints
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -152,6 +164,33 @@ def _hardware_active(hardware: Any) -> Optional[bool]:
     return active if isinstance(active, bool) else None
 
 
+def _hardware_field(hardware: Any, field: str) -> Any:
+    value = getattr(hardware, field, None)
+    if value is None and isinstance(hardware, dict):
+        return hardware.get(field)
+    return value
+
+
+def _platform_inventory(
+    hardware_entries: Iterable[Any],
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Read OS/platform only from rows backed by real device inventory."""
+    os_names: set[str] = set()
+    platforms: set[str] = set()
+    for hardware in hardware_entries:
+        gpus = _hardware_gpus(hardware)
+        processors = _hardware_field(hardware, "processors")
+        if gpus is None and processors is None:
+            continue
+        os_name = _hardware_field(hardware, "os")
+        platform = _hardware_field(hardware, "platform")
+        if isinstance(os_name, str) and os_name.strip():
+            os_names.add(os_name.strip().lower())
+        if isinstance(platform, str) and platform.strip():
+            platforms.add(platform.strip().lower())
+    return frozenset(os_names), frozenset(platforms)
+
+
 def build_capability_snapshot(
     hardware_entries: Iterable[Any],
     node_count: Optional[int] = None,
@@ -189,12 +228,16 @@ def build_capability_snapshot(
     if node_count is None:
         node_count = len({_hardware_node_key(hw) for hw in active_entries})
 
+    os_names, platforms = _platform_inventory(active_entries)
+
     return ClusterCapabilitySnapshot(
         gpu_count=len(gpu_dicts),
         gpu_mem_gb=tuple(mem_gb),
         gpu_vendors=frozenset(vendors),
         mig_supported=(any(mig_flags) if mig_flags else None),
         node_count=node_count or 0,
+        os_names=os_names,
+        platforms=platforms,
     )
 
 

--- a/tests/integration/capability_markers.py
+++ b/tests/integration/capability_markers.py
@@ -42,15 +42,13 @@ class ClusterCapabilitySnapshot:
     gpu_vendors: frozenset[str] = frozenset()
     mig_supported: Optional[bool] = None  # None => undeterminable
     node_count: int = 0
-    os_names: frozenset[str] = frozenset()
-    platforms: frozenset[str] = frozenset()
     os_platforms: frozenset[tuple[str, str]] = frozenset()
 
     @property
     def is_apple_silicon(self) -> bool:
-        """Whether trusted hardware inventory identifies Apple Silicon."""
+        """Whether all trusted platform inventory identifies Apple Silicon."""
         arm_hints = ("arm64", "aarch64", "arm-64")
-        return any(
+        return bool(self.os_platforms) and all(
             os_name == "darwin" and any(hint in platform for hint in arm_hints)
             for os_name, platform in self.os_platforms
         )
@@ -177,14 +175,8 @@ def _normalized_text(value: Any) -> str:
 
 def _platform_inventory(
     hardware_entries: Iterable[Any],
-) -> tuple[
-    frozenset[str],
-    frozenset[str],
-    frozenset[tuple[str, str]],
-]:
+) -> frozenset[tuple[str, str]]:
     """Read OS/platform only from rows backed by real device inventory."""
-    os_names: set[str] = set()
-    platforms: set[str] = set()
     os_platforms: set[tuple[str, str]] = set()
     for hardware in hardware_entries:
         gpus = _hardware_gpus(hardware)
@@ -195,13 +187,9 @@ def _platform_inventory(
         platform = _hardware_field(hardware, "platform")
         normalized_os = _normalized_text(os_name)
         normalized_platform = _normalized_text(platform)
-        if normalized_os:
-            os_names.add(normalized_os)
-        if normalized_platform:
-            platforms.add(normalized_platform)
         if normalized_os and normalized_platform:
             os_platforms.add((normalized_os, normalized_platform))
-    return frozenset(os_names), frozenset(platforms), frozenset(os_platforms)
+    return frozenset(os_platforms)
 
 
 def build_capability_snapshot(
@@ -241,7 +229,7 @@ def build_capability_snapshot(
     if node_count is None:
         node_count = len({_hardware_node_key(hw) for hw in active_entries})
 
-    os_names, platforms, os_platforms = _platform_inventory(active_entries)
+    os_platforms = _platform_inventory(active_entries)
 
     return ClusterCapabilitySnapshot(
         gpu_count=len(gpu_dicts),
@@ -249,8 +237,6 @@ def build_capability_snapshot(
         gpu_vendors=frozenset(vendors),
         mig_supported=(any(mig_flags) if mig_flags else None),
         node_count=node_count or 0,
-        os_names=os_names,
-        platforms=platforms,
         os_platforms=os_platforms,
     )
 

--- a/tests/integration/capability_markers.py
+++ b/tests/integration/capability_markers.py
@@ -44,15 +44,15 @@ class ClusterCapabilitySnapshot:
     node_count: int = 0
     os_names: frozenset[str] = frozenset()
     platforms: frozenset[str] = frozenset()
+    os_platforms: frozenset[tuple[str, str]] = frozenset()
 
     @property
     def is_apple_silicon(self) -> bool:
         """Whether trusted hardware inventory identifies Apple Silicon."""
-        if "darwin" not in self.os_names:
-            return False
         arm_hints = ("arm64", "aarch64", "arm-64")
         return any(
-            hint in platform for platform in self.platforms for hint in arm_hints
+            os_name == "darwin" and any(hint in platform for hint in arm_hints)
+            for os_name, platform in self.os_platforms
         )
 
 
@@ -171,12 +171,21 @@ def _hardware_field(hardware: Any, field: str) -> Any:
     return value
 
 
+def _normalized_text(value: Any) -> str:
+    return value.strip().lower() if isinstance(value, str) else ""
+
+
 def _platform_inventory(
     hardware_entries: Iterable[Any],
-) -> tuple[frozenset[str], frozenset[str]]:
+) -> tuple[
+    frozenset[str],
+    frozenset[str],
+    frozenset[tuple[str, str]],
+]:
     """Read OS/platform only from rows backed by real device inventory."""
     os_names: set[str] = set()
     platforms: set[str] = set()
+    os_platforms: set[tuple[str, str]] = set()
     for hardware in hardware_entries:
         gpus = _hardware_gpus(hardware)
         processors = _hardware_field(hardware, "processors")
@@ -184,11 +193,15 @@ def _platform_inventory(
             continue
         os_name = _hardware_field(hardware, "os")
         platform = _hardware_field(hardware, "platform")
-        if isinstance(os_name, str) and os_name.strip():
-            os_names.add(os_name.strip().lower())
-        if isinstance(platform, str) and platform.strip():
-            platforms.add(platform.strip().lower())
-    return frozenset(os_names), frozenset(platforms)
+        normalized_os = _normalized_text(os_name)
+        normalized_platform = _normalized_text(platform)
+        if normalized_os:
+            os_names.add(normalized_os)
+        if normalized_platform:
+            platforms.add(normalized_platform)
+        if normalized_os and normalized_platform:
+            os_platforms.add((normalized_os, normalized_platform))
+    return frozenset(os_names), frozenset(platforms), frozenset(os_platforms)
 
 
 def build_capability_snapshot(
@@ -228,7 +241,7 @@ def build_capability_snapshot(
     if node_count is None:
         node_count = len({_hardware_node_key(hw) for hw in active_entries})
 
-    os_names, platforms = _platform_inventory(active_entries)
+    os_names, platforms, os_platforms = _platform_inventory(active_entries)
 
     return ClusterCapabilitySnapshot(
         gpu_count=len(gpu_dicts),
@@ -238,6 +251,7 @@ def build_capability_snapshot(
         node_count=node_count or 0,
         os_names=os_names,
         platforms=platforms,
+        os_platforms=os_platforms,
     )
 
 

--- a/tests/integration/capability_markers.py
+++ b/tests/integration/capability_markers.py
@@ -184,6 +184,8 @@ def _platform_inventory(
         gpus = _hardware_gpus(hardware)
         processors = _hardware_field(hardware, "processors")
         if gpus is None and processors is None:
+            if _hardware_active(hardware) is True:
+                complete = False
             continue
         os_name = _hardware_field(hardware, "os")
         platform = _hardware_field(hardware, "platform")

--- a/tests/integration/capability_markers.py
+++ b/tests/integration/capability_markers.py
@@ -43,12 +43,13 @@ class ClusterCapabilitySnapshot:
     mig_supported: Optional[bool] = None  # None => undeterminable
     node_count: int = 0
     os_platforms: frozenset[tuple[str, str]] = frozenset()
+    platform_inventory_complete: bool = True
 
     @property
     def is_apple_silicon(self) -> bool:
         """Whether all trusted platform inventory identifies Apple Silicon."""
         arm_hints = ("arm64", "aarch64", "arm-64")
-        return bool(self.os_platforms) and all(
+        return self.platform_inventory_complete and bool(self.os_platforms) and all(
             os_name == "darwin" and any(hint in platform for hint in arm_hints)
             for os_name, platform in self.os_platforms
         )
@@ -175,9 +176,10 @@ def _normalized_text(value: Any) -> str:
 
 def _platform_inventory(
     hardware_entries: Iterable[Any],
-) -> frozenset[tuple[str, str]]:
+) -> tuple[frozenset[tuple[str, str]], bool]:
     """Read OS/platform only from rows backed by real device inventory."""
     os_platforms: set[tuple[str, str]] = set()
+    complete = True
     for hardware in hardware_entries:
         gpus = _hardware_gpus(hardware)
         processors = _hardware_field(hardware, "processors")
@@ -189,7 +191,9 @@ def _platform_inventory(
         normalized_platform = _normalized_text(platform)
         if normalized_os and normalized_platform:
             os_platforms.add((normalized_os, normalized_platform))
-    return frozenset(os_platforms)
+        else:
+            complete = False
+    return frozenset(os_platforms), complete
 
 
 def build_capability_snapshot(
@@ -229,7 +233,7 @@ def build_capability_snapshot(
     if node_count is None:
         node_count = len({_hardware_node_key(hw) for hw in active_entries})
 
-    os_platforms = _platform_inventory(active_entries)
+    os_platforms, platform_inventory_complete = _platform_inventory(active_entries)
 
     return ClusterCapabilitySnapshot(
         gpu_count=len(gpu_dicts),
@@ -238,6 +242,7 @@ def build_capability_snapshot(
         mig_supported=(any(mig_flags) if mig_flags else None),
         node_count=node_count or 0,
         os_platforms=os_platforms,
+        platform_inventory_complete=platform_inventory_complete,
     )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1376,13 +1376,24 @@ def context_llm_prerequisite(
             poll_interval=5,
             timeout=CONTEXT_TEST_LLM_DEPLOY_TIMEOUT_SECONDS,
         )
-    except Exception as exc:  # noqa: BLE001 — any provisioning failure → skip, not error
+    except (TimeoutError, RuntimeError, ValueError) as exc:
         _stop_provisioned(provisioned_deployment_id)
         pytest.skip(
             "No active LLM deployment for context ontology tests and one could not "
             f"be provisioned (repo={context_repo_id}, "
             f"engine={context_engine_name or 'default'}): "
             f"{type(exc).__name__}: {exc}"
+        )
+    except APIError as exc:
+        _stop_provisioned(provisioned_deployment_id)
+        status_code = getattr(exc, "status_code", None)
+        if status_code is not None and status_code < 500:
+            raise
+        pytest.skip(
+            "No active LLM deployment for context ontology tests and one could not "
+            f"be provisioned (repo={context_repo_id}, "
+            f"engine={context_engine_name or 'default'}): "
+            f"APIError {status_code or 'transport'}: {exc}"
         )
 
     if not _platform_deployment_ready(deployment):
@@ -1411,7 +1422,7 @@ def _ensure_deployable_target_ready(
     client: KamiwazaClient,
     ensure_repo_ready: Callable[..., object],
     target: _model_targets.InferenceTarget,
-) -> object:
+) -> Any:
     """Make the selected target artifact ready, or skip capability failures."""
     try:
         return ensure_repo_ready(
@@ -1426,7 +1437,7 @@ def _ensure_deployable_target_ready(
         )
     except APIError as exc:
         status_code = getattr(exc, "status_code", None)
-        if status_code is None or status_code < 500:
+        if status_code is not None and status_code < 500:
             raise
         pytest.skip(
             f"Host cannot make deployable target '{target.repo_id}' ready "
@@ -1438,7 +1449,7 @@ def _ensure_deployable_target_ready(
 def ensure_deployable_model_ready(
     ensure_repo_ready: Callable[..., object],
     deployable_model_target: _model_targets.InferenceTarget,
-) -> Callable[[KamiwazaClient], object]:
+) -> Callable[[KamiwazaClient], Any]:
     """Return a target-aware, skip-not-fail live model readiness helper."""
 
     def _ensure(client: KamiwazaClient) -> object:
@@ -1539,11 +1550,12 @@ def deployable_model_prerequisite(
         # skip, so it is re-raised.
         status_code = getattr(exc, "status_code", None)
         _stop_deployment_quietly(client, probe_deployment_id)
-        if status_code is None or status_code < 500:
+        if status_code is not None and status_code < 500:
             raise
         pytest.skip(
             "Host cannot provision integration test model (download/deploy) "
-            f"'{repo_id}' (engine={engine_name}): APIError {status_code}: {exc}"
+            f"'{repo_id}' (engine={engine_name}): "
+            f"APIError {status_code or 'transport'}: {exc}"
         )
 
     ready = _platform_deployment_ready(deployment)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1399,6 +1399,14 @@ def deployable_model_prerequisite(
     client = live_kamiwaza_session_client
     repo_id = deployable_model_target.repo_id
     engine_name = deployable_model_target.engine_name
+    existing = _preferred_active_model_deployment(
+        client,
+        desired_type="llm",
+        preferred_repo_id=repo_id,
+    )
+    if existing is not None and existing.get("repo_model_id") == repo_id:
+        return
+
     probe_deployment_id: str | None = None
     try:
         model = ensure_repo_ready(client, repo_id)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1990,7 +1990,11 @@ def _model_has_ready_target_files(model: Any, quantization: str) -> bool:
 
 
 def _target_model_file_id(model: Any, quantization: str) -> str | None:
-    """Return a deterministic ready GGUF file matching the prepared quantization."""
+    """Return a deterministic ready GGUF file matching the prepared quantization.
+
+    The nightly default is a single-file GGUF. Split GGUF repositories rely on
+    the serving backend to discover sibling shards from this selected file.
+    """
     target_files = _target_files_for_quantization(model, quantization)
     ready_gguf_files = [
         model_file

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1387,7 +1387,7 @@ def _ensure_deployable_target_ready(
             target.repo_id,
             quantization=target.quantization,
         )
-    except (TimeoutError, RuntimeError) as exc:
+    except (TimeoutError, RuntimeError, ValueError) as exc:
         pytest.skip(
             f"Host cannot make deployable target '{target.repo_id}' ready "
             f"(quantization={target.quantization}): {type(exc).__name__}: {exc}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1375,6 +1375,50 @@ def deployable_model_target(
     return _model_targets.select_inference_target(cluster_capability_snapshot)
 
 
+def _ensure_deployable_target_ready(
+    client: KamiwazaClient,
+    ensure_repo_ready: Callable[..., object],
+    target: _model_targets.InferenceTarget,
+) -> object:
+    """Make the selected target artifact ready, or skip capability failures."""
+    try:
+        return ensure_repo_ready(
+            client,
+            target.repo_id,
+            quantization=target.quantization,
+        )
+    except (TimeoutError, RuntimeError) as exc:
+        pytest.skip(
+            f"Host cannot make deployable target '{target.repo_id}' ready "
+            f"(quantization={target.quantization}): {type(exc).__name__}: {exc}"
+        )
+    except APIError as exc:
+        status_code = getattr(exc, "status_code", None)
+        if status_code is None or status_code < 500:
+            raise
+        pytest.skip(
+            f"Host cannot make deployable target '{target.repo_id}' ready "
+            f"(quantization={target.quantization}): APIError {status_code}: {exc}"
+        )
+
+
+@pytest.fixture(scope="session")
+def ensure_deployable_model_ready(
+    ensure_repo_ready: Callable[..., object],
+    deployable_model_target: _model_targets.InferenceTarget,
+) -> Callable[[KamiwazaClient], object]:
+    """Return a target-aware, skip-not-fail live model readiness helper."""
+
+    def _ensure(client: KamiwazaClient) -> object:
+        return _ensure_deployable_target_ready(
+            client,
+            ensure_repo_ready,
+            deployable_model_target,
+        )
+
+    return _ensure
+
+
 def _default_model_config(
     client: KamiwazaClient, model_id: object, repo_id: str
 ) -> Any:
@@ -1409,7 +1453,11 @@ def deployable_model_prerequisite(
 
     probe_deployment_id: str | None = None
     try:
-        model = ensure_repo_ready(client, repo_id)
+        model = _ensure_deployable_target_ready(
+            client,
+            ensure_repo_ready,
+            deployable_model_target,
+        )
         default_config = _default_model_config(client, model.id, repo_id)
         raw_deployment_id = client.serving.deploy_model(
             model_id=str(model.id),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -125,6 +125,9 @@ _TEXT_BODY_MARKERS = (
 )
 _CONTEXT_TEST_LLM_REPO_OVERRIDE = os.environ.get("KAMIWAZA_CONTEXT_LLM_REPO", "").strip()
 _CONTEXT_TEST_LLM_ENGINE_OVERRIDE = os.environ.get("KAMIWAZA_CONTEXT_LLM_ENGINE", "").strip()
+_CONTEXT_TEST_LLM_QUANTIZATION_OVERRIDE = os.environ.get(
+    "KAMIWAZA_CONTEXT_LLM_QUANTIZATION", ""
+).strip()
 CONTEXT_TEST_LLM_DEPLOY_TIMEOUT_SECONDS = float(
     os.environ.get("KAMIWAZA_CONTEXT_LLM_DEPLOY_TIMEOUT_SECONDS", "600")
 )
@@ -594,6 +597,8 @@ def _active_model_deployments(
                 "model_id": str(deployment.m_id),
                 "model_name": model_name,
                 "repo_model_id": repo_model_id,
+                "engine_name": str(getattr(deployment, "engine_name", "") or ""),
+                "m_file_id": str(getattr(deployment, "m_file_id", "") or ""),
             }
         )
 
@@ -605,30 +610,43 @@ def _preferred_active_model_deployment(
     *,
     desired_type: str,
     preferred_repo_id: str = "",
+    preferred_engine_name: str = "",
 ) -> dict[str, str] | None:
     deployments = _active_model_deployments(client, desired_type=desired_type)
     preferred_repo_id = preferred_repo_id.strip()
+    preferred_engine_name = preferred_engine_name.strip()
     if preferred_repo_id:
         for deployment in deployments:
-            if deployment["repo_model_id"] == preferred_repo_id:
-                return deployment
+            if deployment["repo_model_id"] != preferred_repo_id:
+                continue
+            if (
+                preferred_engine_name
+                and deployment["engine_name"] != preferred_engine_name
+            ):
+                continue
+            return deployment
     return deployments[0] if deployments else None
 
 
 def _context_llm_target(
     snapshot: _cap.ClusterCapabilitySnapshot | None,
-) -> tuple[str, str | None]:
+) -> _model_targets.InferenceTarget:
     """Select a context-test LLM repo/engine for the live host.
 
     Explicit context overrides win; otherwise use the shared platform target.
     """
     if _CONTEXT_TEST_LLM_REPO_OVERRIDE:
-        return (
-            _CONTEXT_TEST_LLM_REPO_OVERRIDE,
-            _CONTEXT_TEST_LLM_ENGINE_OVERRIDE or None,
+        return _model_targets.InferenceTarget(
+            repo_id=_CONTEXT_TEST_LLM_REPO_OVERRIDE,
+            engine_name=_CONTEXT_TEST_LLM_ENGINE_OVERRIDE,
+            quantization=_CONTEXT_TEST_LLM_QUANTIZATION_OVERRIDE or "q6_k",
         )
     target = _model_targets.select_inference_target(snapshot)
-    return target.repo_id, _CONTEXT_TEST_LLM_ENGINE_OVERRIDE or target.engine_name
+    return _model_targets.InferenceTarget(
+        repo_id=target.repo_id,
+        engine_name=_CONTEXT_TEST_LLM_ENGINE_OVERRIDE or target.engine_name,
+        quantization=_CONTEXT_TEST_LLM_QUANTIZATION_OVERRIDE or target.quantization,
+    )
 
 
 def _active_embedding_deployment(client: KamiwazaClient) -> dict[str, str] | None:
@@ -1280,7 +1298,9 @@ def context_llm_prerequisite(
     instead of a cascade of fixture-setup ERRORs.
     """
     client = live_kamiwaza_session_client
-    context_repo_id, context_engine_name = _context_llm_target(cluster_capability_snapshot)
+    context_target = _context_llm_target(cluster_capability_snapshot)
+    context_repo_id = context_target.repo_id
+    context_engine_name = context_target.engine_name
 
     def _stop_provisioned(deployment_id: str | None) -> None:
         """Best-effort teardown of a deployment THIS fixture provisioned."""
@@ -1295,8 +1315,13 @@ def context_llm_prerequisite(
         client,
         desired_type="llm",
         preferred_repo_id=context_repo_id,
+        preferred_engine_name=context_engine_name,
     )
-    if existing is not None:
+    if (
+        existing is not None
+        and existing.get("repo_model_id") == context_repo_id
+        and existing.get("engine_name") == context_engine_name
+    ):
         yield existing["deployment_id"]
         return
 
@@ -1305,7 +1330,11 @@ def context_llm_prerequisite(
     # capacity-limited host) would be orphaned when we skip.
     provisioned_deployment_id: str | None = None
     try:
-        model = ensure_repo_ready(client, context_repo_id)
+        model = ensure_repo_ready(
+            client,
+            context_repo_id,
+            quantization=context_target.quantization,
+        )
         configs = client.models.get_model_configs(model.id)
         if not configs:
             pytest.skip(
@@ -1331,6 +1360,9 @@ def context_llm_prerequisite(
         }
         if context_engine_name:
             deploy_kwargs["engine_name"] = context_engine_name
+        model_file_id = _target_model_file_id(model, context_target.quantization)
+        if model_file_id:
+            deploy_kwargs["m_file_id"] = model_file_id
         raw_deployment_id = client.serving.deploy_model(**deploy_kwargs)
         if not raw_deployment_id:
             pytest.skip(
@@ -1447,8 +1479,13 @@ def deployable_model_prerequisite(
         client,
         desired_type="llm",
         preferred_repo_id=repo_id,
+        preferred_engine_name=engine_name,
     )
-    if existing is not None and existing.get("repo_model_id") == repo_id:
+    if (
+        existing is not None
+        and existing.get("repo_model_id") == repo_id
+        and existing.get("engine_name") == engine_name
+    ):
         return
 
     probe_deployment_id: str | None = None
@@ -1467,6 +1504,9 @@ def deployable_model_prerequisite(
             min_copies=1,
             starting_copies=1,
             engine_name=engine_name,
+            m_file_id=_target_model_file_id(
+                model, deployable_model_target.quantization
+            ),
             # The probe's wait_for_deployment below owns the timeout
             # (DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS), not the SDK default.
             wait=False,
@@ -1935,6 +1975,31 @@ def _model_has_ready_target_files(model: Any, quantization: str) -> bool:
     if not target_files:
         return False
     return all(model_file_download_satisfied(f) for f in target_files)
+
+
+def _target_model_file_id(model: Any, quantization: str) -> str | None:
+    """Return a deterministic ready GGUF file matching the prepared quantization."""
+    target_files = _target_files_for_quantization(model, quantization)
+    ready_gguf_files = [
+        model_file
+        for model_file in target_files
+        if str(getattr(model_file, "name", "") or "").lower().endswith(".gguf")
+        and getattr(model_file, "id", None)
+        and model_file_download_satisfied(model_file)
+    ]
+    if not ready_gguf_files:
+        return None
+    selected = min(
+        ready_gguf_files,
+        key=lambda model_file: str(getattr(model_file, "name", "") or "").lower(),
+    )
+    return str(selected.id)
+
+
+@pytest.fixture(scope="session")
+def target_model_file_id() -> Callable[[Any, str], str | None]:
+    """Resolve the exact prepared weights file for a quantized target."""
+    return _target_model_file_id
 
 
 def _get_model_by_repo_id_with_files(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1375,6 +1375,15 @@ def deployable_model_target(
     return _model_targets.select_inference_target(cluster_capability_snapshot)
 
 
+def _default_model_config(
+    client: KamiwazaClient, model_id: object, repo_id: str
+) -> Any:
+    configs = client.models.get_model_configs(model_id)
+    if not configs:
+        pytest.skip(f"No model configs available for deployable test model '{repo_id}'")
+    return next((config for config in configs if config.default), configs[0])
+
+
 @pytest.fixture(scope="session")
 def deployable_model_prerequisite(
     live_kamiwaza_session_client: KamiwazaClient,
@@ -1393,15 +1402,7 @@ def deployable_model_prerequisite(
     probe_deployment_id: str | None = None
     try:
         model = ensure_repo_ready(client, repo_id)
-        configs = client.models.get_model_configs(model.id)
-        if not configs:
-            pytest.skip(
-                "No model configs available for deployable test model "
-                f"'{repo_id}'"
-            )
-        default_config = next(
-            (config for config in configs if config.default), configs[0]
-        )
+        default_config = _default_model_config(client, model.id, repo_id)
         raw_deployment_id = client.serving.deploy_model(
             model_id=str(model.id),
             m_config_id=default_config.id,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,6 +35,7 @@ from kamiwaza_sdk.utils.model_file_readiness import model_file_download_satisfie
 # is loaded by name, not as part of the ``integration`` package).
 sys.path.insert(0, str(Path(__file__).parent))
 import capability_markers as _cap  # noqa: E402
+import model_targets as _model_targets  # noqa: E402
 import peer_auth as _peer_auth  # noqa: E402
 
 DOCKER_COMPOSE_FILE = Path(__file__).parent / "docker" / "docker-compose.yml"
@@ -124,24 +125,9 @@ _TEXT_BODY_MARKERS = (
 )
 _CONTEXT_TEST_LLM_REPO_OVERRIDE = os.environ.get("KAMIWAZA_CONTEXT_LLM_REPO", "").strip()
 _CONTEXT_TEST_LLM_ENGINE_OVERRIDE = os.environ.get("KAMIWAZA_CONTEXT_LLM_ENGINE", "").strip()
-CONTEXT_TEST_MLX_LLM_REPO = os.environ.get(
-    "KAMIWAZA_CONTEXT_MLX_LLM_REPO",
-    "mlx-community/Qwen3-4B-4bit",
-)
-CONTEXT_TEST_VLLM_LLM_REPO = os.environ.get(
-    "KAMIWAZA_CONTEXT_VLLM_LLM_REPO",
-    "Qwen/Qwen3-0.6B",
-)
 CONTEXT_TEST_LLM_DEPLOY_TIMEOUT_SECONDS = float(
     os.environ.get("KAMIWAZA_CONTEXT_LLM_DEPLOY_TIMEOUT_SECONDS", "600")
 )
-# Must stay in sync with TEST_REPO_ID in test_serving_workflow.py and
-# test_cli_live.py: the capability probe deploys the same model through the
-# same default-engine path the gated tests use, so the gate's skip/run verdict
-# matches what the tests will actually do. Intentionally not env-overridable —
-# an override here that the test modules don't honor would let the probe pass
-# while the tests deploy a different model and fail instead of skip.
-DEPLOYABLE_TEST_MODEL_REPO = "mlx-community/Qwen3-4B-4bit"
 DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS = float(
     os.environ.get("KAMIWAZA_DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS", "600")
 )
@@ -634,17 +620,15 @@ def _context_llm_target(
 ) -> tuple[str, str | None]:
     """Select a context-test LLM repo/engine for the live host.
 
-    MLX remains the default for non-NVIDIA hosts, but Linux/NVIDIA release UAT
-    must not send the MLX-quantized smoke model through vLLM by accident.
+    Explicit context overrides win; otherwise use the shared platform target.
     """
     if _CONTEXT_TEST_LLM_REPO_OVERRIDE:
         return (
             _CONTEXT_TEST_LLM_REPO_OVERRIDE,
             _CONTEXT_TEST_LLM_ENGINE_OVERRIDE or None,
         )
-    if snapshot is not None and "nvidia" in snapshot.gpu_vendors:
-        return CONTEXT_TEST_VLLM_LLM_REPO, _CONTEXT_TEST_LLM_ENGINE_OVERRIDE or "vllm"
-    return CONTEXT_TEST_MLX_LLM_REPO, _CONTEXT_TEST_LLM_ENGINE_OVERRIDE or "mlx"
+    target = _model_targets.select_inference_target(snapshot)
+    return target.repo_id, _CONTEXT_TEST_LLM_ENGINE_OVERRIDE or target.engine_name
 
 
 def _active_embedding_deployment(client: KamiwazaClient) -> dict[str, str] | None:
@@ -1384,39 +1368,36 @@ def context_llm_prerequisite(
 
 
 @pytest.fixture(scope="session")
+def deployable_model_target(
+    cluster_capability_snapshot: _cap.ClusterCapabilitySnapshot | None,
+) -> _model_targets.InferenceTarget:
+    """The shared model/engine pair used by probe, serving, and CLI tests."""
+    return _model_targets.select_inference_target(cluster_capability_snapshot)
+
+
+@pytest.fixture(scope="session")
 def deployable_model_prerequisite(
     live_kamiwaza_session_client: KamiwazaClient,
     ensure_repo_ready,
+    deployable_model_target: _model_targets.InferenceTarget,
 ) -> None:
     """Skip once if this host cannot deploy the integration test model.
 
-    Serving/CLI tests that deploy ``DEPLOYABLE_TEST_MODEL_REPO`` (an MLX model)
-    fail with a 5xx on hosts without compatible inference capacity — e.g. the
-    x86 CPU Azure smoke. Probe deployability once per session and skip the
-    marked tests instead of failing them. Mirrors ``embedding_model_prerequisite``
-    / ``context_llm_prerequisite``; the probe tears down its own deployment so
-    dependent tests perform their own deploys.
+    Probe deployability once per session and skip the marked tests instead of
+    failing them. The shared target fixture keeps the probe and tests on the
+    exact same platform-compatible model and engine.
     """
     client = live_kamiwaza_session_client
-    # Short-circuit ONLY when the exact test model is already deployed — a
-    # different active LLM does not prove this host can deploy DEPLOYABLE_TEST_MODEL_REPO
-    # (e.g. MLX on x86), so in that case we must still probe.
-    existing = _preferred_active_model_deployment(
-        client,
-        desired_type="llm",
-        preferred_repo_id=DEPLOYABLE_TEST_MODEL_REPO,
-    )
-    if existing is not None and existing.get("repo_model_id") == DEPLOYABLE_TEST_MODEL_REPO:
-        return  # the test model itself is already deployed → host is capable
-
+    repo_id = deployable_model_target.repo_id
+    engine_name = deployable_model_target.engine_name
     probe_deployment_id: str | None = None
     try:
-        model = ensure_repo_ready(client, DEPLOYABLE_TEST_MODEL_REPO)
+        model = ensure_repo_ready(client, repo_id)
         configs = client.models.get_model_configs(model.id)
         if not configs:
             pytest.skip(
                 "No model configs available for deployable test model "
-                f"'{DEPLOYABLE_TEST_MODEL_REPO}'"
+                f"'{repo_id}'"
             )
         default_config = next(
             (config for config in configs if config.default), configs[0]
@@ -1428,13 +1409,14 @@ def deployable_model_prerequisite(
             autoscaling=False,
             min_copies=1,
             starting_copies=1,
+            engine_name=engine_name,
             # The probe's wait_for_deployment below owns the timeout
             # (DEPLOYABLE_TEST_DEPLOY_TIMEOUT_SECONDS), not the SDK default.
             wait=False,
         )
         if not raw_deployment_id:
             pytest.skip(
-                f"deploy_model returned no id for '{DEPLOYABLE_TEST_MODEL_REPO}' "
+                f"deploy_model returned no id for '{repo_id}' "
                 "(deploy refused on this host)."
             )
         probe_deployment_id = str(raw_deployment_id)
@@ -1451,7 +1433,7 @@ def deployable_model_prerequisite(
         _stop_deployment_quietly(client, probe_deployment_id)
         pytest.skip(
             "Host cannot provision integration test model (download/deploy) "
-            f"'{DEPLOYABLE_TEST_MODEL_REPO}': {type(exc).__name__}: {exc}"
+            f"'{repo_id}' (engine={engine_name}): {type(exc).__name__}: {exc}"
         )
     except APIError as exc:
         # Only a 5xx (server cannot bring the model up on this host) is a
@@ -1464,14 +1446,14 @@ def deployable_model_prerequisite(
             raise
         pytest.skip(
             "Host cannot provision integration test model (download/deploy) "
-            f"'{DEPLOYABLE_TEST_MODEL_REPO}': APIError {status_code}: {exc}"
+            f"'{repo_id}' (engine={engine_name}): APIError {status_code}: {exc}"
         )
 
     ready = _platform_deployment_ready(deployment)
     _stop_deployment_quietly(client, probe_deployment_id)
     if not ready:
         pytest.skip(
-            f"Integration test model '{DEPLOYABLE_TEST_MODEL_REPO}' did not become "
+            f"Integration test model '{repo_id}' (engine={engine_name}) did not become "
             "ready on this host."
         )
 

--- a/tests/integration/model_targets.py
+++ b/tests/integration/model_targets.py
@@ -1,0 +1,50 @@
+"""Shared, platform-aware inference targets for live SDK tests."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from capability_markers import ClusterCapabilitySnapshot
+
+
+@dataclass(frozen=True)
+class InferenceTarget:
+    """A model repository paired with the engine that can load its weights."""
+
+    repo_id: str
+    engine_name: str
+
+
+MLX_LLM_TARGET = InferenceTarget(
+    repo_id=os.environ.get(
+        "KAMIWAZA_CONTEXT_MLX_LLM_REPO",
+        "mlx-community/Qwen3-4B-4bit",
+    ),
+    engine_name="mlx",
+)
+VLLM_LLM_TARGET = InferenceTarget(
+    repo_id=os.environ.get(
+        "KAMIWAZA_CONTEXT_VLLM_LLM_REPO",
+        "Qwen/Qwen3-0.6B",
+    ),
+    engine_name="vllm",
+)
+GGUF_LLM_TARGET = InferenceTarget(
+    repo_id=os.environ.get(
+        "KAMIWAZA_CONTEXT_GGUF_LLM_REPO",
+        "unsloth/Qwen3-4B-Instruct-2507-GGUF",
+    ),
+    engine_name="llamacpp",
+)
+
+
+def select_inference_target(
+    snapshot: ClusterCapabilitySnapshot | None,
+) -> InferenceTarget:
+    """Choose weights and engine that match the live cluster hardware."""
+    if snapshot is not None and "nvidia" in snapshot.gpu_vendors:
+        return VLLM_LLM_TARGET
+    if snapshot is not None and snapshot.is_apple_silicon:
+        return MLX_LLM_TARGET
+    return GGUF_LLM_TARGET

--- a/tests/integration/model_targets.py
+++ b/tests/integration/model_targets.py
@@ -46,7 +46,7 @@ GGUF_LLM_TARGET: Final[InferenceTarget] = InferenceTarget(
     repo_id=_configured_repo(
         "KAMIWAZA_TEST_GGUF_LLM_REPO",
         "KAMIWAZA_CONTEXT_GGUF_LLM_REPO",
-        "unsloth/Qwen3-4B-Instruct-2507-GGUF",
+        "unsloth/Qwen3-4B-Thinking-2507-GGUF",
     ),
     engine_name="llamacpp",
 )

--- a/tests/integration/model_targets.py
+++ b/tests/integration/model_targets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import Final
 
 from capability_markers import ClusterCapabilitySnapshot
 
@@ -16,22 +17,34 @@ class InferenceTarget:
     engine_name: str
 
 
-MLX_LLM_TARGET = InferenceTarget(
-    repo_id=os.environ.get(
+def _configured_repo(generic_name: str, legacy_name: str, default: str) -> str:
+    """Resolve a non-blank suite override, retaining context-test compatibility."""
+    return (
+        os.environ.get(generic_name, "").strip()
+        or os.environ.get(legacy_name, "").strip()
+        or default
+    )
+
+
+MLX_LLM_TARGET: Final[InferenceTarget] = InferenceTarget(
+    repo_id=_configured_repo(
+        "KAMIWAZA_TEST_MLX_LLM_REPO",
         "KAMIWAZA_CONTEXT_MLX_LLM_REPO",
         "mlx-community/Qwen3-4B-4bit",
     ),
     engine_name="mlx",
 )
-VLLM_LLM_TARGET = InferenceTarget(
-    repo_id=os.environ.get(
+VLLM_LLM_TARGET: Final[InferenceTarget] = InferenceTarget(
+    repo_id=_configured_repo(
+        "KAMIWAZA_TEST_VLLM_LLM_REPO",
         "KAMIWAZA_CONTEXT_VLLM_LLM_REPO",
         "Qwen/Qwen3-0.6B",
     ),
     engine_name="vllm",
 )
-GGUF_LLM_TARGET = InferenceTarget(
-    repo_id=os.environ.get(
+GGUF_LLM_TARGET: Final[InferenceTarget] = InferenceTarget(
+    repo_id=_configured_repo(
+        "KAMIWAZA_TEST_GGUF_LLM_REPO",
         "KAMIWAZA_CONTEXT_GGUF_LLM_REPO",
         "unsloth/Qwen3-4B-Instruct-2507-GGUF",
     ),

--- a/tests/integration/model_targets.py
+++ b/tests/integration/model_targets.py
@@ -26,30 +26,42 @@ def _configured_repo(generic_name: str, legacy_name: str, default: str) -> str:
     )
 
 
-MLX_LLM_TARGET: Final[InferenceTarget] = InferenceTarget(
-    repo_id=_configured_repo(
-        "KAMIWAZA_TEST_MLX_LLM_REPO",
-        "KAMIWAZA_CONTEXT_MLX_LLM_REPO",
-        "mlx-community/Qwen3-4B-4bit",
-    ),
-    engine_name="mlx",
-)
-VLLM_LLM_TARGET: Final[InferenceTarget] = InferenceTarget(
-    repo_id=_configured_repo(
-        "KAMIWAZA_TEST_VLLM_LLM_REPO",
-        "KAMIWAZA_CONTEXT_VLLM_LLM_REPO",
-        "Qwen/Qwen3-0.6B",
-    ),
-    engine_name="vllm",
-)
-GGUF_LLM_TARGET: Final[InferenceTarget] = InferenceTarget(
-    repo_id=_configured_repo(
-        "KAMIWAZA_TEST_GGUF_LLM_REPO",
-        "KAMIWAZA_CONTEXT_GGUF_LLM_REPO",
-        "unsloth/Qwen3-4B-Thinking-2507-GGUF",
-    ),
-    engine_name="llamacpp",
-)
+_DEFAULT_MLX_LLM_REPO: Final = "mlx-community/Qwen3-4B-4bit"
+_DEFAULT_VLLM_LLM_REPO: Final = "Qwen/Qwen3-0.6B"
+_DEFAULT_GGUF_LLM_REPO: Final = "unsloth/Qwen3-4B-Thinking-2507-GGUF"
+
+
+def _load_inference_targets() -> tuple[InferenceTarget, InferenceTarget, InferenceTarget]:
+    """Resolve all target overrides without mutating module state."""
+    return (
+        InferenceTarget(
+            repo_id=_configured_repo(
+                "KAMIWAZA_TEST_MLX_LLM_REPO",
+                "KAMIWAZA_CONTEXT_MLX_LLM_REPO",
+                _DEFAULT_MLX_LLM_REPO,
+            ),
+            engine_name="mlx",
+        ),
+        InferenceTarget(
+            repo_id=_configured_repo(
+                "KAMIWAZA_TEST_VLLM_LLM_REPO",
+                "KAMIWAZA_CONTEXT_VLLM_LLM_REPO",
+                _DEFAULT_VLLM_LLM_REPO,
+            ),
+            engine_name="vllm",
+        ),
+        InferenceTarget(
+            repo_id=_configured_repo(
+                "KAMIWAZA_TEST_GGUF_LLM_REPO",
+                "KAMIWAZA_CONTEXT_GGUF_LLM_REPO",
+                _DEFAULT_GGUF_LLM_REPO,
+            ),
+            engine_name="llamacpp",
+        ),
+    )
+
+
+MLX_LLM_TARGET, VLLM_LLM_TARGET, GGUF_LLM_TARGET = _load_inference_targets()
 
 
 def select_inference_target(

--- a/tests/integration/model_targets.py
+++ b/tests/integration/model_targets.py
@@ -15,6 +15,7 @@ class InferenceTarget:
 
     repo_id: str
     engine_name: str
+    quantization: str = "q6_k"
 
 
 def _configured_repo(generic_name: str, legacy_name: str, default: str) -> str:
@@ -57,6 +58,7 @@ def _load_inference_targets() -> tuple[InferenceTarget, InferenceTarget, Inferen
                 _DEFAULT_GGUF_LLM_REPO,
             ),
             engine_name="llamacpp",
+            quantization="q4_k",
         ),
     )
 

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -101,6 +101,7 @@ def test_cli_serve_deploy(
     client_factory,
     ensure_deployable_model_ready,
     deployable_model_target: InferenceTarget,
+    target_model_file_id,
     tmp_path: Path,
 ) -> None:
     """CLI ``serve deploy`` round-trip.
@@ -119,7 +120,10 @@ def test_cli_serve_deploy(
         base_args, env, live_username, live_password, token_path, pat_prefix="cli-deploy"
     )
     pat_client = client_factory(base_url=live_server_available, api_key=pat_token)
-    ensure_deployable_model_ready(pat_client)
+    model = ensure_deployable_model_ready(pat_client)
+    model_file_id = target_model_file_id(
+        model, deployable_model_target.quantization
+    )
 
     serve_result = run_cli(
         [
@@ -130,6 +134,7 @@ def test_cli_serve_deploy(
             deployable_model_target.repo_id,
             "--engine-name",
             deployable_model_target.engine_name,
+            *(["--file-id", model_file_id] if model_file_id else []),
             "--wait",
             "--poll-interval",
             "5",

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -107,7 +107,7 @@ def test_cli_serve_deploy(
 
     Requires a host that can actually deploy the test model; gated by
     ``requires_deployable_model`` so it skips (rather than fails) on hosts
-    without compatible inference capacity (e.g. the x86 CPU smoke vs an MLX model).
+    without compatible inference capacity for the platform-selected target.
     """
     token_path = tmp_path / "token.json"
     base_args = ["--base-url", live_server_available, "--token-path", str(token_path)]

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-TEST_REPO_ID = "mlx-community/Qwen3-4B-4bit"
+from model_targets import InferenceTarget
 
 pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
 
@@ -100,6 +100,7 @@ def test_cli_serve_deploy(
     live_password: str,
     client_factory,
     ensure_repo_ready,
+    deployable_model_target: InferenceTarget,
     tmp_path: Path,
 ) -> None:
     """CLI ``serve deploy`` round-trip.
@@ -118,7 +119,7 @@ def test_cli_serve_deploy(
         base_args, env, live_username, live_password, token_path, pat_prefix="cli-deploy"
     )
     pat_client = client_factory(base_url=live_server_available, api_key=pat_token)
-    ensure_repo_ready(pat_client, TEST_REPO_ID)
+    ensure_repo_ready(pat_client, deployable_model_target.repo_id)
 
     serve_result = run_cli(
         [
@@ -126,7 +127,9 @@ def test_cli_serve_deploy(
             "serve",
             "deploy",
             "--repo-id",
-            TEST_REPO_ID,
+            deployable_model_target.repo_id,
+            "--engine-name",
+            deployable_model_target.engine_name,
             "--wait",
             "--poll-interval",
             "5",

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -99,7 +99,7 @@ def test_cli_serve_deploy(
     live_username: str,
     live_password: str,
     client_factory,
-    ensure_repo_ready,
+    ensure_deployable_model_ready,
     deployable_model_target: InferenceTarget,
     tmp_path: Path,
 ) -> None:
@@ -119,7 +119,7 @@ def test_cli_serve_deploy(
         base_args, env, live_username, live_password, token_path, pat_prefix="cli-deploy"
     )
     pat_client = client_factory(base_url=live_server_available, api_key=pat_token)
-    ensure_repo_ready(pat_client, deployable_model_target.repo_id)
+    ensure_deployable_model_ready(pat_client)
 
     serve_result = run_cli(
         [

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import logging
 import os
 import time
 from collections.abc import Generator
@@ -15,6 +16,9 @@ from kamiwaza_sdk import KamiwazaClient
 from kamiwaza_sdk.authentication import UserPasswordAuthenticator
 from kamiwaza_sdk.exceptions import APIError, NotFoundError
 from kamiwaza_sdk.services.context import ContextService
+
+logger = logging.getLogger(__name__)
+_VECTORDB_STOPPED_GRACE_SECONDS = 30.0
 
 pytestmark = [
     pytest.mark.integration,
@@ -52,6 +56,28 @@ def _assert_global_scope_if_exposed(resource: dict[str, object]) -> None:
     assert str(workroom_id) == ContextService.DEFAULT_WORKROOM_ID
 
 
+def _next_stopped_since(
+    vectordb_id: str,
+    status: str,
+    stopped_since: float | None,
+    now: float,
+) -> float | None:
+    """Return updated stopped timing or raise for a terminal provisioning state."""
+    if status == "failed":
+        raise RuntimeError(
+            f"VectorDB {vectordb_id} entered non-recoverable status {status}"
+        )
+    if status != "stopped":
+        return None
+    if stopped_since is None:
+        return now
+    if now - stopped_since >= _VECTORDB_STOPPED_GRACE_SECONDS:
+        raise RuntimeError(
+            f"VectorDB {vectordb_id} remained stopped during provisioning"
+        )
+    return stopped_since
+
+
 def _wait_for_vectordb_ready(
     service: ContextService,
     vectordb_id: str,
@@ -62,6 +88,8 @@ def _wait_for_vectordb_ready(
 ) -> None:
     deadline = time.monotonic() + timeout_seconds
     last_status = "unknown"
+    reported_status: str | None = None
+    stopped_since: float | None = None
 
     while True:
         try:
@@ -74,13 +102,24 @@ def _wait_for_vectordb_ready(
 
         last_status = str(instance.get("status", "unknown")).lower()
         endpoint = instance.get("endpoint")
+        if last_status != reported_status:
+            logger.info(
+                "VectorDB %s provisioning status=%s endpoint=%s",
+                vectordb_id,
+                last_status,
+                endpoint,
+            )
+            reported_status = last_status
         if last_status == "running" and endpoint:
             return
-        if last_status in {"failed", "stopped"}:
-            raise RuntimeError(
-                f"VectorDB {vectordb_id} entered non-recoverable status {last_status}"
-            )
-        if time.monotonic() >= deadline:
+        now = time.monotonic()
+        stopped_since = _next_stopped_since(
+            vectordb_id,
+            last_status,
+            stopped_since,
+            now,
+        )
+        if now >= deadline:
             raise TimeoutError(
                 f"Timed out waiting for VectorDB {vectordb_id} to be ready "
                 f"(last_status={last_status}, endpoint={endpoint})"

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -7,6 +7,7 @@ import logging
 import os
 import time
 from collections.abc import Generator
+from typing import Final
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
@@ -18,7 +19,7 @@ from kamiwaza_sdk.exceptions import APIError, NotFoundError
 from kamiwaza_sdk.services.context import ContextService
 
 logger = logging.getLogger(__name__)
-_VECTORDB_STOPPED_GRACE_SECONDS = 30.0
+_VECTORDB_STOPPED_GRACE_SECONDS: Final[float] = 30.0
 
 pytestmark = [
     pytest.mark.integration,

--- a/tests/integration/test_context_live.py
+++ b/tests/integration/test_context_live.py
@@ -7,8 +7,8 @@ import logging
 import os
 import time
 from collections.abc import Generator
-from typing import Final
 from datetime import datetime, timedelta, timezone
+from typing import Final
 from uuid import uuid4
 
 import pytest

--- a/tests/integration/test_inference_matrix_live.py
+++ b/tests/integration/test_inference_matrix_live.py
@@ -25,9 +25,8 @@ fail. GPU/MIG gating uses the M5 capability markers (autouse-enforced via
 engine-specific deployability is handled by each test's download/deploy wrapper,
 with 5xx/timeout outcomes converted to skips.
 
-CAVEAT: ``ensure_repo_ready`` selects a GGUF quant but cannot pin one exact
-filename the way the smoke's ``files_to_download`` does, so the GGUF tests
-register the repo best-effort and skip-not-fail if it cannot be made ready.
+The engine lanes consume the same overrideable target definitions as the
+deployability probe, and GGUF deployments pin the exact prepared file id.
 """
 
 from __future__ import annotations
@@ -35,21 +34,13 @@ from __future__ import annotations
 import pytest
 
 from kamiwaza_sdk.exceptions import APIError
+from model_targets import GGUF_LLM_TARGET, VLLM_LLM_TARGET, InferenceTarget
 
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.live,
     pytest.mark.withoutresponses,
 ]
-
-# Engine repos mirror cmd_full's defaults. GGUF is file-pinned in the smoke via
-# files_to_download; the SDK download surface cannot reproduce that pin, so the
-# GGUF tests skip-not-fail if the repo can't be made ready.
-LLAMACPP_REPO = "unsloth/Qwen3-4B-Instruct-2507-GGUF"
-LLAMACPP_QUANT = "q4_k"
-# Keep the vLLM lane intentionally small. This is a CUDA engine smoke, not a
-# model-size certification, and it must fit on a busy single-node release UAT.
-VLLM_REPO = "Qwen/Qwen3-0.6B"
 
 WAIT_TIMEOUT = 600
 FRACTIONAL_COPIES = 2
@@ -62,7 +53,7 @@ def _ensure_repo_or_skip(ensure_repo_ready, client, repo_id, **kwargs):
 
     A 5xx (host cannot fetch / register the model) or a download timeout is a
     capability/infra failure -> skip. A 4xx is a real regression and is
-    re-raised. Mirrors ``deployable_model_prerequisite`` + ``_ensure_model_cached``.
+    re-raised. Mirrors ``deployable_model_prerequisite``.
     """
     try:
         return ensure_repo_ready(client, repo_id, **kwargs)
@@ -81,7 +72,13 @@ def _ensure_repo_or_skip(ensure_repo_ready, client, repo_id, **kwargs):
         )
 
 
-def _deploy_or_skip(client, model, *, engine_name):
+def _deploy_or_skip(
+    client,
+    model,
+    *,
+    target: InferenceTarget,
+    target_model_file_id,
+):
     """Deploy one copy with an explicit engine_name; skip-not-fail on 5xx refusal.
 
     Returns the deployment id (str). A falsy deploy_model return (False) or a 5xx
@@ -90,14 +87,17 @@ def _deploy_or_skip(client, model, *, engine_name):
     """
     configs = client.models.get_model_configs(model.id)
     if not configs:
-        pytest.skip(f"No model configs available for '{engine_name}' test model")
+        pytest.skip(
+            f"No model configs available for '{target.engine_name}' test model"
+        )
     default_config = next((c for c in configs if c.default), configs[0])
 
     try:
         raw_deployment_id = client.serving.deploy_model(
             model_id=str(model.id),
             m_config_id=default_config.id,
-            engine_name=engine_name,
+            m_file_id=target_model_file_id(model, target.quantization),
+            engine_name=target.engine_name,
             lb_port=0,
             autoscaling=False,
             min_copies=1,
@@ -111,13 +111,13 @@ def _deploy_or_skip(client, model, *, engine_name):
         if status_code is None or status_code < 500:
             raise
         pytest.skip(
-            f"Host refused to deploy engine '{engine_name}': "
+            f"Host refused to deploy engine '{target.engine_name}': "
             f"APIError {status_code}: {exc}"
         )
 
     if not raw_deployment_id:
         pytest.skip(
-            f"deploy_model returned no id for engine '{engine_name}' "
+            f"deploy_model returned no id for engine '{target.engine_name}' "
             "(deploy refused on this host)."
         )
     return str(raw_deployment_id)
@@ -171,21 +171,31 @@ def _assert_chat_completion(client, deployment_id):
 # --------------------------------------------------------------------------- #
 # Engine matrix tests
 # --------------------------------------------------------------------------- #
-def test_deploy_and_infer_llamacpp_gguf(live_kamiwaza_client, ensure_repo_ready):
+def test_deploy_and_infer_llamacpp_gguf(
+    live_kamiwaza_client, ensure_repo_ready, target_model_file_id
+):
     """llamacpp arm of cmd_full: download GGUF, deploy engine_name='llamacpp', infer.
 
     Covers the CPU-capable GGUF inference path the SDK suite does not yet cover
-    (test_serving_workflow only covers MLX). No GPU marker — gate on
-    requires_deployable_model where it actually deploys.
+    (test_serving_workflow follows the host-selected target). No GPU marker;
+    its own readiness wrapper provides the capability gate.
     """
     client = live_kamiwaza_client
     model = _ensure_repo_or_skip(
-        ensure_repo_ready, client, LLAMACPP_REPO, quantization=LLAMACPP_QUANT
+        ensure_repo_ready,
+        client,
+        GGUF_LLM_TARGET.repo_id,
+        quantization=GGUF_LLM_TARGET.quantization,
     )
 
     deployment_id = None
     try:
-        deployment_id = _deploy_or_skip(client, model, engine_name="llamacpp")
+        deployment_id = _deploy_or_skip(
+            client,
+            model,
+            target=GGUF_LLM_TARGET,
+            target_model_file_id=target_model_file_id,
+        )
         details = _wait_or_skip(client, deployment_id, engine_name="llamacpp")
         assert details.instances, "llamacpp deployment should report instances"
         _assert_chat_completion(client, deployment_id)
@@ -196,7 +206,9 @@ def test_deploy_and_infer_llamacpp_gguf(live_kamiwaza_client, ensure_repo_ready)
 @pytest.mark.gpu_vendor("nvidia")
 @pytest.mark.min_gpu_count(1)
 @pytest.mark.min_gpu_mem(16)
-def test_deploy_and_infer_vllm_nvidia(live_kamiwaza_client, ensure_repo_ready):
+def test_deploy_and_infer_vllm_nvidia(
+    live_kamiwaza_client, ensure_repo_ready, target_model_file_id
+):
     """vllm arm of cmd_full: download safetensors, deploy engine_name='vllm', infer.
 
     The only engine arm that genuinely needs a discrete NVIDIA GPU; the SDK suite
@@ -204,11 +216,21 @@ def test_deploy_and_infer_vllm_nvidia(live_kamiwaza_client, ensure_repo_ready):
     fails) on CPU / Apple / AMD hosts.
     """
     client = live_kamiwaza_client
-    model = _ensure_repo_or_skip(ensure_repo_ready, client, VLLM_REPO)
+    model = _ensure_repo_or_skip(
+        ensure_repo_ready,
+        client,
+        VLLM_LLM_TARGET.repo_id,
+        quantization=VLLM_LLM_TARGET.quantization,
+    )
 
     deployment_id = None
     try:
-        deployment_id = _deploy_or_skip(client, model, engine_name="vllm")
+        deployment_id = _deploy_or_skip(
+            client,
+            model,
+            target=VLLM_LLM_TARGET,
+            target_model_file_id=target_model_file_id,
+        )
         details = _wait_or_skip(client, deployment_id, engine_name="vllm")
         assert details.instances, "vllm deployment should report instances"
         _assert_chat_completion(client, deployment_id)
@@ -219,7 +241,7 @@ def test_deploy_and_infer_vllm_nvidia(live_kamiwaza_client, ensure_repo_ready):
 # --------------------------------------------------------------------------- #
 # Fractional / MIG co-location tests
 # --------------------------------------------------------------------------- #
-def _certify_fractional_colocation(client, model):
+def _certify_fractional_colocation(client, model, target_model_file_id):
     """Deploy FRACTIONAL_COPIES of one model and assert co-location + serve.
 
     Lifts the API-observable subset of _run_fractional_cert: deploy N copies,
@@ -231,7 +253,12 @@ def _certify_fractional_colocation(client, model):
     deployment_ids: list[str] = []
     try:
         for _ in range(FRACTIONAL_COPIES):
-            deployment_id = _deploy_or_skip(client, model, engine_name="llamacpp")
+            deployment_id = _deploy_or_skip(
+                client,
+                model,
+                target=GGUF_LLM_TARGET,
+                target_model_file_id=target_model_file_id,
+            )
             deployment_ids.append(deployment_id)
 
         # ALL must reach DEPLOYED — on a single 1-GPU node this is only possible
@@ -250,11 +277,10 @@ def _certify_fractional_colocation(client, model):
             _stop_quietly(client, deployment_id)
 
 
-@pytest.mark.requires_deployable_model
 @pytest.mark.min_gpu_count(1)
 @pytest.mark.min_gpu_mem(8)
 def test_fractional_colocation_two_models_one_gpu(
-    live_kamiwaza_client, ensure_repo_ready
+    live_kamiwaza_client, ensure_repo_ready, target_model_file_id
 ):
     """Fractional cert: 2 copies of one model co-located on a single GPU, each serving.
 
@@ -264,16 +290,18 @@ def test_fractional_colocation_two_models_one_gpu(
     """
     client = live_kamiwaza_client
     model = _ensure_repo_or_skip(
-        ensure_repo_ready, client, LLAMACPP_REPO, quantization=LLAMACPP_QUANT
+        ensure_repo_ready,
+        client,
+        GGUF_LLM_TARGET.repo_id,
+        quantization=GGUF_LLM_TARGET.quantization,
     )
-    _certify_fractional_colocation(client, model)
+    _certify_fractional_colocation(client, model, target_model_file_id)
 
 
-@pytest.mark.requires_deployable_model
 @pytest.mark.gpu_mig_support
 @pytest.mark.min_gpu_count(1)
 def test_fractional_colocation_mig_partitioned_gpu(
-    live_kamiwaza_client, ensure_repo_ready
+    live_kamiwaza_client, ensure_repo_ready, target_model_file_id
 ):
     """MIG variant of the fractional cert: 2 co-located copies, each serving.
 
@@ -283,6 +311,9 @@ def test_fractional_colocation_mig_partitioned_gpu(
     """
     client = live_kamiwaza_client
     model = _ensure_repo_or_skip(
-        ensure_repo_ready, client, LLAMACPP_REPO, quantization=LLAMACPP_QUANT
+        ensure_repo_ready,
+        client,
+        GGUF_LLM_TARGET.repo_id,
+        quantization=GGUF_LLM_TARGET.quantization,
     )
-    _certify_fractional_colocation(client, model)
+    _certify_fractional_colocation(client, model, target_model_file_id)

--- a/tests/integration/test_serving_workflow.py
+++ b/tests/integration/test_serving_workflow.py
@@ -44,11 +44,11 @@ def _ensure_model_cached(client, model):
 @pytest.mark.requires_deployable_model
 def test_deploy_qwen_and_infer_with_strip_thinking(
     live_kamiwaza_client,
-    ensure_repo_ready,
+    ensure_deployable_model_ready,
     deployable_model_target: InferenceTarget,
 ):
     client = live_kamiwaza_client
-    model = ensure_repo_ready(client, deployable_model_target.repo_id)
+    model = ensure_deployable_model_ready(client)
 
     _ensure_model_cached(client, model)
 

--- a/tests/integration/test_serving_workflow.py
+++ b/tests/integration/test_serving_workflow.py
@@ -32,25 +32,19 @@ def _sample_logs(client, deployment_id):
         return []
 
 
-def _ensure_model_cached(client, model):
-    hub = getattr(model, "hub", None) or "hf"
-    payload = {"model": model.repo_modelId, "hub": hub}
-    try:
-        client.post("/models/download/", json=payload)
-    except APIError as exc:
-        pytest.skip(f"Model download API unavailable: {exc}")
-
-
 @pytest.mark.requires_deployable_model
 def test_deploy_qwen_and_infer_with_strip_thinking(
     live_kamiwaza_client,
     ensure_deployable_model_ready,
     deployable_model_target: InferenceTarget,
+    target_model_file_id,
 ):
     client = live_kamiwaza_client
     model = ensure_deployable_model_ready(client)
 
-    _ensure_model_cached(client, model)
+    model_file_id = target_model_file_id(
+        model, deployable_model_target.quantization
+    )
 
     configs = client.models.get_model_configs(model.id)
     if not configs:
@@ -81,6 +75,7 @@ def test_deploy_qwen_and_infer_with_strip_thinking(
             min_copies=1,
             starting_copies=1,
             engine_name=deployable_model_target.engine_name,
+            m_file_id=model_file_id,
             wait=False,
         )
         deployments.append(default_deployment)
@@ -93,6 +88,7 @@ def test_deploy_qwen_and_infer_with_strip_thinking(
             min_copies=1,
             starting_copies=1,
             engine_name=deployable_model_target.engine_name,
+            m_file_id=model_file_id,
             wait=False,
         )
         deployments.append(strip_deployment)

--- a/tests/integration/test_serving_workflow.py
+++ b/tests/integration/test_serving_workflow.py
@@ -6,10 +6,10 @@ import pytest
 
 from kamiwaza_sdk.exceptions import APIError
 from kamiwaza_sdk.schemas.models.model import CreateModelConfig
+from model_targets import InferenceTarget
 
 pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
 
-TEST_REPO_ID = "mlx-community/Qwen3-4B-4bit"
 CONFIG_PREFIX = "sdk-m2"
 WAIT_TIMEOUT = 600
 
@@ -42,9 +42,13 @@ def _ensure_model_cached(client, model):
 
 
 @pytest.mark.requires_deployable_model
-def test_deploy_qwen_and_infer_with_strip_thinking(live_kamiwaza_client, ensure_repo_ready):
+def test_deploy_qwen_and_infer_with_strip_thinking(
+    live_kamiwaza_client,
+    ensure_repo_ready,
+    deployable_model_target: InferenceTarget,
+):
     client = live_kamiwaza_client
-    model = ensure_repo_ready(client, TEST_REPO_ID)
+    model = ensure_repo_ready(client, deployable_model_target.repo_id)
 
     _ensure_model_cached(client, model)
 
@@ -76,6 +80,7 @@ def test_deploy_qwen_and_infer_with_strip_thinking(live_kamiwaza_client, ensure_
             autoscaling=False,
             min_copies=1,
             starting_copies=1,
+            engine_name=deployable_model_target.engine_name,
             wait=False,
         )
         deployments.append(default_deployment)
@@ -87,6 +92,7 @@ def test_deploy_qwen_and_infer_with_strip_thinking(live_kamiwaza_client, ensure_
             autoscaling=False,
             min_copies=1,
             starting_copies=1,
+            engine_name=deployable_model_target.engine_name,
             wait=False,
         )
         deployments.append(strip_deployment)

--- a/tests/unit/test_authentication.py
+++ b/tests/unit/test_authentication.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
+import time
+from datetime import datetime, timedelta, timezone
+
 import pytest
 import requests
-from datetime import datetime, timedelta, timezone
-import time
 
 from kamiwaza_sdk.authentication import UserPasswordAuthenticator
-from kamiwaza_sdk.token_store import StoredToken, TokenStore
 from kamiwaza_sdk.exceptions import AuthenticationError
 from kamiwaza_sdk.schemas.auth import TokenResponse
+from kamiwaza_sdk.token_store import StoredToken, TokenStore
 
 pytestmark = pytest.mark.unit
 
@@ -135,12 +136,16 @@ def test_user_password_authenticator_invalidates_cached_session() -> None:
     session = requests.Session()
     session.headers["Authorization"] = "Bearer scoped"
     session.cookies.set("access_token", "scoped")
+    session.cookies.set("access_token", "other-scope", domain="other.example")
+    session.cookies.set("load_balancer_affinity", "sticky")
 
     assert authenticator.invalidate_session(session) is True
 
     assert authenticator.token is None
     assert authenticator.refresh_token_value is None
     assert authenticator.token_expiry is None
-    assert store.value is None
+    assert store.value is not None
+    assert store.value.access_token == "scoped"
     assert "Authorization" not in session.headers
-    assert not session.cookies
+    assert all(cookie.name != "access_token" for cookie in session.cookies)
+    assert session.cookies.get("load_balancer_affinity") == "sticky"

--- a/tests/unit/test_authentication.py
+++ b/tests/unit/test_authentication.py
@@ -180,3 +180,14 @@ def test_invalidated_session_clears_stale_cache_after_password_grant_fails() -> 
         authenticator.authenticate(session)
 
     assert store.value is None
+
+    replacement = StoredToken(
+        access_token="unrelated-process-token",
+        refresh_token=None,
+        expires_at=time.time() + 60,
+    )
+    store.save(replacement)
+    with pytest.raises(AuthenticationError, match="bad credentials"):
+        authenticator.authenticate(session)
+
+    assert store.value is replacement

--- a/tests/unit/test_authentication.py
+++ b/tests/unit/test_authentication.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 import pytest
 import requests
 
-from kamiwaza_sdk.authentication import UserPasswordAuthenticator
+from kamiwaza_sdk.authentication import ApiKeyAuthenticator, UserPasswordAuthenticator
 from kamiwaza_sdk.exceptions import AuthenticationError
 from kamiwaza_sdk.schemas.auth import TokenResponse
 from kamiwaza_sdk.token_store import StoredToken, TokenStore
@@ -59,6 +59,15 @@ class DummyAuthService:
         if not self.refresh_response:
             raise RuntimeError("refresh response not configured")
         return self.refresh_response
+
+
+def test_api_key_authenticator_invalidation_is_fail_closed() -> None:
+    authenticator = ApiKeyAuthenticator("fixed-token")
+    session = requests.Session()
+    authenticator.authenticate(session)
+
+    assert authenticator.invalidate_session(session) is False
+    assert session.headers["Authorization"] == "Bearer fixed-token"
 
 
 def test_user_password_authenticator_performs_password_grant():

--- a/tests/unit/test_authentication.py
+++ b/tests/unit/test_authentication.py
@@ -119,3 +119,28 @@ def test_user_password_authenticator_uses_cached_token():
 
     assert auth_service.login_calls == []
     assert session.headers["Authorization"] == "Bearer cached"
+
+
+def test_user_password_authenticator_invalidates_cached_session() -> None:
+    store = MemoryTokenStore()
+    store.value = StoredToken(
+        access_token="scoped",
+        refresh_token="scoped-refresh",
+        expires_at=time.time() + 60,
+    )
+    auth_service = DummyAuthService(login_error=RuntimeError("not used"))
+    authenticator = UserPasswordAuthenticator(
+        "admin", "secret", auth_service, token_store=store
+    )
+    session = requests.Session()
+    session.headers["Authorization"] = "Bearer scoped"
+    session.cookies.set("access_token", "scoped")
+
+    assert authenticator.invalidate_session(session) is True
+
+    assert authenticator.token is None
+    assert authenticator.refresh_token_value is None
+    assert authenticator.token_expiry is None
+    assert store.value is None
+    assert "Authorization" not in session.headers
+    assert not session.cookies

--- a/tests/unit/test_authentication.py
+++ b/tests/unit/test_authentication.py
@@ -149,3 +149,25 @@ def test_user_password_authenticator_invalidates_cached_session() -> None:
     assert "Authorization" not in session.headers
     assert all(cookie.name != "access_token" for cookie in session.cookies)
     assert session.cookies.get("load_balancer_affinity") == "sticky"
+
+
+def test_invalidated_session_clears_stale_cache_after_password_grant_fails() -> None:
+    store = MemoryTokenStore()
+    store.value = StoredToken(
+        access_token="scoped",
+        refresh_token="scoped-refresh",
+        expires_at=time.time() + 60,
+    )
+    authenticator = UserPasswordAuthenticator(
+        "admin",
+        "wrong",
+        DummyAuthService(login_error=RuntimeError("bad credentials")),
+        token_store=store,
+    )
+    session = requests.Session()
+
+    authenticator.invalidate_session(session)
+    with pytest.raises(AuthenticationError, match="bad credentials"):
+        authenticator.authenticate(session)
+
+    assert store.value is None

--- a/tests/unit/test_capability_markers.py
+++ b/tests/unit/test_capability_markers.py
@@ -122,8 +122,9 @@ def test_build_snapshot_detects_apple_silicon_from_real_inventory():
         ]
     )
 
-    assert snap.os_names == frozenset({"darwin"})
-    assert snap.platforms == frozenset({"macos-15.4-arm64-arm-64bit"})
+    assert not hasattr(snap, "os_names")
+    assert not hasattr(snap, "platforms")
+    assert snap.os_platforms == frozenset({("darwin", "macos-15.4-arm64-arm-64bit")})
     assert snap.is_apple_silicon is True
 
 
@@ -146,7 +147,7 @@ def test_build_snapshot_ignores_platform_from_synthetic_inventory_rows():
         ]
     )
 
-    assert snap.os_names == frozenset({"linux"})
+    assert snap.os_platforms == frozenset({("linux", "linux-5.14.0-el9.x86_64")})
     assert snap.is_apple_silicon is False
 
 

--- a/tests/unit/test_capability_markers.py
+++ b/tests/unit/test_capability_markers.py
@@ -172,6 +172,28 @@ def test_build_snapshot_preserves_os_platform_correlation_for_mixed_nodes():
     assert snap.is_apple_silicon is False
 
 
+def test_build_snapshot_rejects_apple_only_inference_when_platform_rows_are_incomplete():
+    snap = cap.build_capability_snapshot(
+        [
+            _hw(
+                [],
+                node_id="apple",
+                processors=["Apple M4"],
+                os="Darwin",
+                platform="macOS-15.4-arm64-arm-64bit",
+            ),
+            _hw(
+                [],
+                node_id="unknown-platform",
+                processors=["AMD EPYC"],
+            ),
+        ]
+    )
+
+    assert snap.platform_inventory_complete is False
+    assert snap.is_apple_silicon is False
+
+
 # --------------------------------------------------------------------------- #
 # collect_capability_requirements
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_capability_markers.py
+++ b/tests/unit/test_capability_markers.py
@@ -25,9 +25,9 @@ pytestmark = pytest.mark.unit
 _Mark = namedtuple("_Mark", ["name", "args"])
 
 
-def _hw(gpus):
+def _hw(gpus, **overrides):
     """A hardware-entry dict shaped like the SDK ``Hardware`` model."""
-    return {"gpus": gpus, "node_id": "node-1"}
+    return {"gpus": gpus, "node_id": "node-1", **overrides}
 
 
 # --------------------------------------------------------------------------- #
@@ -108,6 +108,46 @@ def test_build_snapshot_ignores_inactive_hardware_for_fallback_node_count():
     )
 
     assert snap.node_count == 1
+
+
+def test_build_snapshot_detects_apple_silicon_from_real_inventory():
+    snap = cap.build_capability_snapshot(
+        [
+            _hw(
+                [],
+                processors=["Apple M4"],
+                os="Darwin",
+                platform="macOS-15.4-arm64-arm-64bit",
+            )
+        ]
+    )
+
+    assert snap.os_names == frozenset({"darwin"})
+    assert snap.platforms == frozenset({"macos-15.4-arm64-arm-64bit"})
+    assert snap.is_apple_silicon is True
+
+
+def test_build_snapshot_ignores_platform_from_synthetic_inventory_rows():
+    snap = cap.build_capability_snapshot(
+        [
+            {
+                "active": None,
+                "gpus": None,
+                "processors": None,
+                "os": "Darwin",
+                "platform": "arm64",
+            },
+            _hw(
+                [],
+                processors=["AMD EPYC"],
+                os="Linux",
+                platform="Linux-5.14.0-el9.x86_64",
+            ),
+        ]
+    )
+
+    assert snap.os_names == frozenset({"linux"})
+    assert snap.is_apple_silicon is False
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_capability_markers.py
+++ b/tests/unit/test_capability_markers.py
@@ -210,6 +210,31 @@ def test_build_snapshot_rejects_apple_only_inference_when_platform_rows_are_inco
     assert snap.is_apple_silicon is False
 
 
+def test_build_snapshot_rejects_explicitly_active_device_empty_platform_row():
+    snap = cap.build_capability_snapshot(
+        [
+            _hw(
+                [],
+                node_id="apple",
+                processors=["Apple M4"],
+                os="Darwin",
+                platform="macOS-15.4-arm64-arm-64bit",
+            ),
+            {
+                "active": True,
+                "node_id": "inventory-pending",
+                "gpus": None,
+                "processors": None,
+                "os": None,
+                "platform": None,
+            },
+        ]
+    )
+
+    assert snap.platform_inventory_complete is False
+    assert snap.is_apple_silicon is False
+
+
 # --------------------------------------------------------------------------- #
 # collect_capability_requirements
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_capability_markers.py
+++ b/tests/unit/test_capability_markers.py
@@ -122,8 +122,6 @@ def test_build_snapshot_detects_apple_silicon_from_real_inventory():
         ]
     )
 
-    assert not hasattr(snap, "os_names")
-    assert not hasattr(snap, "platforms")
     assert snap.os_platforms == frozenset({("darwin", "macos-15.4-arm64-arm-64bit")})
     assert snap.is_apple_silicon is True
 

--- a/tests/unit/test_capability_markers.py
+++ b/tests/unit/test_capability_markers.py
@@ -150,6 +150,29 @@ def test_build_snapshot_ignores_platform_from_synthetic_inventory_rows():
     assert snap.is_apple_silicon is False
 
 
+def test_build_snapshot_preserves_os_platform_correlation_for_mixed_nodes():
+    snap = cap.build_capability_snapshot(
+        [
+            _hw(
+                [],
+                node_id="darwin-x86",
+                processors=["Intel"],
+                os="Darwin",
+                platform="macOS-15.4-x86_64-i386-64bit",
+            ),
+            _hw(
+                [],
+                node_id="linux-arm",
+                processors=["Ampere"],
+                os="Linux",
+                platform="Linux-6.8-aarch64-with-glibc2.39",
+            ),
+        ]
+    )
+
+    assert snap.is_apple_silicon is False
+
+
 # --------------------------------------------------------------------------- #
 # collect_capability_requirements
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_capability_markers.py
+++ b/tests/unit/test_capability_markers.py
@@ -85,6 +85,7 @@ def test_build_snapshot_empty_inventory_is_cpu_only():
     assert snap.gpu_count == 0
     assert snap.gpu_mem_gb == ()
     assert snap.node_count == 1
+    assert snap.is_apple_silicon is False
 
 
 def test_build_snapshot_ignores_explicitly_inactive_hardware_entries():
@@ -124,6 +125,21 @@ def test_build_snapshot_detects_apple_silicon_from_real_inventory():
 
     assert snap.os_platforms == frozenset({("darwin", "macos-15.4-arm64-arm-64bit")})
     assert snap.is_apple_silicon is True
+
+
+def test_build_snapshot_does_not_treat_intel_mac_as_apple_silicon():
+    snap = cap.build_capability_snapshot(
+        [
+            _hw(
+                [],
+                processors=["Intel i9"],
+                os="Darwin",
+                platform="macOS-15.4-x86_64-i386-64bit",
+            )
+        ]
+    )
+
+    assert snap.is_apple_silicon is False
 
 
 def test_build_snapshot_ignores_platform_from_synthetic_inventory_rows():

--- a/tests/unit/test_context_live_helpers.py
+++ b/tests/unit/test_context_live_helpers.py
@@ -97,8 +97,16 @@ def test_vectordb_wait_fails_after_stopped_grace_period(
             "endpoint": None,
         }
     )
-    timestamps = iter([0.0, 0.0, 31.0])
-    monkeypatch.setattr(context_live.time, "monotonic", lambda: next(timestamps))
+    timestamps = [0.0, 0.0, 31.0]
+    monotonic_calls = 0
+
+    def monotonic() -> float:
+        nonlocal monotonic_calls
+        value = timestamps[min(monotonic_calls, len(timestamps) - 1)]
+        monotonic_calls += 1
+        return value
+
+    monkeypatch.setattr(context_live.time, "monotonic", monotonic)
     monkeypatch.setattr(context_live.time, "sleep", lambda _seconds: None)
 
     with pytest.raises(RuntimeError, match="remained stopped"):

--- a/tests/unit/test_context_live_helpers.py
+++ b/tests/unit/test_context_live_helpers.py
@@ -7,11 +7,22 @@ from kamiwaza_sdk.services.context import ContextService
 import tests.integration.test_context_live as context_live
 from tests.integration.test_context_live import (
     _assert_global_scope_if_exposed,
+    _next_stopped_since,
     _wait_for_vectordb_ready,
     session_workroom,
 )
 
 pytestmark = pytest.mark.unit
+
+
+def test_stopped_grace_window_resets_after_transient_recovery() -> None:
+    stopped_since = _next_stopped_since("vdb-1", "stopped", None, 1.0)
+
+    assert _next_stopped_since("vdb-1", "provisioning", stopped_since, 2.0) is None
+
+
+def test_stopped_grace_window_preserves_first_stopped_timestamp() -> None:
+    assert _next_stopped_since("vdb-1", "stopped", 1.0, 2.0) == 1.0
 
 
 def test_global_scope_assertion_uses_fixed_global_sentinel(

--- a/tests/unit/test_context_live_helpers.py
+++ b/tests/unit/test_context_live_helpers.py
@@ -7,6 +7,7 @@ from kamiwaza_sdk.services.context import ContextService
 import tests.integration.test_context_live as context_live
 from tests.integration.test_context_live import (
     _assert_global_scope_if_exposed,
+    _wait_for_vectordb_ready,
     session_workroom,
 )
 
@@ -51,3 +52,54 @@ def test_session_workroom_uses_explicit_scope_without_entering() -> None:
         next(generator)
 
     assert calls == ["delete"]
+
+
+def test_vectordb_wait_tolerates_transient_stopped_status(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    responses = iter(
+        [
+            {"status": "stopped", "endpoint": None},
+            {"status": "provisioning", "endpoint": None},
+            {"status": "running", "endpoint": "http://milvus.test"},
+        ]
+    )
+    service = SimpleNamespace(get_vectordb=lambda *_args, **_kwargs: next(responses))
+    monkeypatch.setattr(context_live.time, "sleep", lambda _seconds: None)
+
+    with caplog.at_level("INFO"):
+        _wait_for_vectordb_ready(service, "vdb-1", poll_seconds=0)
+
+    assert "stopped" in caplog.text
+    assert "provisioning" in caplog.text
+    assert "running" in caplog.text
+
+
+def test_vectordb_wait_still_fails_immediately_on_failed_status() -> None:
+    service = SimpleNamespace(
+        get_vectordb=lambda *_args, **_kwargs: {
+            "status": "failed",
+            "endpoint": None,
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="non-recoverable status failed"):
+        _wait_for_vectordb_ready(service, "vdb-1", poll_seconds=0)
+
+
+def test_vectordb_wait_fails_after_stopped_grace_period(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = SimpleNamespace(
+        get_vectordb=lambda *_args, **_kwargs: {
+            "status": "stopped",
+            "endpoint": None,
+        }
+    )
+    timestamps = iter([0.0, 0.0, 31.0])
+    monkeypatch.setattr(context_live.time, "monotonic", lambda: next(timestamps))
+    monkeypatch.setattr(context_live.time, "sleep", lambda _seconds: None)
+
+    with pytest.raises(RuntimeError, match="remained stopped"):
+        _wait_for_vectordb_ready(service, "vdb-1", poll_seconds=0)

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -189,6 +189,9 @@ def test_deployable_model_probe_uses_shared_repo_and_engine(
     deploy_calls: list[dict[str, object]] = []
 
     class Serving:
+        def list_active_deployments(self) -> list[object]:
+            return []
+
         def deploy_model(self, **kwargs: object) -> str:
             deploy_calls.append(kwargs)
             return "dep-1"
@@ -222,6 +225,27 @@ def test_deployable_model_probe_uses_shared_repo_and_engine(
 
     assert deploy_calls[0]["model_id"] == "model-for-org/model.gguf"
     assert deploy_calls[0]["engine_name"] == "llamacpp"
+
+
+def test_deployable_model_probe_reuses_exact_active_target(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_preferred_active_model_deployment",
+        lambda *_args, **_kwargs: {"repo_model_id": target.repo_id},
+    )
+
+    integration_conftest.deployable_model_prerequisite.__wrapped__(
+        object(),
+        lambda *_args: pytest.fail("an active exact target must skip the probe deploy"),
+        target,
+    )
 
 
 def test_embedding_model_prerequisite_marks_harness_provisioned_deployment(

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -284,6 +284,26 @@ def test_ensure_deployable_target_ready_skips_download_timeout(
         )
 
 
+def test_ensure_deployable_target_ready_skips_missing_quantization(
+    integration_conftest,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+        quantization="q4_k",
+    )
+
+    def reject_quantization(*_args: object, **_kwargs: object) -> object:
+        raise ValueError("q4_k is unavailable")
+
+    with pytest.raises(pytest.skip.Exception, match="q4_k is unavailable"):
+        integration_conftest._ensure_deployable_target_ready(
+            object(),
+            reject_quantization,
+            target,
+        )
+
+
 def test_ensure_deployable_target_ready_reraises_client_error(
     integration_conftest,
 ) -> None:

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -227,6 +227,19 @@ def test_deployable_model_probe_uses_shared_repo_and_engine(
     assert deploy_calls[0]["engine_name"] == "llamacpp"
 
 
+def test_deployable_model_target_follows_cluster_inventory(
+    integration_conftest,
+) -> None:
+    snapshot = integration_conftest._cap.ClusterCapabilitySnapshot(
+        gpu_count=1,
+        gpu_vendors=frozenset({"nvidia"}),
+    )
+
+    target = integration_conftest.deployable_model_target.__wrapped__(snapshot)
+
+    assert target is integration_conftest._model_targets.VLLM_LLM_TARGET
+
+
 def test_deployable_model_probe_reuses_exact_active_target(
     integration_conftest,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -178,6 +178,52 @@ def test_requires_embedding_model_marker_leaves_unmarked_tests_alone(
     assert request.requested == []
 
 
+def test_deployable_model_probe_uses_shared_repo_and_engine(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+    )
+    deploy_calls: list[dict[str, object]] = []
+
+    class Serving:
+        def deploy_model(self, **kwargs: object) -> str:
+            deploy_calls.append(kwargs)
+            return "dep-1"
+
+        def wait_for_deployment(self, *_args: object, **_kwargs: object) -> object:
+            return SimpleNamespace(
+                status="DEPLOYED",
+                instances=[SimpleNamespace(status="DEPLOYED")],
+            )
+
+        def stop_deployment(self, **_kwargs: object) -> None:
+            return None
+
+    client = SimpleNamespace(
+        serving=Serving(),
+        models=SimpleNamespace(
+            get_model_configs=lambda _model_id: [
+                SimpleNamespace(id="cfg-1", default=True)
+            ]
+        ),
+    )
+    ensure_repo_ready = lambda _client, repo_id: SimpleNamespace(  # noqa: E731
+        id=f"model-for-{repo_id}"
+    )
+
+    integration_conftest.deployable_model_prerequisite.__wrapped__(
+        client,
+        ensure_repo_ready,
+        target,
+    )
+
+    assert deploy_calls[0]["model_id"] == "model-for-org/model.gguf"
+    assert deploy_calls[0]["engine_name"] == "llamacpp"
+
+
 def test_embedding_model_prerequisite_marks_harness_provisioned_deployment(
     integration_conftest,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -239,17 +239,64 @@ def test_deployable_model_probe_uses_shared_repo_and_engine(
     assert deploy_calls[0]["m_file_id"] == str(model_file_id)
 
 
+@pytest.mark.parametrize(
+    ("snapshot_kwargs", "target_name"),
+    [
+        (
+            {"gpu_count": 1, "gpu_vendors": frozenset({"nvidia"})},
+            "VLLM_LLM_TARGET",
+        ),
+        (
+            {
+                "os_platforms": frozenset(
+                    {("darwin", "macos-15.4-arm64-arm-64bit")}
+                )
+            },
+            "MLX_LLM_TARGET",
+        ),
+        (
+            {
+                "os_platforms": frozenset(
+                    {("linux", "linux-5.14.0-el9.x86_64")}
+                )
+            },
+            "GGUF_LLM_TARGET",
+        ),
+    ],
+)
 def test_deployable_model_target_follows_cluster_inventory(
     integration_conftest,
+    snapshot_kwargs: dict[str, object],
+    target_name: str,
 ) -> None:
     snapshot = integration_conftest._cap.ClusterCapabilitySnapshot(
-        gpu_count=1,
-        gpu_vendors=frozenset({"nvidia"}),
+        **snapshot_kwargs
     )
 
     target = integration_conftest.deployable_model_target.__wrapped__(snapshot)
 
-    assert target is integration_conftest._model_targets.VLLM_LLM_TARGET
+    assert target is getattr(integration_conftest._model_targets, target_name)
+
+
+def test_ensure_deployable_model_ready_forwards_selected_target(
+    integration_conftest,
+) -> None:
+    selected_target = integration_conftest._model_targets.VLLM_LLM_TARGET
+    calls: list[tuple[object, str, str]] = []
+
+    ensure = integration_conftest.ensure_deployable_model_ready.__wrapped__(
+        lambda client, repo_id, *, quantization: calls.append(
+            (client, repo_id, quantization)
+        )
+        or "ready-model",
+        selected_target,
+    )
+    client = object()
+
+    assert ensure(client) == "ready-model"
+    assert calls == [
+        (client, selected_target.repo_id, selected_target.quantization)
+    ]
 
 
 def test_ensure_deployable_target_ready_pins_target_quantization(
@@ -316,6 +363,24 @@ def test_ensure_deployable_target_ready_skips_missing_quantization(
         )
 
 
+def test_ensure_deployable_target_ready_skips_runtime_failure(
+    integration_conftest,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+        quantization="q4_k",
+    )
+
+    def fail_runtime(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("deployment failed")
+
+    with pytest.raises(pytest.skip.Exception, match="deployment failed"):
+        integration_conftest._ensure_deployable_target_ready(
+            object(), fail_runtime, target
+        )
+
+
 def test_ensure_deployable_target_ready_reraises_client_error(
     integration_conftest,
 ) -> None:
@@ -329,14 +394,18 @@ def test_ensure_deployable_target_ready_reraises_client_error(
     def reject(*_args: object, **_kwargs: object) -> object:
         raise error
 
-    with pytest.raises(integration_conftest.APIError) as exc_info:
+    try:
         integration_conftest._ensure_deployable_target_ready(
             object(),
             reject,
             target,
         )
-
-    assert exc_info.value is error
+    except pytest.skip.Exception as skipped:
+        pytest.fail(f"a 4xx must not be masked as a skip: {skipped}")
+    except integration_conftest.APIError as raised:
+        assert raised is error
+    else:
+        pytest.fail("expected the 4xx to propagate")
 
 
 def test_ensure_deployable_target_ready_skips_server_error(
@@ -357,6 +426,25 @@ def test_ensure_deployable_target_ready_skips_server_error(
             object(),
             reject,
             target,
+        )
+
+
+def test_ensure_deployable_target_ready_skips_transport_api_error(
+    integration_conftest,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+        quantization="q4_k",
+    )
+    error = integration_conftest.APIError("connection reset", status_code=None)
+
+    def reject(*_args: object, **_kwargs: object) -> object:
+        raise error
+
+    with pytest.raises(pytest.skip.Exception, match="connection reset"):
+        integration_conftest._ensure_deployable_target_ready(
+            object(), reject, target
         )
 
 
@@ -384,9 +472,18 @@ def test_deployable_model_probe_reuses_exact_active_target(
     )
 
 
-def test_deployable_model_probe_does_not_reuse_wrong_engine(
+@pytest.mark.parametrize(
+    ("active_repo", "active_engine"),
+    [
+        ("org/model.gguf", "mlx"),
+        ("someone-else/other", "llamacpp"),
+    ],
+)
+def test_deployable_model_probe_does_not_reuse_mismatched_target(
     integration_conftest,
     monkeypatch: pytest.MonkeyPatch,
+    active_repo: str,
+    active_engine: str,
 ) -> None:
     target = integration_conftest._model_targets.InferenceTarget(
         repo_id="org/model.gguf",
@@ -396,8 +493,8 @@ def test_deployable_model_probe_does_not_reuse_wrong_engine(
         integration_conftest,
         "_preferred_active_model_deployment",
         lambda *_args, **_kwargs: {
-            "repo_model_id": target.repo_id,
-            "engine_name": "mlx",
+            "repo_model_id": active_repo,
+            "engine_name": active_engine,
         },
     )
     monkeypatch.setattr(
@@ -522,6 +619,116 @@ def test_context_prerequisite_prepares_and_deploys_exact_target_file(
     assert deploy_calls[0]["m_file_id"] == str(model_file_id)
 
 
+def test_context_prerequisite_does_not_mask_programming_errors(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = integration_conftest._model_targets.GGUF_LLM_TARGET
+    monkeypatch.setattr(
+        integration_conftest,
+        "_context_llm_target",
+        lambda _snapshot: target,
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_preferred_active_model_deployment",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def programming_error(*_args: object, **_kwargs: object) -> object:
+        raise TypeError("fixture wiring defect")
+
+    prerequisite = integration_conftest.context_llm_prerequisite.__wrapped__(
+        object(),
+        programming_error,
+        None,
+    )
+    try:
+        next(prerequisite)
+    except pytest.skip.Exception as skipped:
+        pytest.fail(f"a programming error must not be masked as a skip: {skipped}")
+    except TypeError as raised:
+        assert str(raised) == "fixture wiring defect"
+    else:
+        pytest.fail("expected the programming error to propagate")
+
+
+@pytest.mark.parametrize(
+    ("status_code", "should_skip"),
+    [(400, False), (500, True), (None, True)],
+)
+def test_context_prerequisite_preserves_api_error_taxonomy(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int | None,
+    should_skip: bool,
+) -> None:
+    target = integration_conftest._model_targets.GGUF_LLM_TARGET
+    error = integration_conftest.APIError(
+        "context readiness failed", status_code=status_code
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_context_llm_target",
+        lambda _snapshot: target,
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_preferred_active_model_deployment",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def fail_readiness(*_args: object, **_kwargs: object) -> object:
+        raise error
+
+    prerequisite = integration_conftest.context_llm_prerequisite.__wrapped__(
+        object(), fail_readiness, None
+    )
+    if should_skip:
+        with pytest.raises(pytest.skip.Exception, match="context readiness failed"):
+            next(prerequisite)
+        return
+
+    try:
+        next(prerequisite)
+    except pytest.skip.Exception as skipped:
+        pytest.fail(f"a 4xx must not be masked as a skip: {skipped}")
+    except integration_conftest.APIError as raised:
+        assert raised is error
+    else:
+        pytest.fail("expected the 4xx to propagate")
+
+
+def test_deployable_probe_skips_transport_api_error(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = integration_conftest._model_targets.GGUF_LLM_TARGET
+    error = integration_conftest.APIError("connection reset", status_code=None)
+    monkeypatch.setattr(
+        integration_conftest,
+        "_preferred_active_model_deployment",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def fail_readiness(*_args: object, **_kwargs: object) -> object:
+        raise error
+
+    monkeypatch.setattr(
+        integration_conftest,
+        "_ensure_deployable_target_ready",
+        fail_readiness,
+    )
+    client = SimpleNamespace(
+        serving=SimpleNamespace(stop_deployment=lambda **_kwargs: None)
+    )
+
+    with pytest.raises(pytest.skip.Exception, match="APIError transport"):
+        integration_conftest.deployable_model_prerequisite.__wrapped__(
+            client, object(), target
+        )
+
+
 def test_target_model_file_id_pins_ready_gguf_quantization(
     integration_conftest,
 ) -> None:
@@ -548,6 +755,61 @@ def test_target_model_file_id_pins_ready_gguf_quantization(
     assert integration_conftest._target_model_file_id(model, "q4_k") == str(
         selected_id
     )
+
+
+def test_target_model_file_id_ignores_unready_files(integration_conftest) -> None:
+    ready_id = uuid4()
+    model = SimpleNamespace(
+        m_files=[
+            SimpleNamespace(
+                id=uuid4(),
+                name="a-Q4_K_M.gguf",
+                storage_location=None,
+                is_downloading=True,
+                dl_requested_at=None,
+            ),
+            SimpleNamespace(
+                id=ready_id,
+                name="z-Q4_K_M.gguf",
+                storage_location="oci://z-Q4_K_M.gguf",
+                is_downloading=False,
+                dl_requested_at=None,
+            ),
+        ]
+    )
+
+    assert integration_conftest._target_model_file_id(model, "q4_k") == str(
+        ready_id
+    )
+
+
+def test_target_model_file_id_is_deterministic_across_input_order(
+    integration_conftest,
+) -> None:
+    first_id = uuid4()
+    files = [
+        SimpleNamespace(
+            id=first_id,
+            name="a-Q4_K_M.gguf",
+            storage_location="oci://a-Q4_K_M.gguf",
+            is_downloading=False,
+            dl_requested_at=None,
+        ),
+        SimpleNamespace(
+            id=uuid4(),
+            name="z-Q4_K_M.gguf",
+            storage_location="oci://z-Q4_K_M.gguf",
+            is_downloading=False,
+            dl_requested_at=None,
+        ),
+    ]
+
+    assert integration_conftest._target_model_file_id(
+        SimpleNamespace(m_files=files), "q4_k"
+    ) == str(first_id)
+    assert integration_conftest._target_model_file_id(
+        SimpleNamespace(m_files=list(reversed(files))), "q4_k"
+    ) == str(first_id)
 
 
 def test_embedding_model_prerequisite_marks_harness_provisioned_deployment(

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -213,7 +213,7 @@ def test_deployable_model_probe_uses_shared_repo_and_engine(
             ]
         ),
     )
-    ensure_repo_ready = lambda _client, repo_id: SimpleNamespace(  # noqa: E731
+    ensure_repo_ready = lambda _client, repo_id, **_kwargs: SimpleNamespace(  # noqa: E731
         id=f"model-for-{repo_id}"
     )
 
@@ -238,6 +238,94 @@ def test_deployable_model_target_follows_cluster_inventory(
     target = integration_conftest.deployable_model_target.__wrapped__(snapshot)
 
     assert target is integration_conftest._model_targets.VLLM_LLM_TARGET
+
+
+def test_ensure_deployable_target_ready_pins_target_quantization(
+    integration_conftest,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+        quantization="q4_k",
+    )
+    calls: list[tuple[object, str, str]] = []
+    client = object()
+
+    result = integration_conftest._ensure_deployable_target_ready(
+        client,
+        lambda actual_client, repo_id, *, quantization: calls.append(
+            (actual_client, repo_id, quantization)
+        )
+        or "ready-model",
+        target,
+    )
+
+    assert result == "ready-model"
+    assert calls == [(client, "org/model.gguf", "q4_k")]
+
+
+def test_ensure_deployable_target_ready_skips_download_timeout(
+    integration_conftest,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+        quantization="q4_k",
+    )
+
+    def time_out(*_args: object, **_kwargs: object) -> object:
+        raise TimeoutError("download stalled")
+
+    with pytest.raises(pytest.skip.Exception, match="download stalled"):
+        integration_conftest._ensure_deployable_target_ready(
+            object(),
+            time_out,
+            target,
+        )
+
+
+def test_ensure_deployable_target_ready_reraises_client_error(
+    integration_conftest,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+        quantization="q4_k",
+    )
+    error = integration_conftest.APIError("invalid request", status_code=400)
+
+    def reject(*_args: object, **_kwargs: object) -> object:
+        raise error
+
+    with pytest.raises(integration_conftest.APIError) as exc_info:
+        integration_conftest._ensure_deployable_target_ready(
+            object(),
+            reject,
+            target,
+        )
+
+    assert exc_info.value is error
+
+
+def test_ensure_deployable_target_ready_skips_server_error(
+    integration_conftest,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+        quantization="q4_k",
+    )
+    error = integration_conftest.APIError("runtime unavailable", status_code=500)
+
+    def reject(*_args: object, **_kwargs: object) -> object:
+        raise error
+
+    with pytest.raises(pytest.skip.Exception, match="APIError 500"):
+        integration_conftest._ensure_deployable_target_ready(
+            object(),
+            reject,
+            target,
+        )
 
 
 def test_deployable_model_probe_reuses_exact_active_target(

--- a/tests/unit/test_integration_conftest_model_ready.py
+++ b/tests/unit/test_integration_conftest_model_ready.py
@@ -4,6 +4,7 @@ import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from uuid import uuid4
 
 import pytest
 
@@ -213,8 +214,18 @@ def test_deployable_model_probe_uses_shared_repo_and_engine(
             ]
         ),
     )
+    model_file_id = uuid4()
     ensure_repo_ready = lambda _client, repo_id, **_kwargs: SimpleNamespace(  # noqa: E731
-        id=f"model-for-{repo_id}"
+        id=f"model-for-{repo_id}",
+        m_files=[
+            SimpleNamespace(
+                id=model_file_id,
+                name="model-Q4_K_M.gguf",
+                storage_location="oci://model-Q4_K_M.gguf",
+                is_downloading=False,
+                dl_requested_at=None,
+            )
+        ],
     )
 
     integration_conftest.deployable_model_prerequisite.__wrapped__(
@@ -225,6 +236,7 @@ def test_deployable_model_probe_uses_shared_repo_and_engine(
 
     assert deploy_calls[0]["model_id"] == "model-for-org/model.gguf"
     assert deploy_calls[0]["engine_name"] == "llamacpp"
+    assert deploy_calls[0]["m_file_id"] == str(model_file_id)
 
 
 def test_deployable_model_target_follows_cluster_inventory(
@@ -359,13 +371,182 @@ def test_deployable_model_probe_reuses_exact_active_target(
     monkeypatch.setattr(
         integration_conftest,
         "_preferred_active_model_deployment",
-        lambda *_args, **_kwargs: {"repo_model_id": target.repo_id},
+        lambda *_args, **_kwargs: {
+            "repo_model_id": target.repo_id,
+            "engine_name": target.engine_name,
+        },
     )
 
     integration_conftest.deployable_model_prerequisite.__wrapped__(
         object(),
         lambda *_args: pytest.fail("an active exact target must skip the probe deploy"),
         target,
+    )
+
+
+def test_deployable_model_probe_does_not_reuse_wrong_engine(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_preferred_active_model_deployment",
+        lambda *_args, **_kwargs: {
+            "repo_model_id": target.repo_id,
+            "engine_name": "mlx",
+        },
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_ensure_deployable_target_ready",
+        lambda *_args, **_kwargs: SimpleNamespace(id="model-1", m_files=[]),
+    )
+    deploy_calls: list[dict[str, object]] = []
+    client = SimpleNamespace(
+        models=SimpleNamespace(
+            get_model_configs=lambda _model_id: [
+                SimpleNamespace(id="cfg-1", default=True)
+            ]
+        ),
+        serving=SimpleNamespace(
+            deploy_model=lambda **kwargs: deploy_calls.append(kwargs) or "dep-1",
+            wait_for_deployment=lambda *_args, **_kwargs: SimpleNamespace(
+                status="DEPLOYED",
+                instances=[SimpleNamespace(status="DEPLOYED")],
+            ),
+            stop_deployment=lambda **_kwargs: None,
+        ),
+    )
+
+    integration_conftest.deployable_model_prerequisite.__wrapped__(
+        client,
+        lambda *_args, **_kwargs: pytest.fail("patched readiness should be used"),
+        target,
+    )
+
+    assert deploy_calls[0]["engine_name"] == "llamacpp"
+
+
+def test_context_target_carries_shared_quantization(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/model.gguf",
+        engine_name="llamacpp",
+        quantization="q4_k",
+    )
+    monkeypatch.setattr(integration_conftest, "_CONTEXT_TEST_LLM_REPO_OVERRIDE", "")
+    monkeypatch.setattr(integration_conftest, "_CONTEXT_TEST_LLM_ENGINE_OVERRIDE", "")
+    monkeypatch.setattr(
+        integration_conftest._model_targets,
+        "select_inference_target",
+        lambda _snapshot: target,
+    )
+
+    assert integration_conftest._context_llm_target(None) == target
+
+
+def test_context_prerequisite_prepares_and_deploys_exact_target_file(
+    integration_conftest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = integration_conftest._model_targets.InferenceTarget(
+        repo_id="org/context.gguf",
+        engine_name="llamacpp",
+        quantization="q4_k",
+    )
+    model_file_id = uuid4()
+    readiness_calls: list[tuple[str, str]] = []
+    deploy_calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        integration_conftest,
+        "_context_llm_target",
+        lambda _snapshot: target,
+    )
+    monkeypatch.setattr(
+        integration_conftest,
+        "_preferred_active_model_deployment",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def ensure_repo_ready(
+        _client: object, repo_id: str, *, quantization: str
+    ) -> object:
+        readiness_calls.append((repo_id, quantization))
+        return SimpleNamespace(
+            id="model-1",
+            m_files=[
+                SimpleNamespace(
+                    id=model_file_id,
+                    name="context-Q4_K_M.gguf",
+                    storage_location="oci://context-Q4_K_M.gguf",
+                    is_downloading=False,
+                    dl_requested_at=None,
+                )
+            ],
+        )
+
+    client = SimpleNamespace(
+        models=SimpleNamespace(
+            get_model_configs=lambda _model_id: [
+                SimpleNamespace(id="cfg-1", default=True)
+            ]
+        ),
+        serving=SimpleNamespace(
+            deploy_model=lambda **kwargs: deploy_calls.append(kwargs) or "dep-1",
+            wait_for_deployment=lambda *_args, **_kwargs: SimpleNamespace(
+                id="dep-1",
+                status="DEPLOYED",
+                instances=[SimpleNamespace(status="DEPLOYED")],
+            ),
+            stop_deployment=lambda **_kwargs: None,
+        ),
+    )
+
+    prerequisite = integration_conftest.context_llm_prerequisite.__wrapped__(
+        client,
+        ensure_repo_ready,
+        None,
+    )
+    assert next(prerequisite) == "dep-1"
+    with pytest.raises(StopIteration):
+        next(prerequisite)
+
+    assert readiness_calls == [(target.repo_id, target.quantization)]
+    assert deploy_calls[0]["engine_name"] == target.engine_name
+    assert deploy_calls[0]["m_file_id"] == str(model_file_id)
+
+
+def test_target_model_file_id_pins_ready_gguf_quantization(
+    integration_conftest,
+) -> None:
+    selected_id = uuid4()
+    model = SimpleNamespace(
+        m_files=[
+            SimpleNamespace(
+                id=uuid4(),
+                name="model-Q6_K.gguf",
+                storage_location="oci://model-Q6_K.gguf",
+                is_downloading=False,
+                dl_requested_at=None,
+            ),
+            SimpleNamespace(
+                id=selected_id,
+                name="model-Q4_K_M.gguf",
+                storage_location="oci://model-Q4_K_M.gguf",
+                is_downloading=False,
+                dl_requested_at=None,
+            ),
+        ]
+    )
+
+    assert integration_conftest._target_model_file_id(model, "q4_k") == str(
+        selected_id
     )
 
 

--- a/tests/unit/test_integration_model_targets.py
+++ b/tests/unit/test_integration_model_targets.py
@@ -52,9 +52,7 @@ def test_apple_silicon_selects_mlx() -> None:
     snapshot = cap.ClusterCapabilitySnapshot(
         os_names=frozenset({"darwin"}),
         platforms=frozenset({"macos-15.4-arm64-arm-64bit"}),
-        os_platforms=frozenset(
-            {("darwin", "macos-15.4-arm64-arm-64bit")}
-        ),
+        os_platforms=frozenset({("darwin", "macos-15.4-arm64-arm-64bit")}),
     )
 
     assert targets.select_inference_target(snapshot) == targets.MLX_LLM_TARGET

--- a/tests/unit/test_integration_model_targets.py
+++ b/tests/unit/test_integration_model_targets.py
@@ -13,6 +13,32 @@ import model_targets as targets  # noqa: E402
 pytestmark = pytest.mark.unit
 
 
+def test_suite_repo_override_wins_and_rejects_blank_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KAMIWAZA_TEST_TARGET_REPO", "  org/suite-target  ")
+    monkeypatch.setenv("KAMIWAZA_CONTEXT_TARGET_REPO", "org/legacy-target")
+
+    assert (
+        targets._configured_repo(
+            "KAMIWAZA_TEST_TARGET_REPO",
+            "KAMIWAZA_CONTEXT_TARGET_REPO",
+            "org/default-target",
+        )
+        == "org/suite-target"
+    )
+
+    monkeypatch.setenv("KAMIWAZA_TEST_TARGET_REPO", "  ")
+    assert (
+        targets._configured_repo(
+            "KAMIWAZA_TEST_TARGET_REPO",
+            "KAMIWAZA_CONTEXT_TARGET_REPO",
+            "org/default-target",
+        )
+        == "org/legacy-target"
+    )
+
+
 def test_cpu_linux_selects_gguf_for_llamacpp() -> None:
     snapshot = cap.ClusterCapabilitySnapshot(
         os_names=frozenset({"linux"}),
@@ -26,6 +52,9 @@ def test_apple_silicon_selects_mlx() -> None:
     snapshot = cap.ClusterCapabilitySnapshot(
         os_names=frozenset({"darwin"}),
         platforms=frozenset({"macos-15.4-arm64-arm-64bit"}),
+        os_platforms=frozenset(
+            {("darwin", "macos-15.4-arm64-arm-64bit")}
+        ),
     )
 
     assert targets.select_inference_target(snapshot) == targets.MLX_LLM_TARGET

--- a/tests/unit/test_integration_model_targets.py
+++ b/tests/unit/test_integration_model_targets.py
@@ -72,6 +72,21 @@ def test_unknown_inventory_uses_portable_cpu_target() -> None:
     assert targets.select_inference_target(None) == targets.GGUF_LLM_TARGET
 
 
+@pytest.mark.parametrize(
+    ("target", "engine_name"),
+    [
+        (targets.MLX_LLM_TARGET, "mlx"),
+        (targets.VLLM_LLM_TARGET, "vllm"),
+        (targets.GGUF_LLM_TARGET, "llamacpp"),
+    ],
+)
+def test_target_engine_names(
+    target: targets.InferenceTarget,
+    engine_name: str,
+) -> None:
+    assert target.engine_name == engine_name
+
+
 def test_mixed_apple_and_linux_cluster_uses_portable_cpu_target() -> None:
     snapshot = cap.ClusterCapabilitySnapshot(
         os_platforms=frozenset(

--- a/tests/unit/test_integration_model_targets.py
+++ b/tests/unit/test_integration_model_targets.py
@@ -73,18 +73,20 @@ def test_unknown_inventory_uses_portable_cpu_target() -> None:
 
 
 @pytest.mark.parametrize(
-    ("target", "engine_name"),
+    ("target", "engine_name", "quantization"),
     [
-        (targets.MLX_LLM_TARGET, "mlx"),
-        (targets.VLLM_LLM_TARGET, "vllm"),
-        (targets.GGUF_LLM_TARGET, "llamacpp"),
+        (targets.MLX_LLM_TARGET, "mlx", "q6_k"),
+        (targets.VLLM_LLM_TARGET, "vllm", "q6_k"),
+        (targets.GGUF_LLM_TARGET, "llamacpp", "q4_k"),
     ],
 )
-def test_target_engine_names(
+def test_target_engine_names_and_quantization(
     target: targets.InferenceTarget,
     engine_name: str,
+    quantization: str,
 ) -> None:
     assert target.engine_name == engine_name
+    assert target.quantization == quantization
 
 
 def test_mixed_apple_and_linux_cluster_uses_portable_cpu_target() -> None:

--- a/tests/unit/test_integration_model_targets.py
+++ b/tests/unit/test_integration_model_targets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
 
@@ -41,8 +42,7 @@ def test_suite_repo_override_wins_and_rejects_blank_values(
 
 def test_cpu_linux_selects_gguf_for_llamacpp() -> None:
     snapshot = cap.ClusterCapabilitySnapshot(
-        os_names=frozenset({"linux"}),
-        platforms=frozenset({"linux-5.14.0-el9.x86_64"}),
+        os_platforms=frozenset({("linux", "linux-5.14.0-el9.x86_64")}),
     )
 
     selected = targets.select_inference_target(snapshot)
@@ -53,8 +53,6 @@ def test_cpu_linux_selects_gguf_for_llamacpp() -> None:
 
 def test_apple_silicon_selects_mlx() -> None:
     snapshot = cap.ClusterCapabilitySnapshot(
-        os_names=frozenset({"darwin"}),
-        platforms=frozenset({"macos-15.4-arm64-arm-64bit"}),
         os_platforms=frozenset({("darwin", "macos-15.4-arm64-arm-64bit")}),
     )
 
@@ -65,8 +63,7 @@ def test_nvidia_selects_vllm_before_host_platform() -> None:
     snapshot = cap.ClusterCapabilitySnapshot(
         gpu_count=1,
         gpu_vendors=frozenset({"nvidia"}),
-        os_names=frozenset({"linux"}),
-        platforms=frozenset({"linux-x86_64"}),
+        os_platforms=frozenset({("darwin", "macos-15.4-arm64-arm-64bit")}),
     )
 
     assert targets.select_inference_target(snapshot) == targets.VLLM_LLM_TARGET
@@ -74,3 +71,52 @@ def test_nvidia_selects_vllm_before_host_platform() -> None:
 
 def test_unknown_inventory_uses_portable_cpu_target() -> None:
     assert targets.select_inference_target(None) == targets.GGUF_LLM_TARGET
+
+
+def test_mixed_apple_and_linux_cluster_uses_portable_cpu_target() -> None:
+    snapshot = cap.ClusterCapabilitySnapshot(
+        os_platforms=frozenset(
+            {
+                ("darwin", "macos-15.4-arm64-arm-64bit"),
+                ("linux", "linux-5.14.0-el9.x86_64"),
+            }
+        ),
+    )
+
+    assert targets.select_inference_target(snapshot) == targets.GGUF_LLM_TARGET
+
+
+@pytest.mark.parametrize(
+    ("env_name", "target_name"),
+    [
+        ("KAMIWAZA_TEST_MLX_LLM_REPO", "MLX_LLM_TARGET"),
+        ("KAMIWAZA_CONTEXT_MLX_LLM_REPO", "MLX_LLM_TARGET"),
+        ("KAMIWAZA_TEST_VLLM_LLM_REPO", "VLLM_LLM_TARGET"),
+        ("KAMIWAZA_CONTEXT_VLLM_LLM_REPO", "VLLM_LLM_TARGET"),
+        ("KAMIWAZA_TEST_GGUF_LLM_REPO", "GGUF_LLM_TARGET"),
+        ("KAMIWAZA_CONTEXT_GGUF_LLM_REPO", "GGUF_LLM_TARGET"),
+    ],
+)
+def test_real_repo_override_names_are_honored(
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+    target_name: str,
+) -> None:
+    override_names = {
+        "KAMIWAZA_TEST_MLX_LLM_REPO",
+        "KAMIWAZA_CONTEXT_MLX_LLM_REPO",
+        "KAMIWAZA_TEST_VLLM_LLM_REPO",
+        "KAMIWAZA_CONTEXT_VLLM_LLM_REPO",
+        "KAMIWAZA_TEST_GGUF_LLM_REPO",
+        "KAMIWAZA_CONTEXT_GGUF_LLM_REPO",
+    }
+    for name in override_names:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(env_name, "org/override")
+
+    reloaded = importlib.reload(targets)
+    try:
+        assert getattr(reloaded, target_name).repo_id == "org/override"
+    finally:
+        monkeypatch.delenv(env_name)
+        importlib.reload(targets)

--- a/tests/unit/test_integration_model_targets.py
+++ b/tests/unit/test_integration_model_targets.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "integration"))
+
+import capability_markers as cap  # noqa: E402
+import model_targets as targets  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_cpu_linux_selects_gguf_for_llamacpp() -> None:
+    snapshot = cap.ClusterCapabilitySnapshot(
+        os_names=frozenset({"linux"}),
+        platforms=frozenset({"linux-5.14.0-el9.x86_64"}),
+    )
+
+    assert targets.select_inference_target(snapshot) == targets.GGUF_LLM_TARGET
+
+
+def test_apple_silicon_selects_mlx() -> None:
+    snapshot = cap.ClusterCapabilitySnapshot(
+        os_names=frozenset({"darwin"}),
+        platforms=frozenset({"macos-15.4-arm64-arm-64bit"}),
+    )
+
+    assert targets.select_inference_target(snapshot) == targets.MLX_LLM_TARGET
+
+
+def test_nvidia_selects_vllm_before_host_platform() -> None:
+    snapshot = cap.ClusterCapabilitySnapshot(
+        gpu_count=1,
+        gpu_vendors=frozenset({"nvidia"}),
+        os_names=frozenset({"linux"}),
+        platforms=frozenset({"linux-x86_64"}),
+    )
+
+    assert targets.select_inference_target(snapshot) == targets.VLLM_LLM_TARGET
+
+
+def test_unknown_inventory_uses_portable_cpu_target() -> None:
+    assert targets.select_inference_target(None) == targets.GGUF_LLM_TARGET

--- a/tests/unit/test_integration_model_targets.py
+++ b/tests/unit/test_integration_model_targets.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import importlib
 import sys
 from pathlib import Path
 
@@ -48,7 +47,7 @@ def test_cpu_linux_selects_gguf_for_llamacpp() -> None:
     selected = targets.select_inference_target(snapshot)
 
     assert selected == targets.GGUF_LLM_TARGET
-    assert "Thinking-2507" in selected.repo_id
+    assert "Thinking-2507" in targets._DEFAULT_GGUF_LLM_REPO
 
 
 def test_apple_silicon_selects_mlx() -> None:
@@ -114,9 +113,11 @@ def test_real_repo_override_names_are_honored(
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv(env_name, "org/override")
 
-    reloaded = importlib.reload(targets)
-    try:
-        assert getattr(reloaded, target_name).repo_id == "org/override"
-    finally:
-        monkeypatch.delenv(env_name)
-        importlib.reload(targets)
+    mlx_target, vllm_target, gguf_target = targets._load_inference_targets()
+    resolved_targets = {
+        "MLX_LLM_TARGET": mlx_target,
+        "VLLM_LLM_TARGET": vllm_target,
+        "GGUF_LLM_TARGET": gguf_target,
+    }
+
+    assert resolved_targets[target_name].repo_id == "org/override"

--- a/tests/unit/test_integration_model_targets.py
+++ b/tests/unit/test_integration_model_targets.py
@@ -45,7 +45,10 @@ def test_cpu_linux_selects_gguf_for_llamacpp() -> None:
         platforms=frozenset({"linux-5.14.0-el9.x86_64"}),
     )
 
-    assert targets.select_inference_target(snapshot) == targets.GGUF_LLM_TARGET
+    selected = targets.select_inference_target(snapshot)
+
+    assert selected == targets.GGUF_LLM_TARGET
+    assert "Thinking-2507" in selected.repo_id
 
 
 def test_apple_silicon_selects_mlx() -> None:

--- a/tests/unit/test_serving_service.py
+++ b/tests/unit/test_serving_service.py
@@ -74,7 +74,24 @@ def _active_deployment_payload(
             }
         ],
         "m_name": "test-model",
+        "engine_name": "llamacpp",
+        "m_file_id": str(uuid4()),
     }
+
+
+def test_list_active_deployments_preserves_engine_and_model_file(
+    mock_client, monkeypatch
+):
+    _clear_runtime_url_env(monkeypatch)
+    deployment_id = uuid4()
+    payload = _active_deployment_payload(deployment_id)
+    mock_client.base_url = "https://kamiwaza.test/api"
+    mock_client.expect("GET", "/serving/deployments", [payload])
+
+    deployments = ServingService(mock_client).list_active_deployments()
+
+    assert deployments[0].engine_name == "llamacpp"
+    assert str(deployments[0].m_file_id) == payload["m_file_id"]
 
 
 def _clear_runtime_url_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_workroom_service.py
+++ b/tests/unit/test_workroom_service.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import io
+import time
 import uuid
 from types import SimpleNamespace
 
 import pytest
 from pydantic import ValidationError
 
+from kamiwaza_sdk.authentication import UserPasswordAuthenticator
+from kamiwaza_sdk.client import KamiwazaClient
 from kamiwaza_sdk.exceptions import APIError, NotFoundError
+from kamiwaza_sdk.schemas.auth import TokenResponse
 from kamiwaza_sdk.schemas.workrooms import (
     CreateWorkroom,
     DeleteWorkroomResponse,
@@ -19,11 +23,69 @@ from kamiwaza_sdk.schemas.workrooms import (
     WorkroomType,
 )
 from kamiwaza_sdk.services.workrooms import WorkroomService
+from kamiwaza_sdk.token_store import InMemoryTokenStore, StoredToken
 
 pytestmark = pytest.mark.unit
 
 WORKROOM_ID = "12345678-1234-5678-9012-123456789012"
 WORKROOM_UUID = uuid.UUID(WORKROOM_ID)
+
+
+def _deleted_scope_denial(
+    detail: str = "Workroom access denied", *, message: str = "denied"
+) -> APIError:
+    return APIError(
+        message,
+        status_code=403,
+        response_data={"detail": detail},
+    )
+
+
+def _leave_response() -> dict[str, object]:
+    return {
+        "workroom_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        "access_token": "global-token",
+        "expires_in": 3600,
+        "message": "Returned to no-workroom scope",
+    }
+
+
+class _RecoveryAuthenticator:
+    def __init__(self, *, recoverable: bool, fail_if_called: bool = False) -> None:
+        self.recoverable = recoverable
+        self.fail_if_called = fail_if_called
+        self.invalidations = 0
+
+    def invalidate_session(self, _session: object) -> bool:
+        if self.fail_if_called:
+            pytest.fail("credentials must not be invalidated")
+        self.invalidations += 1
+        return self.recoverable
+
+
+class _RecoveryClient:
+    def __init__(
+        self,
+        responses: list[dict[str, object] | Exception],
+        *,
+        recoverable: bool = True,
+        fail_on_invalidation: bool = False,
+    ) -> None:
+        self.authenticator = _RecoveryAuthenticator(
+            recoverable=recoverable,
+            fail_if_called=fail_on_invalidation,
+        )
+        self.session = SimpleNamespace()
+        self.responses = iter(responses)
+        self.calls = 0
+
+    def post(self, path: str) -> dict[str, object]:
+        assert path == "/workrooms/leave"
+        self.calls += 1
+        response = next(self.responses)
+        if isinstance(response, Exception):
+            raise response
+        return response
 
 
 def _workroom_response(**overrides):
@@ -510,37 +572,7 @@ def test_leave_posts_to_leave_endpoint(dummy_client):
 
 
 def test_leave_recovers_once_from_deleted_workroom_scope() -> None:
-    class RecoverableAuthenticator:
-        def __init__(self) -> None:
-            self.invalidations = 0
-
-        def invalidate_session(self, _session) -> bool:
-            self.invalidations += 1
-            return True
-
-    class RecoverableClient:
-        def __init__(self) -> None:
-            self.authenticator = RecoverableAuthenticator()
-            self.session = SimpleNamespace()
-            self.calls = 0
-
-        def post(self, path: str):
-            assert path == "/workrooms/leave"
-            self.calls += 1
-            if self.calls == 1:
-                raise APIError(
-                    "denied",
-                    status_code=403,
-                    response_data={"detail": "Workroom access denied"},
-                )
-            return {
-                "workroom_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
-                "access_token": "global-token",
-                "expires_in": 3600,
-                "message": "Returned to no-workroom scope",
-            }
-
-    client = RecoverableClient()
+    client = _RecoveryClient([_deleted_scope_denial(), _leave_response()])
 
     result = WorkroomService(client).leave()
 
@@ -549,26 +581,83 @@ def test_leave_recovers_once_from_deleted_workroom_scope() -> None:
     assert client.authenticator.invalidations == 1
 
 
-def test_leave_does_not_mask_retry_failure() -> None:
-    class RecoverableAuthenticator:
-        def invalidate_session(self, _session) -> bool:
-            return True
-
-    class FailingClient:
+def test_leave_reauthenticates_real_client_after_deleted_workroom_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class AuthService:
         def __init__(self) -> None:
-            self.authenticator = RecoverableAuthenticator()
-            self.session = SimpleNamespace()
-            self.calls = 0
+            self.login_calls: list[tuple[str, str]] = []
 
-        def post(self, _path: str):
-            self.calls += 1
-            raise APIError(
-                "denied",
-                status_code=403,
-                response_data={"detail": "Workroom access denied"},
+        def login_with_password(self, username: str, password: str) -> TokenResponse:
+            self.login_calls.append((username, password))
+            return TokenResponse(
+                access_token="global-token",
+                refresh_token="global-refresh",
+                expires_in=3600,
             )
 
-    client = FailingClient()
+    class Response:
+        def __init__(self, status_code: int, payload: dict[str, object]) -> None:
+            self.status_code = status_code
+            self._payload = payload
+            self.text = str(payload)
+            self.headers = {"content-type": "application/json"}
+
+        def json(self) -> dict[str, object]:
+            return self._payload
+
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="scoped-token",
+            refresh_token="scoped-refresh",
+            expires_at=time.time() + 3600,
+        )
+    )
+    auth_service = AuthService()
+    authenticator = UserPasswordAuthenticator(
+        "admin",
+        "secret",
+        auth_service,
+        token_store=store,
+    )
+    client = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=authenticator,
+    )
+    responses = iter(
+        [
+            Response(403, {"detail": "Workroom access denied"}),
+            Response(
+                200,
+                {
+                    "workroom_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                    "access_token": "global-token",
+                    "expires_in": 3600,
+                    "message": "Returned to no-workroom scope",
+                },
+            ),
+        ]
+    )
+    observed_authorization: list[str | None] = []
+
+    def request(*_args: object, **_kwargs: object) -> Response:
+        observed_authorization.append(client.session.headers.get("Authorization"))
+        return next(responses)
+
+    monkeypatch.setattr(client.session, "request", request)
+
+    result = client.workrooms.leave()
+
+    assert result.access_token == "global-token"
+    assert auth_service.login_calls == [("admin", "secret")]
+    assert observed_authorization == ["Bearer scoped-token", "Bearer global-token"]
+    assert store.load() is not None
+    assert store.load().access_token == "global-token"
+
+
+def test_leave_does_not_mask_retry_failure() -> None:
+    client = _RecoveryClient([_deleted_scope_denial(), _deleted_scope_denial()])
 
     with pytest.raises(APIError, match="denied"):
         WorkroomService(client).leave()
@@ -577,25 +666,10 @@ def test_leave_does_not_mask_retry_failure() -> None:
 
 
 def test_leave_does_not_retry_unrelated_forbidden_response() -> None:
-    class UnexpectedClient:
-        def __init__(self) -> None:
-            self.authenticator = SimpleNamespace(
-                invalidate_session=lambda _session: pytest.fail(
-                    "unrelated 403 must not invalidate credentials"
-                )
-            )
-            self.session = SimpleNamespace()
-            self.calls = 0
-
-        def post(self, _path: str):
-            self.calls += 1
-            raise APIError(
-                "forbidden",
-                status_code=403,
-                response_data={"detail": "Insufficient permissions"},
-            )
-
-    client = UnexpectedClient()
+    client = _RecoveryClient(
+        [_deleted_scope_denial("Insufficient permissions", message="forbidden")],
+        fail_on_invalidation=True,
+    )
 
     with pytest.raises(APIError, match="forbidden"):
         WorkroomService(client).leave()
@@ -604,25 +678,7 @@ def test_leave_does_not_retry_unrelated_forbidden_response() -> None:
 
 
 def test_leave_does_not_retry_deleted_scope_denial_for_fixed_credentials() -> None:
-    class FixedAuthenticator:
-        def invalidate_session(self, _session) -> bool:
-            return False
-
-    class FixedCredentialClient:
-        def __init__(self) -> None:
-            self.authenticator = FixedAuthenticator()
-            self.session = SimpleNamespace()
-            self.calls = 0
-
-        def post(self, _path: str):
-            self.calls += 1
-            raise APIError(
-                "denied",
-                status_code=403,
-                response_data={"detail": "Workroom access denied"},
-            )
-
-    client = FixedCredentialClient()
+    client = _RecoveryClient([_deleted_scope_denial()], recoverable=False)
 
     with pytest.raises(APIError, match="denied"):
         WorkroomService(client).leave()

--- a/tests/unit/test_workroom_service.py
+++ b/tests/unit/test_workroom_service.py
@@ -509,6 +509,127 @@ def test_leave_posts_to_leave_endpoint(dummy_client):
     assert result.expires_in == 3600
 
 
+def test_leave_recovers_once_from_deleted_workroom_scope() -> None:
+    class RecoverableAuthenticator:
+        def __init__(self) -> None:
+            self.invalidations = 0
+
+        def invalidate_session(self, _session) -> bool:
+            self.invalidations += 1
+            return True
+
+    class RecoverableClient:
+        def __init__(self) -> None:
+            self.authenticator = RecoverableAuthenticator()
+            self.session = SimpleNamespace()
+            self.calls = 0
+
+        def post(self, path: str):
+            assert path == "/workrooms/leave"
+            self.calls += 1
+            if self.calls == 1:
+                raise APIError(
+                    "denied",
+                    status_code=403,
+                    response_data={"detail": "Workroom access denied"},
+                )
+            return {
+                "workroom_id": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                "access_token": "global-token",
+                "expires_in": 3600,
+                "message": "Returned to no-workroom scope",
+            }
+
+    client = RecoverableClient()
+
+    result = WorkroomService(client).leave()
+
+    assert result.access_token == "global-token"
+    assert client.calls == 2
+    assert client.authenticator.invalidations == 1
+
+
+def test_leave_does_not_mask_retry_failure() -> None:
+    class RecoverableAuthenticator:
+        def invalidate_session(self, _session) -> bool:
+            return True
+
+    class FailingClient:
+        def __init__(self) -> None:
+            self.authenticator = RecoverableAuthenticator()
+            self.session = SimpleNamespace()
+            self.calls = 0
+
+        def post(self, _path: str):
+            self.calls += 1
+            raise APIError(
+                "denied",
+                status_code=403,
+                response_data={"detail": "Workroom access denied"},
+            )
+
+    client = FailingClient()
+
+    with pytest.raises(APIError, match="denied"):
+        WorkroomService(client).leave()
+
+    assert client.calls == 2
+
+
+def test_leave_does_not_retry_unrelated_forbidden_response() -> None:
+    class UnexpectedClient:
+        def __init__(self) -> None:
+            self.authenticator = SimpleNamespace(
+                invalidate_session=lambda _session: pytest.fail(
+                    "unrelated 403 must not invalidate credentials"
+                )
+            )
+            self.session = SimpleNamespace()
+            self.calls = 0
+
+        def post(self, _path: str):
+            self.calls += 1
+            raise APIError(
+                "forbidden",
+                status_code=403,
+                response_data={"detail": "Insufficient permissions"},
+            )
+
+    client = UnexpectedClient()
+
+    with pytest.raises(APIError, match="forbidden"):
+        WorkroomService(client).leave()
+
+    assert client.calls == 1
+
+
+def test_leave_does_not_retry_deleted_scope_denial_for_fixed_credentials() -> None:
+    class FixedAuthenticator:
+        def invalidate_session(self, _session) -> bool:
+            return False
+
+    class FixedCredentialClient:
+        def __init__(self) -> None:
+            self.authenticator = FixedAuthenticator()
+            self.session = SimpleNamespace()
+            self.calls = 0
+
+        def post(self, _path: str):
+            self.calls += 1
+            raise APIError(
+                "denied",
+                status_code=403,
+                response_data={"detail": "Workroom access denied"},
+            )
+
+    client = FixedCredentialClient()
+
+    with pytest.raises(APIError, match="denied"):
+        WorkroomService(client).leave()
+
+    assert client.calls == 1
+
+
 def test_enter_leave_expose_tokens_without_mutating_client_auth(dummy_client):
     responses = {
         ("post", f"/workrooms/{WORKROOM_UUID}/enter"): {


### PR DESCRIPTION
## Summary

Harden Kajiya nightly SDK coverage across platform-aware model selection, shared deployment targets, transient VectorDB provisioning states, and stale workroom-scoped password sessions.

## Linear

- [ENG-9625](https://linear.app/kamiwaza/issue/ENG-9625/kajiya-nightly-context-llm-engine-selection-picks-mlx-on-cpu-only)
- [ENG-9626](https://linear.app/kamiwaza/issue/ENG-9626/kajiya-nightly-deployable-test-model-repo-hardcoded-to-the-mlx-repo-in)
- [ENG-9627](https://linear.app/kamiwaza/issue/ENG-9627/kajiya-nightly-two-node-mesh-sdk-smoke-flake-5-context-vectordb-tests)
- [ENG-9628](https://linear.app/kamiwaza/issue/ENG-9628/kajiya-nightly-sdk-workroom-scoped-token-wedges-the-session-after-the)

## Changes

- Select an exact repo/engine pair by trusted cluster inventory: NVIDIA → vLLM, Apple Silicon → MLX, CPU Linux/unknown → GGUF with llama.cpp.
- Preserve per-node OS/platform correlation so heterogeneous clusters cannot be misclassified as Apple Silicon.
- Reuse the same overridable inference target in the prerequisite probe, serving workflow, and CLI live test.
- Log VectorDB status transitions and tolerate a continuous `stopped` state for 30 seconds while retaining immediate failure for `failed`.
- Invalidate stale password-session credentials after the exact deleted-workroom 403 and retry `workrooms.leave()` once; fixed credentials and unrelated failures remain fail-closed.
- Document the bounded stale-scope recovery extension point.

## Acceptance criteria

| Ticket | Evidence | Result |
|---|---|---|
| ENG-9625 | CPU Linux, Apple Silicon, NVIDIA, unknown, synthetic-row, and mixed-node platform regressions | PASS |
| ENG-9626 | Shared target probe/serving/CLI tests assert the same repo and engine | PASS |
| ENG-9627 | Transient stopped, terminal failed, continuous stopped grace, and transition logging regressions | PASS |
| ENG-9628 | Exact denial, bounded retry, retry failure, unrelated 403, fixed credential, invalidation, and real-client reauthentication regressions | PASS |

## Verification

- `3080 passed, 262 deselected` with integration/live/e2e/slow tests excluded
- `122 passed` in the ticket-focused regression suite
- 35 affected live integration tests collect successfully
- Ruff passes all changed Python files
- CI-style mypy passes both changed SDK production files
- isort/Black checks pass on newly formatted hunks
- `uv build` produces the sdist and wheel
- LocalReview iteration 2: PASS, all six dimensions 9/10, no critical or important findings

Two pre-existing frontend smoke tests cannot run on this host because its Node 16.20.2 is below Next.js's Node >=18.18 requirement. Repository-wide Ruff/mypy also report existing baseline findings in untouched files; the changed-file gates pass. No dependency was added.

## Documentation

`docs/services/auth/README.md` now describes deleted-workroom session recovery and custom authenticator behavior.

## Deployment notes

No migrations, feature flags, or release-order constraints.

## Review focus

- Platform inventory trust/correlation and repo/engine pairing
- Exactness and one-retry bound of stale-scope recovery
- VectorDB stopped-state grace/reset behavior
