### PR TITLE
test(e2e): map S2 to workrooms.app-launch; implement S2 handlers (ENG-9767)

### DIFF
--- a/tests/e2e/scenarios/runbooks/s2-workroom-manager-launch.yaml
+++ b/tests/e2e/scenarios/runbooks/s2-workroom-manager-launch.yaml
@@ -1,6 +1,8 @@
 id: "S2"
 name: "App launched from Workroom Manager"
 sign_off_actor: "SDK team"
+capability_ids:
+  - "workrooms.app-launch"
 uacs:
   - UAC-9c
   - UAC-16

--- a/tests/e2e/scenarios/test_s2_workroom_manager.py
+++ b/tests/e2e/scenarios/test_s2_workroom_manager.py
@@ -7,19 +7,27 @@ extension side once the platform lists the deployment.
 The runbook maps to the ``workrooms.app-launch`` capability document in
 ``kamiwaza-internal/capability-kit`` (salesdevkit1 T1.4); runs emit
 ``scenario-evidence.v2`` records naming it via the runbook's
-``capability_ids``.
+``capability_ids``. That mapping is pinned by a unit test below so CI
+guards the join even though the full-loop driver is e2e-only.
 
-Handler notes: the three assertion steps exercise the runtime library's
+Handler notes: the two identity steps exercise the runtime library's
 identity contract against the canonical test vectors
-(``docs/extensions/non-sdk-flow/test-vectors.json``) — the same checks
-the 2026-05-01 run performed. ``scaffold_app`` scaffolds via ``kz-ext
-create`` and then deliberately skips the staging deploy (recording the
-step ``skipped`` with detail, which derives a ``passed_with_notes``
-scenario status); the deploy path lands with the T3.3 dry-run.
+(``docs/extensions/non-sdk-flow/test-vectors.json``). The boundary step
+verifies that ``extract_identity`` rejects unbound envelopes with
+``MisboundAuthError``, then records itself ``skipped``: no
+``kamiwaza_extensions_lib`` code path raises ``OutOfEnvelopeAccessError``
+yet, so the runbook's "assert the runtime lib raises
+OutOfEnvelopeAccessError" cannot be exercised honestly — the step stays
+skipped (deriving ``passed_with_notes``) until that enforcement path
+lands. ``scaffold_app`` scaffolds via ``kz-ext create`` and deliberately
+skips the staging deploy (the deploy path lands with the T3.3 dry-run);
+a missing ``kz-ext`` CLI is treated as a provisioning gap (skip), not a
+capability failure.
 """
 
 from __future__ import annotations
 
+import functools
 import json
 import shutil
 import subprocess
@@ -29,8 +37,8 @@ from pathlib import Path
 import pytest
 
 from kamiwaza_extensions_lib import (
+    Identity,
     MisboundAuthError,
-    OutOfEnvelopeAccessError,
     extract_identity,
 )
 from tests.e2e.scenarios.harness import (
@@ -47,22 +55,36 @@ _VECTORS_PATH = (
     _REPO_ROOT / "docs" / "extensions" / "non-sdk-flow" / "test-vectors.json"
 )
 
+_UNBOUND_ENVELOPE_CASES = ("missing-workroom", "missing-user-id")
+
+
+class _Missing:
+    def __repr__(self) -> str:
+        return "<no such field on Identity>"
+
+
+_MISSING = _Missing()
+
+
+@functools.lru_cache(maxsize=1)
+def _load_vectors() -> tuple[dict, ...]:
+    return tuple(json.loads(_VECTORS_PATH.read_text()))
+
 
 def _vector(case: str) -> dict:
-    vectors = json.loads(_VECTORS_PATH.read_text())
-    for entry in vectors:
+    for entry in _load_vectors():
         if entry["case"] == case:
             return entry
     raise AssertionError(f"test vector {case!r} not found in {_VECTORS_PATH}")
 
 
-def _assert_identity_matches(identity: object, expected: dict) -> list[str]:
+def _assert_identity_matches(identity: Identity, expected: dict) -> list[str]:
     """Compare an extracted Identity against a vector's expected_identity."""
-    mismatches = []
-    for field, want in expected.items():
-        got = getattr(identity, field)
-        if got != want:
-            mismatches.append(f"{field}: expected {want!r}, got {got!r}")
+    mismatches = [
+        f"{field}: expected {want!r}, got {got!r}"
+        for field, want in expected.items()
+        if (got := getattr(identity, field, _MISSING)) != want
+    ]
     if mismatches:
         raise AssertionError("; ".join(mismatches))
     return sorted(expected)
@@ -70,29 +92,35 @@ def _assert_identity_matches(identity: object, expected: dict) -> list[str]:
 
 def _scaffold_app() -> str:
     if shutil.which("kz-ext") is None:
-        raise AssertionError("kz-ext CLI not on PATH — cannot scaffold")
-    workdir = tempfile.mkdtemp(prefix="s2-scaffold-")
-    proc = subprocess.run(
-        ["kz-ext", "create", "--type", "app", "--name", "s2-evidence-app"],
-        cwd=workdir,
-        capture_output=True,
-        text=True,
-        timeout=180,
-    )
-    if proc.returncode != 0:
-        raise AssertionError(
-            f"kz-ext create failed (rc={proc.returncode}): {proc.stderr[-500:]}"
+        pytest.skip(
+            "kz-ext CLI not on PATH — provisioning gap in this environment, "
+            "not a capability failure; install the SDK CLI to exercise the "
+            "scaffold step"
         )
-    # kz-ext create scaffolds into the current directory (no subdir).
-    created = Path(workdir)
-    manifest = created / "kamiwaza.json"
-    if not manifest.is_file():
-        raise AssertionError(
-            f"kz-ext create reported success but {manifest} is missing"
+    with tempfile.TemporaryDirectory(prefix="s2-scaffold-") as workdir:
+        proc = subprocess.run(
+            ["kz-ext", "create", "--type", "app", "--name", "s2-evidence-app"],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            timeout=180,
         )
-    n_files = sum(
-        1 for p in created.rglob("*") if p.is_file() and ".git" not in p.parts
-    )
+        if proc.returncode != 0:
+            raise AssertionError(
+                f"kz-ext create failed (rc={proc.returncode}): {proc.stderr[-500:]}"
+            )
+        # Scaffolder.create targets cwd itself only when cwd is empty (true
+        # for a fresh TemporaryDirectory); with visible files present it
+        # would scaffold into cwd/{name} instead.
+        created = Path(workdir)
+        manifest = created / "kamiwaza.json"
+        if not manifest.is_file():
+            raise AssertionError(
+                f"kz-ext create reported success but {manifest} is missing"
+            )
+        n_files = sum(
+            1 for p in created.rglob("*") if p.is_file() and ".git" not in p.parts
+        )
     pytest.skip(
         f"kz-ext create OK — app scaffold with {n_files} files; deploy via "
         "kz-ext dev to staging deliberately not exercised in this run "
@@ -114,28 +142,17 @@ def _assert_global_workroom_sentinel_handling() -> str:
     vec = _vector("global-workroom-sentinel")
     identity = extract_identity(vec["headers"])
     fields = _assert_identity_matches(identity, vec["expected_identity"])
-    sentinel = vec["headers"]["X-Workroom-Id"]
-    if identity.workroom_id != sentinel:
-        raise AssertionError(
-            f"sentinel not preserved: {identity.workroom_id!r} != {sentinel!r}"
-        )
+    sentinel = vec["expected_identity"]["workroom_id"]
     return (
         f"global-workroom sentinel {sentinel} honored per canonical vector; "
         f"fields verified: {', '.join(fields)}"
     )
 
 
-def _assert_workroom_boundary_enforcement() -> str:
-    # The runtime library's boundary contract: OutOfEnvelopeAccessError is
-    # the refusal an SDK-built app receives on out-of-workroom access, and
-    # requests arriving without a bound workroom identity are rejected at
-    # extraction (MisboundAuthError) rather than defaulting open.
-    try:
-        raise OutOfEnvelopeAccessError("s2 boundary probe")
-    except OutOfEnvelopeAccessError as exc:
-        caught = type(exc).__name__
+def _check_unbound_envelope_rejection() -> list[str]:
+    """Assert extract_identity rejects unbound envelopes; return the cases."""
     rejected = []
-    for case in ("missing-workroom", "missing-user-id"):
+    for case in _UNBOUND_ENVELOPE_CASES:
         vec = _vector(case)
         try:
             extract_identity(vec["headers"])
@@ -146,9 +163,25 @@ def _assert_workroom_boundary_enforcement() -> str:
                 f"extract_identity accepted the {case!r} vector — envelope "
                 "binding not enforced"
             )
-    return (
-        f"{caught} importable and raisable; extract_identity rejects "
-        f"unbound envelopes ({', '.join(rejected)}) with MisboundAuthError"
+    return rejected
+
+
+def _assert_workroom_boundary_enforcement() -> str:
+    # Requests arriving without a bound workroom identity must be rejected
+    # at extraction (MisboundAuthError) rather than defaulting open — that
+    # half is asserted for real. The step's headline contract ("the runtime
+    # lib raises OutOfEnvelopeAccessError on out-of-workroom access") has no
+    # code path in kamiwaza_extensions_lib that raises it yet, so the step
+    # records skipped instead of claiming boundary coverage it never
+    # exercised; it flips to a hard assertion when the enforcement path
+    # lands (T3.3 dry-run).
+    rejected = _check_unbound_envelope_rejection()
+    pytest.skip(
+        "unbound envelopes rejected with MisboundAuthError "
+        f"({', '.join(rejected)}); OutOfEnvelopeAccessError enforcement not "
+        "yet exercisable — no kamiwaza_extensions_lib code path raises it, "
+        "so this step stays skipped rather than recording boundary coverage "
+        "it did not verify (pending T3.3)"
     )
 
 
@@ -186,3 +219,55 @@ def test_s2_full_loop(staging_url, build_id):
         f"S2 unexpected non-passing result: artifact={artifact}, sign-off={sign_off}, "
         f"steps={[(s.name, s.status) for s in result.steps]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# CI-visible unit coverage (make test deselects e2e; these run everywhere).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_s2_runbook_maps_to_workrooms_app_launch():
+    """Pin the PR's headline deliverable: S2 names the capability it feeds.
+
+    The evidence schema warns that a near-miss id (e.g. the kebab-only
+    ``workroom-app-launch``) silently joins to nothing in capability-kit,
+    so the exact mapping needs a guard.
+    """
+    assert load_runbook(SCENARIO_ID)["capability_ids"] == ["workrooms.app-launch"]
+
+
+@pytest.mark.unit
+def test_workroom_scoped_identity_headers_handler():
+    detail = _assert_workroom_scoped_identity_headers()
+    assert "happy-path" in detail
+
+
+@pytest.mark.unit
+def test_global_workroom_sentinel_handler():
+    detail = _assert_global_workroom_sentinel_handling()
+    assert "sentinel" in detail
+
+
+@pytest.mark.unit
+def test_unbound_envelopes_rejected():
+    assert _check_unbound_envelope_rejection() == list(_UNBOUND_ENVELOPE_CASES)
+
+
+@pytest.mark.unit
+def test_boundary_step_skips_pending_enforcement_path():
+    """The boundary step must not record coverage it cannot exercise."""
+    with pytest.raises(pytest.skip.Exception, match="OutOfEnvelopeAccessError"):
+        _assert_workroom_boundary_enforcement()
+
+
+@pytest.mark.unit
+def test_identity_mismatches_aggregate_instead_of_attribute_error():
+    identity = extract_identity(_vector("happy-path")["headers"])
+    with pytest.raises(AssertionError) as excinfo:
+        _assert_identity_matches(
+            identity, {"user_id": "someone-else", "not_a_field": "x"}
+        )
+    message = str(excinfo.value)
+    assert "user_id" in message
+    assert "not_a_field" in message

--- a/tests/e2e/scenarios/test_s2_workroom_manager.py
+++ b/tests/e2e/scenarios/test_s2_workroom_manager.py
@@ -3,12 +3,36 @@
 SDK-team automated. UACs 9c / 16. Platform-side discoverability is
 out-of-scope for D210 per PRD §EDX-E2E-1 Note; this driver validates the
 extension side once the platform lists the deployment.
+
+The runbook maps to the ``workrooms.app-launch`` capability document in
+``kamiwaza-internal/capability-kit`` (salesdevkit1 T1.4); runs emit
+``scenario-evidence.v2`` records naming it via the runbook's
+``capability_ids``.
+
+Handler notes: the three assertion steps exercise the runtime library's
+identity contract against the canonical test vectors
+(``docs/extensions/non-sdk-flow/test-vectors.json``) — the same checks
+the 2026-05-01 run performed. ``scaffold_app`` scaffolds via ``kz-ext
+create`` and then deliberately skips the staging deploy (recording the
+step ``skipped`` with detail, which derives a ``passed_with_notes``
+scenario status); the deploy path lands with the T3.3 dry-run.
 """
 
 from __future__ import annotations
 
+import json
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
 import pytest
 
+from kamiwaza_extensions_lib import (
+    MisboundAuthError,
+    OutOfEnvelopeAccessError,
+    extract_identity,
+)
 from tests.e2e.scenarios.harness import (
     load_runbook,
     record_run,
@@ -18,13 +42,129 @@ from tests.e2e.scenarios.harness import (
 
 SCENARIO_ID = "S2"
 
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_VECTORS_PATH = (
+    _REPO_ROOT / "docs" / "extensions" / "non-sdk-flow" / "test-vectors.json"
+)
+
+
+def _vector(case: str) -> dict:
+    vectors = json.loads(_VECTORS_PATH.read_text())
+    for entry in vectors:
+        if entry["case"] == case:
+            return entry
+    raise AssertionError(f"test vector {case!r} not found in {_VECTORS_PATH}")
+
+
+def _assert_identity_matches(identity: object, expected: dict) -> list[str]:
+    """Compare an extracted Identity against a vector's expected_identity."""
+    mismatches = []
+    for field, want in expected.items():
+        got = getattr(identity, field)
+        if got != want:
+            mismatches.append(f"{field}: expected {want!r}, got {got!r}")
+    if mismatches:
+        raise AssertionError("; ".join(mismatches))
+    return sorted(expected)
+
+
+def _scaffold_app() -> str:
+    if shutil.which("kz-ext") is None:
+        raise AssertionError("kz-ext CLI not on PATH — cannot scaffold")
+    workdir = tempfile.mkdtemp(prefix="s2-scaffold-")
+    proc = subprocess.run(
+        ["kz-ext", "create", "--type", "app", "--name", "s2-evidence-app"],
+        cwd=workdir,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"kz-ext create failed (rc={proc.returncode}): {proc.stderr[-500:]}"
+        )
+    # kz-ext create scaffolds into the current directory (no subdir).
+    created = Path(workdir)
+    manifest = created / "kamiwaza.json"
+    if not manifest.is_file():
+        raise AssertionError(
+            f"kz-ext create reported success but {manifest} is missing"
+        )
+    n_files = sum(
+        1 for p in created.rglob("*") if p.is_file() and ".git" not in p.parts
+    )
+    pytest.skip(
+        f"kz-ext create OK — app scaffold with {n_files} files; deploy via "
+        "kz-ext dev to staging deliberately not exercised in this run "
+        "(lands with the T3.3 dry-run)"
+    )
+
+
+def _assert_workroom_scoped_identity_headers() -> str:
+    vec = _vector("happy-path")
+    identity = extract_identity(vec["headers"])
+    fields = _assert_identity_matches(identity, vec["expected_identity"])
+    return (
+        "runtime-lib extract_identity round-trips the canonical happy-path "
+        f"vector; fields verified: {', '.join(fields)}"
+    )
+
+
+def _assert_global_workroom_sentinel_handling() -> str:
+    vec = _vector("global-workroom-sentinel")
+    identity = extract_identity(vec["headers"])
+    fields = _assert_identity_matches(identity, vec["expected_identity"])
+    sentinel = vec["headers"]["X-Workroom-Id"]
+    if identity.workroom_id != sentinel:
+        raise AssertionError(
+            f"sentinel not preserved: {identity.workroom_id!r} != {sentinel!r}"
+        )
+    return (
+        f"global-workroom sentinel {sentinel} honored per canonical vector; "
+        f"fields verified: {', '.join(fields)}"
+    )
+
+
+def _assert_workroom_boundary_enforcement() -> str:
+    # The runtime library's boundary contract: OutOfEnvelopeAccessError is
+    # the refusal an SDK-built app receives on out-of-workroom access, and
+    # requests arriving without a bound workroom identity are rejected at
+    # extraction (MisboundAuthError) rather than defaulting open.
+    try:
+        raise OutOfEnvelopeAccessError("s2 boundary probe")
+    except OutOfEnvelopeAccessError as exc:
+        caught = type(exc).__name__
+    rejected = []
+    for case in ("missing-workroom", "missing-user-id"):
+        vec = _vector(case)
+        try:
+            extract_identity(vec["headers"])
+        except MisboundAuthError:
+            rejected.append(case)
+        else:
+            raise AssertionError(
+                f"extract_identity accepted the {case!r} vector — envelope "
+                "binding not enforced"
+            )
+    return (
+        f"{caught} importable and raisable; extract_identity rejects "
+        f"unbound envelopes ({', '.join(rejected)}) with MisboundAuthError"
+    )
+
 
 @pytest.mark.e2e
 def test_s2_full_loop(staging_url, build_id):
     runbook = load_runbook(SCENARIO_ID)
 
     handlers = {
-        # Implement during T3.3 dry-run.
+        "scaffold_app": _scaffold_app,
+        "assert_workroom_scoped_identity_headers": (
+            _assert_workroom_scoped_identity_headers
+        ),
+        "assert_global_workroom_sentinel_handling": (
+            _assert_global_workroom_sentinel_handling
+        ),
+        "assert_workroom_boundary_enforcement": _assert_workroom_boundary_enforcement,
     }
 
     result = run_scenario(runbook, handlers, build=build_id)

--- a/tests/e2e/scenarios/test_s2_workroom_manager.py
+++ b/tests/e2e/scenarios/test_s2_workroom_manager.py
@@ -33,6 +33,7 @@ import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 
@@ -55,8 +56,6 @@ _VECTORS_PATH = (
     _REPO_ROOT / "docs" / "extensions" / "non-sdk-flow" / "test-vectors.json"
 )
 
-_UNBOUND_ENVELOPE_CASES = ("missing-workroom", "missing-user-id")
-
 
 class _Missing:
     def __repr__(self) -> str:
@@ -78,6 +77,19 @@ def _vector(case: str) -> dict:
     raise AssertionError(f"test vector {case!r} not found in {_VECTORS_PATH}")
 
 
+def _unbound_envelope_cases() -> list[str]:
+    """Cases the vectors file tags as misbound-auth rejections.
+
+    Derived from ``should_fail_class`` so a newly added misbound vector is
+    covered automatically instead of silently ignored.
+    """
+    return [
+        entry["case"]
+        for entry in _load_vectors()
+        if entry.get("should_fail_class") == "misbound_auth"
+    ]
+
+
 def _assert_identity_matches(identity: Identity, expected: dict) -> list[str]:
     """Compare an extracted Identity against a vector's expected_identity."""
     mismatches = [
@@ -90,7 +102,7 @@ def _assert_identity_matches(identity: Identity, expected: dict) -> list[str]:
     return sorted(expected)
 
 
-def _scaffold_app() -> str:
+def _scaffold_app() -> NoReturn:
     if shutil.which("kz-ext") is None:
         pytest.skip(
             "kz-ext CLI not on PATH — provisioning gap in this environment, "
@@ -109,17 +121,24 @@ def _scaffold_app() -> str:
             raise AssertionError(
                 f"kz-ext create failed (rc={proc.returncode}): {proc.stderr[-500:]}"
             )
-        # Scaffolder.create targets cwd itself only when cwd is empty (true
-        # for a fresh TemporaryDirectory); with visible files present it
-        # would scaffold into cwd/{name} instead.
+        # Scaffolder.create targets cwd itself when cwd is empty (true for a
+        # fresh TemporaryDirectory) and cwd/{name} otherwise; accept either
+        # so a scaffolder behavior change surfaces as a wrong-shape failure,
+        # not a false negative here.
         created = Path(workdir)
-        manifest = created / "kamiwaza.json"
-        if not manifest.is_file():
+        candidates = (
+            created / "kamiwaza.json",
+            created / "s2-evidence-app" / "kamiwaza.json",
+        )
+        manifest = next((m for m in candidates if m.is_file()), None)
+        if manifest is None:
             raise AssertionError(
-                f"kz-ext create reported success but {manifest} is missing"
+                "kz-ext create reported success but kamiwaza.json is missing "
+                f"(looked in {', '.join(str(c) for c in candidates)})"
             )
+        scaffold_root = manifest.parent
         n_files = sum(
-            1 for p in created.rglob("*") if p.is_file() and ".git" not in p.parts
+            1 for p in scaffold_root.rglob("*") if p.is_file() and ".git" not in p.parts
         )
     pytest.skip(
         f"kz-ext create OK — app scaffold with {n_files} files; deploy via "
@@ -151,8 +170,14 @@ def _assert_global_workroom_sentinel_handling() -> str:
 
 def _check_unbound_envelope_rejection() -> list[str]:
     """Assert extract_identity rejects unbound envelopes; return the cases."""
+    cases = _unbound_envelope_cases()
+    if not cases:
+        raise AssertionError(
+            f"no misbound_auth-tagged vectors in {_VECTORS_PATH} — the "
+            "unbound-envelope check would be vacuous"
+        )
     rejected = []
-    for case in _UNBOUND_ENVELOPE_CASES:
+    for case in cases:
         vec = _vector(case)
         try:
             extract_identity(vec["headers"])
@@ -166,7 +191,7 @@ def _check_unbound_envelope_rejection() -> list[str]:
     return rejected
 
 
-def _assert_workroom_boundary_enforcement() -> str:
+def _assert_workroom_boundary_enforcement() -> NoReturn:
     # Requests arriving without a bound workroom identity must be rejected
     # at extraction (MisboundAuthError) rather than defaulting open — that
     # half is asserted for real. The step's headline contract ("the runtime
@@ -251,7 +276,10 @@ def test_global_workroom_sentinel_handler():
 
 @pytest.mark.unit
 def test_unbound_envelopes_rejected():
-    assert _check_unbound_envelope_rejection() == list(_UNBOUND_ENVELOPE_CASES)
+    assert sorted(_check_unbound_envelope_rejection()) == [
+        "missing-user-id",
+        "missing-workroom",
+    ]
 
 
 @pytest.mark.unit
@@ -259,6 +287,55 @@ def test_boundary_step_skips_pending_enforcement_path():
     """The boundary step must not record coverage it cannot exercise."""
     with pytest.raises(pytest.skip.Exception, match="OutOfEnvelopeAccessError"):
         _assert_workroom_boundary_enforcement()
+
+
+class _FakeProc:
+    def __init__(self, returncode: int, stderr: str = ""):
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+@pytest.mark.unit
+def test_scaffold_app_missing_cli_skips(monkeypatch):
+    """A missing kz-ext CLI is a provisioning gap, not a capability failure."""
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    with pytest.raises(pytest.skip.Exception, match="provisioning gap"):
+        _scaffold_app()
+
+
+@pytest.mark.unit
+def test_scaffold_app_nonzero_rc_fails(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/kz-ext")
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _FakeProc(2, "registry unreachable")
+    )
+    with pytest.raises(AssertionError, match=r"rc=2.*registry unreachable"):
+        _scaffold_app()
+
+
+@pytest.mark.unit
+def test_scaffold_app_missing_manifest_fails(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/kz-ext")
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _FakeProc(0))
+    with pytest.raises(AssertionError, match="kamiwaza.json is missing"):
+        _scaffold_app()
+
+
+@pytest.mark.unit
+def test_scaffold_app_success_skips_deploy(monkeypatch):
+    """The success path always ends in the deliberate deploy skip."""
+
+    def fake_create(cmd, cwd=None, **kwargs):
+        Path(cwd, "kamiwaza.json").write_text("{}")
+        Path(cwd, "app.py").write_text("")
+        return _FakeProc(0)
+
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/kz-ext")
+    monkeypatch.setattr(subprocess, "run", fake_create)
+    with pytest.raises(
+        pytest.skip.Exception, match=r"2 files.*deliberately not exercised"
+    ):
+        _scaffold_app()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
Maps the S2 runbook to the `workrooms.app-launch` capability and implements its four step handlers, producing the first live `scenario-evidence.v2` record that names a capability (salesdevkit1 T1.4, ENG-9767).

## Type
- [ ] Feature - New functionality
- [ ] Bug Fix - Corrects existing behavior
- [ ] Refactor - Code improvement without behavior change
- [ ] Documentation - Docs only
- [x] Test - Test coverage improvement
- [ ] Chore - Dependencies, config, CI/CD

## Change Flags
- [ ] API change - Endpoints added, modified, or removed
- [ ] Configuration change - New or modified config parameters
- [ ] Requirements change - Dependencies added, updated, or removed
- [ ] Schema change - Database or Pydantic model changes

## Breaking Changes
- [x] None - Fully backward compatible

## Motivation
T1.3 (#250) gave the harness the v2 record shape; this PR closes the G2 join in practice — an evidence record naming the capability document it substantiates. The S2 driver's handlers were never committed (the 2026-05-01 run was produced ad hoc; the committed driver had an empty dict "Implement during T3.3 dry-run"), so runs could not be reproduced. Now they can.

## Source
- [x] Issue/Ticket: Linear ENG-9767 (M1 — One capability, end to end)
- [x] Spec/Design Doc: kamiwaza-docs-engineering-internal `docs/specifications/tooling/sales-developer-release-kit/sales-developer-release-kit-design.md` §4.4, §6.2

## Alternatives Considered
- Full `kz-ext dev` staging deploy in `scaffold_app` — deferred: the deploy path belongs to the T3.3 dry-run; the handler scaffolds via `kz-ext create`, verifies the scaffold, and skips the deploy with an explicit detail message, deriving an honest `passed_with_notes` scenario status rather than overclaiming.
- Reconstructing handlers as pytest-only asserts outside the harness — rejected: the point is a durable evidence record per run.

## Changes Made
- `runbooks/s2-workroom-manager-launch.yaml`: adds `capability_ids: ["workrooms.app-launch"]`
- `test_s2_workroom_manager.py`: implements the four handlers — happy-path identity round-trip and global-workroom sentinel (asserted against the canonical vectors in `docs/extensions/non-sdk-flow/test-vectors.json`); the boundary step genuinely asserts `MisboundAuthError` rejection of unbound envelopes, then records itself `skipped` with an honest detail because no runtime-lib code path raises `OutOfEnvelopeAccessError` yet (review high #1) — it flips to a hard assertion when the enforcement path lands (T3.3); `scaffold_app` via `kz-ext create` with deploy deliberately skipped, and a missing `kz-ext` CLI skips as a provisioning gap instead of failing the evidence record (high #2)
- Unit-marked tests (run by `make test` in CI) pin `capability_ids == ["workrooms.app-launch"]` and execute every handler path (high #3)

## Technical Notes
- New run artifacts are NOT committed here: evidence records carry internal build/environment identity, and this repo is public. Records are collected into `kamiwaza-internal/capability-kit` (its collector skips the four committed v1 artifacts, which stay untouched).
- `kz-ext create` scaffolds into the current directory (no subdir) — the handler verifies `kamiwaza.json` at the workdir root.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No tests needed - explain below

The driver is itself the test (e2e-marked). Existing harness suite unaffected: `pytest tests/e2e/scenarios -q` green.

## Verification
| Environment | Steps Performed | Result |
|-------------|-----------------|--------|
| Live local cluster (`kamiwaza.test`, k0s; core@sha256:f2c05487…) | `KAMIWAZA_STAGING_URL=… KAMIWAZA_BUILD=… uv run pytest tests/e2e/scenarios/test_s2_workroom_manager.py` | 1 passed; record `s2-20260807T200738809355`: scaffold skipped (by design), 3 asserts passed, scenario `passed_with_notes`, `capability_ids: ["workrooms.app-launch"]` |
| Local, post-review fixes (same host) | `KAMIWAZA_STAGING_URL=… KAMIWAZA_BUILD=… uv run pytest tests/e2e/scenarios/test_s2_workroom_manager.py -m e2e`; `make test` | 1 passed; record `s2-20260810T055448107556`: scaffold skipped (by design), 2 asserts passed, boundary skipped with honest detail, scenario `passed_with_notes`; full suite 3307 passed |

## Test Coverage
Identity round-trip (all expected fields), sentinel preservation, unbound-envelope rejection (missing-workroom, missing-user-id), boundary step's honest-skip contract, capability-mapping pin, identity-mismatch aggregation, scaffold structure verification, kz-ext failure surfaced with stderr.

## Review Focus
- The `scaffold_app` skip-after-create pattern: `pytest.skip` inside the handler records the step `skipped` with detail and derives `passed_with_notes` — is that the agreed reading of a deliberately-partial step?
- Handler fidelity vs the 2026-05-01 ad hoc run's step details (they match its recorded assertions).

## Deployment Notes
N/A — test-lane only.

## Checklist
- [x] Self-reviewed the code
- [x] Tests pass locally
- [x] Verified on live system (see Verification above)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-08-10T15:17:22.001Z
pr:
  repo: kamiwaza-ai/kamiwaza-sdk
  number: 251
linear_issues:
  - ENG-9767
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: "All 7 checks pass on fa44800: CodeScene Code Health, Coverage,
      Cyclomatic Complexity, Mypy, Ruff, Unit Tests, check-linear-issue"
  - kind: pr-evidence
    required: false
    status: fail
    detail: "Not required: test-only change (harness driver + runbook mapping), no
      cluster-running code touched; no pr-evidence block present"
  - kind: linear-issue-present
    required: true
    status: pass
    detail: ENG-9767 in PR title, branch, and body
  - kind: no-debug-statements
    required: true
    status: pass
    detail: "Diff scan clean: no print/console.log/pdb/breakpoint/debugger additions"
  - kind: pr-review-approved
    required: true
    status: pass
    detail: "Multi-engine /pr-review report on head fa44800: Verdict APPROVE, no
      criticals/highs (Claude APPROVE, Codex no findings)"
  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "minimum PR age satisfied: created 2026-08-07T20:09:12.000Z; eligible
      since 2026-08-07T20:54:12.000Z"
manual_steps: []
verdict:
  decision: approve
  rationale: All required auto-checks passed (required-checks,
    linear-issue-present, no-debug-statements, pr-review-approved,
    minimum-pr-age); 0 manual steps verified.
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
linear:
  - id: ENG-9767
    url: https://linear.app/kamiwaza/issue/ENG-9767/t14-map-one-runbook-to-the-capability-run-against-a-current-build
    cached_description: >-
      Component C5 · Size M · Design §6.2


      Map the chosen S1–S5 runbook to the T1.2 capability's `id` and run it
      against a current build, emitting the first `scenario-evidence.v2` record
      with real `build`, `method`, `capability_ids` values. **This closes the G2
      join in practice — the highest-value link of the cycle** — and refreshes
      G4's three-month-old evidence.


      **Accept:** a schema-valid record in `runs/` naming the capability and the
      build it ran against.
    cached_at: 2026-08-10T15:16:46Z
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->