### PR TITLE
Add requires_shared_idp marker for federation posture tests (ENG-9848)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ markers = [
     "withoutresponses: tests needing real network access",
     "requires_embedding_model: live tests that require a platform embedding deployment that can generate embeddings",
     "requires_two_clusters: live tests that require a federation peer cluster reachable via KAMIWAZA_PEER_BASE_URL / KAMIWAZA_PEER_API_KEY (ENG-5784)",
-    "requires_shared_idp: live federation tests exercising the shared_idp (Alt C) trust posture — receiver validates a shared-realm token against a trusted issuer (ENG-8213). The single-cluster identity gate carries this without requires_two_clusters; two-cluster shared_idp suites carry both.",
+    "requires_shared_idp: live federation tests exercising the shared_idp (Alt C) trust posture — receiver validates a shared-realm token against a trusted issuer (ENG-8213). The single-cluster identity gate carries this without requires_two_clusters; two-cluster shared_idp suites will carry both once tagged (currently deferred).",
     "requires_deployable_model: live tests that require the host to deploy the integration test model; skips on hosts without compatible inference capacity (e.g. x86 CPU smoke vs an MLX model)",
     "extension_regression: D210 12-issue regression checklist (UAC-17 / EDX-OPS-2). See tests/unit/extensions/regression/inventory.yaml.",
     "live_extension: live extension-contract tests against a real cluster (relocated from kamiwaza, env-gated by RUN_LIVE_EXTENSION_TESTS=1)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ markers = [
     "withoutresponses: tests needing real network access",
     "requires_embedding_model: live tests that require a platform embedding deployment that can generate embeddings",
     "requires_two_clusters: live tests that require a federation peer cluster reachable via KAMIWAZA_PEER_BASE_URL / KAMIWAZA_PEER_API_KEY (ENG-5784)",
+    "requires_shared_idp: live federation tests exercising the shared_idp (Alt C) trust posture — receiver validates a shared-realm token against a trusted issuer (ENG-8213). The single-cluster identity gate carries this without requires_two_clusters; two-cluster shared_idp suites carry both.",
     "requires_deployable_model: live tests that require the host to deploy the integration test model; skips on hosts without compatible inference capacity (e.g. x86 CPU smoke vs an MLX model)",
     "extension_regression: D210 12-issue regression checklist (UAC-17 / EDX-OPS-2). See tests/unit/extensions/regression/inventory.yaml.",
     "live_extension: live extension-contract tests against a real cluster (relocated from kamiwaza, env-gated by RUN_LIVE_EXTENSION_TESTS=1)",

--- a/tests/integration/test_federation_identity_gate_live.py
+++ b/tests/integration/test_federation_identity_gate_live.py
@@ -22,7 +22,17 @@ import pytest
 
 from kamiwaza_sdk.exceptions import APIError
 
-pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.live,
+    pytest.mark.withoutresponses,
+    # Single-cluster federation POSTURE check: exercises the shared_idp trust gate
+    # on one cluster (no peer needed). Tagged requires_shared_idp so provisioned
+    # smokes can select it per-cluster via `requires_shared_idp and not
+    # requires_two_clusters` — without dragging in the full single-cluster
+    # integration suite (ENG-8213 / ENG-9848).
+    pytest.mark.requires_shared_idp,
+]
 
 
 def _cleanup(client, name_prefix: str) -> None:


### PR DESCRIPTION
## What
Register the `requires_shared_idp` pytest marker and tag the single-cluster federation identity gate test (`test_federation_identity_gate_live.py`) with it.

## Why
Kajiya's provisioned M2 federation smoke needs to run the single-cluster shared_idp **posture** check on each cluster without dragging in the whole single-cluster integration suite (model-serving / context / workroom), which a CPU-only smoke node cannot run — that breadth timed out the M2 run (ENG-9848). With this marker the smoke selects `-m "requires_shared_idp and not requires_two_clusters"` (posture only) on the CPU cluster and posture + `requires_deployable_model` inference on the GPU cluster.

`edge_markers` in kajiya's dual-single-node topology already referenced `requires_shared_idp`; this completes the half-finished marker.

## Scope
- `pyproject.toml`: register the marker.
- `test_federation_identity_gate_live.py`: add `pytest.mark.requires_shared_idp` (single-cluster; NOT the two-cluster gated-retrieval test, which is deferred).

No behavior change to any test — marker only. Linked: ENG-9848, ENG-8213.

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-08-08T23:19:20.000Z
pr:
  repo: kamiwaza-ai/kamiwaza-sdk
  number: 252
linear_issues:
  - ENG-9848
  - ENG-8213
auto_checks:
  - kind: required-checks
    required: true
    status: pass
  - kind: pr-evidence
    required: false
    status: skipped
  - kind: linear-issue-present
    required: true
    status: pass
  - kind: no-debug-statements
    required: true
    status: pass
  - kind: pr-review-approved
    required: true
    status: pass
  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "minimum PR age satisfied: created 2026-08-08T15:40:20.000Z; eligible
      since 2026-08-08T16:25:20.000Z"
manual_steps: []
verdict:
  decision: approve
  rationale: All required auto-checks passed (required-checks,
    linear-issue-present, no-debug-statements, pr-review-approved,
    minimum-pr-age); 0 manual steps verified.
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
linear:
  - id: ENG-9848
    url: https://linear.app/kamiwaza/issue/ENG-9848
    cached_description: >
      ## Symptom


      M2 provisioned federation smoke (run 31228555031) failed at 134 min. The
      per-cluster posture suite (`pytest tests/integration -m "not
      requires_two_clusters"`) sat blocked ~40 min (0.1% CPU) then failed:


      *
      `test_serving_workflow.py::test_deploy_qwen_and_infer_with_strip_thinking`

      * `test_cli_live.py::test_cli_serve_deploy` — llamacpp
      `unsloth/Qwen3-4B-Instruct-2507-GGUF` deploy `TimeoutError` (600s, never
      reached DEPLOYED)

      * `test_context_live.py::*` ×5 ERROR (vectordb)

      * `test_workroom_isolation_live.py`, `test_seeding_live.py` FAILED


      One `llamacpp` deploy went CrashLoopBackOff (resource contention on the 64
      GB CPU node; 3/4 llamacpp came up).


      ## Root cause


      `infra/smoke-rhel9/topologies/dual-single-node.yaml` `defaults` sets
      `edge_markers` but **no per-cluster** `markers:`, so `topology-smoke.sh`'s
      `c_markers` defaults to `not requires_two_clusters` — the **entire**
      single-cluster integration suite (model-serving / context / workroom /
      seeding), which deploys real models a CPU-only node cannot serve within
      timeout.


      ## Fix


      Register a `requires_shared_idp` pytest marker in kamiwaza-sdk and apply
      it to the single-cluster federation identity-gate test, then set
      per-cluster `markers` in the kajiya topology so each cluster runs only the
      suite it can support. Provision heterogeneous hardware (CPU + GPU) so the
      GPU cluster can additionally run the deployable-model inference tests. (No
      `requires_gpu` marker exists in the SDK; capability is expressed via
      `requires_deployable_model` / `requires_embedding_model` / `min_gpu_*`.)


      ## Acceptance Criteria (Definition of Done)


      The per-cluster posture suite must select ONLY the federation posture on
      each cluster, never the broad model-serving/context/workroom suite a CPU
      node cannot serve. Verifiable:


      1. **SDK marker registered + applied.** `requires_shared_idp` is
      registered in `kamiwaza-sdk/pyproject.toml`
      `[tool.pytest.ini_options].markers` (accepted under `--strict-markers`)
      and applied to `tests/integration/test_federation_identity_gate_live.py`
      (single-cluster posture). The two-cluster gated-retrieval suite stays
      untagged (deferred), and the marker description says so.

      2. **Selector correctness.** `pytest tests/integration -m
      "requires_shared_idp and not requires_two_clusters"` collects exactly the
      single-cluster federation identity-gate posture tests and nothing from
      serving/context/workroom/seeding; `-m "requires_shared_idp and
      requires_two_clusters"` collects zero (no two-cluster test tagged yet).

      3. **Per-cluster topology markers.** `kajiya
      infra/smoke-rhel9/topologies/dual-single-node.yaml` sets per-cluster
      `markers`: the CPU cluster runs posture-only (`requires_shared_idp and not
      requires_two_clusters`); the GPU cluster runs posture + inference
      (`(requires_shared_idp or requires_deployable_model) and not
      requires_two_clusters`).

      4. **No CPU model-serving.** In an M2 run, no `requires_deployable_model`
      model-serving test executes on the CPU cluster — so no CrashLoopBackOff /
      600s `TimeoutError` from an unservable deploy, and no ~40-min hang on a
      blocked model deploy.

      5. **M2 posture green.** The M2 provisioned federation smoke's per-cluster
      posture suite passes (pairing prerequisite + identity-gate posture)
      independent of the broad single-cluster integration suite.


      ## Scope


      The fix spans two repos: (a) **kamiwaza-sdk** — register + apply the
      `requires_shared_idp` marker (PR #252); (b) **kajiya** — per-cluster
      `markers` + heterogeneous CPU/GPU `vm_size` in `dual-single-node.yaml`,
      and the provisioner reading per-cluster `vm_size` + topology `location`
      (feat/eng-8554). Out of scope: tagging the two-cluster gated-retrieval
      suite (deferred upstream).


      ## Notes


      M2 CORE passed — provisioning, SDK self-bootstrap, trust-config delivery,
      and shared_idp pairing all validated live (the suite only runs after the
      pairing prereq under `set -e`). This is design risk #2 ("narrow precisely
      if it reddens"). Related: ENG-6504, ENG-6533 (same SDK-e2e-suite
      territory). Run:
      https://github.com/kamiwaza-internal/kajiya/actions/runs/31228555031
    cached_at: 2026-08-08T23:17:37Z
  - id: ENG-8213
    url: https://linear.app/kamiwaza/issue/ENG-8213
    cached_description: |
      ## Symptom

      Mesh data-plane calls by a **PAT-authenticated** caller fail fail-closed:
      `403 peer_jwt_validation_failed: Peer JWT kid='<platform-PAT-key>' not present in peer JWKs`

      ## Root cause (verified, file:line)

      The receiver validates the forwarded mesh identity **only against the peer's Keycloak realm JWKS**, but the mesh forwards the caller's **platform PAT** (`typ=pat`, `iss=<platform-host>`, signed by the platform PAT key at `/api/auth/jwks`) — whose kid is never in the realm JWKS.

      * `kamiwaza/services/auth/peer_jwt.py` — `validate_peer_jwt` derives the JWKS from the token issuer (`jwks_uri_from_issuer`) → **realm JWKS only, no PAT path**.
      * `kamiwaza/services/mesh/services.py:215-256` — extracts the caller's `Bearer` token and forwards it verbatim as `MESH_HEADER_PEER_TOKEN`.
      * ENG-6983 OBO (`obo_exchange_from_env`) cannot rescue it: Keycloak token-exchange rejects a non-KC subject (`invalid_request (Invalid token)`) → falls back to forwarding the raw PAT.

      ## Scope: on `develop` (mainline), NOT introduced by the connector-spec wave

      * `peer_jwt.py` is **byte-identical** on `develop` (`git diff origin/develop...HEAD` = no diff).
      * `develop`'s mesh forwards the raw caller token directly (`services.py:215-256`) and does **not** even call the OBO (ENG-6983 is wave-added), so a PAT fails on `develop` identically. Verified 2026-07-04.

      ## Impact

      PATs are kamiwaza's default long-lived programmatic credential (`Kamiwaza.from_env()` reads `KAMIWAZA_PAT`). Any PAT-authenticated cross-cluster/mesh call fails. **A Keycloak session/offline JWT works** (the OBO succeeds on a KC-JWT subject and mints a valid realm token).

      ## Reproduction

      Two-cluster paired mesh (spark-1 ↔ spark-2); caller authenticates with a platform PAT; mesh data-plane call → `403 peer_jwt_validation_failed`. Reproduced on the fleet at wave tip `fd37238e0`.

      ## Workaround (1.0)

      Authenticate mesh callers with a **Keycloak session or offline token**, not a platform PAT. Ship as a documented 1.0 limitation.

      ## Real fix (1.1 / August)

      Retarget mesh identity onto **receiver-owned realm credentials** — design: `kamiwaza-docs-engineering-internal/docs/specifications/core/federated-identity-isolation/design.md` (branch `design/federated-identity-isolation`), which has been through a 5-lens adversarial security review (§12). The design also documents scoped tactical options (Alt A: receiver validates PATs against the peer **platform** JWKS; Alt B: source converts PAT→KC JWT) if a 1.0 code fix is ever required.

      ## Context

      Found during **M4 T4.3 (ENG-6866)** two-cluster gated-mesh E2E. That E2E is not blocked — it runs under KC-JWT auth; PAT-over-mesh is deferred to 1.1.
    cached_at: 2026-08-08T23:17:37Z
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->