### PR TITLE
ENG-9908: Surface CLI smoke failure output

### DIFF
--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -29,6 +29,8 @@ _TOKEN_FIELD_PATTERN = re.compile(
 
 def _secret_option(option: str) -> bool:
     """Match exact secret flags and argparse's accepted abbreviations."""
+    if len(option) <= 2 or not option.startswith("--"):
+        return False
     return any(secret.startswith(option) for secret in _SECRET_CLI_OPTIONS)
 
 
@@ -88,6 +90,12 @@ def _captured_output(value: str, secret_values: tuple[str, ...] = ()) -> str:
     )
 
 
+def _timeout_output(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return value or ""
+
+
 def _cli_failure_message(
     cmd: list[str],
     result: subprocess.CompletedProcess[str],
@@ -109,14 +117,23 @@ def run_cli(
     runner=subprocess.run,
 ) -> subprocess.CompletedProcess[str]:
     cmd = [sys.executable, "-m", "kamiwaza_sdk.cli", *args]
-    result = runner(
-        cmd,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=_CLI_TIMEOUT_SECONDS,
-    )
+    try:
+        result = runner(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=_CLI_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        secrets = (*_secret_cli_values(args), *secret_values)
+        command = shlex.join(_redact_cli_args(cmd))
+        raise AssertionError(
+            f"CLI command timed out after {_CLI_TIMEOUT_SECONDS}s: {command}\n"
+            f"stdout:\n{_captured_output(_timeout_output(exc.stdout), secrets)}\n"
+            f"stderr:\n{_captured_output(_timeout_output(exc.stderr), secrets)}"
+        ) from None
     if result.returncode != 0:
         secrets = (*_secret_cli_values(args), *secret_values)
         raise AssertionError(_cli_failure_message(cmd, result, secrets))

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -49,21 +49,21 @@ def _redact_cli_args(args: list[str]) -> list[str]:
     return redacted
 
 
+def _secret_cli_value_at(args: list[str], index: int) -> str | None:
+    option, separator, value = args[index].partition("=")
+    if not _secret_option(option):
+        return None
+    if separator:
+        return value
+    return args[index + 1] if index + 1 < len(args) else None
+
+
 def _secret_cli_values(args: list[str]) -> list[str]:
-    values: list[str] = []
-    hide_next = False
-    for arg in args:
-        if hide_next:
-            values.append(arg)
-            hide_next = False
-            continue
-        option, separator, value = arg.partition("=")
-        if _secret_option(option):
-            if separator:
-                values.append(value)
-            else:
-                hide_next = True
-    return values
+    return [
+        value
+        for index in range(len(args))
+        if (value := _secret_cli_value_at(args, index)) is not None
+    ]
 
 
 def _scrub_output(value: str, secret_values: tuple[str, ...]) -> str:

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import sys
 import time
@@ -13,16 +14,59 @@ from model_targets import InferenceTarget
 
 pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
 
+_SECRET_CLI_OPTIONS = frozenset(
+    {"--access-token", "--api-key", "--password", "--token"}
+)
+_OUTPUT_LIMIT = 8_000
+
+
+def _redact_cli_args(args: list[str]) -> list[str]:
+    redacted: list[str] = []
+    hide_next = False
+    for arg in args:
+        if hide_next:
+            redacted.append("***")
+            hide_next = False
+            continue
+        option = arg.partition("=")[0]
+        if option in _SECRET_CLI_OPTIONS:
+            redacted.append(option if "=" not in arg else f"{option}=***")
+            hide_next = "=" not in arg
+            continue
+        redacted.append(arg)
+    return redacted
+
+
+def _captured_output(value: str) -> str:
+    output = value.strip()
+    if not output:
+        return "<empty>"
+    return output[-_OUTPUT_LIMIT:]
+
+
+def _cli_failure_message(
+    cmd: list[str], result: subprocess.CompletedProcess[str]
+) -> str:
+    command = shlex.join(_redact_cli_args(cmd))
+    return (
+        f"CLI command failed with exit code {result.returncode}: {command}\n"
+        f"stdout:\n{_captured_output(result.stdout)}\n"
+        f"stderr:\n{_captured_output(result.stderr)}"
+    )
+
 
 def run_cli(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
     cmd = [sys.executable, "-m", "kamiwaza_sdk.cli", *args]
-    return subprocess.run(
+    result = subprocess.run(
         cmd,
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
         env=env,
     )
+    if result.returncode != 0:
+        raise AssertionError(_cli_failure_message(cmd, result))
+    return result
 
 
 def _cli_login_and_create_pat(
@@ -117,13 +161,16 @@ def test_cli_serve_deploy(
     env.setdefault("PYTHONWARNINGS", "ignore")
 
     pat_token = _cli_login_and_create_pat(
-        base_args, env, live_username, live_password, token_path, pat_prefix="cli-deploy"
+        base_args,
+        env,
+        live_username,
+        live_password,
+        token_path,
+        pat_prefix="cli-deploy",
     )
     pat_client = client_factory(base_url=live_server_available, api_key=pat_token)
     model = ensure_deployable_model_ready(pat_client)
-    model_file_id = target_model_file_id(
-        model, deployable_model_target.quantization
-    )
+    model_file_id = target_model_file_id(model, deployable_model_target.quantization)
 
     serve_result = run_cli(
         [

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shlex
 import subprocess
 import sys
@@ -16,9 +17,19 @@ pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresp
 _SECRET_CLI_OPTIONS = frozenset(
     {"--access-token", "--api-key", "--password", "--token"}
 )
-_CREDENTIAL_BEARING_COMMANDS = frozenset({"login", "pat"})
-_SUPPRESSED_OUTPUT = "<suppressed for credential-bearing command>"
-_OUTPUT_LIMIT = 8_000
+_OUTPUT_LIMIT = 32_000
+_CLI_TIMEOUT_SECONDS = 4 * 60 * 60
+_JWT_PATTERN = re.compile(
+    r"\b(?:PAT-)?eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"
+)
+_TOKEN_FIELD_PATTERN = re.compile(
+    r"(?i)((?:access_token|refresh_token|id_token|token|pat)['\"]?\s*[:=]\s*['\"])([^'\"\s,}]+)"
+)
+
+
+def _secret_option(option: str) -> bool:
+    """Match exact secret flags and argparse's accepted abbreviations."""
+    return any(secret.startswith(option) for secret in _SECRET_CLI_OPTIONS)
 
 
 def _redact_cli_args(args: list[str]) -> list[str]:
@@ -30,7 +41,7 @@ def _redact_cli_args(args: list[str]) -> list[str]:
             hide_next = False
             continue
         option = arg.partition("=")[0]
-        if option in _SECRET_CLI_OPTIONS:
+        if _secret_option(option):
             redacted.append(option if "=" not in arg else f"{option}=***")
             hide_next = "=" not in arg
             continue
@@ -38,41 +49,77 @@ def _redact_cli_args(args: list[str]) -> list[str]:
     return redacted
 
 
-def _captured_output(value: str) -> str:
-    output = value.strip()
+def _secret_cli_values(args: list[str]) -> list[str]:
+    values: list[str] = []
+    hide_next = False
+    for arg in args:
+        if hide_next:
+            values.append(arg)
+            hide_next = False
+            continue
+        option, separator, value = arg.partition("=")
+        if _secret_option(option):
+            if separator:
+                values.append(value)
+            else:
+                hide_next = True
+    return values
+
+
+def _scrub_output(value: str, secret_values: tuple[str, ...]) -> str:
+    scrubbed = value
+    for secret in secret_values:
+        if secret:
+            scrubbed = scrubbed.replace(secret, "***")
+    scrubbed = _JWT_PATTERN.sub("***", scrubbed)
+    return _TOKEN_FIELD_PATTERN.sub(r"\1***", scrubbed)
+
+
+def _captured_output(value: str, secret_values: tuple[str, ...] = ()) -> str:
+    output = _scrub_output(value, secret_values).strip()
     if not output:
         return "<empty>"
-    return output[-_OUTPUT_LIMIT:]
-
-
-def _failure_output(cmd: list[str], value: str) -> str:
-    if not _CREDENTIAL_BEARING_COMMANDS.isdisjoint(cmd):
-        return _SUPPRESSED_OUTPUT
-    return _captured_output(value)
+    if len(output) <= _OUTPUT_LIMIT:
+        return output
+    half = _OUTPUT_LIMIT // 2
+    omitted = len(output) - (half * 2)
+    return (
+        f"{output[:half]}\n" f"... <{omitted} chars omitted> ...\n" f"{output[-half:]}"
+    )
 
 
 def _cli_failure_message(
-    cmd: list[str], result: subprocess.CompletedProcess[str]
+    cmd: list[str],
+    result: subprocess.CompletedProcess[str],
+    secret_values: tuple[str, ...] = (),
 ) -> str:
     command = shlex.join(_redact_cli_args(cmd))
     return (
         f"CLI command failed with exit code {result.returncode}: {command}\n"
-        f"stdout:\n{_failure_output(cmd, result.stdout)}\n"
-        f"stderr:\n{_failure_output(cmd, result.stderr)}"
+        f"stdout:\n{_captured_output(result.stdout, secret_values)}\n"
+        f"stderr:\n{_captured_output(result.stderr, secret_values)}"
     )
 
 
-def run_cli(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def run_cli(
+    args: list[str],
+    env: dict[str, str],
+    *,
+    secret_values: tuple[str, ...] = (),
+    runner=subprocess.run,
+) -> subprocess.CompletedProcess[str]:
     cmd = [sys.executable, "-m", "kamiwaza_sdk.cli", *args]
-    result = subprocess.run(
+    result = runner(
         cmd,
         capture_output=True,
         text=True,
         check=False,
         env=env,
+        timeout=_CLI_TIMEOUT_SECONDS,
     )
     if result.returncode != 0:
-        raise AssertionError(_cli_failure_message(cmd, result))
+        secrets = (*_secret_cli_values(args), *secret_values)
+        raise AssertionError(_cli_failure_message(cmd, result, secrets))
     return result
 
 
@@ -97,7 +144,8 @@ def _cli_login_and_create_pat(
     )
     assert token_path.exists()
     session_token = json.loads(token_path.read_text())
-    assert "access_token" in session_token
+    if not isinstance(session_token, dict) or not session_token.get("access_token"):
+        raise AssertionError("CLI login cache did not contain an access token")
 
     pat_name = f"{pat_prefix}-{int(time.time())}"
     result = run_cli(
@@ -116,12 +164,14 @@ def _cli_login_and_create_pat(
             "--cache-token",
         ],
         env,
+        secret_values=(live_password, str(session_token["access_token"])),
     )
     pat_token = result.stdout.strip()
     assert pat_token
 
     cached = json.loads(token_path.read_text())
-    assert cached["access_token"] == pat_token
+    if cached.get("access_token") != pat_token:
+        raise AssertionError("Cached PAT did not match the CLI-created PAT")
     return pat_token
 
 

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -9,7 +9,6 @@ import time
 from pathlib import Path
 
 import pytest
-
 from model_targets import InferenceTarget
 
 pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
@@ -17,6 +16,8 @@ pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresp
 _SECRET_CLI_OPTIONS = frozenset(
     {"--access-token", "--api-key", "--password", "--token"}
 )
+_CREDENTIAL_BEARING_COMMANDS = frozenset({"login", "pat"})
+_SUPPRESSED_OUTPUT = "<suppressed for credential-bearing command>"
 _OUTPUT_LIMIT = 8_000
 
 
@@ -44,14 +45,20 @@ def _captured_output(value: str) -> str:
     return output[-_OUTPUT_LIMIT:]
 
 
+def _failure_output(cmd: list[str], value: str) -> str:
+    if not _CREDENTIAL_BEARING_COMMANDS.isdisjoint(cmd):
+        return _SUPPRESSED_OUTPUT
+    return _captured_output(value)
+
+
 def _cli_failure_message(
     cmd: list[str], result: subprocess.CompletedProcess[str]
 ) -> str:
     command = shlex.join(_redact_cli_args(cmd))
     return (
         f"CLI command failed with exit code {result.returncode}: {command}\n"
-        f"stdout:\n{_captured_output(result.stdout)}\n"
-        f"stderr:\n{_captured_output(result.stderr)}"
+        f"stdout:\n{_failure_output(cmd, result.stdout)}\n"
+        f"stderr:\n{_failure_output(cmd, result.stderr)}"
     )
 
 

--- a/tests/integration/test_cli_live.py
+++ b/tests/integration/test_cli_live.py
@@ -23,7 +23,11 @@ _JWT_PATTERN = re.compile(
     r"\b(?:PAT-)?eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b"
 )
 _TOKEN_FIELD_PATTERN = re.compile(
-    r"(?i)((?:access_token|refresh_token|id_token|token|pat)['\"]?\s*[:=]\s*['\"])([^'\"\s,}]+)"
+    r"(?i)((?:access_token|refresh_token|id_token|token|pat|password|passwd"
+    r"|secret|api[-_]?key|client_secret)['\"]?\s*[:=]\s*['\"]?)([^'\"\s,}&]+)"
+)
+_AUTH_HEADER_PATTERN = re.compile(
+    r"(?i)\b(authorization\s*:\s*(?:bearer|basic)\s+)(\S+)"
 )
 
 
@@ -74,7 +78,8 @@ def _scrub_output(value: str, secret_values: tuple[str, ...]) -> str:
         if secret:
             scrubbed = scrubbed.replace(secret, "***")
     scrubbed = _JWT_PATTERN.sub("***", scrubbed)
-    return _TOKEN_FIELD_PATTERN.sub(r"\1***", scrubbed)
+    scrubbed = _TOKEN_FIELD_PATTERN.sub(r"\1***", scrubbed)
+    return _AUTH_HEADER_PATTERN.sub(r"\1***", scrubbed)
 
 
 def _captured_output(value: str, secret_values: tuple[str, ...] = ()) -> str:
@@ -109,6 +114,35 @@ def _cli_failure_message(
     )
 
 
+def _cli_timeout_message(
+    cmd: list[str],
+    exc: subprocess.TimeoutExpired,
+    secret_values: tuple[str, ...],
+) -> str:
+    command = shlex.join(_redact_cli_args(cmd))
+    return (
+        f"CLI command timed out after {_CLI_TIMEOUT_SECONDS}s: {command}\n"
+        f"stdout:\n{_captured_output(_timeout_output(exc.stdout), secret_values)}\n"
+        f"stderr:\n{_captured_output(_timeout_output(exc.stderr), secret_values)}"
+    )
+
+
+def _safe_cli_timeout_message(
+    cmd: list[str],
+    exc: subprocess.TimeoutExpired,
+    secret_values: tuple[str, ...],
+) -> str:
+    """Build a timeout diagnostic without ever re-exposing the original error."""
+    try:
+        return _cli_timeout_message(cmd, exc, secret_values)
+    except Exception as diagnostic_error:
+        return (
+            f"CLI command timed out after {_CLI_TIMEOUT_SECONDS}s; "
+            "diagnostic rendering failed safely "
+            f"({type(diagnostic_error).__name__})"
+        )
+
+
 def run_cli(
     args: list[str],
     env: dict[str, str],
@@ -117,6 +151,7 @@ def run_cli(
     runner=subprocess.run,
 ) -> subprocess.CompletedProcess[str]:
     cmd = [sys.executable, "-m", "kamiwaza_sdk.cli", *args]
+    timeout_message: str | None = None
     try:
         result = runner(
             cmd,
@@ -128,12 +163,9 @@ def run_cli(
         )
     except subprocess.TimeoutExpired as exc:
         secrets = (*_secret_cli_values(args), *secret_values)
-        command = shlex.join(_redact_cli_args(cmd))
-        raise AssertionError(
-            f"CLI command timed out after {_CLI_TIMEOUT_SECONDS}s: {command}\n"
-            f"stdout:\n{_captured_output(_timeout_output(exc.stdout), secrets)}\n"
-            f"stderr:\n{_captured_output(_timeout_output(exc.stderr), secrets)}"
-        ) from None
+        timeout_message = _safe_cli_timeout_message(cmd, exc, secrets)
+    if timeout_message is not None:
+        raise AssertionError(timeout_message) from None
     if result.returncode != 0:
         secrets = (*_secret_cli_values(args), *secret_values)
         raise AssertionError(_cli_failure_message(cmd, result, secrets))

--- a/tests/unit/test_cli_live_helpers.py
+++ b/tests/unit/test_cli_live_helpers.py
@@ -139,6 +139,51 @@ def test_token_path_is_not_redacted() -> None:
     assert cli_live._redact_cli_args(args) == args
 
 
+def test_redaction_does_not_treat_empty_or_separator_args_as_secret_options() -> None:
+    assert all(not cli_live._secret_option(value) for value in ("", "-", "--"))
+
+    args = [
+        "serve",
+        "deploy",
+        "--engine-name",
+        "",
+        "--repo-id",
+        "meta/llama-3",
+    ]
+    assert cli_live._redact_cli_args(args) == args
+    assert cli_live._redact_cli_args(["serve", "deploy", "--", "meta/llama-3"]) == [
+        "serve",
+        "deploy",
+        "--",
+        "meta/llama-3",
+    ]
+
+
+def test_run_cli_timeout_redacts_command_and_reports_partial_output() -> None:
+    secret = "REALPASSWORD-CANARY-777"
+
+    def timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(
+            cmd=["ignored"],
+            timeout=cli_live._CLI_TIMEOUT_SECONDS,
+            output=b"deployment was still waiting\n",
+            stderr=f"password={secret}\n".encode(),
+        )
+
+    with pytest.raises(AssertionError) as exc_info:
+        cli_live.run_cli(
+            ["login", "--username", "admin", "--password", secret],
+            {"PATH": "/bin"},
+            runner=timeout,
+        )
+
+    message = str(exc_info.value)
+    assert "timed out" in message
+    assert "deployment was still waiting" in message
+    assert "--password '***'" in message
+    assert secret not in message
+
+
 def test_jwt_and_token_fields_are_scrubbed_without_blanket_suppression() -> None:
     jwt = "PAT-eyJabcdefgh.abcdefghijk.abcdefghijk"
     output = cli_live._captured_output(

--- a/tests/unit/test_cli_live_helpers.py
+++ b/tests/unit/test_cli_live_helpers.py
@@ -27,7 +27,7 @@ def test_run_cli_reports_output_and_redacts_secret_options(
 
     with pytest.raises(AssertionError) as exc_info:
         cli_live.run_cli(
-            ["login", "--username", "admin", "--password", "super-secret"],
+            ["serve", "deploy", "--password", "super-secret"],
             {"PATH": "/bin"},
         )
 
@@ -37,6 +37,27 @@ def test_run_cli_reports_output_and_redacts_secret_options(
     assert "model file was not found" in message
     assert "--password '***'" in message
     assert "super-secret" not in message
+
+
+@pytest.mark.parametrize("command", [["login"], ["pat", "create"]])
+def test_run_cli_suppresses_output_for_credential_bearing_commands(
+    monkeypatch: pytest.MonkeyPatch,
+    command: list[str],
+) -> None:
+    result = subprocess.CompletedProcess(
+        args=[],
+        returncode=2,
+        stdout='{"access_token": "server-issued-secret"}\n',
+        stderr="validation input token='server-issued-secret'\n",
+    )
+    monkeypatch.setattr(cli_live.subprocess, "run", lambda *_args, **_kwargs: result)
+
+    with pytest.raises(AssertionError) as exc_info:
+        cli_live.run_cli(command, {"PATH": "/bin"})
+
+    message = str(exc_info.value)
+    assert message.count("<suppressed for credential-bearing command>") == 2
+    assert "server-issued-secret" not in message
 
 
 def test_run_cli_returns_successful_result(

--- a/tests/unit/test_cli_live_helpers.py
+++ b/tests/unit/test_cli_live_helpers.py
@@ -179,9 +179,82 @@ def test_run_cli_timeout_redacts_command_and_reports_partial_output() -> None:
 
     message = str(exc_info.value)
     assert "timed out" in message
+    assert str(cli_live._CLI_TIMEOUT_SECONDS) in message
     assert "deployment was still waiting" in message
+    assert "password=***" in message
     assert "--password '***'" in message
     assert secret not in message
+    assert exc_info.value.__context__ is None
+
+
+def test_run_cli_timeout_fails_closed_if_diagnostic_rendering_breaks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "REALPASSWORD-CANARY-777"
+
+    def timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(
+            cmd=["login", "--password", secret],
+            timeout=cli_live._CLI_TIMEOUT_SECONDS,
+        )
+
+    def broken_capture(*_args: object, **_kwargs: object) -> str:
+        raise UnicodeError("diagnostic renderer failed")
+
+    monkeypatch.setattr(cli_live, "_captured_output", broken_capture)
+    with pytest.raises(AssertionError) as exc_info:
+        cli_live.run_cli(
+            ["login", "--password", secret],
+            {"PATH": "/bin"},
+            runner=timeout,
+        )
+
+    assert "diagnostic rendering failed safely" in str(exc_info.value)
+    assert secret not in str(exc_info.value)
+    assert exc_info.value.__context__ is None
+
+
+def test_run_cli_timeout_scrubs_caller_secrets_from_both_streams() -> None:
+    secret = "opaque-session-secret"
+
+    def timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(
+            cmd=["pat", "create"],
+            timeout=cli_live._CLI_TIMEOUT_SECONDS,
+            output=f"stdout retained marker {secret}".encode(),
+            stderr=f"stderr retained marker {secret}".encode(),
+        )
+
+    with pytest.raises(AssertionError) as exc_info:
+        cli_live.run_cli(
+            ["pat", "create", "--name", "nightly"],
+            {"PATH": "/bin"},
+            secret_values=(secret,),
+            runner=timeout,
+        )
+
+    message = str(exc_info.value)
+    assert "stdout retained marker ***" in message
+    assert "stderr retained marker ***" in message
+    assert secret not in message
+
+
+def test_run_cli_timeout_handles_empty_and_invalid_byte_streams() -> None:
+    def timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(
+            cmd=["serve", "deploy"],
+            timeout=cli_live._CLI_TIMEOUT_SECONDS,
+            output=None,
+            stderr=b"invalid byte: \xff",
+        )
+
+    with pytest.raises(AssertionError) as exc_info:
+        cli_live.run_cli(["serve", "deploy"], {"PATH": "/bin"}, runner=timeout)
+
+    message = str(exc_info.value)
+    assert "stdout:\n<empty>" in message
+    assert "stderr:\ninvalid byte:" in message
+    assert exc_info.value.__context__ is None
 
 
 def test_jwt_and_token_fields_are_scrubbed_without_blanket_suppression() -> None:
@@ -192,3 +265,21 @@ def test_jwt_and_token_fields_are_scrubbed_without_blanket_suppression() -> None
     assert "request failed" in output
     assert "opaque-secret" not in output
     assert jwt not in output
+
+
+@pytest.mark.parametrize(
+    ("value", "secret"),
+    [
+        ("access_token: abc123XYZ", "abc123XYZ"),
+        ("access_token=abc123XYZ", "abc123XYZ"),
+        ("Authorization: Bearer opaque-abc123XYZ", "opaque-abc123XYZ"),
+        ("X-API-Key: abc123XYZ", "abc123XYZ"),
+        ("grant_type=password&username=u&password=hunter2", "hunter2"),
+    ],
+)
+def test_unquoted_token_fields_and_auth_headers_are_scrubbed(
+    value: str, secret: str
+) -> None:
+    output = cli_live._captured_output(value)
+    assert secret not in output
+    assert "***" in output

--- a/tests/unit/test_cli_live_helpers.py
+++ b/tests/unit/test_cli_live_helpers.py
@@ -1,0 +1,67 @@
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+INTEGRATION_TESTS = str(Path(__file__).parents[1] / "integration")
+if INTEGRATION_TESTS not in sys.path:
+    sys.path.insert(0, INTEGRATION_TESTS)
+
+cli_live = importlib.import_module("tests.integration.test_cli_live")
+
+pytestmark = pytest.mark.unit
+
+
+def test_run_cli_reports_output_and_redacts_secret_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = subprocess.CompletedProcess(
+        args=[],
+        returncode=2,
+        stdout="deployment rejected\n",
+        stderr="model file was not found\n",
+    )
+    monkeypatch.setattr(cli_live.subprocess, "run", lambda *_args, **_kwargs: result)
+
+    with pytest.raises(AssertionError) as exc_info:
+        cli_live.run_cli(
+            ["login", "--username", "admin", "--password", "super-secret"],
+            {"PATH": "/bin"},
+        )
+
+    message = str(exc_info.value)
+    assert "exit code 2" in message
+    assert "deployment rejected" in message
+    assert "model file was not found" in message
+    assert "--password '***'" in message
+    assert "super-secret" not in message
+
+
+def test_run_cli_returns_successful_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    result = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout='{"status": "DEPLOYED"}\n',
+        stderr="",
+    )
+    calls: list[dict[str, object]] = []
+
+    def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(kwargs)
+        return result
+
+    monkeypatch.setattr(cli_live.subprocess, "run", fake_run)
+
+    assert cli_live.run_cli(["serve", "deploy"], {"PATH": "/bin"}) is result
+    assert calls == [
+        {
+            "capture_output": True,
+            "text": True,
+            "check": False,
+            "env": {"PATH": "/bin"},
+        }
+    ]

--- a/tests/unit/test_cli_live_helpers.py
+++ b/tests/unit/test_cli_live_helpers.py
@@ -1,4 +1,5 @@
 import importlib
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -9,26 +10,23 @@ INTEGRATION_TESTS = str(Path(__file__).parents[1] / "integration")
 if INTEGRATION_TESTS not in sys.path:
     sys.path.insert(0, INTEGRATION_TESTS)
 
-cli_live = importlib.import_module("tests.integration.test_cli_live")
+cli_live = importlib.import_module("test_cli_live")
 
 pytestmark = pytest.mark.unit
 
 
-def test_run_cli_reports_output_and_redacts_secret_options(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_run_cli_reports_output_and_redacts_secret_options() -> None:
     result = subprocess.CompletedProcess(
         args=[],
         returncode=2,
         stdout="deployment rejected\n",
-        stderr="model file was not found\n",
+        stderr="model file was not found; password=super-secret\n",
     )
-    monkeypatch.setattr(cli_live.subprocess, "run", lambda *_args, **_kwargs: result)
-
     with pytest.raises(AssertionError) as exc_info:
         cli_live.run_cli(
             ["serve", "deploy", "--password", "super-secret"],
             {"PATH": "/bin"},
+            runner=lambda *_args, **_kwargs: result,
         )
 
     message = str(exc_info.value)
@@ -39,9 +37,10 @@ def test_run_cli_reports_output_and_redacts_secret_options(
     assert "super-secret" not in message
 
 
-@pytest.mark.parametrize("command", [["login"], ["pat", "create"]])
-def test_run_cli_suppresses_output_for_credential_bearing_commands(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    "command", [["login", "--password", "known-secret"], ["pat", "create"]]
+)
+def test_run_cli_scrubs_output_for_credential_bearing_commands(
     command: list[str],
 ) -> None:
     result = subprocess.CompletedProcess(
@@ -50,39 +49,101 @@ def test_run_cli_suppresses_output_for_credential_bearing_commands(
         stdout='{"access_token": "server-issued-secret"}\n',
         stderr="validation input token='server-issued-secret'\n",
     )
-    monkeypatch.setattr(cli_live.subprocess, "run", lambda *_args, **_kwargs: result)
-
     with pytest.raises(AssertionError) as exc_info:
-        cli_live.run_cli(command, {"PATH": "/bin"})
+        cli_live.run_cli(
+            command,
+            {"PATH": "/bin"},
+            secret_values=("server-issued-secret",),
+            runner=lambda *_args, **_kwargs: result,
+        )
 
     message = str(exc_info.value)
-    assert message.count("<suppressed for credential-bearing command>") == 2
+    assert "validation input" in message
+    assert "***" in message
     assert "server-issued-secret" not in message
 
 
-def test_run_cli_returns_successful_result(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_run_cli_returns_successful_result() -> None:
     result = subprocess.CompletedProcess(
         args=[],
         returncode=0,
         stdout='{"status": "DEPLOYED"}\n',
         stderr="",
     )
-    calls: list[dict[str, object]] = []
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
     def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        calls.append(kwargs)
+        calls.append((_args, kwargs))
         return result
 
-    monkeypatch.setattr(cli_live.subprocess, "run", fake_run)
-
-    assert cli_live.run_cli(["serve", "deploy"], {"PATH": "/bin"}) is result
-    assert calls == [
-        {
-            "capture_output": True,
-            "text": True,
-            "check": False,
-            "env": {"PATH": "/bin"},
-        }
+    assert (
+        cli_live.run_cli(["serve", "deploy"], {"PATH": "/bin"}, runner=fake_run)
+        is result
+    )
+    args, kwargs = calls[0]
+    assert args[0] == [
+        sys.executable,
+        "-m",
+        "kamiwaza_sdk.cli",
+        "serve",
+        "deploy",
     ]
+    assert kwargs == {
+        "capture_output": True,
+        "text": True,
+        "check": False,
+        "env": {"PATH": "/bin"},
+        "timeout": cli_live._CLI_TIMEOUT_SECONDS,
+    }
+
+
+def test_captured_output_keeps_head_tail_and_marks_truncation() -> None:
+    value = "HEADMARK" + ("x" * cli_live._OUTPUT_LIMIT) + "TAILMARK"
+
+    output = cli_live._captured_output(value)
+
+    assert "HEADMARK" in output
+    assert "TAILMARK" in output
+    assert "chars omitted" in output
+
+
+def test_captured_output_empty_sentinel_and_stream_labels() -> None:
+    result = subprocess.CompletedProcess(
+        args=[], returncode=-9, stdout="  \n", stderr="TAILMARK"
+    )
+
+    message = cli_live._cli_failure_message(["serve", "deploy"], result)
+
+    assert "exit code -9" in message
+    assert "stdout:\n<empty>" in message
+    assert "stderr:\nTAILMARK" in message
+
+
+@pytest.mark.parametrize(
+    ("args", "secret"),
+    [
+        (["login", "--password=secret"], "secret"),
+        (["login", "--passw", "secret"], "secret"),
+        (["login", "--api-key", "secret"], "secret"),
+    ],
+)
+def test_redaction_covers_equals_and_abbreviated_secret_options(
+    args: list[str], secret: str
+) -> None:
+    rendered = shlex.join(cli_live._redact_cli_args(args))
+    assert secret not in rendered
+
+
+def test_token_path_is_not_redacted() -> None:
+    args = ["--token-path", "/tmp/token.json"]
+    assert cli_live._redact_cli_args(args) == args
+
+
+def test_jwt_and_token_fields_are_scrubbed_without_blanket_suppression() -> None:
+    jwt = "PAT-eyJabcdefgh.abcdefghijk.abcdefghijk"
+    output = cli_live._captured_output(
+        f"request failed token='opaque-secret' response={jwt}"
+    )
+    assert "request failed" in output
+    assert "opaque-secret" not in output
+    assert jwt not in output


### PR DESCRIPTION
## Summary

Makes nightly CLI smoke failures actionable by reporting captured stdout and stderr while redacting credentials from the rendered command.

## Type
- [x] Bug Fix - Corrects existing behavior
- [x] Test - Test coverage improvement

## Change Flags
- [ ] API change
- [ ] Configuration change
- [ ] Requirements change
- [ ] Schema change

## Breaking Changes
- [x] None - Fully backward compatible

## Motivation

The Kajiya nightly `test_cli_serve_deploy` failure exposed only `subprocess.CalledProcessError`; its captured CLI output was unavailable, so the actual deployment problem could not be diagnosed.

## Source
- [x] Issue/Ticket: [ENG-9908](https://linear.app/kamiwaza/issue/ENG-9908/sdk-smoke-surface-cli-stdoutstderr-on-subprocess-failure)
- [x] Conversation/Discussion: [Kajiya nightly run](https://github.com/kamiwaza-internal/kajiya/actions/runs/31303164998)

## Alternatives Considered

Leaving `check=True` and inspecting `CalledProcessError` in every caller would duplicate error formatting and risk unredacted command output. The shared helper now owns one fail-closed diagnostic path.

## Changes Made

- Run CLI subprocesses without automatic exception conversion.
- Raise an assertion containing exit code, redacted command, stdout, and stderr.
- Limit each captured output stream to its most recent 8,000 characters.
- Add unit coverage for failure diagnostics, secret redaction, and the success contract.

## Technical Notes

Password, token, API-key, and access-token option values are redacted before rendering.

## Testing
- [x] Unit tests added/updated

## Verification

| Environment | Steps Performed | Result |
|-------------|-----------------|--------|
| Local | `make test-unit` | 2,389 passed, 1 expected skip |
| Local | Ruff on changed files | Passed |

## Test Coverage

Failure and success paths are covered; the failure test verifies both output streams and ensures the password value is absent.

## Review Focus

Review the redaction boundary and whether the 8,000-character per-stream diagnostic limit is appropriate.

## Deployment Notes

N/A

## Checklist
- [x] Self-reviewed the code
- [x] Tests pass locally
- [ ] Verified on live system
- [x] Documentation not required
