### PR TITLE
test(e2e): opt-in evidence emitter — existing suite emits scenario-evidence.v2 (ENG-10026)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,7 @@ collated.txt
 tests/integration/catalog_stack/data/
 .env.local
 
+# scenario-evidence.v2 records emitted by --emit-evidence (ENG-10026, T3.7)
+tests/e2e/evidence-out/
+
 handroll/

--- a/conftest.py
+++ b/conftest.py
@@ -3,7 +3,19 @@ from __future__ import annotations
 import pytest
 
 from _kamiwaza_pytest_options import add_live_options
+from tests.e2e import _evidence_emitter
+
+# pytester powers the in-process pytest runs in
+# tests/e2e/test_evidence_emitter.py (ENG-10026).
+pytest_plugins = ["pytester"]
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     add_live_options(parser)
+    _evidence_emitter.add_evidence_options(parser)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    # Opt-in scenario-evidence.v2 emission (--emit-evidence); no-op without
+    # the flag, refuses without a build identity.
+    _evidence_emitter.maybe_register(config)

--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,9 @@ from _kamiwaza_pytest_options import add_live_options
 from tests.e2e import _evidence_emitter
 
 # pytester powers the in-process pytest runs in
-# tests/e2e/test_evidence_emitter.py (ENG-10026).
+# tests/e2e/test_evidence_emitter.py (ENG-10026). It has to live here, not
+# beside those tests: pytest only honors `pytest_plugins` in the rootdir
+# conftest, so repo-wide registration is a requirement, not a preference.
 pytest_plugins = ["pytester"]
 
 

--- a/tests/e2e/_evidence_emitter.py
+++ b/tests/e2e/_evidence_emitter.py
@@ -186,6 +186,14 @@ def _parse_entry(item: object, i: int, *, source: str) -> MapEntry:
 
 def _require_entry_keys(item: dict, i: int, *, source: str) -> None:
     keys = set(item)
+    # YAML happily yields non-string keys (`1:`, `true:`). Reject them before
+    # the sorted() calls below, which would raise TypeError comparing them
+    # against the required string keys and escape the UsageError contract.
+    if not all(isinstance(k, str) for k in keys):
+        raise ValueError(
+            f"{source}: entry[{i}] keys must all be strings; "
+            f"got {sorted(map(repr, keys))}"
+        )
     unexpected = sorted(
         (keys - _REQUIRED_ENTRY_KEYS - _OPTIONAL_ENTRY_KEYS)
         | (_REQUIRED_ENTRY_KEYS - keys)

--- a/tests/e2e/_evidence_emitter.py
+++ b/tests/e2e/_evidence_emitter.py
@@ -4,8 +4,8 @@ ENG-10026 (T3.7): with ``--emit-evidence`` AND a build identity
 (``--build`` / ``KAMIWAZA_BUILD``), this pytest plugin groups the run's
 test outcomes by the reviewed entries in ``tests/e2e/capability_map.yaml``
 and, after the session, writes one ``scenario-evidence.v2`` record per
-entry that saw at least one matched test actually run, into
-``tests/e2e/evidence-out/`` (gitignored). Records carry
+entry that saw at least one matched test run to a non-skipped outcome,
+into ``tests/e2e/evidence-out/`` (gitignored). Records carry
 ``evidence_provenance: "pre-existing"`` — they harvest what the existing
 suite already demonstrates; they do not author new coverage.
 
@@ -17,12 +17,27 @@ Guarantees:
   (``pytest.UsageError``), mirroring the scenario harness's G1 stance:
   evidence that does not name its build is not evidence.
 * Mapping is explicit, never inferred: a test matched by no map entry
-  emits nothing, and a map entry none of whose tests ran emits nothing.
+  emits nothing, and a map entry none of whose tests ran — or whose
+  tests all skipped — emits nothing.
 * Status derivation reuses :func:`harness.derive_status` — every matched
   test becomes one step; all passed → ``passed``, any failure →
   ``failed``, green-with-skips → ``passed_with_notes``.
 * Every record is validated with :func:`harness.validate_evidence_record`
   (the vendored-schema mirror) before it is written.
+
+Because a partial run emits from whatever subset of an entry's tests
+actually ran, three rules keep "nothing failed" from masquerading as
+"the capability is evidenced":
+
+* Only tests that reached a *terminal* report contribute a step. A test
+  whose setup passed but whose call never reported (the session died
+  mid-test) is dropped rather than counted as ``passed``.
+* An aborted session — Ctrl-C, ``-x``, internal error — writes **no**
+  records at all: its coverage is unknowable, so no claim is honest.
+* An entry whose matched tests all *skipped* emits nothing. Runtime skips
+  are the normal outcome on an under-provisioned host, and
+  ``passed_with_notes`` over an all-skipped set would claim evidence the
+  run never produced.
 """
 
 from __future__ import annotations
@@ -50,8 +65,22 @@ MARKER_PREFIX = "marker:"
 # itself; human sign-off happens downstream on the kit side.
 SIGN_OFF_ACTOR = "automated e2e suite (pre-existing evidence)"
 
-_ENTRY_KEYS = frozenset({"pattern", "capability_ids", "scenario_name"})
+_REQUIRED_ENTRY_KEYS = frozenset({"pattern", "capability_ids", "scenario_name"})
+_OPTIONAL_ENTRY_KEYS = frozenset({"exclude"})
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+# Exit codes that mean the run did not finish the work it was asked to do.
+_ABORTED_EXIT_CODES = frozenset(
+    {
+        int(pytest.ExitCode.INTERRUPTED),
+        int(pytest.ExitCode.INTERNAL_ERROR),
+        int(pytest.ExitCode.USAGE_ERROR),
+    }
+)
+ABORTED_RUN_MESSAGE = (
+    "evidence emitter: run was interrupted or stopped early — no "
+    "scenario-evidence records written (an aborted run's coverage is unknown)."
+)
 
 
 def slugify(name: str) -> str:
@@ -61,17 +90,29 @@ def slugify(name: str) -> str:
 
 @dataclass(frozen=True)
 class MapEntry:
-    """One reviewed mapping: a nodeid glob / marker → capability ids."""
+    """One reviewed mapping: a nodeid glob / marker → capability ids.
+
+    ``exclude`` carves nodeid globs back out of a broad ``pattern`` so that
+    every test the entry still matches is one that, on its own, exercises
+    the capability — negative-path and availability-only tests must not be
+    able to stand in as evidence for it.
+    """
 
     pattern: str
     scenario_name: str
     capability_ids: tuple[str, ...]
+    exclude: tuple[str, ...] = ()
 
     @property
     def scenario_id(self) -> str:
         return slugify(self.scenario_name)
 
     def matches(self, item: pytest.Item) -> bool:
+        if not self._matches_pattern(item):
+            return False
+        return not any(fnmatchcase(item.nodeid, glob) for glob in self.exclude)
+
+    def _matches_pattern(self, item: pytest.Item) -> bool:
         if self.pattern.startswith(MARKER_PREFIX):
             marker = self.pattern[len(MARKER_PREFIX) :]
             return item.get_closest_marker(marker) is not None
@@ -82,7 +123,12 @@ def load_capability_map(path: Path) -> list[MapEntry]:
     """Parse and validate the explicit capability map. Raises ``ValueError``."""
     if not path.is_file():
         raise ValueError(f"capability map not found: {path}")
-    raw = yaml.safe_load(path.read_text()) or []
+    try:
+        raw = yaml.safe_load(path.read_text()) or []
+    except yaml.YAMLError as exc:
+        # Surfaces as the same UsageError refusal as any other bad map,
+        # instead of a raw pytest_configure traceback.
+        raise ValueError(f"{path.name}: invalid YAML: {exc}") from None
     if not isinstance(raw, list):
         raise ValueError(f"{path.name}: top level must be a list of entries")
     entries = [_parse_entry(item, i, source=path.name) for i, item in enumerate(raw)]
@@ -93,11 +139,7 @@ def load_capability_map(path: Path) -> list[MapEntry]:
 def _parse_entry(item: object, i: int, *, source: str) -> MapEntry:
     if not isinstance(item, dict):
         raise ValueError(f"{source}: entry[{i}] must be a mapping")
-    if set(item) != _ENTRY_KEYS:
-        raise ValueError(
-            f"{source}: entry[{i}] must have exactly the keys "
-            f"{sorted(_ENTRY_KEYS)}; got {sorted(item)}"
-        )
+    _require_entry_keys(item, i, source=source)
     _require_non_empty_str(item["pattern"], f"entry[{i}].pattern", source=source)
     _require_non_empty_str(
         item["scenario_name"], f"entry[{i}].scenario_name", source=source
@@ -107,7 +149,30 @@ def _parse_entry(item: object, i: int, *, source: str) -> MapEntry:
         pattern=item["pattern"],
         scenario_name=item["scenario_name"],
         capability_ids=cap_ids,
+        exclude=_parse_exclude(item.get("exclude", []), i, source=source),
     )
+
+
+def _require_entry_keys(item: dict, i: int, *, source: str) -> None:
+    keys = set(item)
+    unexpected = sorted(
+        (keys - _REQUIRED_ENTRY_KEYS - _OPTIONAL_ENTRY_KEYS)
+        | (_REQUIRED_ENTRY_KEYS - keys)
+    )
+    if unexpected:
+        raise ValueError(
+            f"{source}: entry[{i}] must have exactly the keys "
+            f"{sorted(_REQUIRED_ENTRY_KEYS)} (optionally "
+            f"{sorted(_OPTIONAL_ENTRY_KEYS)}); got {sorted(keys)}"
+        )
+
+
+def _parse_exclude(value: object, i: int, *, source: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{source}: entry[{i}].exclude must be a list of nodeid globs")
+    for j, glob in enumerate(value):
+        _require_non_empty_str(glob, f"entry[{i}].exclude[{j}]", source=source)
+    return tuple(value)
 
 
 def _require_non_empty_str(value: object, label: str, *, source: str) -> None:
@@ -203,6 +268,7 @@ class _TestOutcome:
 
     status: str = "passed"
     duration_s: float = 0.0
+    complete: bool = False
 
     def fold(self, report: pytest.TestReport) -> None:
         self.duration_s += report.duration
@@ -210,6 +276,23 @@ class _TestOutcome:
             self.status = "failed"
         elif report.skipped and self.status != "failed":
             self.status = "skipped"
+        if _is_terminal(report):
+            self.complete = True
+
+
+def _is_terminal(report: pytest.TestReport) -> bool:
+    """True once this report settles the test's outcome.
+
+    A ``call`` report always settles it. A ``setup`` report settles it only
+    when it failed or skipped, because the call phase never runs in that
+    case. A *passing* setup with no call report means the session died
+    mid-test — ``status`` still reads ``"passed"`` there, so such a test must
+    not be counted as evidence.
+    """
+    when = getattr(report, "when", "call")
+    if when == "call":
+        return True
+    return when == "setup" and not report.passed
 
 
 class EvidenceEmitterPlugin:
@@ -236,20 +319,25 @@ class EvidenceEmitterPlugin:
             return
         self._outcomes.setdefault(report.nodeid, _TestOutcome()).fold(report)
 
-    def pytest_sessionfinish(self, session: pytest.Session) -> None:
+    def pytest_sessionfinish(self, session: pytest.Session, exitstatus: int) -> None:
+        if _run_was_aborted(session, exitstatus):
+            _warn_aborted(session)
+            return
         finished_at = _utc_now_iso()
         for entry in self._entries:
             steps = self._steps_for(entry)
-            if steps:
+            if _is_evidence(steps):
                 self._write_record(entry, steps, finished_at)
 
     def _steps_for(self, entry: MapEntry) -> list[harness.StepResult]:
-        """One step per matched test that ran, in stable nodeid order."""
+        """One step per matched test that ran to a terminal report."""
         steps = []
         for nodeid in sorted(self._outcomes):
             if entry not in self._matched[nodeid]:
                 continue
             outcome = self._outcomes[nodeid]
+            if not outcome.complete:
+                continue
             steps.append(
                 harness.StepResult(
                     name=nodeid,
@@ -278,6 +366,9 @@ class EvidenceEmitterPlugin:
             "schema": harness.EVIDENCE_SCHEMA_ID,
             "scenario_id": entry.scenario_id,
             "scenario_name": entry.scenario_name,
+            # started_at/finished_at bracket the whole pytest session, while
+            # duration_s is the summed cost of *this entry's* steps — they are
+            # deliberately different quantities and will not agree.
             "started_at": self._started_at,
             "finished_at": finished_at,
             "duration_s": round(sum(s.duration_s for s in steps), 6),
@@ -292,6 +383,34 @@ class EvidenceEmitterPlugin:
             # Traceability extra (schema allows additionalProperties).
             "map_pattern": entry.pattern,
         }
+
+
+def _is_evidence(steps: list[harness.StepResult]) -> bool:
+    """True when these steps actually say something about the capability.
+
+    An empty or all-skipped step list emits nothing: runtime skips
+    (``requires_two_clusters``, ``requires_deployable_model``, GPU-count
+    gates) are the normal outcome on an under-provisioned host, and
+    ``derive_status`` would score that green-with-notes — an affirmative
+    claim over a capability the run never exercised.
+    """
+    return any(s.status != "skipped" for s in steps)
+
+
+def _run_was_aborted(session: pytest.Session, exitstatus: int) -> bool:
+    """True when the session stopped short of the work it was asked to do."""
+    if getattr(session, "shouldstop", False):
+        return True
+    if getattr(session, "shouldfail", False):
+        return True
+    return int(exitstatus) in _ABORTED_EXIT_CODES
+
+
+def _warn_aborted(session: pytest.Session) -> None:
+    """Make the suppression visible rather than silent."""
+    reporter = session.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        reporter.write_line(ABORTED_RUN_MESSAGE, yellow=True)
 
 
 def _utc_now_iso() -> str:

--- a/tests/e2e/_evidence_emitter.py
+++ b/tests/e2e/_evidence_emitter.py
@@ -128,19 +128,35 @@ def load_capability_map(path: Path) -> list[MapEntry]:
     """Parse and validate the explicit capability map. Raises ``ValueError``."""
     if not path.is_file():
         raise ValueError(f"capability map not found: {path}")
-    try:
-        raw = yaml.safe_load(path.read_text()) or []
-    except OSError as exc:
-        raise ValueError(f"{path.name}: cannot read capability map: {exc}") from None
-    except yaml.YAMLError as exc:
-        # Surfaces as the same UsageError refusal as any other bad map,
-        # instead of a raw pytest_configure traceback.
-        raise ValueError(f"{path.name}: invalid YAML: {exc}") from None
+    raw = _read_map_yaml(path)
     if not isinstance(raw, list):
         raise ValueError(f"{path.name}: top level must be a list of entries")
+    if not raw:
+        raise ValueError(
+            f"{path.name}: contains no entries — an opted-in run with an "
+            "empty map can never produce evidence"
+        )
     entries = [_parse_entry(item, i, source=path.name) for i, item in enumerate(raw)]
     _reject_duplicate_scenario_ids(entries, source=path.name)
     return entries
+
+
+def _read_map_yaml(path: Path) -> object:
+    """Read and parse the map, funneling every failure into ``ValueError``.
+
+    Both branches surface as the same ``UsageError`` refusal as any other bad
+    map, instead of a raw ``pytest_configure`` traceback.
+    """
+    try:
+        raw = yaml.safe_load(path.read_text())
+    except OSError as exc:
+        raise ValueError(f"{path.name}: cannot read capability map: {exc}") from None
+    except yaml.YAMLError as exc:
+        raise ValueError(f"{path.name}: invalid YAML: {exc}") from None
+    # Only an empty file means "no document". A falsey scalar or mapping
+    # (``{}``, ``0``, ``false``) is a malformed map and must reach the
+    # is-a-list check rather than being coerced into an empty entry list.
+    return [] if raw is None else raw
 
 
 def _parse_entry(item: object, i: int, *, source: str) -> MapEntry:
@@ -243,7 +259,12 @@ def add_evidence_options(parser: pytest.Parser) -> None:
         "--evidence-map",
         action="store",
         default=str(DEFAULT_MAP_PATH),
-        help="Path to the capability map YAML (default: tests/e2e/capability_map.yaml).",
+        help=(
+            "Path to the capability map YAML (default: "
+            "tests/e2e/capability_map.yaml). Keep it inside the repo: pytest "
+            "treats an existing path in argv as a rootdir candidate, so an "
+            "outside path can shift rootdir and break collection."
+        ),
     )
     group.addoption(
         "--evidence-out",

--- a/tests/e2e/_evidence_emitter.py
+++ b/tests/e2e/_evidence_emitter.py
@@ -38,6 +38,11 @@ actually ran, three rules keep "nothing failed" from masquerading as
   are the normal outcome on an under-provisioned host, and
   ``passed_with_notes`` over an all-skipped set would claim evidence the
   run never produced.
+
+Records are written one-per-file with a UTC timestamp in the name and
+*accumulate* across runs; the output directory is a spool, not a snapshot.
+Each record names its own ``build``, so a collector reading the directory
+should group by ``build`` rather than assume every file came from one run.
 """
 
 from __future__ import annotations
@@ -125,6 +130,8 @@ def load_capability_map(path: Path) -> list[MapEntry]:
         raise ValueError(f"capability map not found: {path}")
     try:
         raw = yaml.safe_load(path.read_text()) or []
+    except OSError as exc:
+        raise ValueError(f"{path.name}: cannot read capability map: {exc}") from None
     except yaml.YAMLError as exc:
         # Surfaces as the same UsageError refusal as any other bad map,
         # instead of a raw pytest_configure traceback.
@@ -145,12 +152,20 @@ def _parse_entry(item: object, i: int, *, source: str) -> MapEntry:
         item["scenario_name"], f"entry[{i}].scenario_name", source=source
     )
     cap_ids = _parse_capability_ids(item["capability_ids"], i, source=source)
-    return MapEntry(
+    entry = MapEntry(
         pattern=item["pattern"],
         scenario_name=item["scenario_name"],
         capability_ids=cap_ids,
         exclude=_parse_exclude(item.get("exclude", []), i, source=source),
     )
+    if not entry.scenario_id:
+        # Caught here rather than at session finish, where the whole run would
+        # already have executed before schema validation rejected the record.
+        raise ValueError(
+            f"{source}: entry[{i}].scenario_name {entry.scenario_name!r} slugs "
+            "to an empty scenario_id; use a name containing ASCII letters or digits"
+        )
+    return entry
 
 
 def _require_entry_keys(item: dict, i: int, *, source: str) -> None:

--- a/tests/e2e/_evidence_emitter.py
+++ b/tests/e2e/_evidence_emitter.py
@@ -1,0 +1,298 @@
+"""Opt-in scenario-evidence.v2 emitter for the existing e2e/live suite.
+
+ENG-10026 (T3.7): with ``--emit-evidence`` AND a build identity
+(``--build`` / ``KAMIWAZA_BUILD``), this pytest plugin groups the run's
+test outcomes by the reviewed entries in ``tests/e2e/capability_map.yaml``
+and, after the session, writes one ``scenario-evidence.v2`` record per
+entry that saw at least one matched test actually run, into
+``tests/e2e/evidence-out/`` (gitignored). Records carry
+``evidence_provenance: "pre-existing"`` — they harvest what the existing
+suite already demonstrates; they do not author new coverage.
+
+Guarantees:
+
+* Without ``--emit-evidence`` the plugin is never registered — zero
+  behavior change for a normal run.
+* ``--emit-evidence`` without a build identity is a refusal
+  (``pytest.UsageError``), mirroring the scenario harness's G1 stance:
+  evidence that does not name its build is not evidence.
+* Mapping is explicit, never inferred: a test matched by no map entry
+  emits nothing, and a map entry none of whose tests ran emits nothing.
+* Status derivation reuses :func:`harness.derive_status` — every matched
+  test becomes one step; all passed → ``passed``, any failure →
+  ``failed``, green-with-skips → ``passed_with_notes``.
+* Every record is validated with :func:`harness.validate_evidence_record`
+  (the vendored-schema mirror) before it is written.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.e2e.scenarios import harness
+
+E2E_DIR = Path(__file__).resolve().parent
+DEFAULT_MAP_PATH = E2E_DIR / "capability_map.yaml"
+DEFAULT_OUT_DIR = E2E_DIR / "evidence-out"
+
+PLUGIN_NAME = "kamiwaza-evidence-emitter"
+MARKER_PREFIX = "marker:"
+# The accountable actor for pre-existing automated evidence is the suite
+# itself; human sign-off happens downstream on the kit side.
+SIGN_OFF_ACTOR = "automated e2e suite (pre-existing evidence)"
+
+_ENTRY_KEYS = frozenset({"pattern", "capability_ids", "scenario_name"})
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slugify(name: str) -> str:
+    """Stable kebab-case slug of a scenario name (record ``scenario_id``)."""
+    return _SLUG_RE.sub("-", name.lower()).strip("-")
+
+
+@dataclass(frozen=True)
+class MapEntry:
+    """One reviewed mapping: a nodeid glob / marker → capability ids."""
+
+    pattern: str
+    scenario_name: str
+    capability_ids: tuple[str, ...]
+
+    @property
+    def scenario_id(self) -> str:
+        return slugify(self.scenario_name)
+
+    def matches(self, item: pytest.Item) -> bool:
+        if self.pattern.startswith(MARKER_PREFIX):
+            marker = self.pattern[len(MARKER_PREFIX) :]
+            return item.get_closest_marker(marker) is not None
+        return fnmatchcase(item.nodeid, self.pattern)
+
+
+def load_capability_map(path: Path) -> list[MapEntry]:
+    """Parse and validate the explicit capability map. Raises ``ValueError``."""
+    if not path.is_file():
+        raise ValueError(f"capability map not found: {path}")
+    raw = yaml.safe_load(path.read_text()) or []
+    if not isinstance(raw, list):
+        raise ValueError(f"{path.name}: top level must be a list of entries")
+    entries = [_parse_entry(item, i, source=path.name) for i, item in enumerate(raw)]
+    _reject_duplicate_scenario_ids(entries, source=path.name)
+    return entries
+
+
+def _parse_entry(item: object, i: int, *, source: str) -> MapEntry:
+    if not isinstance(item, dict):
+        raise ValueError(f"{source}: entry[{i}] must be a mapping")
+    if set(item) != _ENTRY_KEYS:
+        raise ValueError(
+            f"{source}: entry[{i}] must have exactly the keys "
+            f"{sorted(_ENTRY_KEYS)}; got {sorted(item)}"
+        )
+    _require_non_empty_str(item["pattern"], f"entry[{i}].pattern", source=source)
+    _require_non_empty_str(
+        item["scenario_name"], f"entry[{i}].scenario_name", source=source
+    )
+    cap_ids = _parse_capability_ids(item["capability_ids"], i, source=source)
+    return MapEntry(
+        pattern=item["pattern"],
+        scenario_name=item["scenario_name"],
+        capability_ids=cap_ids,
+    )
+
+
+def _require_non_empty_str(value: object, label: str, *, source: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{source}: {label} must be a non-empty string")
+
+
+def _parse_capability_ids(value: object, i: int, *, source: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(
+            f"{source}: entry[{i}].capability_ids must be a non-empty list"
+        )
+    for cap in value:
+        if not isinstance(cap, str) or not harness.CAPABILITY_ID_RE.fullmatch(cap):
+            raise ValueError(
+                f"{source}: entry[{i}] capability id {cap!r} must be kebab-case, "
+                "optionally dot-namespaced (e.g. 'workrooms.create')"
+            )
+    return tuple(value)
+
+
+def _reject_duplicate_scenario_ids(entries: list[MapEntry], *, source: str) -> None:
+    seen: dict[str, str] = {}
+    for entry in entries:
+        clash = seen.get(entry.scenario_id)
+        if clash is not None:
+            raise ValueError(
+                f"{source}: scenario_name {entry.scenario_name!r} slugs to "
+                f"{entry.scenario_id!r}, already used by {clash!r}"
+            )
+        seen[entry.scenario_id] = entry.scenario_name
+
+
+# ---------------------------------------------------------------------------
+# pytest wiring (called from the root conftest.py)
+# ---------------------------------------------------------------------------
+
+
+def add_evidence_options(parser: pytest.Parser) -> None:
+    """Register the opt-in evidence flags (ENG-10026, T3.7)."""
+    group = parser.getgroup("kamiwaza")
+    group.addoption(
+        "--emit-evidence",
+        action="store_true",
+        default=False,
+        help=(
+            "After the run, emit one scenario-evidence.v2 record per "
+            "capability_map.yaml entry whose tests ran, as pre-existing "
+            "evidence. Requires a build identity (--build / KAMIWAZA_BUILD)."
+        ),
+    )
+    group.addoption(
+        "--evidence-map",
+        action="store",
+        default=str(DEFAULT_MAP_PATH),
+        help="Path to the capability map YAML (default: tests/e2e/capability_map.yaml).",
+    )
+    group.addoption(
+        "--evidence-out",
+        action="store",
+        default=str(DEFAULT_OUT_DIR),
+        help="Directory evidence records are written to (default: tests/e2e/evidence-out/).",
+    )
+
+
+def maybe_register(config: pytest.Config) -> None:
+    """Register the emitter iff ``--emit-evidence`` is on.
+
+    Refuses (``pytest.UsageError``) when no build identity is resolvable or
+    the capability map is malformed — an opted-in run must never silently
+    produce anonymous or partial evidence.
+    """
+    if not config.getoption("emit_evidence"):
+        return
+    try:
+        build = harness.resolve_build_identity(
+            str(config.getoption("build", default="")) or None
+        )
+        entries = load_capability_map(Path(config.getoption("evidence_map")))
+    except ValueError as exc:
+        raise pytest.UsageError(f"--emit-evidence: {exc}") from None
+    plugin = EvidenceEmitterPlugin(
+        entries=entries,
+        build=build,
+        out_dir=Path(config.getoption("evidence_out")),
+    )
+    config.pluginmanager.register(plugin, PLUGIN_NAME)
+
+
+@dataclass
+class _TestOutcome:
+    """Folded per-test outcome across setup/call/teardown reports."""
+
+    status: str = "passed"
+    duration_s: float = 0.0
+
+    def fold(self, report: pytest.TestReport) -> None:
+        self.duration_s += report.duration
+        if report.failed:
+            self.status = "failed"
+        elif report.skipped and self.status != "failed":
+            self.status = "skipped"
+
+
+class EvidenceEmitterPlugin:
+    """Collects mapped test outcomes and writes v2 records at session end."""
+
+    def __init__(self, *, entries: list[MapEntry], build: str, out_dir: Path) -> None:
+        self._entries = entries
+        self._build = build
+        self._out_dir = out_dir
+        self._started_at = _utc_now_iso()
+        # nodeid → entries it matched (collection time; explicit map only).
+        self._matched: dict[str, list[MapEntry]] = {}
+        # nodeid → folded outcome; only tests that actually ran appear here.
+        self._outcomes: dict[str, _TestOutcome] = {}
+
+    def pytest_collection_modifyitems(self, items: list[pytest.Item]) -> None:
+        for item in items:
+            matches = [e for e in self._entries if e.matches(item)]
+            if matches:
+                self._matched[item.nodeid] = matches
+
+    def pytest_runtest_logreport(self, report: pytest.TestReport) -> None:
+        if report.nodeid not in self._matched:
+            return
+        self._outcomes.setdefault(report.nodeid, _TestOutcome()).fold(report)
+
+    def pytest_sessionfinish(self, session: pytest.Session) -> None:
+        finished_at = _utc_now_iso()
+        for entry in self._entries:
+            steps = self._steps_for(entry)
+            if steps:
+                self._write_record(entry, steps, finished_at)
+
+    def _steps_for(self, entry: MapEntry) -> list[harness.StepResult]:
+        """One step per matched test that ran, in stable nodeid order."""
+        steps = []
+        for nodeid in sorted(self._outcomes):
+            if entry not in self._matched[nodeid]:
+                continue
+            outcome = self._outcomes[nodeid]
+            steps.append(
+                harness.StepResult(
+                    name=nodeid,
+                    status=outcome.status,
+                    duration_s=outcome.duration_s,
+                    detail=f"pytest outcome: {outcome.status}",
+                )
+            )
+        return steps
+
+    def _write_record(
+        self, entry: MapEntry, steps: list[harness.StepResult], finished_at: str
+    ) -> Path:
+        record = self._build_record(entry, steps, finished_at)
+        harness.validate_evidence_record(record)
+        self._out_dir.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%f")
+        out = self._out_dir / f"{entry.scenario_id}-{stamp}.json"
+        out.write_text(json.dumps(record, indent=2) + "\n")
+        return out
+
+    def _build_record(
+        self, entry: MapEntry, steps: list[harness.StepResult], finished_at: str
+    ) -> dict:
+        return {
+            "schema": harness.EVIDENCE_SCHEMA_ID,
+            "scenario_id": entry.scenario_id,
+            "scenario_name": entry.scenario_name,
+            "started_at": self._started_at,
+            "finished_at": finished_at,
+            "duration_s": round(sum(s.duration_s for s in steps), 6),
+            "sign_off_actor": SIGN_OFF_ACTOR,
+            "ci_job_url": os.environ.get("CI_JOB_URL"),
+            "build": self._build,
+            "method": "automated",
+            "capability_ids": list(entry.capability_ids),
+            "evidence_provenance": "pre-existing",
+            "status": harness.derive_status(steps),
+            "steps": [asdict(s) for s in steps],
+            # Traceability extra (schema allows additionalProperties).
+            "map_pattern": entry.pattern,
+        }
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/tests/e2e/capability_map.yaml
+++ b/tests/e2e/capability_map.yaml
@@ -59,10 +59,12 @@
 #     models.local-deployment, so it stays unmapped.
 #   * test_retrieval_live.py — TestRetrievalJobOperations::test_create_and_get_job
 #     does create a real job and poll it, but its status assertion is
-#     `isinstance(status, str)`, so a job that ran and FAILED passes. The two
-#     retained retrieval entries below assert row_count >= 1 on a real result,
-#     which is strictly stronger; mapping this one too would only weaken the
-#     claim, so retrieval.async-retrieval-jobs rests on those instead.
+#     `isinstance(status, str)`, so a job that ran and FAILED passes. Every
+#     test under the two retained retrieval entries below asserts a real
+#     retrieval *artifact* instead — rows returned (row_count > 0), SSE events
+#     emitted, or a gRPC transport handshake — which is strictly stronger;
+#     mapping this one alongside them would only weaken the claim, so
+#     retrieval.async-retrieval-jobs rests on those instead.
 #   * test_context_workroom_scope_clients_isolate_vectordb_views — NOT
 #     evidence for workrooms.session-scoping despite its name. Its own
 #     docstring is the accurate one ("Derived SDK clients can carry workroom

--- a/tests/e2e/capability_map.yaml
+++ b/tests/e2e/capability_map.yaml
@@ -155,17 +155,17 @@
   scenario_name: "Multi-source catalog ingestion"
 
 # Justification: the subset that actually submits a retrieval job over the
-# ingested data — the two *_inline_retrieval tests, inline_small_object
-# (asserts row_count > 0), large_object_sse_retrieval, and
-# postgres_ingestion_metadata (POSTs /retrieval/jobs and asserts rows).
-# Excluded: the metadata-only ingestions and container_link never submit a
-# job, and inline_large_object_hits_threshold asserts a 422 rejection rather
-# than a successful retrieval.
+# ingested data and asserts the result — the two *_inline_retrieval tests,
+# inline_small_object and file_ingestion_metadata (both POST /retrieval/jobs
+# and assert row_count), large_object_sse_retrieval, and
+# postgres_ingestion_metadata.
+# Excluded: kafka (xfails before any retrieval), slack, and container_link
+# never submit a job at all, and inline_large_object_hits_threshold asserts a
+# 422 rejection rather than a successful retrieval.
 - pattern: "tests/integration/test_catalog_multi_source.py::*"
   capability_ids: [retrieval.async-retrieval-jobs]
   scenario_name: "Multi-source inline and SSE retrieval"
   exclude:
-    - "*::test_catalog_file_ingestion_metadata"
     - "*::test_catalog_kafka_ingestion_metadata"
     - "*::test_catalog_slack_ingestion_metadata"
     - "*::test_catalog_container_link_sets_dataset_container_urn"
@@ -219,9 +219,14 @@
 # not affect another), and the ?workroom_id=all bypass (TestSentinelAllBypass).
 # The CRUD class overlaps intentionally, but only for its two own-vs-other
 # visibility assertions (create/get own, list returns own).
-# Excluded: the rest of the CRUD class — the Global guardrails plus
-# update/archive of one's own workroom — performs a single-session operation
-# and asserts nothing about isolation between sessions.
+# Excluded across every class, by one rule applied consistently: a test that
+# issues a single unscoped operation and asserts nothing about what another
+# session can or cannot see is not evidence of session scoping. That covers
+# the Global guardrails and update/archive of one's own workroom; the plain
+# read of the Global workroom in TestWorkspaceCanSeeGlobal (an exact twin of
+# the excluded CRUD-class read); archive-visibility-with-flag, which lists
+# only its own workroom; and the ?workroom_id=all deployments test, whose
+# only assertion is isinstance(result, list).
 - pattern: "tests/integration/test_workroom_isolation_live.py::*"
   capability_ids: [workrooms.session-scoping]
   scenario_name: "Workroom session-scoping access matrix"
@@ -230,6 +235,9 @@
     - "*::test_cannot_delete_global_workroom"
     - "*::TestWorkroomCrudIsolation::test_update_own_workroom"
     - "*::TestWorkroomCrudIsolation::test_archive_own_workroom"
+    - "*::test_workspace_user_can_read_global_workroom"
+    - "*::test_archive_workroom_still_visible_with_flag"
+    - "*::test_deployments_all_returns_across_workrooms"
 
 # Justification: ENG-6952 control plane — test_register_from_spec_returns_dataset_urn
 # registers a managed data source from a connector spec and asserts the

--- a/tests/e2e/capability_map.yaml
+++ b/tests/e2e/capability_map.yaml
@@ -57,6 +57,13 @@
 #   * test_serving_endpoints_live.py — reads serving status/health/logs of
 #     whatever is already deployed; it observes but does not demonstrate
 #     models.local-deployment, so it stays unmapped.
+#   * test_context_workroom_scope_clients_isolate_vectordb_views — NOT
+#     evidence for workrooms.session-scoping despite its name. Its own
+#     docstring is the accurate one ("Derived SDK clients can carry workroom
+#     scope as a context manager"): it creates ONE workroom and ONE scoped
+#     client, then asserts the vectordb it made is listed and carries that
+#     workroom_id. No second scope, no absence assertion — it fails the
+#     retention test applied to the access-matrix entry below.
 
 # Justification: test_live_model_metadata_and_download searches the hub for
 # the canonical repo (mlx-community/Qwen3-4B-4bit), ensures it is downloaded
@@ -183,13 +190,6 @@
     - "*::test_catalog_slack_ingestion_metadata"
     - "*::test_catalog_container_link_sets_dataset_container_urn"
     - "*::test_catalog_inline_large_object_hits_threshold"
-
-# Justification: test_context_workroom_scope_clients_isolate_vectordb_views
-# proves two workroom-scoped clients see isolated vectordb views — the
-# session-scoping contract applied to context resources.
-- pattern: "tests/integration/test_context_live.py::test_context_workroom_scope_clients_isolate_vectordb_views"
-  capability_ids: [workrooms.session-scoping]
-  scenario_name: "Workroom-scoped clients isolate vectordb views"
 
 # Justification: TestWorkroomCrudIsolation — create/get/list/update/archive
 # workrooms. Every retained test creates one, either through the workroom_a /

--- a/tests/e2e/capability_map.yaml
+++ b/tests/e2e/capability_map.yaml
@@ -1,0 +1,186 @@
+# Capability map for pre-existing e2e/live evidence (ENG-10026, T3.7).
+#
+# RULE: this mapping is EXPLICIT, REVIEWED, and NEVER INFERRED. An entry
+# exists only where the named tests genuinely exercise the capability
+# end-to-end against a running platform; tests not matched by any entry
+# emit NO evidence. Adding an entry is a reviewed change, not something
+# tooling derives from test names.
+#
+# Each entry is {pattern, capability_ids, scenario_name}:
+#   * pattern — a pytest nodeid glob (fnmatch, rooted at the repo root,
+#     e.g. "tests/integration/test_x.py::*"), or "marker:<name>" to match
+#     every test carrying that pytest marker.
+#   * capability_ids — capability-document ids (kit inventory, dot-namespaced)
+#     the matched tests evidence.
+#   * scenario_name — human-readable scenario title; its slug becomes the
+#     emitted record's scenario_id.
+#
+# With `--emit-evidence` (and a --build/KAMIWAZA_BUILD identity) the
+# emitter in tests/e2e/_evidence_emitter.py writes one scenario-evidence.v2
+# record per entry that had at least one matched test actually run, with
+# evidence_provenance "pre-existing".
+#
+# DELIBERATELY UNMAPPED (reviewed 2026-08-10; empty mapping is the honest
+# answer — do not "fix" without new tests):
+#   * models.external-endpoints — no existing e2e/live test registers or
+#     exercises an external/BYO OpenAI-compatible endpoint.
+#   * auth.enterprise-sso — test_auth_live.py covers password + PAT auth
+#     and test_auth_endpoints_live.py the auth endpoint surface; neither
+#     is an enterprise SSO/IdP login. The federation shared-IdP suites
+#     (test_federation_idp_lifecycle_live.py, ..._shared_idp_gated_...)
+#     provision Keycloak trust for FEDERATION, not enterprise SSO sign-in.
+#   * tests/e2e/scenarios/test_s1..s5 drivers — they already emit native
+#     scenario-evidence.v2 records through the harness (cycle-authored);
+#     mapping them here would double-count the same runs.
+#   * test_jobs_recoverable_drop_recovery.py — NOT evidence for
+#     federation.remote-jobs: its own docstring says it is a unit-style
+#     test mocked at the _request boundary, no remote execution happens.
+#   * test_serving_endpoints_live.py — reads serving status/health/logs of
+#     whatever is already deployed; it observes but does not demonstrate
+#     models.local-deployment, so it stays unmapped.
+
+# Justification: test_live_model_metadata_and_download searches the hub for
+# the canonical repo (mlx-community/Qwen3-4B-4bit), ensures it is downloaded
+# via ensure_repo_ready, and verifies model metadata + files on the platform.
+- pattern: "tests/integration/test_models_live.py::test_live_model_metadata_and_download"
+  capability_ids: [models.discover-and-download]
+  scenario_name: "Model discovery, metadata, and hub download"
+
+# Justification: TS11 surface — TestModelFileSearch (hub model-file search),
+# TestModelFileDownloadStatus / TestModelFileDownloadOperations (download
+# status, cancel-all, cancel-specific), TestModelFileCreateAndDelete and
+# read operations against downloaded files.
+- pattern: "tests/integration/test_model_files_live.py::*"
+  capability_ids: [models.discover-and-download]
+  scenario_name: "Model file search and download management"
+
+# Justification: TS12 surface — TestModelListOperations, TestModelSearchOperations
+# (search_models_by_repo_id / exact match / get_model_by_repo_id),
+# TestModelDownloadHelpers (initiate_model_download on an already-downloaded
+# repo), plus model metadata/memory-usage reads.
+- pattern: "tests/integration/test_models_extended_live.py::*"
+  capability_ids: [models.discover-and-download]
+  scenario_name: "Model registry search and metadata (extended)"
+
+# Justification: test_deploy_qwen_and_infer_with_strip_thinking deploys two
+# configs of the target model locally (serving.deploy_model + wait), then
+# infers through client.openai.get_client(...) chat completions — the
+# OpenAI-compatible inference path — before cleanup.
+- pattern: "tests/integration/test_serving_workflow.py::test_deploy_qwen_and_infer_with_strip_thinking"
+  capability_ids: [models.local-deployment, models.openai-compatible-inference]
+  scenario_name: "Deploy model locally and infer via OpenAI-compatible client"
+
+# Justification: ENG-6948 engine matrix — test_deploy_and_infer_llamacpp_gguf /
+# test_deploy_and_infer_vllm_nvidia deploy with explicit engine_name and
+# assert a chat completion via the OpenAI-compatible client
+# (_assert_chat_completion); the fractional co-location tests deploy two
+# copies on one GPU and serve prompts from both.
+- pattern: "tests/integration/test_inference_matrix_live.py::*"
+  capability_ids: [models.local-deployment, models.openai-compatible-inference]
+  scenario_name: "Engine matrix deploy and infer with fractional co-location"
+
+# Justification: TS17 — TestRetrievalJobOperations::test_create_and_get_job
+# creates an async retrieval job and polls its status by job_id;
+# TestRetrievalJobStatus covers the job-status API including error paths.
+- pattern: "tests/integration/test_retrieval_live.py::*"
+  capability_ids: [retrieval.async-retrieval-jobs]
+  scenario_name: "Async retrieval job lifecycle"
+
+# Justification: test_s3_ingest_and_retrieve_inline / _grpc ingest a sample
+# dataset into the catalog and then run retrieval jobs streaming results
+# inline and over gRPC (per test_retrieval_live.py's docstring these carry
+# TS17.001/TS17.003 coverage).
+- pattern: "tests/integration/test_catalog_ingest_retrieval.py::*"
+  capability_ids: [catalog.dataset-registry, retrieval.async-retrieval-jobs]
+  scenario_name: "Catalog ingest to retrieval round-trip (inline and gRPC)"
+
+# Justification: test_catalog_dataset_and_secret_lifecycle registers a
+# dataset and secret in the catalog and walks their full lifecycle.
+- pattern: "tests/integration/test_catalog_live.py::test_catalog_dataset_and_secret_lifecycle"
+  capability_ids: [catalog.dataset-registry]
+  scenario_name: "Catalog dataset and secret lifecycle"
+
+# Justification: dataset schema/variant endpoints, container list/URN/path/v2
+# endpoints, and secret endpoints — the catalog registry API surface
+# (test_catalog_dataset_schema_endpoints, test_catalog_dataset_variant_endpoints,
+# test_catalog_container_by_urn_and_path_endpoints, ...).
+- pattern: "tests/integration/test_catalog_endpoints.py::*"
+  capability_ids: [catalog.dataset-registry]
+  scenario_name: "Catalog dataset, container, and secret endpoint surface"
+
+# Justification: file/object/parquet/postgres/kafka/slack ingestion registers
+# datasets with metadata in the catalog (test_catalog_*_ingestion_metadata,
+# test_catalog_container_link_sets_dataset_container_urn) and the inline /
+# SSE retrieval tests run retrieval jobs over the ingested data.
+- pattern: "tests/integration/test_catalog_multi_source.py::*"
+  capability_ids: [catalog.dataset-registry, retrieval.async-retrieval-jobs]
+  scenario_name: "Multi-source catalog ingestion with inline retrieval"
+
+# Justification: test_context_search_contract and
+# test_context_agentic_search_contract search over documents ingested into a
+# workroom-scoped vectordb (session_workroom + search_contract_vectordb
+# fixtures). NOTE the deliberately tight glob: a plain "test_context_*_contract"
+# would also catch test_context_list_raw_files_empty_contract /
+# test_context_list_omniparses_contract, which are listing-endpoint contracts,
+# not document search.
+- pattern: "tests/integration/test_context_live.py::test_context_*search_contract"
+  capability_ids: [context.workroom-document-search]
+  scenario_name: "Workroom-scoped document search contracts"
+
+# Justification: test_context_retrieve_contract retrieves sources for a query
+# from the same workroom-scoped vectordb as the search contracts above
+# (separate entry because no single glob covers exactly the three
+# search/retrieve contract tests).
+- pattern: "tests/integration/test_context_live.py::test_context_retrieve_contract"
+  capability_ids: [context.workroom-document-search]
+  scenario_name: "Workroom-scoped document retrieve contract"
+
+# Justification: test_context_workroom_scope_clients_isolate_vectordb_views
+# proves two workroom-scoped clients see isolated vectordb views — the
+# session-scoping contract applied to context resources.
+- pattern: "tests/integration/test_context_live.py::test_context_workroom_scope_clients_isolate_vectordb_views"
+  capability_ids: [workrooms.session-scoping]
+  scenario_name: "Workroom-scoped clients isolate vectordb views"
+
+# Justification: TestWorkroomCrudIsolation — create/get/list/update/archive
+# workrooms plus the Global-workroom guardrails (exists, cannot delete).
+- pattern: "tests/integration/test_workroom_isolation_live.py::TestWorkroomCrudIsolation::*"
+  capability_ids: [workrooms.create]
+  scenario_name: "Workroom creation and CRUD lifecycle"
+
+# Justification: the whole module validates the workroom access matrix with
+# workroom-scoped sessions (X-Workroom-Id): self-access allowed
+# (TestSelfAccess), cross-workroom NEVER (TestCrossWorkspaceBlocked),
+# Global cannot see workspaces (TestGlobalCannotSeeWorkspaces), workspaces
+# can read Global (TestWorkspaceCanSeeGlobal), lifecycle isolation. The
+# CRUD class is included by the glob; its create/list visibility checks are
+# themselves per-session scoping assertions, so the overlap is intentional.
+- pattern: "tests/integration/test_workroom_isolation_live.py::*"
+  capability_ids: [workrooms.session-scoping]
+  scenario_name: "Workroom session-scoping access matrix"
+
+# Justification: ENG-6952 control plane — test_register_from_spec_returns_dataset_urn
+# registers a managed data source from a connector spec (returning its
+# dataset URN), the rejection tests pin spec validation (inline secret,
+# missing platform, unknown field), and test_publisher_grant_then_revoke
+# covers publisher access management.
+- pattern: "tests/integration/test_connector_spec_live.py::*"
+  capability_ids: [connectors.managed-data-sources]
+  scenario_name: "Managed data source registration from connector spec"
+
+# Justification: TestFederationTwoClusterWalkthrough::test_federated_job_run_via_mesh
+# runs a job on the peer cluster through the mesh and
+# ::test_federated_job_audit_actor_round_trip proves the audit actor
+# round-trip for that remote execution (ENG-5784 two-cluster rig).
+- pattern: "tests/integration/test_federation_two_cluster_live.py::*test_federated_job_*"
+  capability_ids: [federation.remote-jobs]
+  scenario_name: "Federated job execution via mesh"
+
+# Justification: the M3 ship-gate walkthrough's step 7 submits a federated
+# job via kz.jobs.run against the paired LYRA/ORION fleet and step 8
+# asserts the audit_actor round-trip. (Its gate/dataset steps exercise
+# federation surfaces outside this kit's capability inventory, so only
+# remote-jobs is claimed.)
+- pattern: "tests/integration/test_m3_walkthrough_live.py::test_m3_full_walkthrough_against_live_fleet"
+  capability_ids: [federation.remote-jobs]
+  scenario_name: "M3 fleet walkthrough federated job submission"

--- a/tests/e2e/capability_map.yaml
+++ b/tests/e2e/capability_map.yaml
@@ -6,7 +6,8 @@
 # emit NO evidence. Adding an entry is a reviewed change, not something
 # tooling derives from test names.
 #
-# Each entry is {pattern, capability_ids, scenario_name}:
+# Each entry is {pattern, capability_ids, scenario_name} plus optional
+# {exclude}:
 #   * pattern — a pytest nodeid glob (fnmatch, rooted at the repo root,
 #     e.g. "tests/integration/test_x.py::*"), or "marker:<name>" to match
 #     every test carrying that pytest marker.
@@ -14,6 +15,14 @@
 #     the matched tests evidence.
 #   * scenario_name — human-readable scenario title; its slug becomes the
 #     emitted record's scenario_id.
+#   * exclude — nodeid globs carved back out of a broad pattern.
+#
+# THE PER-TEST RULE: a record is composed from whichever matched tests
+# actually ran, so *every* test an entry matches must, on its own, exercise
+# the capability. A module-wide "::*" pattern therefore needs `exclude` for
+# the module's negative-path tests (get/delete-nonexistent, rejection
+# assertions) and availability-only tests: running just one of those must
+# never be able to emit a passing record for the capability.
 #
 # With `--emit-evidence` (and a --build/KAMIWAZA_BUILD identity) the
 # emitter in tests/e2e/_evidence_emitter.py writes one scenario-evidence.v2
@@ -50,17 +59,30 @@
 # TestModelFileDownloadStatus / TestModelFileDownloadOperations (download
 # status, cancel-all, cancel-specific), TestModelFileCreateAndDelete and
 # read operations against downloaded files.
+# Excluded: TestModelFileValidation and test_delete_nonexistent_model_file
+# assert error handling for a fabricated UUID — no model is discovered or
+# downloaded, so they cannot stand as evidence for this capability.
 - pattern: "tests/integration/test_model_files_live.py::*"
   capability_ids: [models.discover-and-download]
   scenario_name: "Model file search and download management"
+  exclude:
+    - "*::TestModelFileValidation::*"
+    - "*::test_delete_nonexistent_model_file"
 
 # Justification: TS12 surface — TestModelListOperations, TestModelSearchOperations
 # (search_models_by_repo_id / exact match / get_model_by_repo_id),
 # TestModelDownloadHelpers (initiate_model_download on an already-downloaded
 # repo), plus model metadata/memory-usage reads.
+# Excluded: TestModelValidation (nonexistent model/search error paths) and
+# TestModelCleanupOperations / test_get_pending_deployments, which act on
+# deployments rather than on model discovery or download.
 - pattern: "tests/integration/test_models_extended_live.py::*"
   capability_ids: [models.discover-and-download]
   scenario_name: "Model registry search and metadata (extended)"
+  exclude:
+    - "*::TestModelValidation::*"
+    - "*::TestModelCleanupOperations::*"
+    - "*::test_get_pending_deployments"
 
 # Justification: test_deploy_qwen_and_infer_with_strip_thinking deploys two
 # configs of the target model locally (serving.deploy_model + wait), then
@@ -80,9 +102,12 @@
   scenario_name: "Engine matrix deploy and infer with fractional co-location"
 
 # Justification: TS17 — TestRetrievalJobOperations::test_create_and_get_job
-# creates an async retrieval job and polls its status by job_id;
-# TestRetrievalJobStatus covers the job-status API including error paths.
-- pattern: "tests/integration/test_retrieval_live.py::*"
+# creates an async retrieval job and polls its status by job_id. That class
+# is the only part of the module that runs a job; TestRetrievalServiceAvailability
+# merely asserts the SDK service object exists (no platform call at all) and
+# TestRetrievalJobStatus queries a fabricated job id expecting a 404, so both
+# are excluded rather than allowed to evidence the capability.
+- pattern: "tests/integration/test_retrieval_live.py::TestRetrievalJobOperations::*"
   capability_ids: [retrieval.async-retrieval-jobs]
   scenario_name: "Async retrieval job lifecycle"
 
@@ -104,9 +129,15 @@
 # endpoints, and secret endpoints — the catalog registry API surface
 # (test_catalog_dataset_schema_endpoints, test_catalog_dataset_variant_endpoints,
 # test_catalog_container_by_urn_and_path_endpoints, ...).
+# Excluded: test_catalog_metadata_and_health reads service health, and
+# test_catalog_container_endpoints_require_admin_user asserts an authz
+# rejection; neither registers or reads a dataset.
 - pattern: "tests/integration/test_catalog_endpoints.py::*"
   capability_ids: [catalog.dataset-registry]
   scenario_name: "Catalog dataset, container, and secret endpoint surface"
+  exclude:
+    - "*::test_catalog_metadata_and_health"
+    - "*::test_catalog_container_endpoints_require_admin_user"
 
 # Justification: file/object/parquet/postgres/kafka/slack ingestion registers
 # datasets with metadata in the catalog (test_catalog_*_ingestion_metadata,
@@ -161,12 +192,15 @@
 
 # Justification: ENG-6952 control plane — test_register_from_spec_returns_dataset_urn
 # registers a managed data source from a connector spec (returning its
-# dataset URN), the rejection tests pin spec validation (inline secret,
-# missing platform, unknown field), and test_publisher_grant_then_revoke
-# covers publisher access management.
+# dataset URN) and test_publisher_grant_then_revoke covers publisher access
+# management. Excluded: the test_register_rejects_* trio asserts spec
+# validation refusals — nothing is registered, so on their own they are not
+# evidence that managed data sources work.
 - pattern: "tests/integration/test_connector_spec_live.py::*"
   capability_ids: [connectors.managed-data-sources]
   scenario_name: "Managed data source registration from connector spec"
+  exclude:
+    - "*::test_register_rejects_*"
 
 # Justification: TestFederationTwoClusterWalkthrough::test_federated_job_run_via_mesh
 # runs a job on the peer cluster through the mesh and

--- a/tests/e2e/capability_map.yaml
+++ b/tests/e2e/capability_map.yaml
@@ -57,6 +57,12 @@
 #   * test_serving_endpoints_live.py — reads serving status/health/logs of
 #     whatever is already deployed; it observes but does not demonstrate
 #     models.local-deployment, so it stays unmapped.
+#   * test_retrieval_live.py — TestRetrievalJobOperations::test_create_and_get_job
+#     does create a real job and poll it, but its status assertion is
+#     `isinstance(status, str)`, so a job that ran and FAILED passes. The two
+#     retained retrieval entries below assert row_count >= 1 on a real result,
+#     which is strictly stronger; mapping this one too would only weaken the
+#     claim, so retrieval.async-retrieval-jobs rests on those instead.
 #   * test_context_workroom_scope_clients_isolate_vectordb_views — NOT
 #     evidence for workrooms.session-scoping despite its name. Its own
 #     docstring is the accurate one ("Derived SDK clients can carry workroom
@@ -64,6 +70,16 @@
 #     client, then asserts the vectordb it made is listed and carries that
 #     workroom_id. No second scope, no absence assertion — it fails the
 #     retention test applied to the access-matrix entry below.
+
+# KNOWN LIMIT of every models.discover-and-download entry below (reviewed,
+# accepted): the download leg runs only on a COLD cluster. `ensure_repo_ready`
+# (tests/integration/conftest.py) returns early when the repo already has ready
+# target files, so on a warm cluster these tests evidence discovery, metadata,
+# and file readiness without re-fetching anything. That is the honest reading of
+# these records. Forcing a fresh multi-GB download on every run belongs in the
+# integration tests as a deliberate choice, not in this mapping; until then,
+# read a warm-cluster record as "the model is discoverable, present, and
+# readable", and a cold-cluster one as the full acquisition path.
 
 # Justification: test_live_model_metadata_and_download searches the hub for
 # the canonical repo (mlx-community/Qwen3-4B-4bit), ensures it is downloaded
@@ -123,16 +139,6 @@
 - pattern: "tests/integration/test_inference_matrix_live.py::*"
   capability_ids: [models.local-deployment, models.openai-compatible-inference]
   scenario_name: "Engine matrix deploy and infer with fractional co-location"
-
-# Justification: TS17 — TestRetrievalJobOperations::test_create_and_get_job
-# creates an async retrieval job and polls its status by job_id. That class
-# is the only part of the module that runs a job; TestRetrievalServiceAvailability
-# merely asserts the SDK service object exists (no platform call at all) and
-# TestRetrievalJobStatus queries a fabricated job id expecting a 404, so both
-# are excluded rather than allowed to evidence the capability.
-- pattern: "tests/integration/test_retrieval_live.py::TestRetrievalJobOperations::*"
-  capability_ids: [retrieval.async-retrieval-jobs]
-  scenario_name: "Async retrieval job lifecycle"
 
 # Justification: test_s3_ingest_and_retrieve_inline / _grpc ingest a sample
 # dataset into the catalog and then run retrieval jobs streaming results

--- a/tests/e2e/capability_map.yaml
+++ b/tests/e2e/capability_map.yaml
@@ -33,6 +33,16 @@
 # answer — do not "fix" without new tests):
 #   * models.external-endpoints — no existing e2e/live test registers or
 #     exercises an external/BYO OpenAI-compatible endpoint.
+#   * context.workroom-document-search — the search/retrieve/agentic-search
+#     contract tests run against `search_contract_vectordb`, whose own
+#     docstring says it exists to give them a CLEAN backend so that "earlier
+#     vector insert/query tests cannot leave collections that turn a shape
+#     check into a data-search assertion". They search a deliberately empty
+#     vectordb and assert only isinstance(results, list), so they pass without
+#     finding anything; the vectordb insert/query tests likewise assert only
+#     that the result is a list. No existing test searches indexed content and
+#     asserts what came back, so this capability has no honest mapping until
+#     one is written.
 #   * auth.enterprise-sso — test_auth_live.py covers password + PAT auth
 #     and test_auth_endpoints_live.py the auth endpoint surface; neither
 #     is an enterprise SSO/IdP login. The federation shared-IdP suites
@@ -174,25 +184,6 @@
     - "*::test_catalog_container_link_sets_dataset_container_urn"
     - "*::test_catalog_inline_large_object_hits_threshold"
 
-# Justification: test_context_search_contract and
-# test_context_agentic_search_contract search over documents ingested into a
-# workroom-scoped vectordb (session_workroom + search_contract_vectordb
-# fixtures). NOTE the deliberately tight glob: a plain "test_context_*_contract"
-# would also catch test_context_list_raw_files_empty_contract /
-# test_context_list_omniparses_contract, which are listing-endpoint contracts,
-# not document search.
-- pattern: "tests/integration/test_context_live.py::test_context_*search_contract"
-  capability_ids: [context.workroom-document-search]
-  scenario_name: "Workroom-scoped document search contracts"
-
-# Justification: test_context_retrieve_contract retrieves sources for a query
-# from the same workroom-scoped vectordb as the search contracts above
-# (separate entry because no single glob covers exactly the three
-# search/retrieve contract tests).
-- pattern: "tests/integration/test_context_live.py::test_context_retrieve_contract"
-  capability_ids: [context.workroom-document-search]
-  scenario_name: "Workroom-scoped document retrieve contract"
-
 # Justification: test_context_workroom_scope_clients_isolate_vectordb_views
 # proves two workroom-scoped clients see isolated vectordb views — the
 # session-scoping contract applied to context resources.
@@ -214,42 +205,58 @@
     - "*::test_cannot_delete_global_workroom"
 
 # THE RETENTION TEST, applied per test rather than per class: the test must
-# assert something about what one session can or cannot see *relative to
-# another* (or relative to the no-header default). Asserting only that a
-# fetched object reports its own id, or that a list is a list, does not
-# demonstrate scoping no matter which class it sits in.
+# assert that something is ABSENT from a session's view — a resource another
+# session owns, or a workspace resource missing from Global, or a non-Global
+# connector missing from a header-less request. A test that only reads a
+# resource and asserts the object it got back reports its own id proves
+# access is permitted, not that scoping is enforced; so does a test that
+# asserts only that a list is a list.
 #
-# Retained (11 of 23): TestSelfAccess (connectors/extensions scoped to own
-# workroom); TestCrossWorkspaceBlocked's three A-cannot-see-B / B-cannot-see-A
-# assertions; TestGlobalCannotSeeWorkspaces' two "Global excludes workspace
-# resources" assertions; TestLifecycleIsolation::test_delete_workroom_does_not
-# _affect_other; TestSentinelAllBypass::test_connectors_without_header_defaults
-# _to_global; and, from the CRUD class, its two own-vs-other visibility checks
-# (create/get own, list returns own) — that overlap is intentional.
+# Retained (9 of 23), each with an absence assertion:
+#   * TestSelfAccess (2) — _assert_only_own_or_global on both A's and B's
+#     connector/extension lists;
+#   * TestCrossWorkspaceBlocked (3) — B cannot see A's connectors, A cannot
+#     see B's, B cannot see A's extensions;
+#   * TestGlobalCannotSeeWorkspaces (2) — Global's connector and extension
+#     lists exclude the workspace's;
+#   * TestLifecycleIsolation::test_delete_workroom_does_not_affect_other —
+#     deleting A leaves B active and A gone;
+#   * TestSentinelAllBypass::test_connectors_without_header_defaults_to_global
+#     — a header-less request returns no non-Global connector.
 #
 # Excluded, each failing the retention test above:
-#   * the Global guardrails and update/archive of one's own workroom — single
-#     unscoped operations by one session;
-#   * TestWorkspaceCanSeeGlobal in full — all four tests read a Global resource
-#     and assert only that the object returned reports GLOBAL as its id; that
-#     shows access is permitted, not that scoping is enforced;
+#   * TestWorkroomCrudIsolation in full — every test is a single-session
+#     operation on its own (or the Global) workroom: get/list own, update,
+#     archive, read Global, 403 on deleting Global. Even create-and-get-own
+#     has no "other" in it; it asserts the workroom it fetched is the one it
+#     created. Its create/list coverage is claimed by the workrooms.create
+#     entry above, which is where it belongs.
+#   * TestWorkspaceCanSeeGlobal in full — all four read a Global resource and
+#     assert only that the object returned reports GLOBAL as its id.
 #   * test_global_export_excludes_workspace_resources — despite its name it
-#     takes no workroom fixture, so no workspace exists during the test, and it
-#     asserts only manifest.workroom_id == GLOBAL;
+#     takes no workroom fixture, so no workspace exists during the test, and
+#     it asserts only manifest.workroom_id == GLOBAL.
 #   * test_workroom_export_only_shows_own_resources — workroom_b is never
-#     requested; it asserts A's manifest is A's and non-empty;
+#     requested; it asserts A's manifest is A's and non-empty.
 #   * test_archive_workroom_still_visible_with_flag — lists only its own
-#     workroom;
+#     workroom.
 #   * test_deployments_all_returns_across_workrooms — its only assertion is
 #     isinstance(result, list); it never checks the result spans workrooms.
+#
+# KNOWN LIMIT of the retained set (reviewed, accepted): the absence assertions
+# are vacuously satisfiable. The fixtures create workrooms but seed no
+# connectors or extensions, so on a bare cluster "B cannot see A's connectors"
+# passes over an empty list. They are retained because they do drive the
+# scoped request path (X-Workroom-Id) and assert the right property, and
+# because the fix belongs in the tests — seeding sentinel resources in both
+# scopes — not in this mapping. Strengthening them would strengthen this
+# evidence; until then read these records as "isolation not violated", which
+# is what the tests actually check.
 - pattern: "tests/integration/test_workroom_isolation_live.py::*"
   capability_ids: [workrooms.session-scoping]
   scenario_name: "Workroom session-scoping access matrix"
   exclude:
-    - "*::test_global_workroom_exists"
-    - "*::test_cannot_delete_global_workroom"
-    - "*::TestWorkroomCrudIsolation::test_update_own_workroom"
-    - "*::TestWorkroomCrudIsolation::test_archive_own_workroom"
+    - "*::TestWorkroomCrudIsolation::*"
     - "*::TestWorkspaceCanSeeGlobal::*"
     - "*::test_global_export_excludes_workspace_resources"
     - "*::test_workroom_export_only_shows_own_resources"
@@ -269,19 +276,22 @@
     - "*::test_register_rejects_*"
     - "*::test_publisher_grant_then_revoke"
 
-# Justification: TestFederationTwoClusterWalkthrough::test_federated_job_run_via_mesh
-# runs a job on the peer cluster through the mesh and
-# ::test_federated_job_audit_actor_round_trip proves the audit actor
-# round-trip for that remote execution (ENG-5784 two-cluster rig).
-- pattern: "tests/integration/test_federation_two_cluster_live.py::*test_federated_job_*"
+# Justification: test_federated_job_audit_actor_round_trip runs a job on the
+# peer cluster through the mesh and proves the originating identity survives
+# the round-trip (ENG-5784 two-cluster rig). Its own docstring pins the strict
+# gate this mapping relies on: "status MUST be SUCCEEDED — accepting FAILED
+# would mask the very failure modes this test exists to catch".
+#
+# The pattern names that one test rather than excluding its siblings, because
+# this file is marker-gated (requires_two_clusters) and deselects wholesale on
+# a single-cluster host — where an `exclude` glob could rot unverified. Two
+# siblings are deliberately outside it:
+#   * ::test_federated_job_run_via_mesh — asserts only isinstance(resp, dict),
+#     so a job that ran and failed would still emit a passing record;
+#   * test_m3_walkthrough_live.py's walkthrough — its step-8 assertion is
+#     `result.status in {"SUCCEEDED", "FAILED"}`, explicitly accepting a
+#     failed remote job. It is a strong audit-actor test but, by its own
+#     assertion, not evidence that remote job execution succeeds.
+- pattern: "tests/integration/test_federation_two_cluster_live.py::TestFederationTwoClusterWalkthrough::test_federated_job_audit_actor_round_trip"
   capability_ids: [federation.remote-jobs]
   scenario_name: "Federated job execution via mesh"
-
-# Justification: the M3 ship-gate walkthrough's step 7 submits a federated
-# job via kz.jobs.run against the paired LYRA/ORION fleet and step 8
-# asserts the audit_actor round-trip. (Its gate/dataset steps exercise
-# federation surfaces outside this kit's capability inventory, so only
-# remote-jobs is claimed.)
-- pattern: "tests/integration/test_m3_walkthrough_live.py::test_m3_full_walkthrough_against_live_fleet"
-  capability_ids: [federation.remote-jobs]
-  scenario_name: "M3 fleet walkthrough federated job submission"

--- a/tests/e2e/capability_map.yaml
+++ b/tests/e2e/capability_map.yaml
@@ -55,20 +55,23 @@
   capability_ids: [models.discover-and-download]
   scenario_name: "Model discovery, metadata, and hub download"
 
-# Justification: TS11 surface — TestModelFileSearch (hub model-file search),
-# TestModelFileReadOperations and TestModelFileMemoryUsage (reads against the
-# repo ensure_repo_ready downloaded), TestModelFileDownloadStatus, and
-# test_delete_existing_model_file. (TestModelFileDownloadOperations carries
-# unconditional @pytest.mark.skip, so it can never contribute a step.)
+# Justification: TS11 surface — TestModelFileReadOperations and
+# TestModelFileMemoryUsage (reads against the repo ensure_repo_ready actually
+# downloaded), TestModelFileDownloadStatus, and test_delete_existing_model_file.
+# (TestModelFileDownloadOperations carries unconditional @pytest.mark.skip, so
+# it can never contribute a step.)
 # Excluded: TestModelFileValidation and test_delete_nonexistent_model_file
-# assert error handling for a fabricated UUID, and test_create_model_file
-# only registers a SCRATCH metadata row — none of them discovers or
-# downloads a model, so none can stand as evidence for this capability.
+# assert error handling for a fabricated UUID; test_create_model_file only
+# registers a SCRATCH metadata row; and TestModelFileSearch asserts nothing
+# beyond isinstance(results, list) — its own comment notes the hub result may
+# legitimately be empty, so it passes without discovering anything. None of
+# them discovers or downloads a model.
 - pattern: "tests/integration/test_model_files_live.py::*"
   capability_ids: [models.discover-and-download]
-  scenario_name: "Model file search and download management"
+  scenario_name: "Model file read and download management"
   exclude:
     - "*::TestModelFileValidation::*"
+    - "*::TestModelFileSearch::*"
     - "*::test_delete_nonexistent_model_file"
     - "*::test_create_model_file"
 
@@ -210,23 +213,35 @@
     - "*::test_global_workroom_exists"
     - "*::test_cannot_delete_global_workroom"
 
-# Justification: the module validates the workroom access matrix with
-# workroom-scoped sessions (X-Workroom-Id): self-access allowed
-# (TestSelfAccess), cross-workroom NEVER (TestCrossWorkspaceBlocked),
-# Global cannot see workspaces (TestGlobalCannotSeeWorkspaces), workspaces
-# can read Global (TestWorkspaceCanSeeGlobal), lifecycle isolation
-# (TestLifecycleIsolation — both tests assert one workroom's operation does
-# not affect another), and the ?workroom_id=all bypass (TestSentinelAllBypass).
-# The CRUD class overlaps intentionally, but only for its two own-vs-other
-# visibility assertions (create/get own, list returns own).
-# Excluded across every class, by one rule applied consistently: a test that
-# issues a single unscoped operation and asserts nothing about what another
-# session can or cannot see is not evidence of session scoping. That covers
-# the Global guardrails and update/archive of one's own workroom; the plain
-# read of the Global workroom in TestWorkspaceCanSeeGlobal (an exact twin of
-# the excluded CRUD-class read); archive-visibility-with-flag, which lists
-# only its own workroom; and the ?workroom_id=all deployments test, whose
-# only assertion is isinstance(result, list).
+# THE RETENTION TEST, applied per test rather than per class: the test must
+# assert something about what one session can or cannot see *relative to
+# another* (or relative to the no-header default). Asserting only that a
+# fetched object reports its own id, or that a list is a list, does not
+# demonstrate scoping no matter which class it sits in.
+#
+# Retained (11 of 23): TestSelfAccess (connectors/extensions scoped to own
+# workroom); TestCrossWorkspaceBlocked's three A-cannot-see-B / B-cannot-see-A
+# assertions; TestGlobalCannotSeeWorkspaces' two "Global excludes workspace
+# resources" assertions; TestLifecycleIsolation::test_delete_workroom_does_not
+# _affect_other; TestSentinelAllBypass::test_connectors_without_header_defaults
+# _to_global; and, from the CRUD class, its two own-vs-other visibility checks
+# (create/get own, list returns own) — that overlap is intentional.
+#
+# Excluded, each failing the retention test above:
+#   * the Global guardrails and update/archive of one's own workroom — single
+#     unscoped operations by one session;
+#   * TestWorkspaceCanSeeGlobal in full — all four tests read a Global resource
+#     and assert only that the object returned reports GLOBAL as its id; that
+#     shows access is permitted, not that scoping is enforced;
+#   * test_global_export_excludes_workspace_resources — despite its name it
+#     takes no workroom fixture, so no workspace exists during the test, and it
+#     asserts only manifest.workroom_id == GLOBAL;
+#   * test_workroom_export_only_shows_own_resources — workroom_b is never
+#     requested; it asserts A's manifest is A's and non-empty;
+#   * test_archive_workroom_still_visible_with_flag — lists only its own
+#     workroom;
+#   * test_deployments_all_returns_across_workrooms — its only assertion is
+#     isinstance(result, list); it never checks the result spans workrooms.
 - pattern: "tests/integration/test_workroom_isolation_live.py::*"
   capability_ids: [workrooms.session-scoping]
   scenario_name: "Workroom session-scoping access matrix"
@@ -235,7 +250,9 @@
     - "*::test_cannot_delete_global_workroom"
     - "*::TestWorkroomCrudIsolation::test_update_own_workroom"
     - "*::TestWorkroomCrudIsolation::test_archive_own_workroom"
-    - "*::test_workspace_user_can_read_global_workroom"
+    - "*::TestWorkspaceCanSeeGlobal::*"
+    - "*::test_global_export_excludes_workspace_resources"
+    - "*::test_workroom_export_only_shows_own_resources"
     - "*::test_archive_workroom_still_visible_with_flag"
     - "*::test_deployments_all_returns_across_workrooms"
 

--- a/tests/e2e/capability_map.yaml
+++ b/tests/e2e/capability_map.yaml
@@ -56,18 +56,21 @@
   scenario_name: "Model discovery, metadata, and hub download"
 
 # Justification: TS11 surface — TestModelFileSearch (hub model-file search),
-# TestModelFileDownloadStatus / TestModelFileDownloadOperations (download
-# status, cancel-all, cancel-specific), TestModelFileCreateAndDelete and
-# read operations against downloaded files.
+# TestModelFileReadOperations and TestModelFileMemoryUsage (reads against the
+# repo ensure_repo_ready downloaded), TestModelFileDownloadStatus, and
+# test_delete_existing_model_file. (TestModelFileDownloadOperations carries
+# unconditional @pytest.mark.skip, so it can never contribute a step.)
 # Excluded: TestModelFileValidation and test_delete_nonexistent_model_file
-# assert error handling for a fabricated UUID — no model is discovered or
-# downloaded, so they cannot stand as evidence for this capability.
+# assert error handling for a fabricated UUID, and test_create_model_file
+# only registers a SCRATCH metadata row — none of them discovers or
+# downloads a model, so none can stand as evidence for this capability.
 - pattern: "tests/integration/test_model_files_live.py::*"
   capability_ids: [models.discover-and-download]
   scenario_name: "Model file search and download management"
   exclude:
     - "*::TestModelFileValidation::*"
     - "*::test_delete_nonexistent_model_file"
+    - "*::test_create_model_file"
 
 # Justification: TS12 surface — TestModelListOperations, TestModelSearchOperations
 # (search_models_by_repo_id / exact match / get_model_by_repo_id),
@@ -129,23 +132,44 @@
 # endpoints, and secret endpoints — the catalog registry API surface
 # (test_catalog_dataset_schema_endpoints, test_catalog_dataset_variant_endpoints,
 # test_catalog_container_by_urn_and_path_endpoints, ...).
-# Excluded: test_catalog_metadata_and_health reads service health, and
+# Excluded: test_catalog_metadata_and_health reads service health,
 # test_catalog_container_endpoints_require_admin_user asserts an authz
-# rejection; neither registers or reads a dataset.
+# rejection, and the two secret tests manipulate only catalog secrets —
+# none of them registers or reads a dataset or container.
 - pattern: "tests/integration/test_catalog_endpoints.py::*"
   capability_ids: [catalog.dataset-registry]
-  scenario_name: "Catalog dataset, container, and secret endpoint surface"
+  scenario_name: "Catalog dataset and container endpoint surface"
   exclude:
     - "*::test_catalog_metadata_and_health"
     - "*::test_catalog_container_endpoints_require_admin_user"
+    - "*::test_catalog_secret_list"
+    - "*::test_catalog_secret_endpoints"
 
-# Justification: file/object/parquet/postgres/kafka/slack ingestion registers
-# datasets with metadata in the catalog (test_catalog_*_ingestion_metadata,
-# test_catalog_container_link_sets_dataset_container_urn) and the inline /
-# SSE retrieval tests run retrieval jobs over the ingested data.
+# Justification: every test in the module ingests from some source
+# (file/object/parquet/postgres/kafka/slack) and asserts the resulting
+# dataset's catalog metadata, so the whole module evidences the registry.
+# Split from the retrieval entry below: `exclude` is per-entry, so a single
+# entry claiming two capabilities cannot satisfy the per-test rule for both.
 - pattern: "tests/integration/test_catalog_multi_source.py::*"
-  capability_ids: [catalog.dataset-registry, retrieval.async-retrieval-jobs]
-  scenario_name: "Multi-source catalog ingestion with inline retrieval"
+  capability_ids: [catalog.dataset-registry]
+  scenario_name: "Multi-source catalog ingestion"
+
+# Justification: the subset that actually submits a retrieval job over the
+# ingested data — the two *_inline_retrieval tests, inline_small_object
+# (asserts row_count > 0), large_object_sse_retrieval, and
+# postgres_ingestion_metadata (POSTs /retrieval/jobs and asserts rows).
+# Excluded: the metadata-only ingestions and container_link never submit a
+# job, and inline_large_object_hits_threshold asserts a 422 rejection rather
+# than a successful retrieval.
+- pattern: "tests/integration/test_catalog_multi_source.py::*"
+  capability_ids: [retrieval.async-retrieval-jobs]
+  scenario_name: "Multi-source inline and SSE retrieval"
+  exclude:
+    - "*::test_catalog_file_ingestion_metadata"
+    - "*::test_catalog_kafka_ingestion_metadata"
+    - "*::test_catalog_slack_ingestion_metadata"
+    - "*::test_catalog_container_link_sets_dataset_container_urn"
+    - "*::test_catalog_inline_large_object_hits_threshold"
 
 # Justification: test_context_search_contract and
 # test_context_agentic_search_contract search over documents ingested into a
@@ -174,33 +198,51 @@
   scenario_name: "Workroom-scoped clients isolate vectordb views"
 
 # Justification: TestWorkroomCrudIsolation — create/get/list/update/archive
-# workrooms plus the Global-workroom guardrails (exists, cannot delete).
+# workrooms. Every retained test creates one, either through the workroom_a /
+# workroom_b fixtures or inline (test_archive_own_workroom).
+# Excluded: the two Global-workroom guardrails read (test_global_workroom_exists)
+# or assert a 403 (test_cannot_delete_global_workroom) against the pre-existing
+# Global workroom — neither creates anything.
 - pattern: "tests/integration/test_workroom_isolation_live.py::TestWorkroomCrudIsolation::*"
   capability_ids: [workrooms.create]
   scenario_name: "Workroom creation and CRUD lifecycle"
+  exclude:
+    - "*::test_global_workroom_exists"
+    - "*::test_cannot_delete_global_workroom"
 
-# Justification: the whole module validates the workroom access matrix with
+# Justification: the module validates the workroom access matrix with
 # workroom-scoped sessions (X-Workroom-Id): self-access allowed
 # (TestSelfAccess), cross-workroom NEVER (TestCrossWorkspaceBlocked),
 # Global cannot see workspaces (TestGlobalCannotSeeWorkspaces), workspaces
-# can read Global (TestWorkspaceCanSeeGlobal), lifecycle isolation. The
-# CRUD class is included by the glob; its create/list visibility checks are
-# themselves per-session scoping assertions, so the overlap is intentional.
+# can read Global (TestWorkspaceCanSeeGlobal), lifecycle isolation
+# (TestLifecycleIsolation — both tests assert one workroom's operation does
+# not affect another), and the ?workroom_id=all bypass (TestSentinelAllBypass).
+# The CRUD class overlaps intentionally, but only for its two own-vs-other
+# visibility assertions (create/get own, list returns own).
+# Excluded: the rest of the CRUD class — the Global guardrails plus
+# update/archive of one's own workroom — performs a single-session operation
+# and asserts nothing about isolation between sessions.
 - pattern: "tests/integration/test_workroom_isolation_live.py::*"
   capability_ids: [workrooms.session-scoping]
   scenario_name: "Workroom session-scoping access matrix"
+  exclude:
+    - "*::test_global_workroom_exists"
+    - "*::test_cannot_delete_global_workroom"
+    - "*::TestWorkroomCrudIsolation::test_update_own_workroom"
+    - "*::TestWorkroomCrudIsolation::test_archive_own_workroom"
 
 # Justification: ENG-6952 control plane — test_register_from_spec_returns_dataset_urn
-# registers a managed data source from a connector spec (returning its
-# dataset URN) and test_publisher_grant_then_revoke covers publisher access
-# management. Excluded: the test_register_rejects_* trio asserts spec
-# validation refusals — nothing is registered, so on their own they are not
-# evidence that managed data sources work.
+# registers a managed data source from a connector spec and asserts the
+# returned dataset URN. It is the only test here that registers one.
+# Excluded: the test_register_rejects_* trio asserts spec validation refusals
+# (nothing is registered), and test_publisher_grant_then_revoke only calls the
+# catalog publisher grant/revoke APIs without configuring a connector at all.
 - pattern: "tests/integration/test_connector_spec_live.py::*"
   capability_ids: [connectors.managed-data-sources]
   scenario_name: "Managed data source registration from connector spec"
   exclude:
     - "*::test_register_rejects_*"
+    - "*::test_publisher_grant_then_revoke"
 
 # Justification: TestFederationTwoClusterWalkthrough::test_federated_job_run_via_mesh
 # runs a job on the peer cluster through the mesh and

--- a/tests/e2e/test_capability_map.py
+++ b/tests/e2e/test_capability_map.py
@@ -1,0 +1,134 @@
+"""Guards on the *shipped* capability map (ENG-10026, T3.7).
+
+Separate from ``test_evidence_emitter.py`` on purpose: those tests pin the
+plugin's runtime behavior against synthetic maps and simulated results, while
+these validate the real ``capability_map.yaml`` against the repo's actual test
+collection. Different subject, different inputs, no shared state.
+
+What these pin is the map's load-bearing property: an entry emits evidence
+composed from whichever of its matched tests ran, so a stale ``pattern``
+silently stops an entry from ever emitting, and a stale ``exclude`` silently
+re-admits a test the carve-out existed to keep out. Either can be voided by an
+ordinary rename with every other test in the suite still green.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from fnmatch import fnmatchcase
+from pathlib import Path
+
+import pytest
+
+from tests.e2e import _evidence_emitter as emitter
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _collect_repo_nodeids() -> list[str]:
+    """Nodeids pytest actually collects for the files the shipped map names."""
+    entries = emitter.load_capability_map(emitter.DEFAULT_MAP_PATH)
+    files = sorted(
+        {
+            e.pattern.split("::", 1)[0]
+            for e in entries
+            if not e.pattern.startswith(emitter.MARKER_PREFIX)
+        }
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "--no-header",
+            "-p",
+            "no:cacheprovider",
+            *files,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    # A collection error must fail loudly: silently losing a module's nodeids
+    # would make every glob in its entries vacuously "unverifiable" below.
+    # Marker deselection still exits 0, so this does not fire on a host that
+    # merely lacks a second cluster.
+    assert proc.returncode == 0, (
+        f"pytest --collect-only failed (rc={proc.returncode}); cannot validate "
+        f"the map.\nstdout tail:\n{proc.stdout[-2000:]}\n"
+        f"stderr tail:\n{proc.stderr[-2000:]}"
+    )
+    return [
+        line.strip()
+        for line in proc.stdout.splitlines()
+        if line.startswith("tests/") and "::" in line
+    ]
+
+
+def _stale_globs(entry: emitter.MapEntry, nodeids: list[str]) -> list[str]:
+    """Globs in one entry that no longer match anything they should."""
+    matched = [n for n in nodeids if fnmatchcase(n, entry.pattern)]
+    if not matched:
+        return _unmatched_pattern_problems(entry, nodeids)
+    return [
+        f"{entry.scenario_name!r}: exclude {glob!r} matches nothing"
+        for glob in entry.exclude
+        if not any(fnmatchcase(n, glob) for n in matched)
+    ]
+
+
+def _unmatched_pattern_problems(
+    entry: emitter.MapEntry, nodeids: list[str]
+) -> list[str]:
+    """Diagnose an entry whose pattern matched no collected nodeid."""
+    file_part = entry.pattern.split("::", 1)[0]
+    if any(n.startswith(f"{file_part}::") for n in nodeids):
+        # The file collected tests, so the pattern itself has gone stale.
+        return [f"{entry.scenario_name!r}: pattern {entry.pattern!r} matches nothing"]
+    if entry.exclude:
+        # Nothing collected, so this entry's carve-outs cannot be checked here.
+        # That is only safe while it has none: an unverifiable `exclude` could
+        # rot in the false-evidence direction, unseen by this guard.
+        return [
+            f"{entry.scenario_name!r}: file {file_part!r} collected no tests, "
+            f"so its {len(entry.exclude)} exclude glob(s) cannot be verified "
+            "here — run on a host where this file collects, or drop them"
+        ]
+    return []
+
+
+def test_shipped_map_globs_still_match_real_nodeids():
+    """Every pattern and carve-out in the shipped map must still bite.
+
+    One known gap remains, in the safe direction (missing evidence, never
+    false evidence): ``marker:`` patterns are not checked at all, since a
+    marker match cannot be resolved from nodeids alone. A wholly deselected
+    file is handled explicitly — its pattern cannot be checked, so the entry
+    is required to carry no ``exclude`` that would go unverified.
+    """
+    nodeids = _collect_repo_nodeids()
+    assert nodeids, "collection produced no nodeids; cannot validate the map"
+
+    stale: list[str] = []
+    for entry in emitter.load_capability_map(emitter.DEFAULT_MAP_PATH):
+        stale.extend(_stale_globs(entry, nodeids))
+    assert not stale, "stale globs in capability_map.yaml: " + "; ".join(stale)
+
+
+def test_repo_capability_map_is_valid_and_references_real_files():
+    """The shipped map loads, and every nodeid pattern names a real file."""
+    entries = emitter.load_capability_map(emitter.DEFAULT_MAP_PATH)
+    assert entries, "shipped capability map must not be empty"
+    for entry in entries:
+        if entry.pattern.startswith(emitter.MARKER_PREFIX):
+            continue
+        file_part = entry.pattern.split("::", 1)[0]
+        assert "*" not in file_part, entry.pattern
+        assert (
+            REPO_ROOT / file_part
+        ).is_file(), f"capability_map.yaml pattern references missing file: {file_part}"

--- a/tests/e2e/test_evidence_emitter.py
+++ b/tests/e2e/test_evidence_emitter.py
@@ -1,0 +1,331 @@
+"""Tests for the opt-in scenario-evidence.v2 emitter (ENG-10026, T3.7).
+
+Pins the plugin contract: no behavior without ``--emit-evidence``; refusal
+without a build identity; explicit-map-only matching (unmapped tests emit
+nothing, unrun entries emit nothing); one conforming, schema-validated
+``scenario-evidence.v2`` record per map entry whose tests ran, with
+``evidence_provenance: "pre-existing"`` and harness ``derive_status``
+composition (all passed → passed, skips → passed_with_notes, any failure
+→ failed).
+
+End-to-end cases run pytest in-process via ``pytester`` with a fixture
+capability map and simulated test results; loader and outcome-folding
+semantics are pinned by direct unit tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.e2e import _evidence_emitter as emitter
+from tests.e2e.scenarios import harness
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TEST_BUILD = "kamiwaza-0.99.0+test.abc1234"
+
+# Mirrors the real wiring in the repo-root conftest.py: register the
+# options, then conditionally register the plugin. The sys.path insert
+# keeps the conftest importable under pytester's subprocess mode too.
+INNER_CONFTEST = f"""
+import sys
+
+sys.path.insert(0, {str(REPO_ROOT)!r})
+
+from tests.e2e import _evidence_emitter as em
+
+
+def pytest_addoption(parser):
+    parser.addoption("--build", action="store", default="")
+    em.add_evidence_options(parser)
+
+
+def pytest_configure(config):
+    em.maybe_register(config)
+"""
+
+MAP_ONE_ENTRY = """
+- pattern: "test_mapped.py::*"
+  capability_ids: [workrooms.create]
+  scenario_name: "Mapped scenario"
+"""
+
+
+@pytest.fixture(autouse=True)
+def _build_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deterministic build identity; refusal tests delete it explicitly."""
+    monkeypatch.setenv("KAMIWAZA_BUILD", TEST_BUILD)
+
+
+@pytest.fixture()
+def evidence_out(pytester: pytest.Pytester) -> Path:
+    return pytester.path / "evidence-out"
+
+
+def _run_emitting(pytester, evidence_out, *extra_args, map_yaml=MAP_ONE_ENTRY):
+    """Run the inner suite with evidence emission wired up."""
+    pytester.makeconftest(INNER_CONFTEST)
+    map_path = pytester.path / "capability_map.yaml"
+    map_path.write_text(map_yaml)
+    return pytester.runpytest_inprocess(
+        "--evidence-map",
+        str(map_path),
+        "--evidence-out",
+        str(evidence_out),
+        *extra_args,
+    )
+
+
+def _records(evidence_out: Path) -> list[dict]:
+    return [json.loads(p.read_text()) for p in sorted(evidence_out.glob("*.json"))]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end plugin behavior (pytester)
+# ---------------------------------------------------------------------------
+
+
+def test_flag_off_emits_nothing(pytester, evidence_out):
+    pytester.makepyfile(test_mapped="def test_ok():\n    assert True\n")
+    result = _run_emitting(pytester, evidence_out)
+    result.assert_outcomes(passed=1)
+    assert not evidence_out.exists()
+
+
+def test_unmapped_tests_emit_nothing(pytester, evidence_out):
+    """A run where no mapped test executed writes zero records."""
+    pytester.makepyfile(test_other="def test_ok():\n    assert True\n")
+    result = _run_emitting(
+        pytester, evidence_out, "--emit-evidence", "--build", TEST_BUILD
+    )
+    result.assert_outcomes(passed=1)
+    assert not evidence_out.exists()
+
+
+def test_pass_plus_skip_emits_passed_with_notes(pytester, evidence_out):
+    pytester.makepyfile(
+        test_mapped=(
+            "import pytest\n"
+            "def test_ok():\n    assert True\n"
+            "def test_skipped():\n    pytest.skip('not applicable')\n"
+        ),
+        test_unmapped="def test_also_ok():\n    assert True\n",
+    )
+    result = _run_emitting(
+        pytester, evidence_out, "--emit-evidence", "--build", TEST_BUILD
+    )
+    result.assert_outcomes(passed=2, skipped=1)
+
+    records = _records(evidence_out)
+    assert len(records) == 1  # the unmapped test contributed nothing
+    record = records[0]
+    harness.validate_evidence_record(record)
+    assert record["schema"] == harness.EVIDENCE_SCHEMA_ID
+    assert record["scenario_id"] == "mapped-scenario"
+    assert record["build"] == TEST_BUILD
+    assert record["method"] == "automated"
+    assert record["evidence_provenance"] == "pre-existing"
+    assert record["capability_ids"] == ["workrooms.create"]
+    assert record["status"] == "passed_with_notes"
+    assert [(s["name"], s["status"]) for s in record["steps"]] == [
+        ("test_mapped.py::test_ok", "passed"),
+        ("test_mapped.py::test_skipped", "skipped"),
+    ]
+
+
+def test_all_passed_emits_passed(pytester, evidence_out):
+    pytester.makepyfile(
+        test_mapped="def test_a():\n    pass\ndef test_b():\n    pass\n"
+    )
+    _run_emitting(pytester, evidence_out, "--emit-evidence", "--build", TEST_BUILD)
+    (record,) = _records(evidence_out)
+    harness.validate_evidence_record(record)
+    assert record["status"] == "passed"
+    assert all(s["status"] == "passed" for s in record["steps"])
+
+
+def test_any_failure_emits_failed(pytester, evidence_out):
+    pytester.makepyfile(
+        test_mapped=(
+            "def test_ok():\n    assert True\n" "def test_broken():\n    assert False\n"
+        )
+    )
+    result = _run_emitting(
+        pytester, evidence_out, "--emit-evidence", "--build", TEST_BUILD
+    )
+    result.assert_outcomes(passed=1, failed=1)
+    (record,) = _records(evidence_out)
+    harness.validate_evidence_record(record)
+    assert record["status"] == "failed"
+    statuses = {s["name"]: s["status"] for s in record["steps"]}
+    assert statuses["test_mapped.py::test_broken"] == "failed"
+    assert statuses["test_mapped.py::test_ok"] == "passed"
+
+
+def test_marker_pattern_matches(pytester, evidence_out):
+    map_yaml = """
+- pattern: "marker:mapped_cap"
+  capability_ids: [models.local-deployment]
+  scenario_name: "Marker mapped scenario"
+"""
+    pytester.makepyfile(
+        test_marked=(
+            "import pytest\n"
+            "@pytest.mark.mapped_cap\n"
+            "def test_ok():\n    assert True\n"
+            "def test_unmarked():\n    assert True\n"
+        )
+    )
+    _run_emitting(
+        pytester,
+        evidence_out,
+        "--emit-evidence",
+        "--build",
+        TEST_BUILD,
+        map_yaml=map_yaml,
+    )
+    (record,) = _records(evidence_out)
+    assert [s["name"] for s in record["steps"]] == ["test_marked.py::test_ok"]
+
+
+def test_record_conforms_to_vendored_schema(pytester, evidence_out):
+    """The emitted record satisfies the vendored v2 schema's constraints."""
+    pytester.makepyfile(test_mapped="def test_ok():\n    assert True\n")
+    _run_emitting(pytester, evidence_out, "--emit-evidence", "--build", TEST_BUILD)
+    (record,) = _records(evidence_out)
+
+    schema = json.loads(harness.EVIDENCE_SCHEMA_PATH.read_text())
+    assert set(schema["required"]) <= set(record)
+    assert record["schema"] == schema["properties"]["schema"]["const"]
+    assert record["status"] in schema["properties"]["status"]["enum"]
+    assert record["method"] in schema["properties"]["method"]["enum"]
+    assert (
+        record["evidence_provenance"]
+        in schema["properties"]["evidence_provenance"]["enum"]
+    )
+    step_required = set(schema["$defs"]["step"]["required"])
+    assert all(step_required <= set(s) for s in record["steps"])
+    # And the harness-side mirror of that schema agrees.
+    harness.validate_evidence_record(record)
+
+
+def test_refusal_without_build_identity(pytester, evidence_out, monkeypatch):
+    monkeypatch.delenv("KAMIWAZA_BUILD", raising=False)
+    pytester.makepyfile(test_mapped="def test_ok():\n    assert True\n")
+    result = _run_emitting(pytester, evidence_out, "--emit-evidence")
+    assert result.ret == pytest.ExitCode.USAGE_ERROR
+    result.stderr.fnmatch_lines(["*build identity*"])
+    assert not evidence_out.exists()
+
+
+# ---------------------------------------------------------------------------
+# Capability-map loader
+# ---------------------------------------------------------------------------
+
+
+def test_loader_missing_file_raises(tmp_path):
+    with pytest.raises(ValueError, match="not found"):
+        emitter.load_capability_map(tmp_path / "nope.yaml")
+
+
+def test_loader_rejects_non_list(tmp_path):
+    path = tmp_path / "map.yaml"
+    path.write_text("pattern: oops\n")
+    with pytest.raises(ValueError, match="must be a list"):
+        emitter.load_capability_map(path)
+
+
+def test_loader_rejects_unknown_or_missing_keys(tmp_path):
+    path = tmp_path / "map.yaml"
+    path.write_text(
+        "- pattern: 'x::*'\n  capability_ids: [workrooms.create]\n"
+        "  scenario_name: 'A'\n  extra: nope\n"
+    )
+    with pytest.raises(ValueError, match="exactly the keys"):
+        emitter.load_capability_map(path)
+
+
+def test_loader_rejects_malformed_capability_id(tmp_path):
+    path = tmp_path / "map.yaml"
+    path.write_text(
+        "- pattern: 'x::*'\n  capability_ids: ['Not Valid!']\n" "  scenario_name: 'A'\n"
+    )
+    with pytest.raises(ValueError, match="kebab-case"):
+        emitter.load_capability_map(path)
+
+
+def test_loader_rejects_empty_capability_ids(tmp_path):
+    path = tmp_path / "map.yaml"
+    path.write_text("- pattern: 'x::*'\n  capability_ids: []\n  scenario_name: 'A'\n")
+    with pytest.raises(ValueError, match="non-empty list"):
+        emitter.load_capability_map(path)
+
+
+def test_loader_rejects_duplicate_scenario_slugs(tmp_path):
+    path = tmp_path / "map.yaml"
+    path.write_text(
+        "- pattern: 'x::*'\n  capability_ids: [workrooms.create]\n"
+        "  scenario_name: 'Same Name'\n"
+        "- pattern: 'y::*'\n  capability_ids: [workrooms.create]\n"
+        "  scenario_name: 'same name'\n"
+    )
+    with pytest.raises(ValueError, match="slugs to"):
+        emitter.load_capability_map(path)
+
+
+def test_slugify_is_stable_kebab_case():
+    assert emitter.slugify("Model discovery, metadata, and hub download") == (
+        "model-discovery-metadata-and-hub-download"
+    )
+    assert emitter.slugify("  Weird -- Name!  ") == "weird-name"
+
+
+def test_repo_capability_map_is_valid_and_references_real_files():
+    """The shipped map loads, and every nodeid pattern names a real file."""
+    entries = emitter.load_capability_map(emitter.DEFAULT_MAP_PATH)
+    assert entries, "shipped capability map must not be empty"
+    for entry in entries:
+        if entry.pattern.startswith(emitter.MARKER_PREFIX):
+            continue
+        file_part = entry.pattern.split("::", 1)[0]
+        assert "*" not in file_part, entry.pattern
+        assert (
+            REPO_ROOT / file_part
+        ).is_file(), f"capability_map.yaml pattern references missing file: {file_part}"
+
+
+# ---------------------------------------------------------------------------
+# Outcome folding (setup/call/teardown composition)
+# ---------------------------------------------------------------------------
+
+
+def _report(*, failed=False, skipped=False, duration=0.1):
+    return SimpleNamespace(failed=failed, skipped=skipped, duration=duration)
+
+
+def test_outcome_fold_failure_wins_over_later_phases():
+    outcome = emitter._TestOutcome()
+    outcome.fold(_report())  # setup passed
+    outcome.fold(_report(failed=True))  # call failed
+    outcome.fold(_report())  # teardown passed
+    assert outcome.status == "failed"
+    assert outcome.duration_s == pytest.approx(0.3)
+
+
+def test_outcome_fold_skip_does_not_mask_failure():
+    outcome = emitter._TestOutcome()
+    outcome.fold(_report(failed=True))
+    outcome.fold(_report(skipped=True))
+    assert outcome.status == "failed"
+
+
+def test_outcome_fold_setup_skip_marks_skipped():
+    outcome = emitter._TestOutcome()
+    outcome.fold(_report(skipped=True))
+    outcome.fold(_report())
+    assert outcome.status == "skipped"

--- a/tests/e2e/test_evidence_emitter.py
+++ b/tests/e2e/test_evidence_emitter.py
@@ -1,12 +1,16 @@
 """Tests for the opt-in scenario-evidence.v2 emitter (ENG-10026, T3.7).
 
 Pins the plugin contract: no behavior without ``--emit-evidence``; refusal
-without a build identity; explicit-map-only matching (unmapped tests emit
-nothing, unrun entries emit nothing); one conforming, schema-validated
-``scenario-evidence.v2`` record per map entry whose tests ran, with
-``evidence_provenance: "pre-existing"`` and harness ``derive_status``
-composition (all passed → passed, skips → passed_with_notes, any failure
-→ failed).
+without a build identity (and without a parseable map); explicit-map-only
+matching with ``exclude`` carve-outs (unmapped, excluded, and unrun tests
+emit nothing); one conforming, schema-validated ``scenario-evidence.v2``
+record per map entry whose tests ran, with ``evidence_provenance:
+"pre-existing"`` and harness ``derive_status`` composition (all passed →
+passed, skips → passed_with_notes, any failure → failed).
+
+Also pins the three rules that stop a partial run from claiming evidence:
+an incomplete test contributes no step, an aborted session writes nothing,
+and an all-skipped entry emits nothing.
 
 End-to-end cases run pytest in-process via ``pytester`` with a fixture
 capability map and simulated test results; loader and outcome-folding
@@ -67,12 +71,22 @@ def evidence_out(pytester: pytest.Pytester) -> Path:
     return pytester.path / "evidence-out"
 
 
-def _run_emitting(pytester, evidence_out, *extra_args, map_yaml=MAP_ONE_ENTRY):
-    """Run the inner suite with evidence emission wired up."""
+def _run_emitting(
+    pytester, evidence_out, *extra_args, map_yaml=MAP_ONE_ENTRY, subprocess=False
+):
+    """Run the inner suite with evidence emission wired up.
+
+    ``subprocess=True`` is needed for the interrupted-run case: an inner
+    ``KeyboardInterrupt`` propagates straight out of ``runpytest_inprocess``
+    and would tear down the outer session too.
+    """
     pytester.makeconftest(INNER_CONFTEST)
     map_path = pytester.path / "capability_map.yaml"
     map_path.write_text(map_yaml)
-    return pytester.runpytest_inprocess(
+    runner = (
+        pytester.runpytest_subprocess if subprocess else pytester.runpytest_inprocess
+    )
+    return runner(
         "--evidence-map",
         str(map_path),
         "--evidence-out",
@@ -214,6 +228,147 @@ def test_record_conforms_to_vendored_schema(pytester, evidence_out):
     harness.validate_evidence_record(record)
 
 
+def test_all_skipped_entry_emits_nothing(pytester, evidence_out):
+    """The under-provisioned-host shape: every mapped test skips at runtime.
+
+    ``derive_status`` would score this ``passed_with_notes``; emitting that
+    would claim non-failing evidence for a capability nothing exercised.
+    """
+    pytester.makepyfile(
+        test_mapped=(
+            "import pytest\n"
+            "def test_needs_gpu():\n    pytest.skip('no gpu')\n"
+            "def test_needs_peer():\n    pytest.skip('single cluster')\n"
+        )
+    )
+    result = _run_emitting(
+        pytester, evidence_out, "--emit-evidence", "--build", TEST_BUILD
+    )
+    result.assert_outcomes(skipped=2)
+    assert not evidence_out.exists()
+
+
+def test_skip_at_collection_gate_emits_nothing(pytester, evidence_out):
+    """Module-level skip (the marker/fixture gate shape) is also not evidence."""
+    pytester.makepyfile(
+        test_mapped=(
+            "import pytest\n"
+            "pytestmark = pytest.mark.skip('requires two clusters')\n"
+            "def test_a():\n    assert True\n"
+        )
+    )
+    result = _run_emitting(
+        pytester, evidence_out, "--emit-evidence", "--build", TEST_BUILD
+    )
+    result.assert_outcomes(skipped=1)
+    assert not evidence_out.exists()
+
+
+def test_failure_among_skips_still_emits_failed(pytester, evidence_out):
+    """The all-skipped gate must not swallow genuine failure evidence."""
+    pytester.makepyfile(
+        test_mapped=(
+            "import pytest\n"
+            "def test_skipped():\n    pytest.skip('n/a')\n"
+            "def test_broken():\n    assert False\n"
+        )
+    )
+    _run_emitting(pytester, evidence_out, "--emit-evidence", "--build", TEST_BUILD)
+    (record,) = _records(evidence_out)
+    assert record["status"] == "failed"
+
+
+def test_interrupted_session_emits_nothing(pytester, evidence_out):
+    """Ctrl-C mid-suite: coverage is unknowable, so no record is honest."""
+    pytester.makepyfile(
+        test_mapped=(
+            "def test_a():\n    assert True\n"
+            "def test_b_interrupts():\n    raise KeyboardInterrupt\n"
+            "def test_c():\n    assert True\n"
+        )
+    )
+    result = _run_emitting(
+        pytester,
+        evidence_out,
+        "--emit-evidence",
+        "--build",
+        TEST_BUILD,
+        subprocess=True,
+    )
+    assert result.ret == pytest.ExitCode.INTERRUPTED
+    assert not evidence_out.exists()
+    result.stdout.fnmatch_lines(["*no scenario-evidence records written*"])
+
+
+def test_stop_early_on_maxfail_emits_nothing(pytester, evidence_out):
+    """``-x`` leaves later mapped tests unrun — the same partial-coverage risk."""
+    pytester.makepyfile(
+        test_mapped=(
+            "def test_a_broken():\n    assert False\n"
+            "def test_b():\n    assert True\n"
+        )
+    )
+    _run_emitting(
+        pytester, evidence_out, "--emit-evidence", "--build", TEST_BUILD, "-x"
+    )
+    assert not evidence_out.exists()
+
+
+def test_exclude_narrows_a_broad_pattern(pytester, evidence_out):
+    """A negative-path test carved out of a module glob emits no evidence."""
+    map_yaml = """
+- pattern: "test_mapped.py::*"
+  capability_ids: [workrooms.create]
+  scenario_name: "Mapped scenario"
+  exclude:
+    - "*::test_get_nonexistent*"
+"""
+    pytester.makepyfile(
+        test_mapped=(
+            "def test_real_work():\n    assert True\n"
+            "def test_get_nonexistent_thing():\n    assert True\n"
+        )
+    )
+    _run_emitting(
+        pytester,
+        evidence_out,
+        "--emit-evidence",
+        "--build",
+        TEST_BUILD,
+        map_yaml=map_yaml,
+    )
+    (record,) = _records(evidence_out)
+    assert [s["name"] for s in record["steps"]] == ["test_mapped.py::test_real_work"]
+
+
+def test_excluded_test_alone_emits_nothing(pytester, evidence_out):
+    """Codex's targeted-run case: running only the excluded test claims nothing."""
+    map_yaml = """
+- pattern: "test_mapped.py::*"
+  capability_ids: [workrooms.create]
+  scenario_name: "Mapped scenario"
+  exclude:
+    - "*::test_get_nonexistent*"
+"""
+    pytester.makepyfile(
+        test_mapped=(
+            "def test_real_work():\n    assert True\n"
+            "def test_get_nonexistent_thing():\n    assert True\n"
+        )
+    )
+    _run_emitting(
+        pytester,
+        evidence_out,
+        "--emit-evidence",
+        "--build",
+        TEST_BUILD,
+        "-k",
+        "nonexistent",
+        map_yaml=map_yaml,
+    )
+    assert not evidence_out.exists()
+
+
 def test_refusal_without_build_identity(pytester, evidence_out, monkeypatch):
     monkeypatch.delenv("KAMIWAZA_BUILD", raising=False)
     pytester.makepyfile(test_mapped="def test_ok():\n    assert True\n")
@@ -247,6 +402,62 @@ def test_loader_rejects_unknown_or_missing_keys(tmp_path):
         "  scenario_name: 'A'\n  extra: nope\n"
     )
     with pytest.raises(ValueError, match="exactly the keys"):
+        emitter.load_capability_map(path)
+
+
+def test_loader_rejects_malformed_yaml_as_value_error(tmp_path):
+    """A YAML syntax error must reach callers as the documented ValueError."""
+    path = tmp_path / "map.yaml"
+    path.write_text("- pattern: 'x::*'\n   bad: [unclosed\n")
+    with pytest.raises(ValueError, match="invalid YAML"):
+        emitter.load_capability_map(path)
+
+
+def test_malformed_yaml_map_refuses_with_usage_error(pytester, evidence_out):
+    """End to end: a broken map is a clean refusal, not a configure traceback."""
+    pytester.makepyfile(test_mapped="def test_ok():\n    assert True\n")
+    result = _run_emitting(
+        pytester,
+        evidence_out,
+        "--emit-evidence",
+        "--build",
+        TEST_BUILD,
+        map_yaml="- pattern: 'x::*'\n   bad: [unclosed\n",
+    )
+    assert result.ret == pytest.ExitCode.USAGE_ERROR
+    result.stderr.fnmatch_lines(["*invalid YAML*"])
+    assert not evidence_out.exists()
+
+
+def test_loader_accepts_and_applies_exclude(tmp_path):
+    path = tmp_path / "map.yaml"
+    path.write_text(
+        "- pattern: 'tests/x.py::*'\n  capability_ids: [workrooms.create]\n"
+        "  scenario_name: 'A'\n  exclude: ['*::test_nope']\n"
+    )
+    (entry,) = emitter.load_capability_map(path)
+    assert entry.exclude == ("*::test_nope",)
+    assert entry.matches(SimpleNamespace(nodeid="tests/x.py::test_yes"))
+    assert not entry.matches(SimpleNamespace(nodeid="tests/x.py::test_nope"))
+
+
+def test_loader_rejects_non_list_exclude(tmp_path):
+    path = tmp_path / "map.yaml"
+    path.write_text(
+        "- pattern: 'x::*'\n  capability_ids: [workrooms.create]\n"
+        "  scenario_name: 'A'\n  exclude: 'oops'\n"
+    )
+    with pytest.raises(ValueError, match="exclude must be a list"):
+        emitter.load_capability_map(path)
+
+
+def test_loader_rejects_empty_exclude_glob(tmp_path):
+    path = tmp_path / "map.yaml"
+    path.write_text(
+        "- pattern: 'x::*'\n  capability_ids: [workrooms.create]\n"
+        "  scenario_name: 'A'\n  exclude: ['']\n"
+    )
+    with pytest.raises(ValueError, match=r"exclude\[0\]"):
         emitter.load_capability_map(path)
 
 
@@ -304,15 +515,21 @@ def test_repo_capability_map_is_valid_and_references_real_files():
 # ---------------------------------------------------------------------------
 
 
-def _report(*, failed=False, skipped=False, duration=0.1):
-    return SimpleNamespace(failed=failed, skipped=skipped, duration=duration)
+def _report(*, failed=False, skipped=False, duration=0.1, when="call"):
+    return SimpleNamespace(
+        failed=failed,
+        skipped=skipped,
+        duration=duration,
+        when=when,
+        passed=not (failed or skipped),
+    )
 
 
 def test_outcome_fold_failure_wins_over_later_phases():
     outcome = emitter._TestOutcome()
-    outcome.fold(_report())  # setup passed
+    outcome.fold(_report(when="setup"))  # setup passed
     outcome.fold(_report(failed=True))  # call failed
-    outcome.fold(_report())  # teardown passed
+    outcome.fold(_report(when="teardown"))  # teardown passed
     assert outcome.status == "failed"
     assert outcome.duration_s == pytest.approx(0.3)
 
@@ -326,6 +543,51 @@ def test_outcome_fold_skip_does_not_mask_failure():
 
 def test_outcome_fold_setup_skip_marks_skipped():
     outcome = emitter._TestOutcome()
-    outcome.fold(_report(skipped=True))
-    outcome.fold(_report())
+    outcome.fold(_report(skipped=True, when="setup"))
+    outcome.fold(_report(when="teardown"))
     assert outcome.status == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Completion tracking: only terminal reports make a test count as evidence
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_passing_setup_alone_is_incomplete():
+    """The mid-test-death shape: setup passed, call never reported."""
+    outcome = emitter._TestOutcome()
+    outcome.fold(_report(when="setup"))
+    assert outcome.status == "passed"  # default status is still affirmative...
+    assert outcome.complete is False  # ...so completion is what gates emission
+
+
+def test_outcome_call_report_completes():
+    outcome = emitter._TestOutcome()
+    outcome.fold(_report(when="setup"))
+    outcome.fold(_report(when="call"))
+    assert outcome.complete is True
+
+
+@pytest.mark.parametrize("kwargs", [{"failed": True}, {"skipped": True}])
+def test_outcome_terminal_setup_completes(kwargs):
+    """A failed or skipped setup settles the test — no call phase follows."""
+    outcome = emitter._TestOutcome()
+    outcome.fold(_report(when="setup", **kwargs))
+    assert outcome.complete is True
+
+
+def test_incomplete_outcome_contributes_no_step():
+    entry = emitter.MapEntry(
+        pattern="test_x.py::*",
+        scenario_name="X",
+        capability_ids=("workrooms.create",),
+    )
+    plugin = emitter.EvidenceEmitterPlugin(
+        entries=[entry], build=TEST_BUILD, out_dir=Path("unused")
+    )
+    plugin._matched = {"test_x.py::test_a": [entry], "test_x.py::test_b": [entry]}
+    plugin._outcomes = {
+        "test_x.py::test_a": emitter._TestOutcome(status="passed", complete=True),
+        "test_x.py::test_b": emitter._TestOutcome(status="passed", complete=False),
+    }
+    assert [s.name for s in plugin._steps_for(entry)] == ["test_x.py::test_a"]

--- a/tests/e2e/test_evidence_emitter.py
+++ b/tests/e2e/test_evidence_emitter.py
@@ -15,14 +15,15 @@ and an all-skipped entry emits nothing.
 End-to-end cases run pytest in-process via ``pytester`` with a fixture
 capability map and simulated test results; loader and outcome-folding
 semantics are pinned by direct unit tests.
+
+Guards on the *shipped* ``capability_map.yaml`` — that its patterns and
+``exclude`` globs still match real collected nodeids — live next door in
+``test_capability_map.py``.
 """
 
 from __future__ import annotations
 
 import json
-import subprocess
-import sys
-from fnmatch import fnmatchcase
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -548,117 +549,6 @@ def test_slugify_is_stable_kebab_case():
         "model-discovery-metadata-and-hub-download"
     )
     assert emitter.slugify("  Weird -- Name!  ") == "weird-name"
-
-
-def _collect_repo_nodeids() -> list[str]:
-    """Nodeids pytest actually collects for the files the shipped map names."""
-    entries = emitter.load_capability_map(emitter.DEFAULT_MAP_PATH)
-    files = sorted(
-        {
-            e.pattern.split("::", 1)[0]
-            for e in entries
-            if not e.pattern.startswith(emitter.MARKER_PREFIX)
-        }
-    )
-    proc = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "pytest",
-            "--collect-only",
-            "-q",
-            "--no-header",
-            "-p",
-            "no:cacheprovider",
-            *files,
-        ],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-    )
-    # A collection error must fail loudly: silently losing a module's nodeids
-    # would make every glob in its entries vacuously "unverifiable" below.
-    # Marker deselection still exits 0, so this does not fire on a host that
-    # merely lacks a second cluster.
-    assert proc.returncode == 0, (
-        f"pytest --collect-only failed (rc={proc.returncode}); cannot validate "
-        f"the map.\nstdout tail:\n{proc.stdout[-2000:]}\n"
-        f"stderr tail:\n{proc.stderr[-2000:]}"
-    )
-    return [
-        line.strip()
-        for line in proc.stdout.splitlines()
-        if line.startswith("tests/") and "::" in line
-    ]
-
-
-def _stale_globs(entry: emitter.MapEntry, nodeids: list[str]) -> list[str]:
-    """Globs in one entry that no longer match anything they should."""
-    matched = [n for n in nodeids if fnmatchcase(n, entry.pattern)]
-    if not matched:
-        return _unmatched_pattern_problems(entry, nodeids)
-    return [
-        f"{entry.scenario_name!r}: exclude {glob!r} matches nothing"
-        for glob in entry.exclude
-        if not any(fnmatchcase(n, glob) for n in matched)
-    ]
-
-
-def _unmatched_pattern_problems(
-    entry: emitter.MapEntry, nodeids: list[str]
-) -> list[str]:
-    """Diagnose an entry whose pattern matched no collected nodeid."""
-    file_part = entry.pattern.split("::", 1)[0]
-    if any(n.startswith(f"{file_part}::") for n in nodeids):
-        # The file collected tests, so the pattern itself has gone stale.
-        return [f"{entry.scenario_name!r}: pattern {entry.pattern!r} matches nothing"]
-    if entry.exclude:
-        # Nothing collected, so this entry's carve-outs cannot be checked here.
-        # That is only safe while it has none: an unverifiable `exclude` could
-        # rot in the false-evidence direction, unseen by this guard.
-        return [
-            f"{entry.scenario_name!r}: file {file_part!r} collected no tests, "
-            f"so its {len(entry.exclude)} exclude glob(s) cannot be verified "
-            "here — run on a host where this file collects, or drop them"
-        ]
-    return []
-
-
-def test_shipped_map_globs_still_match_real_nodeids():
-    """Every pattern and carve-out in the shipped map must still bite.
-
-    The ``exclude`` globs are the whole defense against a targeted run
-    claiming a capability it never exercised, and a live ``pattern`` is what
-    makes an entry produce evidence at all. Either can be voided by a rename
-    with every other test still green, so pin both against a real collection.
-
-    One known gap remains, in the safe direction (missing evidence, never
-    false evidence): ``marker:`` patterns are not checked at all, since a
-    marker match cannot be resolved from nodeids alone. A wholly deselected
-    file is handled explicitly — its pattern cannot be checked, so the entry
-    is required to carry no ``exclude`` that would go unverified.
-    """
-    nodeids = _collect_repo_nodeids()
-    assert nodeids, "collection produced no nodeids; cannot validate the map"
-
-    stale: list[str] = []
-    for entry in emitter.load_capability_map(emitter.DEFAULT_MAP_PATH):
-        stale.extend(_stale_globs(entry, nodeids))
-    assert not stale, "stale globs in capability_map.yaml: " + "; ".join(stale)
-
-
-def test_repo_capability_map_is_valid_and_references_real_files():
-    """The shipped map loads, and every nodeid pattern names a real file."""
-    entries = emitter.load_capability_map(emitter.DEFAULT_MAP_PATH)
-    assert entries, "shipped capability map must not be empty"
-    for entry in entries:
-        if entry.pattern.startswith(emitter.MARKER_PREFIX):
-            continue
-        file_part = entry.pattern.split("::", 1)[0]
-        assert "*" not in file_part, entry.pattern
-        assert (
-            REPO_ROOT / file_part
-        ).is_file(), f"capability_map.yaml pattern references missing file: {file_part}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_evidence_emitter.py
+++ b/tests/e2e/test_evidence_emitter.py
@@ -20,6 +20,9 @@ semantics are pinned by direct unit tests.
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
+from fnmatch import fnmatchcase
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -395,13 +398,35 @@ def test_loader_rejects_non_list(tmp_path):
         emitter.load_capability_map(path)
 
 
-def test_loader_rejects_unknown_or_missing_keys(tmp_path):
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(
+            "- pattern: 'x::*'\n  capability_ids: [workrooms.create]\n"
+            "  scenario_name: 'A'\n  extra: nope\n",
+            id="unknown-key",
+        ),
+        pytest.param(
+            "- pattern: 'x::*'\n  capability_ids: [workrooms.create]\n",
+            id="missing-required-key",
+        ),
+    ],
+)
+def test_loader_rejects_unknown_or_missing_keys(tmp_path, body):
+    path = tmp_path / "map.yaml"
+    path.write_text(body)
+    with pytest.raises(ValueError, match="exactly the keys"):
+        emitter.load_capability_map(path)
+
+
+def test_loader_rejects_scenario_name_slugging_to_empty(tmp_path):
+    """A non-empty name of only non-ASCII characters yields no scenario_id."""
     path = tmp_path / "map.yaml"
     path.write_text(
         "- pattern: 'x::*'\n  capability_ids: [workrooms.create]\n"
-        "  scenario_name: 'A'\n  extra: nope\n"
+        "  scenario_name: '日本語'\n"
     )
-    with pytest.raises(ValueError, match="exactly the keys"):
+    with pytest.raises(ValueError, match="empty scenario_id"):
         emitter.load_capability_map(path)
 
 
@@ -494,6 +519,62 @@ def test_slugify_is_stable_kebab_case():
         "model-discovery-metadata-and-hub-download"
     )
     assert emitter.slugify("  Weird -- Name!  ") == "weird-name"
+
+
+def _collect_repo_nodeids() -> list[str]:
+    """Nodeids pytest actually collects for the files the shipped map names."""
+    entries = emitter.load_capability_map(emitter.DEFAULT_MAP_PATH)
+    files = sorted(
+        {
+            e.pattern.split("::", 1)[0]
+            for e in entries
+            if not e.pattern.startswith(emitter.MARKER_PREFIX)
+        }
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "--no-header",
+            "-p",
+            "no:cacheprovider",
+            *files,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        line.strip()
+        for line in proc.stdout.splitlines()
+        if line.startswith("tests/") and "::" in line
+    ]
+
+
+def test_shipped_exclude_globs_still_match_real_nodeids():
+    """Every carve-out must still bite.
+
+    The ``exclude`` globs are the whole defense against a targeted run
+    claiming a capability it never exercised. A class rename would silently
+    void one and leave every other test green, so pin them against a real
+    collection. Entries whose pattern matches nothing are skipped: marker
+    deselection (e.g. ``requires_two_clusters``) legitimately empties a file.
+    """
+    nodeids = _collect_repo_nodeids()
+    assert nodeids, "collection produced no nodeids; cannot validate the map"
+
+    stale: list[str] = []
+    for entry in emitter.load_capability_map(emitter.DEFAULT_MAP_PATH):
+        matched = [n for n in nodeids if fnmatchcase(n, entry.pattern)]
+        if not matched:
+            continue  # whole file deselected on this host
+        for glob in entry.exclude:
+            if not any(fnmatchcase(n, glob) for n in matched):
+                stale.append(f"{entry.scenario_name!r}: {glob!r} matches nothing")
+    assert not stale, "stale exclude globs in capability_map.yaml: " + "; ".join(stale)
 
 
 def test_repo_capability_map_is_valid_and_references_real_files():

--- a/tests/e2e/test_evidence_emitter.py
+++ b/tests/e2e/test_evidence_emitter.py
@@ -391,10 +391,23 @@ def test_loader_missing_file_raises(tmp_path):
         emitter.load_capability_map(tmp_path / "nope.yaml")
 
 
-def test_loader_rejects_non_list(tmp_path):
+@pytest.mark.parametrize(
+    "body", ["pattern: oops\n", "{}\n", "0\n", "false\n"], ids=lambda b: b.strip()
+)
+def test_loader_rejects_non_list(tmp_path, body):
+    """Falsey scalars/mappings are malformed maps, not 'no entries'."""
     path = tmp_path / "map.yaml"
-    path.write_text("pattern: oops\n")
+    path.write_text(body)
     with pytest.raises(ValueError, match="must be a list"):
+        emitter.load_capability_map(path)
+
+
+@pytest.mark.parametrize("body", ["", "[]\n"], ids=["empty-file", "empty-list"])
+def test_loader_rejects_empty_map(tmp_path, body):
+    """An opted-in run against an empty map can never produce evidence."""
+    path = tmp_path / "map.yaml"
+    path.write_text(body)
+    with pytest.raises(ValueError, match="contains no entries"):
         emitter.load_capability_map(path)
 
 
@@ -547,6 +560,15 @@ def _collect_repo_nodeids() -> list[str]:
         capture_output=True,
         text=True,
     )
+    # A collection error must fail loudly: silently losing a module's nodeids
+    # would make every glob in its entries vacuously "unverifiable" below.
+    # Marker deselection still exits 0, so this does not fire on a host that
+    # merely lacks a second cluster.
+    assert proc.returncode == 0, (
+        f"pytest --collect-only failed (rc={proc.returncode}); cannot validate "
+        f"the map.\nstdout tail:\n{proc.stdout[-2000:]}\n"
+        f"stderr tail:\n{proc.stderr[-2000:]}"
+    )
     return [
         line.strip()
         for line in proc.stdout.splitlines()
@@ -554,27 +576,41 @@ def _collect_repo_nodeids() -> list[str]:
     ]
 
 
-def test_shipped_exclude_globs_still_match_real_nodeids():
-    """Every carve-out must still bite.
+def _stale_globs(entry: emitter.MapEntry, nodeids: list[str]) -> list[str]:
+    """Globs in one entry that no longer match anything they should."""
+    matched = [n for n in nodeids if fnmatchcase(n, entry.pattern)]
+    if not matched:
+        # A pattern matching nothing is stale only if its file still collected
+        # tests; a wholly marker-deselected file (the two-cluster suite on a
+        # single-cluster host) legitimately contributes none.
+        file_part = entry.pattern.split("::", 1)[0]
+        if any(n.startswith(f"{file_part}::") for n in nodeids):
+            return [
+                f"{entry.scenario_name!r}: pattern {entry.pattern!r} matches nothing"
+            ]
+        return []
+    return [
+        f"{entry.scenario_name!r}: exclude {glob!r} matches nothing"
+        for glob in entry.exclude
+        if not any(fnmatchcase(n, glob) for n in matched)
+    ]
+
+
+def test_shipped_map_globs_still_match_real_nodeids():
+    """Every pattern and carve-out in the shipped map must still bite.
 
     The ``exclude`` globs are the whole defense against a targeted run
-    claiming a capability it never exercised. A class rename would silently
-    void one and leave every other test green, so pin them against a real
-    collection. Entries whose pattern matches nothing are skipped: marker
-    deselection (e.g. ``requires_two_clusters``) legitimately empties a file.
+    claiming a capability it never exercised, and a live ``pattern`` is what
+    makes an entry produce evidence at all. Either can be voided by a rename
+    with every other test still green, so pin both against a real collection.
     """
     nodeids = _collect_repo_nodeids()
     assert nodeids, "collection produced no nodeids; cannot validate the map"
 
     stale: list[str] = []
     for entry in emitter.load_capability_map(emitter.DEFAULT_MAP_PATH):
-        matched = [n for n in nodeids if fnmatchcase(n, entry.pattern)]
-        if not matched:
-            continue  # whole file deselected on this host
-        for glob in entry.exclude:
-            if not any(fnmatchcase(n, glob) for n in matched):
-                stale.append(f"{entry.scenario_name!r}: {glob!r} matches nothing")
-    assert not stale, "stale exclude globs in capability_map.yaml: " + "; ".join(stale)
+        stale.extend(_stale_globs(entry, nodeids))
+    assert not stale, "stale globs in capability_map.yaml: " + "; ".join(stale)
 
 
 def test_repo_capability_map_is_valid_and_references_real_files():

--- a/tests/e2e/test_evidence_emitter.py
+++ b/tests/e2e/test_evidence_emitter.py
@@ -596,20 +596,32 @@ def _stale_globs(entry: emitter.MapEntry, nodeids: list[str]) -> list[str]:
     """Globs in one entry that no longer match anything they should."""
     matched = [n for n in nodeids if fnmatchcase(n, entry.pattern)]
     if not matched:
-        # A pattern matching nothing is stale only if its file still collected
-        # tests; a wholly marker-deselected file (the two-cluster suite on a
-        # single-cluster host) legitimately contributes none.
-        file_part = entry.pattern.split("::", 1)[0]
-        if any(n.startswith(f"{file_part}::") for n in nodeids):
-            return [
-                f"{entry.scenario_name!r}: pattern {entry.pattern!r} matches nothing"
-            ]
-        return []
+        return _unmatched_pattern_problems(entry, nodeids)
     return [
         f"{entry.scenario_name!r}: exclude {glob!r} matches nothing"
         for glob in entry.exclude
         if not any(fnmatchcase(n, glob) for n in matched)
     ]
+
+
+def _unmatched_pattern_problems(
+    entry: emitter.MapEntry, nodeids: list[str]
+) -> list[str]:
+    """Diagnose an entry whose pattern matched no collected nodeid."""
+    file_part = entry.pattern.split("::", 1)[0]
+    if any(n.startswith(f"{file_part}::") for n in nodeids):
+        # The file collected tests, so the pattern itself has gone stale.
+        return [f"{entry.scenario_name!r}: pattern {entry.pattern!r} matches nothing"]
+    if entry.exclude:
+        # Nothing collected, so this entry's carve-outs cannot be checked here.
+        # That is only safe while it has none: an unverifiable `exclude` could
+        # rot in the false-evidence direction, unseen by this guard.
+        return [
+            f"{entry.scenario_name!r}: file {file_part!r} collected no tests, "
+            f"so its {len(entry.exclude)} exclude glob(s) cannot be verified "
+            "here — run on a host where this file collects, or drop them"
+        ]
+    return []
 
 
 def test_shipped_map_globs_still_match_real_nodeids():
@@ -620,10 +632,11 @@ def test_shipped_map_globs_still_match_real_nodeids():
     makes an entry produce evidence at all. Either can be voided by a rename
     with every other test still green, so pin both against a real collection.
 
-    Two known gaps, both in the safe direction (missing evidence, never false
-    evidence): ``marker:`` patterns are not checked at all, and a rename
-    inside a wholly marker-deselected file (the two-cluster suite on a
-    single-cluster host) cannot be seen from here.
+    One known gap remains, in the safe direction (missing evidence, never
+    false evidence): ``marker:`` patterns are not checked at all, since a
+    marker match cannot be resolved from nodeids alone. A wholly deselected
+    file is handled explicitly — its pattern cannot be checked, so the entry
+    is required to carry no ``exclude`` that would go unverified.
     """
     nodeids = _collect_repo_nodeids()
     assert nodeids, "collection produced no nodeids; cannot validate the map"

--- a/tests/e2e/test_evidence_emitter.py
+++ b/tests/e2e/test_evidence_emitter.py
@@ -432,6 +432,22 @@ def test_loader_rejects_unknown_or_missing_keys(tmp_path, body):
         emitter.load_capability_map(path)
 
 
+@pytest.mark.parametrize("key", ["1", "true"], ids=["int-key", "bool-key"])
+def test_loader_rejects_non_string_keys(tmp_path, key):
+    """YAML yields real ints/bools for bare `1:` / `true:` keys.
+
+    Left unchecked they reach ``sorted()`` alongside the required string keys
+    and raise TypeError, escaping the UsageError refusal contract.
+    """
+    path = tmp_path / "map.yaml"
+    path.write_text(
+        "- pattern: 'x::*'\n  capability_ids: [workrooms.create]\n"
+        f"  scenario_name: 'A'\n  {key}: nope\n"
+    )
+    with pytest.raises(ValueError, match="keys must all be strings"):
+        emitter.load_capability_map(path)
+
+
 def test_loader_rejects_scenario_name_slugging_to_empty(tmp_path):
     """A non-empty name of only non-ASCII characters yields no scenario_id."""
     path = tmp_path / "map.yaml"
@@ -603,6 +619,11 @@ def test_shipped_map_globs_still_match_real_nodeids():
     claiming a capability it never exercised, and a live ``pattern`` is what
     makes an entry produce evidence at all. Either can be voided by a rename
     with every other test still green, so pin both against a real collection.
+
+    Two known gaps, both in the safe direction (missing evidence, never false
+    evidence): ``marker:`` patterns are not checked at all, and a rename
+    inside a wholly marker-deselected file (the two-cluster suite on a
+    single-cluster host) cannot be seen from here.
     """
     nodeids = _collect_repo_nodeids()
     assert nodeids, "collection produced no nodeids; cannot validate the map"


### PR DESCRIPTION
## Summary
Opt-in pytest instrumentation that makes the existing e2e/live suite emit `scenario-evidence.v2` records as pre-existing evidence for the release kit — one instrumented run evidences ~8 capabilities without writing a new test (salesdevkit1 T3.7, ENG-10026).

## Type
- [ ] Feature - New functionality
- [ ] Bug Fix - Corrects existing behavior
- [ ] Refactor - Code improvement without behavior change
- [ ] Documentation - Docs only
- [x] Test - Test coverage improvement
- [ ] Chore - Dependencies, config, CI/CD

## Change Flags
- [x] Configuration change - New pytest options `--emit-evidence` / `--evidence-map` / `--evidence-out` (all opt-in)
- [ ] API change / Requirements change / Schema change

## Breaking Changes
- [x] None - Fully backward compatible (zero behavior change without the flag; full unit/contract sweep re-verified green)

## Motivation
Design R1 gates the kit's SDK reference on all passing evidence including pre-existing tests (`evidence_provenance: pre-existing`); A1 assumed the suite could cheaply produce records. This makes it real: the live suite already exercises models, catalog, retrieval, context, workrooms, and federation — now those runs leave capability-linked evidence.

## Source
- [x] Issue/Ticket: Linear ENG-10026 (M3 — Value streams enter the kit)
- [x] Spec/Design Doc: kamiwaza-docs-engineering-internal `.../sales-developer-release-kit-design.md` R1/A1, §4.4

## Alternatives Considered
- Inferring capability mappings from test names — rejected: mapping is explicit and reviewed (`capability_map.yaml`), unmapped tests emit nothing, ever.
- Mapping the S1–S5 scenario drivers — rejected: they emit v2 natively via the harness; mapping would double-count.

## Changes Made
- `tests/e2e/capability_map.yaml` — 17 reviewed pattern→capability entries, each with a justification comment; header documents the rule and the deliberate omissions (external-endpoints and enterprise-sso have no genuine covering test — verified, not assumed; a mocked federation test excluded)
- `tests/e2e/_evidence_emitter.py` — plugin reusing the harness's own `resolve_build_identity`, `derive_status`, `validate_evidence_record`, and id regex (no parallel implementations)
- Root `conftest.py` wiring (conditional registration); `.gitignore` for `tests/e2e/evidence-out/`

## Technical Notes
- Steps are built only from mapped tests that actually ran — deselected tests drop out, so partial runs yield smaller-but-honest records; an entry with zero ran tests writes nothing.
- Each step names its test nodeid with outcome + duration; `map_pattern` carries traceability to the map entry.
- Records land in a gitignored dir for the kit's collector — never committed here (public repo; internal build identity).

## Testing
- [x] Unit tests added/updated

19 new tests (flag off → nothing; simulated results → conforming records; unmapped emits nothing; schema validation; refusal without build identity; partial-run composition).

## Verification
| Environment | Steps Performed | Result |
|-------------|-----------------|--------|
| Local | `pytest tests/e2e/scenarios tests/e2e/test_evidence_emitter.py -q` | 125 passed, 6 skipped (pre-existing env-gated) |
| Local | full `-m "not integration and not live and not e2e"` sweep | 3339 passed, 2 skipped |
| Local | `--emit-evidence` without build | hard refusal with G1 message (re-verified) |
| Local | `--emit-evidence --build smoke-check` on scenarios | 106 passed, zero records (no mapped test ran — correct) |

Live instrumented run against `kamiwaza.test` is the follow-up step (produces the actual evidence batch for collection).

## Test Coverage
Mapping semantics (glob tightness, overlap, zero-ran entries), status composition (pass/fail/skip incl. setup errors), record conformance, refusal paths, opt-in isolation.

## Review Focus
- `capability_map.yaml` entries — each mapping's justification; the deliberately tight `test_context_live` globs
- The intentional CRUD/session-scoping overlap in `test_workroom_isolation_live` (commented in the map)

## Deployment Notes
N/A — opt-in test tooling only.

## Checklist
- [x] Self-reviewed the code
- [x] Tests pass locally
- [ ] Verified on live system (live instrumented run is the follow-up)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-verify-start -->
<details>
<summary>🔐 <b>pr-verify</b> · format_version 0 · machine-readable YAML (click to expand)</summary>

```yaml
format_version: 0
tool: pr-verify
tool_version: 0.1.0
generated_at: 2026-08-11T05:39:00.000Z
pr:
  repo: kamiwaza-ai/kamiwaza-sdk
  number: 260
linear_issues:
  - ENG-10026
auto_checks:
  - kind: required-checks
    required: true
    status: pass
    detail: All 7 checks green at head 6452ac7 (CodeScene Code Health, Coverage,
      Cyclomatic Complexity, Mypy, Ruff, Unit Tests, check-linear-issue). Gate
      will re-verify.
  - kind: pr-evidence
    required: false
    status: skipped
    detail: Opt-in pytest test tooling only; no cluster-running code and no deploy
      effect, so pr-evidence is not applicable.
  - kind: linear-issue-present
    required: true
    status: pass
    detail: Found ENG-10026 in the PR title and head branch
      (feature/eng-10026-t37-e2e-evidence-instrumentation).
  - kind: no-debug-statements
    required: true
    status: pass
    detail: Scanned added lines of the full PR diff for
      breakpoint()/pdb.set_trace/console.log/debugger/stray print/TODO/FIXME
      markers; no matches.
  - kind: pr-review-approved
    required: true
    status: pass
    detail: Multi-engine /pr-review (Claude Code + Codex) returned APPROVE at head
      6452ac7 after 7 rounds; Codex reported no actionable correctness
      regressions. Report posted as PR comment 5249160018.
  - kind: minimum-pr-age
    required: true
    status: pass
    detail: "minimum PR age satisfied: created 2026-08-10T22:00:28.000Z; eligible
      since 2026-08-10T22:45:28.000Z"
manual_steps:
  - id: ms-1
    description: Run `env -u KAMIWAZA_BUILD uv run pytest tests/e2e/scenarios
      --emit-evidence`. What exact error text does pytest print, and what exit
      code does it return?
    observation: 'pytest printed: "ERROR: --emit-evidence: scenario evidence
      requires a build identity: pass build=... to run_scenario (the drivers
      wire the --build pytest option), or set KAMIWAZA_BUILD. Refusing to run -
      a record without build identity cannot support staleness queries (G1)."
      The exit code was 4 (pytest USAGE_ERROR). No tests executed and
      tests/e2e/evidence-out/ was never created.'
    status: pass
  - id: ms-2
    description: With no --emit-evidence flag, run `uv run pytest
      tests/e2e/scenarios`, then `ls -d tests/e2e/evidence-out`. What does the
      ls print?
    observation: 'The suite reported "106 passed, 6 skipped in 0.19s" (the 6 skips
      are pre-existing env gates, e.g. "KAMIWAZA_STAGING_URL not set - scenario
      driver requires a staging cluster"). The ls printed: "ls:
      tests/e2e/evidence-out: No such file or directory" - the output directory
      was never created.'
    status: pass
  - id: ms-3
    description: Create tests/e2e/evidence-out/probe.json, then run `git status
      --short | grep evidence-out` and `git check-ignore -v` on it. What do the
      two commands report?
    observation: 'git status --short produced no evidence-out entry (grep matched
      nothing, so the fallback printed "NOT LISTED in git status"). git
      check-ignore -v printed:
      ".gitignore:169:tests/e2e/evidence-out/\ttests/e2e/evidence-out/probe.json",
      confirming the ignore rule at .gitignore line 169 matches the emitted
      record path.'
    status: pass
verdict:
  decision: approve
  rationale: All required auto-checks passed (required-checks,
    linear-issue-present, no-debug-statements, pr-review-approved,
    minimum-pr-age); 3 manual steps verified.
gate:
  approval_submitted: false
  approval_blocked_reason: freshly-planned bundle; run gate to validate
linear:
  - id: ENG-10026
    url: https://linear.app/kamiwaza/issue/ENG-10026/t37-instrument-existing-sdk-e2e-suite-to-emit-pre-existing-evidence
    cached_description: >-
      Design R1/A1 · the highest-leverage SDK-arm move


      The existing `kamiwaza-sdk/tests/e2e` suite already exercises much of
      models/serving/retrieval. R1 gates the SDK reference on **all** passing
      evidence including pre-existing tests, carried as `evidence_provenance:
      pre-existing`; A1 assumed the suite "can cheaply be made to produce"
      per-test records. This task makes that real: an opt-in pytest hook
      (`--emit-evidence`, requires `--build`) plus a reviewed
      `capability_map.yaml` (test pattern → `capability_ids[]`) that emits
      conforming `scenario-evidence.v2` records from a normal suite run. One
      instrumented run against `kamiwaza.test` should evidence ~6-10 P1
      sdk-routed capabilities without writing new tests.


      **Accept:** opt-in only (no behavior change without the flag); records
      validate against the vendored schema; unmapped tests emit nothing (mapping
      is explicit, never inferred); records land locally for the kit collector —
      never committed to the public repo.
    cached_at: 2026-08-11T05:06:00Z
```

</details>

# pr-verify bundle — synthesized by /pr-verify plan
# Reviewer-facing notes belong in the manual_steps observations above.

<!-- pr-verify-end -->