### PR TITLE
ENG-10260: Resolve compound Compose defaults in kz-ext dev

### DIFF
--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -297,7 +297,7 @@ def _fallback_image_basename(
 # A single Compose substitution. The fallback is greedy so nested defaults
 # are parsed after ``_compose_substitution_end`` finds the balanced expression.
 _COMPOSE_SUB_RE = re.compile(
-    r"^\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?[-?])(.*))?\}$",
+    r"^\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?[-?+])(.*))?\}$",
     re.DOTALL,
 )
 _COMPOSE_BRACE_RE = re.compile(r"[{}]")
@@ -342,9 +342,10 @@ _DEFAULT_LIMITS: Dict[str, Dict[str, str]] = {
 class ComposeTransformer:
     """Transform a local-dev compose dict into a deployment-ready dict.
 
-    All operations are pure (no I/O).  The caller provides the parsed
-    compose dict and receives a new dict suitable for building a
-    ``CreateExtension`` payload.
+    The caller provides the parsed compose dict and receives a new dict
+    suitable for building a ``CreateExtension`` payload. Transformations are
+    pure; ``resolve_env_placeholders`` additionally reads the process
+    environment without modifying it.
     """
 
     def transform(
@@ -487,6 +488,8 @@ class ComposeTransformer:
           substitution semantics.
         - ``${VAR:-default}`` / ``${VAR-default}`` for non-platform
           keys → recursively collapsed to a host value or literal default.
+        - ``${VAR:+alternate}`` / ``${VAR+alternate}`` → the alternate when
+          the corresponding non-empty/set condition is satisfied, else empty.
         - Placeholder-bearing entries whose key starts with ``KAMIWAZA_`` →
           dropped. The kamiwaza-extension operator injects these via ConfigMap
           envFrom; an explicit resolved entry would shadow the cluster-internal
@@ -513,12 +516,13 @@ class ComposeTransformer:
 def _resolve_shell_refs(env: Any) -> Any:
     """Resolve compose ``${VAR:-default}`` substitutions, drop unresolvable.
 
-    Two rules:
+    Three rules:
 
     1. Non-platform placeholders use the current process environment and
-       Compose unset/empty semantics for ``:-``, ``-``, ``:?``, and ``?``.
-       Embedded substitutions and nested defaults are resolved recursively.
-       The cluster deployment carries the resolved value through to the pod
+       Compose unset/empty semantics for ``:-``, ``-``, ``:?``, ``?``,
+       ``:+``, and ``+``. Embedded substitutions and nested defaults are
+       resolved recursively. The cluster deployment carries the resolved
+       value through to the pod
        — and ``detect_service_url_rewrites`` (called by
        ``PayloadBuilder``) emits a ``service-ref-rewrites`` annotation
        so the operator can swap cross-service hostnames at deploy time.
@@ -531,12 +535,12 @@ def _resolve_shell_refs(env: Any) -> Any:
 
     3. Unset bare substitutions and unsatisfied required forms are dropped.
 
-    Plain values without ``${`` pass through unchanged.
+    Values without supported substitutions or ``$$`` escapes pass unchanged.
     """
     if isinstance(env, dict):
         out: Dict[str, Any] = {}
         for k, v in env.items():
-            if not isinstance(v, str) or "${" not in v:
+            if not isinstance(v, str) or "$" not in v:
                 out[k] = v
                 continue
             resolved = _resolve_default_substitution(k, v)
@@ -557,10 +561,24 @@ def _resolve_shell_refs(env: Any) -> Any:
 
 
 def _resolve_default_substitution(key: str, value: str) -> Optional[str]:
-    """Resolve Compose substitutions in one non-platform environment value."""
-    if key.startswith(_PLATFORM_INJECTED_PREFIX):
+    """Resolve Compose substitutions in one environment value."""
+    is_platform_key = key.startswith(_PLATFORM_INJECTED_PREFIX)
+    if is_platform_key and _has_braced_substitution(value):
         return None
     return _resolve_compose_value(value)
+
+
+def _has_braced_substitution(value: str) -> bool:
+    """Whether *value* contains an unescaped ``${...}`` opener."""
+    cursor = 0
+    while (dollar := value.find("$", cursor)) >= 0:
+        if value.startswith("$$", dollar):
+            cursor = dollar + 2
+            continue
+        if value.startswith("${", dollar):
+            return True
+        cursor = dollar + 1
+    return False
 
 
 def _resolve_compose_value(value: str) -> Optional[str]:
@@ -619,6 +637,10 @@ def _resolve_compose_substitution(value: str) -> Optional[str]:
         return host_value
     if operator in ("-", "?") and is_set:
         return host_value
+    if operator == ":+":
+        return _resolve_compose_value(fallback) if host_value else ""
+    if operator == "+":
+        return _resolve_compose_value(fallback) if is_set else ""
     if operator in (":?", "?"):
         return None
     return _resolve_compose_value(fallback)
@@ -637,9 +659,9 @@ def _resolve_list_entry(entry: Any) -> Optional[str]:
 
 def _entry_has_shell_ref(entry: Any) -> bool:
     if isinstance(entry, str) and "=" in entry:
-        return "${" in entry.split("=", 1)[1]
+        return "$" in entry.split("=", 1)[1]
     if isinstance(entry, dict):
-        return "${" in str(entry.get("value", ""))
+        return "$" in str(entry.get("value", ""))
     return False
 
 

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -300,6 +300,7 @@ _COMPOSE_SUB_RE = re.compile(
     r"^\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?[-?])(.*))?\}$",
     re.DOTALL,
 )
+_COMPOSE_SUB_TOKEN_RE = re.compile(r"\$\{|}")
 
 # Env var names that should be left to the platform's ConfigMap envFrom
 # injection (operator writes the cluster-internal value; an explicit
@@ -581,17 +582,10 @@ def _resolve_compose_value(value: str) -> Optional[str]:
 def _compose_substitution_end(value: str, start: int) -> Optional[int]:
     """Find the closing brace paired with the ``${`` at *start*."""
     depth = 1
-    cursor = start + 2
-    while cursor < len(value):
-        if value.startswith("${", cursor):
-            depth += 1
-            cursor += 2
-            continue
-        if value[cursor] == "}":
-            depth -= 1
-            if depth == 0:
-                return cursor
-        cursor += 1
+    for token in _COMPOSE_SUB_TOKEN_RE.finditer(value, start + 2):
+        depth += 1 if token.group() == "${" else -1
+        if depth == 0:
+            return token.start()
     return None
 
 

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -300,7 +300,7 @@ _COMPOSE_SUB_RE = re.compile(
     r"^\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?[-?])(.*))?\}$",
     re.DOTALL,
 )
-_COMPOSE_SUB_TOKEN_RE = re.compile(r"\$\{|}")
+_COMPOSE_BRACE_RE = re.compile(r"[{}]")
 
 # Env var names that should be left to the platform's ConfigMap envFrom
 # injection (operator writes the cluster-internal value; an explicit
@@ -483,12 +483,14 @@ class ComposeTransformer:
         the pod verbatim.
 
         Rules (per env var):
-        - Host environment values are used with normal Compose semantics.
+        - Host environment values are used with Compose's supported braced
+          substitution semantics.
         - ``${VAR:-default}`` / ``${VAR-default}`` for non-platform
           keys → recursively collapsed to a host value or literal default.
-        - ``${KAMIWAZA_*:-default}`` → dropped. The kamiwaza-extension
-          operator injects these via ConfigMap envFrom; an explicit
-          env entry would shadow the cluster-internal value.
+        - Placeholder-bearing entries whose key starts with ``KAMIWAZA_`` →
+          dropped. The kamiwaza-extension operator injects these via ConfigMap
+          envFrom; an explicit resolved entry would shadow the cluster-internal
+          value.
         - Unset ``${VAR}`` and unsatisfied required forms are dropped.
         - Plain values pass through unchanged.
 
@@ -514,18 +516,18 @@ def _resolve_shell_refs(env: Any) -> Any:
     Two rules:
 
     1. Non-platform placeholders use the current process environment and
-       normal Compose unset/empty semantics. Embedded substitutions and nested
-       defaults are resolved recursively. The cluster deployment carries the
-       resolved value through to the pod
+       Compose unset/empty semantics for ``:-``, ``-``, ``:?``, and ``?``.
+       Embedded substitutions and nested defaults are resolved recursively.
+       The cluster deployment carries the resolved value through to the pod
        — and ``detect_service_url_rewrites`` (called by
        ``PayloadBuilder``) emits a ``service-ref-rewrites`` annotation
        so the operator can swap cross-service hostnames at deploy time.
 
-    2. ``${KAMIWAZA_*:-default}`` → drop. The kamiwaza-extension
-       operator injects these via ConfigMap envFrom; an explicit env
-       entry would shadow the cluster-internal value. Compose defaults
-       point to laptop-only addresses (``host.docker.internal:7777``)
-       that don't resolve in-cluster anyway.
+    2. Placeholder-bearing entries whose key starts with ``KAMIWAZA_`` → drop.
+       The kamiwaza-extension operator injects these via ConfigMap envFrom; an
+       explicit resolved entry would shadow the cluster-internal value.
+       Compose defaults point to laptop-only addresses
+       (``host.docker.internal:7777``) that don't resolve in-cluster anyway.
 
     3. Unset bare substitutions and unsatisfied required forms are dropped.
 
@@ -562,31 +564,45 @@ def _resolve_default_substitution(key: str, value: str) -> Optional[str]:
 
 
 def _resolve_compose_value(value: str) -> Optional[str]:
-    """Resolve every balanced ``${...}`` expression embedded in *value*."""
+    """Resolve braced expressions while honoring Compose's ``$$`` escape."""
     resolved: List[str] = []
     cursor = 0
-    while (start := value.find("${", cursor)) >= 0:
-        end = _compose_substitution_end(value, start)
+    while cursor < len(value):
+        dollar = value.find("$", cursor)
+        if dollar < 0:
+            resolved.append(value[cursor:])
+            break
+        resolved.append(value[cursor:dollar])
+        if value.startswith("$$", dollar):
+            resolved.append("$")
+            cursor = dollar + 2
+            continue
+        if not value.startswith("${", dollar):
+            resolved.append("$")
+            cursor = dollar + 1
+            continue
+        end = _compose_substitution_end(value, dollar)
         if end is None:
             return None
-        resolved.append(value[cursor:start])
-        substitution = _resolve_compose_substitution(value[start : end + 1])
+        substitution = _resolve_compose_substitution(value[dollar : end + 1])
         if substitution is None:
             return None
         resolved.append(substitution)
         cursor = end + 1
-    resolved.append(value[cursor:])
     return "".join(resolved)
 
 
 def _compose_substitution_end(value: str, start: int) -> Optional[int]:
     """Find the closing brace paired with the ``${`` at *start*."""
     depth = 1
-    for token in _COMPOSE_SUB_TOKEN_RE.finditer(value, start + 2):
-        depth += 1 if token.group() == "${" else -1
+    for brace in _COMPOSE_BRACE_RE.finditer(value, start + 2):
+        depth += 1 if brace.group() == "{" else -1
         if depth == 0:
-            return token.start()
-    return None
+            return brace.start()
+    # Compose's greedy fallback accepts an unmatched literal ``{`` inside a
+    # default. In that case its final ``}`` still closes the substitution.
+    final_brace = value.rfind("}", start + 2)
+    return final_brace if final_brace >= 0 else None
 
 
 def _resolve_compose_substitution(value: str) -> Optional[str]:

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -496,7 +496,12 @@ class ComposeTransformer:
           envFrom; an explicit resolved entry would shadow the cluster-internal
           value.
         - Unset ``${VAR}`` and unsatisfied required forms are dropped.
+        - Unbraced ``$VAR`` references stay literal; this resolver intentionally
+          handles only braced Compose substitutions.
         - Plain values pass through unchanged.
+
+        ``$$`` escapes collapse to a literal dollar. A resulting ``$(VAR)``
+        token can still be expanded later by Kubernetes container-env handling.
 
         Skip this step when the destination DOES perform install-time
         substitution (e.g. a catalog template consumed by the platform
@@ -536,7 +541,8 @@ def _resolve_shell_refs(env: Any) -> Any:
 
     3. Unset bare substitutions and unsatisfied required forms are dropped.
 
-    Values without supported substitutions or ``$$`` escapes pass unchanged.
+    Values without supported substitutions or ``$$`` escapes pass unchanged;
+    unbraced ``$VAR`` references are outside this resolver's scope.
     """
     if isinstance(env, dict):
         out: Dict[str, Any] = {}
@@ -663,7 +669,9 @@ def _resolve_list_entry(entry: Any) -> Optional[Any]:
 
 
 def _resolve_dict_list_entry(entry: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    """Resolve a Kubernetes-style ``name``/``value`` environment entry."""
+    """Resolve a tolerated environment-list mapping."""
+    if "name" not in entry:
+        return _resolve_mapping_list_entry(entry)
     name = entry.get("name")
     value = entry.get("value")
     if name is None or not isinstance(value, str):
@@ -676,13 +684,28 @@ def _resolve_dict_list_entry(entry: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return out
 
 
+def _resolve_mapping_list_entry(entry: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Resolve a mapping-fragment list entry one environment key at a time."""
+    out: Dict[str, Any] = {}
+    for key, value in entry.items():
+        if not isinstance(value, str) or "$" not in value:
+            out[key] = value
+            continue
+        resolved = _resolve_env_value(str(key), value)
+        if resolved is not None:
+            out[key] = resolved
+    return out or None
+
+
 def _entry_has_shell_ref(entry: Any) -> bool:
     if isinstance(entry, str) and "=" in entry:
         return "$" in entry.split("=", 1)[1]
-    if isinstance(entry, dict) and "name" in entry:
+    if not isinstance(entry, dict):
+        return False
+    if "name" in entry:
         value = entry.get("value")
         return isinstance(value, str) and "$" in value
-    return False
+    return any(isinstance(value, str) and "$" in value for value in entry.values())
 
 
 # ------------------------------------------------------------------

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import os
 import re
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
@@ -293,14 +294,12 @@ def _fallback_image_basename(
     return basename or "extension"
 
 
-# Compose ``${VAR:-default}`` (use default if unset OR empty) and the
-# ``${VAR-default}`` form (use default only if unset). For our purposes
-# both collapse to the literal default — there's no host process between
-# us and Kubernetes, so the var is always "unset" by the time the pod
-# starts. The expression may be embedded in a larger value, such as
-# ``neo4j/${NEO4J_PASSWORD:-changeme}``. ``${VAR:?error}`` and bare
-# ``${VAR}`` aren't matched (no safe default → drop downstream).
-_DEFAULT_SUB_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*):?-([^}]*)\}")
+# A single Compose substitution. The fallback is greedy so nested defaults
+# are parsed after ``_compose_substitution_end`` finds the balanced expression.
+_COMPOSE_SUB_RE = re.compile(
+    r"^\$\{([A-Za-z_][A-Za-z0-9_]*)(?:(:?[-?])(.*))?\}$",
+    re.DOTALL,
+)
 
 # Env var names that should be left to the platform's ConfigMap envFrom
 # injection (operator writes the cluster-internal value; an explicit
@@ -483,13 +482,13 @@ class ComposeTransformer:
         the pod verbatim.
 
         Rules (per env var):
+        - Host environment values are used with normal Compose semantics.
         - ``${VAR:-default}`` / ``${VAR-default}`` for non-platform
-          keys → collapsed to the literal ``default``.
+          keys → recursively collapsed to a host value or literal default.
         - ``${KAMIWAZA_*:-default}`` → dropped. The kamiwaza-extension
           operator injects these via ConfigMap envFrom; an explicit
           env entry would shadow the cluster-internal value.
-        - ``${VAR}`` (no default) and ``${VAR:?error}`` (required) →
-          dropped. No safe value to ship.
+        - Unset ``${VAR}`` and unsatisfied required forms are dropped.
         - Plain values pass through unchanged.
 
         Skip this step when the destination DOES perform install-time
@@ -513,12 +512,10 @@ def _resolve_shell_refs(env: Any) -> Any:
 
     Two rules:
 
-    1. ``${VAR:-default}`` where the env key does NOT start with
-       ``KAMIWAZA_`` → resolve to ``default``, including when the
-       expression is embedded in a larger value. The host env isn't
-       consulted (we're nowhere near a docker-compose run); compose
-       semantics for "VAR is unset" simply use the default. The cluster
-       deployment then carries the literal default through to the pod
+    1. Non-platform placeholders use the current process environment and
+       normal Compose unset/empty semantics. Embedded substitutions and nested
+       defaults are resolved recursively. The cluster deployment carries the
+       resolved value through to the pod
        — and ``detect_service_url_rewrites`` (called by
        ``PayloadBuilder``) emits a ``service-ref-rewrites`` annotation
        so the operator can swap cross-service hostnames at deploy time.
@@ -529,8 +526,7 @@ def _resolve_shell_refs(env: Any) -> Any:
        point to laptop-only addresses (``host.docker.internal:7777``)
        that don't resolve in-cluster anyway.
 
-    3. ``${VAR}`` (no default) and ``${VAR:?error}`` (required) → drop.
-       No safe value to ship.
+    3. Unset bare substitutions and unsatisfied required forms are dropped.
 
     Plain values without ``${`` pass through unchanged.
     """
@@ -558,18 +554,64 @@ def _resolve_shell_refs(env: Any) -> Any:
 
 
 def _resolve_default_substitution(key: str, value: str) -> Optional[str]:
-    """Resolve default substitutions in a non-platform env value.
-
-    Returns None when:
-    - any substitution has no safe default
-    - the key is platform-injected (``KAMIWAZA_*``) — let envFrom win
-    """
+    """Resolve Compose substitutions in one non-platform environment value."""
     if key.startswith(_PLATFORM_INJECTED_PREFIX):
         return None
-    resolved = _DEFAULT_SUB_RE.sub(lambda match: match.group(2), value)
-    if "${" in resolved:
+    return _resolve_compose_value(value)
+
+
+def _resolve_compose_value(value: str) -> Optional[str]:
+    """Resolve every balanced ``${...}`` expression embedded in *value*."""
+    resolved: List[str] = []
+    cursor = 0
+    while (start := value.find("${", cursor)) >= 0:
+        end = _compose_substitution_end(value, start)
+        if end is None:
+            return None
+        resolved.append(value[cursor:start])
+        substitution = _resolve_compose_substitution(value[start : end + 1])
+        if substitution is None:
+            return None
+        resolved.append(substitution)
+        cursor = end + 1
+    resolved.append(value[cursor:])
+    return "".join(resolved)
+
+
+def _compose_substitution_end(value: str, start: int) -> Optional[int]:
+    """Find the closing brace paired with the ``${`` at *start*."""
+    depth = 1
+    cursor = start + 2
+    while cursor < len(value):
+        if value.startswith("${", cursor):
+            depth += 1
+            cursor += 2
+            continue
+        if value[cursor] == "}":
+            depth -= 1
+            if depth == 0:
+                return cursor
+        cursor += 1
+    return None
+
+
+def _resolve_compose_substitution(value: str) -> Optional[str]:
+    """Resolve one full substitution using Compose environment semantics."""
+    match = _COMPOSE_SUB_RE.match(value)
+    if match is None:
         return None
-    return resolved
+    name, operator, fallback = match.groups()
+    is_set = name in os.environ
+    host_value = os.environ.get(name, "")
+    if operator is None:
+        return host_value if is_set else None
+    if operator in (":-", ":?") and host_value:
+        return host_value
+    if operator in ("-", "?") and is_set:
+        return host_value
+    if operator in (":?", "?"):
+        return None
+    return _resolve_compose_value(fallback)
 
 
 def _resolve_list_entry(entry: Any) -> Optional[str]:

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -777,7 +777,7 @@ def detect_service_url_rewrites(
 
 
 def _iter_env_entries(env: Any) -> List[Tuple[str, str]]:
-    """Yield ``(key, value)`` pairs from either env shape."""
+    """Yield ``(key, value)`` pairs from supported env shapes."""
     out: List[Tuple[str, str]] = []
     if isinstance(env, dict):
         for k, v in env.items():
@@ -788,8 +788,14 @@ def _iter_env_entries(env: Any) -> List[Tuple[str, str]]:
             if isinstance(entry, str) and "=" in entry:
                 k, v = entry.split("=", 1)
                 out.append((k, v))
-            elif isinstance(entry, dict) and "name" in entry and "value" in entry:
-                out.append((str(entry["name"]), str(entry["value"])))
+            elif isinstance(entry, dict):
+                if "name" in entry and "value" in entry:
+                    out.append((str(entry["name"]), str(entry["value"])))
+                    continue
+                if "name" not in entry:
+                    for k, v in entry.items():
+                        if isinstance(v, (str, int, float, bool)):
+                            out.append((str(k), str(v)))
     return out
 
 

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -301,6 +301,7 @@ _COMPOSE_SUB_RE = re.compile(
     re.DOTALL,
 )
 _COMPOSE_BRACE_RE = re.compile(r"[{}]")
+_MAX_COMPOSE_SUBSTITUTION_DEPTH = 100
 
 # Env var names that should be left to the platform's ConfigMap envFrom
 # injection (operator writes the cluster-internal value; an explicit
@@ -543,7 +544,7 @@ def _resolve_shell_refs(env: Any) -> Any:
             if not isinstance(v, str) or "$" not in v:
                 out[k] = v
                 continue
-            resolved = _resolve_default_substitution(k, v)
+            resolved = _resolve_env_value(k, v)
             if resolved is not None:
                 out[k] = resolved
         return out
@@ -560,7 +561,7 @@ def _resolve_shell_refs(env: Any) -> Any:
     return env
 
 
-def _resolve_default_substitution(key: str, value: str) -> Optional[str]:
+def _resolve_env_value(key: str, value: str) -> Optional[str]:
     """Resolve Compose substitutions in one environment value."""
     is_platform_key = key.startswith(_PLATFORM_INJECTED_PREFIX)
     if is_platform_key and _has_braced_substitution(value):
@@ -581,8 +582,10 @@ def _has_braced_substitution(value: str) -> bool:
     return False
 
 
-def _resolve_compose_value(value: str) -> Optional[str]:
+def _resolve_compose_value(value: str, depth: int = 0) -> Optional[str]:
     """Resolve braced expressions while honoring Compose's ``$$`` escape."""
+    if depth >= _MAX_COMPOSE_SUBSTITUTION_DEPTH:
+        return None
     resolved: List[str] = []
     cursor = 0
     while cursor < len(value):
@@ -602,7 +605,7 @@ def _resolve_compose_value(value: str) -> Optional[str]:
         end = _compose_substitution_end(value, dollar)
         if end is None:
             return None
-        substitution = _resolve_compose_substitution(value[dollar : end + 1])
+        substitution = _resolve_compose_substitution(value[dollar : end + 1], depth)
         if substitution is None:
             return None
         resolved.append(substitution)
@@ -623,7 +626,7 @@ def _compose_substitution_end(value: str, start: int) -> Optional[int]:
     return final_brace if final_brace >= 0 else None
 
 
-def _resolve_compose_substitution(value: str) -> Optional[str]:
+def _resolve_compose_substitution(value: str, depth: int = 0) -> Optional[str]:
     """Resolve one full substitution using Compose environment semantics."""
     match = _COMPOSE_SUB_RE.match(value)
     if match is None:
@@ -638,30 +641,47 @@ def _resolve_compose_substitution(value: str) -> Optional[str]:
     if operator in ("-", "?") and is_set:
         return host_value
     if operator == ":+":
-        return _resolve_compose_value(fallback) if host_value else ""
+        return _resolve_compose_value(fallback, depth + 1) if host_value else ""
     if operator == "+":
-        return _resolve_compose_value(fallback) if is_set else ""
+        return _resolve_compose_value(fallback, depth + 1) if is_set else ""
     if operator in (":?", "?"):
         return None
-    return _resolve_compose_value(fallback)
+    return _resolve_compose_value(fallback, depth + 1)
 
 
-def _resolve_list_entry(entry: Any) -> Optional[str]:
-    """Apply ``_resolve_default_substitution`` to ``KEY=value`` list entries."""
+def _resolve_list_entry(entry: Any) -> Optional[Any]:
+    """Resolve one string or name/value dict environment-list entry."""
+    if isinstance(entry, dict):
+        return _resolve_dict_list_entry(entry)
     if not isinstance(entry, str) or "=" not in entry:
         return None
     key, value = entry.split("=", 1)
-    resolved = _resolve_default_substitution(key, value)
+    resolved = _resolve_env_value(key, value)
     if resolved is None:
         return None
     return f"{key}={resolved}"
 
 
+def _resolve_dict_list_entry(entry: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Resolve a Kubernetes-style ``name``/``value`` environment entry."""
+    name = entry.get("name")
+    value = entry.get("value")
+    if name is None or not isinstance(value, str):
+        return None
+    resolved = _resolve_env_value(str(name), value)
+    if resolved is None:
+        return None
+    out = dict(entry)
+    out["value"] = resolved
+    return out
+
+
 def _entry_has_shell_ref(entry: Any) -> bool:
     if isinstance(entry, str) and "=" in entry:
         return "$" in entry.split("=", 1)[1]
-    if isinstance(entry, dict):
-        return "$" in str(entry.get("value", ""))
+    if isinstance(entry, dict) and "name" in entry:
+        value = entry.get("value")
+        return isinstance(value, str) and "$" in value
     return False
 
 

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -778,25 +778,37 @@ def detect_service_url_rewrites(
 
 def _iter_env_entries(env: Any) -> List[Tuple[str, str]]:
     """Yield ``(key, value)`` pairs from supported env shapes."""
-    out: List[Tuple[str, str]] = []
     if isinstance(env, dict):
-        for k, v in env.items():
-            if isinstance(v, (str, int, float, bool)):
-                out.append((str(k), str(v)))
-    elif isinstance(env, list):
-        for entry in env:
-            if isinstance(entry, str) and "=" in entry:
-                k, v = entry.split("=", 1)
-                out.append((k, v))
-            elif isinstance(entry, dict):
-                if "name" in entry and "value" in entry:
-                    out.append((str(entry["name"]), str(entry["value"])))
-                    continue
-                if "name" not in entry:
-                    for k, v in entry.items():
-                        if isinstance(v, (str, int, float, bool)):
-                            out.append((str(k), str(v)))
+        return _iter_env_mapping(env)
+    if not isinstance(env, list):
+        return []
+    out: List[Tuple[str, str]] = []
+    for entry in env:
+        out.extend(_iter_env_list_entry(entry))
     return out
+
+
+def _iter_env_mapping(env: Dict[Any, Any]) -> List[Tuple[str, str]]:
+    """Return scalar key/value pairs from an environment mapping."""
+    return [
+        (str(key), str(value))
+        for key, value in env.items()
+        if isinstance(value, (str, int, float, bool))
+    ]
+
+
+def _iter_env_list_entry(entry: Any) -> List[Tuple[str, str]]:
+    """Return key/value pairs from one supported environment-list entry."""
+    if isinstance(entry, str) and "=" in entry:
+        key, value = entry.split("=", 1)
+        return [(key, value)]
+    if not isinstance(entry, dict):
+        return []
+    if "name" in entry:
+        if "value" in entry:
+            return [(str(entry["name"]), str(entry["value"]))]
+        return []
+    return _iter_env_mapping(entry)
 
 
 def _rewrite_url_hosts(

--- a/kamiwaza_extensions/compose_transformer.py
+++ b/kamiwaza_extensions/compose_transformer.py
@@ -297,9 +297,10 @@ def _fallback_image_basename(
 # ``${VAR-default}`` form (use default only if unset). For our purposes
 # both collapse to the literal default — there's no host process between
 # us and Kubernetes, so the var is always "unset" by the time the pod
-# starts. ``${VAR:?error}`` and bare ``${VAR}`` aren't matched (no safe
-# default → drop downstream).
-_DEFAULT_SUB_RE = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*):?-([^}]*)\}$")
+# starts. The expression may be embedded in a larger value, such as
+# ``neo4j/${NEO4J_PASSWORD:-changeme}``. ``${VAR:?error}`` and bare
+# ``${VAR}`` aren't matched (no safe default → drop downstream).
+_DEFAULT_SUB_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*):?-([^}]*)\}")
 
 # Env var names that should be left to the platform's ConfigMap envFrom
 # injection (operator writes the cluster-internal value; an explicit
@@ -512,8 +513,9 @@ def _resolve_shell_refs(env: Any) -> Any:
 
     Two rules:
 
-    1. ``${VAR:-default}`` where ``VAR`` does NOT start with
-       ``KAMIWAZA_`` → resolve to ``default``. The host env isn't
+    1. ``${VAR:-default}`` where the env key does NOT start with
+       ``KAMIWAZA_`` → resolve to ``default``, including when the
+       expression is embedded in a larger value. The host env isn't
        consulted (we're nowhere near a docker-compose run); compose
        semantics for "VAR is unset" simply use the default. The cluster
        deployment then carries the literal default through to the pod
@@ -556,18 +558,18 @@ def _resolve_shell_refs(env: Any) -> Any:
 
 
 def _resolve_default_substitution(key: str, value: str) -> Optional[str]:
-    """Return ``default`` from ``${VAR:-default}`` for non-platform keys.
+    """Resolve default substitutions in a non-platform env value.
 
     Returns None when:
-    - the value isn't a single ``${VAR(:-)default}`` substitution
+    - any substitution has no safe default
     - the key is platform-injected (``KAMIWAZA_*``) — let envFrom win
     """
     if key.startswith(_PLATFORM_INJECTED_PREFIX):
         return None
-    m = _DEFAULT_SUB_RE.match(value.strip())
-    if not m:
+    resolved = _DEFAULT_SUB_RE.sub(lambda match: match.group(2), value)
+    if "${" in resolved:
         return None
-    return m.group(2)
+    return resolved
 
 
 def _resolve_list_entry(entry: Any) -> Optional[str]:

--- a/kamiwaza_extensions/dev_env_image_refs.py
+++ b/kamiwaza_extensions/dev_env_image_refs.py
@@ -119,17 +119,27 @@ def rewrite_env_image_refs(
 
 
 def _rewrite_env_list_entry(entry: Any, ref_map: Dict[str, str]) -> Any:
-    """Rewrite one string or tolerated name/value environment-list entry."""
+    """Rewrite one string or tolerated mapping environment-list entry."""
     if isinstance(entry, str) and "=" in entry:
         key, value = entry.split("=", 1)
         rewritten = _rewrite_env_value(key.strip(), value, ref_map)
         return f"{key}={rewritten}" if rewritten != value else entry
-    if isinstance(entry, dict) and "name" in entry:
-        dict_value = entry.get("value")
-        if isinstance(dict_value, str):
-            out = dict(entry)
-            out["value"] = _rewrite_env_value(str(entry["name"]), dict_value, ref_map)
-            return out
+    if isinstance(entry, dict):
+        if "name" in entry:
+            dict_value = entry.get("value")
+            if isinstance(dict_value, str):
+                out = dict(entry)
+                out["value"] = _rewrite_env_value(
+                    str(entry["name"]), dict_value, ref_map
+                )
+                return out
+            return entry
+        return {
+            key: _rewrite_env_value(str(key), value, ref_map)
+            if isinstance(value, str)
+            else value
+            for key, value in entry.items()
+        }
     return entry
 
 

--- a/kamiwaza_extensions/dev_env_image_refs.py
+++ b/kamiwaza_extensions/dev_env_image_refs.py
@@ -114,13 +114,23 @@ def rewrite_env_image_refs(
                     env[key] = _rewrite_env_value(key, val, ref_map)
         elif isinstance(env, list):
             for i, entry in enumerate(env):
-                if not isinstance(entry, str) or "=" not in entry:
-                    continue
-                key, val = entry.split("=", 1)
-                new_val = _rewrite_env_value(key.strip(), val, ref_map)
-                if new_val != val:
-                    env[i] = f"{key}={new_val}"
+                env[i] = _rewrite_env_list_entry(entry, ref_map)
     return out
+
+
+def _rewrite_env_list_entry(entry: Any, ref_map: Dict[str, str]) -> Any:
+    """Rewrite one string or tolerated name/value environment-list entry."""
+    if isinstance(entry, str) and "=" in entry:
+        key, value = entry.split("=", 1)
+        rewritten = _rewrite_env_value(key.strip(), value, ref_map)
+        return f"{key}={rewritten}" if rewritten != value else entry
+    if isinstance(entry, dict) and "name" in entry:
+        dict_value = entry.get("value")
+        if isinstance(dict_value, str):
+            out = dict(entry)
+            out["value"] = _rewrite_env_value(str(entry["name"]), dict_value, ref_map)
+            return out
+    return entry
 
 
 def _rewrite_env_value(name: str, value: str, ref_map: Dict[str, str]) -> str:

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -445,8 +445,7 @@ class PayloadBuilder:
                     else:
                         result.append({"name": item})
                 elif isinstance(item, dict):
-                    for k, v in item.items():
-                        result.append({"name": str(k), "value": str(v)})
+                    result.extend(PayloadBuilder._parse_env_dict_item(item))
         elif isinstance(env, dict):
             for k, v in env.items():
                 entry: Dict[str, Any] = {"name": str(k)}
@@ -454,6 +453,18 @@ class PayloadBuilder:
                     entry["value"] = str(v)
                 result.append(entry)
         return result
+
+    @staticmethod
+    def _parse_env_dict_item(item: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Convert one mapping or Kubernetes-style name/value list item."""
+        if "name" not in item:
+            return [
+                {"name": str(key), "value": str(value)} for key, value in item.items()
+            ]
+        entry: Dict[str, Any] = {"name": str(item["name"])}
+        if item.get("value") is not None:
+            entry["value"] = str(item["value"])
+        return [entry]
 
     @staticmethod
     def _default_health_check(

--- a/kamiwaza_extensions/payload_builder.py
+++ b/kamiwaza_extensions/payload_builder.py
@@ -13,6 +13,13 @@ from kamiwaza_extensions.compose_ports import (
     default_service_port_name,
     extract_container_port,
 )
+from kamiwaza_extensions.compose_transformer import detect_service_url_rewrites
+from kamiwaza_extensions.compose_volumes import (
+    ServiceVolumeSpec,
+    build_service_volume_specs,
+)
+from kamiwaza_extensions.connections import ConnectionInfo
+from kamiwaza_extensions.validators.compose import INVALID_DEPLOY_REQUESTS_TEXT
 from kamiwaza_sdk.schemas.extensions import (
     CreateExtension,
     ExtensionPort,
@@ -22,14 +29,6 @@ from kamiwaza_sdk.schemas.extensions import (
     ResourceSpec,
     SecuritySpec,
 )
-
-from kamiwaza_extensions.compose_transformer import detect_service_url_rewrites
-from kamiwaza_extensions.compose_volumes import (
-    ServiceVolumeSpec,
-    build_service_volume_specs,
-)
-from kamiwaza_extensions.connections import ConnectionInfo
-from kamiwaza_extensions.validators.compose import INVALID_DEPLOY_REQUESTS_TEXT
 
 # CRD annotation keys — namespace is ``kamiwaza.io/*`` (NOT ``kamiwaza.ai/*``).
 # The platform's annotation persister filters incoming Extension CR annotations
@@ -461,8 +460,11 @@ class PayloadBuilder:
             return [
                 {"name": str(key), "value": str(value)} for key, value in item.items()
             ]
-        entry: Dict[str, Any] = {"name": str(item["name"])}
-        if item.get("value") is not None:
+        entry = dict(item)
+        entry["name"] = str(item["name"])
+        if item.get("value") is None:
+            entry.pop("value", None)
+        else:
             entry["value"] = str(item["value"])
         return [entry]
 

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -611,6 +611,8 @@ class TestResolveEnvPlaceholders:
             ("${KZ_TEST_VALUE-fallback}", "", ""),
             ("${KZ_TEST_VALUE:?required}", "set", "set"),
             ("${KZ_TEST_VALUE?required}", "", ""),
+            ("${KZ_TEST_VALUE:+alternate}", "set", "alternate"),
+            ("${KZ_TEST_VALUE+alternate}", "", "alternate"),
         ],
     )
     def test_preserves_compose_empty_value_semantics(
@@ -622,6 +624,20 @@ class TestResolveEnvPlaceholders:
         result = transformer.resolve_env_placeholders(compose)
 
         assert result["services"]["backend"]["environment"] == {"VALUE": expected}
+
+    @pytest.mark.parametrize(
+        "expression",
+        ["${KZ_TEST_VALUE:+alternate}", "${KZ_TEST_VALUE+alternate}"],
+    )
+    def test_alternate_substitution_is_empty_when_unset(
+        self, transformer, monkeypatch, expression
+    ):
+        monkeypatch.delenv("KZ_TEST_VALUE", raising=False)
+        compose = {"services": {"backend": {"environment": {"VALUE": expression}}}}
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {"VALUE": ""}
 
     def test_resolves_nested_default_substitution(self, transformer, monkeypatch):
         monkeypatch.delenv("KZ_TEST_DATABASE_URL", raising=False)
@@ -651,6 +667,7 @@ class TestResolveEnvPlaceholders:
                 "backend": {
                     "environment": {
                         "LITERAL": "$${KZ_TEST_ESCAPED:-fallback}",
+                        "PLAIN_ESCAPE": "cost$$value",
                         "MIXED": (
                             "$${KZ_TEST_ESCAPED:-literal} "
                             "${KZ_TEST_SUFFIX:-resolved}"
@@ -665,6 +682,7 @@ class TestResolveEnvPlaceholders:
 
         assert result["services"]["backend"]["environment"] == {
             "LITERAL": "${KZ_TEST_ESCAPED:-fallback}",
+            "PLAIN_ESCAPE": "cost$value",
             "MIXED": "${KZ_TEST_ESCAPED:-literal} resolved",
         }
 
@@ -730,6 +748,7 @@ class TestResolveEnvPlaceholders:
                 "backend": {
                     "environment": [
                         "AUTH=${KZ_TEST_USER:-neo4j}/${KZ_TEST_PASSWORD:-changeme}",
+                        "LITERAL=cost$$value",
                     ],
                 },
             },
@@ -739,13 +758,14 @@ class TestResolveEnvPlaceholders:
 
         assert result["services"]["backend"]["environment"] == [
             "AUTH=neo4j/changeme",
+            "LITERAL=cost$value",
         ]
 
     def test_plain_values_pass_through(self, transformer):
         compose = {
             "services": {
                 "backend": {
-                    "environment": {"FOO": "bar", "PORT": "8000"},
+                    "environment": {"FOO": "bar", "PORT": "8000", "TAIL": "abc$"},
                 },
             },
         }
@@ -753,6 +773,7 @@ class TestResolveEnvPlaceholders:
         assert result["services"]["backend"]["environment"] == {
             "FOO": "bar",
             "PORT": "8000",
+            "TAIL": "abc$",
         }
 
     def test_does_not_mutate_input(self, transformer):

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -460,16 +460,15 @@ class TestFullTransform:
 
 
 class TestResolveEnvPlaceholders:
-    """``resolve_env_placeholders`` collapses ``${VAR:-default}`` env
-    placeholders to their default, drops unresolvable forms, and drops
-    ``KAMIWAZA_*`` keys (so the operator's ConfigMap envFrom wins)."""
+    """Direct deploy resolves Compose env values and drops platform keys."""
 
-    def test_resolves_default_substitution_dict_form(self, transformer):
+    def test_resolves_default_substitution_dict_form(self, transformer, monkeypatch):
+        monkeypatch.delenv("KZ_TEST_BACKEND_URL", raising=False)
         compose = {
             "services": {
                 "frontend": {
                     "environment": {
-                        "BACKEND_URL": "${BACKEND_URL:-http://backend:8000}",
+                        "BACKEND_URL": "${KZ_TEST_BACKEND_URL:-http://backend:8000}",
                     },
                 },
             },
@@ -479,12 +478,13 @@ class TestResolveEnvPlaceholders:
             "BACKEND_URL": "http://backend:8000",
         }
 
-    def test_resolves_default_substitution_list_form(self, transformer):
+    def test_resolves_default_substitution_list_form(self, transformer, monkeypatch):
+        monkeypatch.delenv("KZ_TEST_BACKEND_URL", raising=False)
         compose = {
             "services": {
                 "frontend": {
                     "environment": [
-                        "BACKEND_URL=${BACKEND_URL:-http://backend:8000}",
+                        "BACKEND_URL=${KZ_TEST_BACKEND_URL:-http://backend:8000}",
                         "PLAIN_VAR=plain-value",
                     ],
                 },
@@ -496,12 +496,13 @@ class TestResolveEnvPlaceholders:
             "PLAIN_VAR=plain-value",
         ]
 
-    def test_resolves_default_substitution_embedded_in_value(self, transformer):
+    def test_resolves_default_substitution_embedded_in_value(self, transformer, monkeypatch):
+        monkeypatch.delenv("KZ_TEST_NEO4J_PASSWORD", raising=False)
         compose = {
             "services": {
                 "neo4j": {
                     "environment": {
-                        "NEO4J_AUTH": "neo4j/${NEO4J_PASSWORD:-changeme}",
+                        "NEO4J_AUTH": "neo4j/${KZ_TEST_NEO4J_PASSWORD:-changeme}",
                     },
                 },
             },
@@ -513,12 +514,13 @@ class TestResolveEnvPlaceholders:
             "NEO4J_AUTH": "neo4j/changeme",
         }
 
-    def test_drops_embedded_substitution_without_safe_default(self, transformer):
+    def test_drops_embedded_substitution_without_safe_default(self, transformer, monkeypatch):
+        monkeypatch.delenv("KZ_TEST_NEO4J_PASSWORD", raising=False)
         compose = {
             "services": {
                 "neo4j": {
                     "environment": {
-                        "NEO4J_AUTH": "neo4j/${NEO4J_PASSWORD:?required}",
+                        "NEO4J_AUTH": "neo4j/${KZ_TEST_NEO4J_PASSWORD:?required}",
                     },
                 },
             },
@@ -548,15 +550,17 @@ class TestResolveEnvPlaceholders:
             "BACKEND_URL": "http://backend:8000",
         }
 
-    def test_drops_unresolvable_substitutions(self, transformer):
+    def test_drops_unresolvable_substitutions(self, transformer, monkeypatch):
         """``${VAR}`` without a default and ``${VAR:?error}`` (required)
         have no safe value to ship — drop them."""
+        monkeypatch.delenv("KZ_TEST_UNSET_VALUE", raising=False)
+        monkeypatch.delenv("KZ_TEST_REQUIRED_VALUE", raising=False)
         compose = {
             "services": {
                 "backend": {
                     "environment": {
-                        "OPENAI_API_KEY": "${OPENAI_API_KEY}",
-                        "REQUIRED_VAR": "${REQUIRED_VAR:?missing}",
+                        "OPENAI_API_KEY": "${KZ_TEST_UNSET_VALUE}",
+                        "REQUIRED_VAR": "${KZ_TEST_REQUIRED_VALUE:?missing}",
                         "PLAIN": "kept",
                     },
                 },
@@ -565,18 +569,69 @@ class TestResolveEnvPlaceholders:
         result = transformer.resolve_env_placeholders(compose)
         assert result["services"]["backend"]["environment"] == {"PLAIN": "kept"}
 
-    def test_alternate_default_form_dash_only(self, transformer):
+    def test_alternate_default_form_dash_only(self, transformer, monkeypatch):
         """Compose accepts both ``${VAR:-default}`` (unset OR empty)
         and ``${VAR-default}`` (unset only). Both collapse to default."""
+        monkeypatch.delenv("KZ_TEST_UNSET_VALUE", raising=False)
         compose = {
             "services": {
                 "backend": {
-                    "environment": {"X": "${UNSET-fallback}"},
+                    "environment": {"X": "${KZ_TEST_UNSET_VALUE-fallback}"},
                 },
             },
         }
         result = transformer.resolve_env_placeholders(compose)
         assert result["services"]["backend"]["environment"] == {"X": "fallback"}
+
+    def test_uses_exported_value_for_bare_placeholder(self, transformer, monkeypatch):
+        monkeypatch.setenv("KZ_TEST_FIELD_KEY", "durable-secret")
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": {"SECRET_ENCRYPTION_KEY": "${KZ_TEST_FIELD_KEY}"},
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {
+            "SECRET_ENCRYPTION_KEY": "durable-secret",
+        }
+
+    @pytest.mark.parametrize(
+        ("expression", "host_value", "expected"),
+        [
+            ("${KZ_TEST_VALUE:-fallback}", "", "fallback"),
+            ("${KZ_TEST_VALUE-fallback}", "", ""),
+            ("${KZ_TEST_VALUE:?required}", "set", "set"),
+            ("${KZ_TEST_VALUE?required}", "", ""),
+        ],
+    )
+    def test_preserves_compose_empty_value_semantics(
+        self, transformer, monkeypatch, expression, host_value, expected
+    ):
+        monkeypatch.setenv("KZ_TEST_VALUE", host_value)
+        compose = {"services": {"backend": {"environment": {"VALUE": expression}}}}
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {"VALUE": expected}
+
+    def test_resolves_nested_default_substitution(self, transformer, monkeypatch):
+        monkeypatch.delenv("KZ_TEST_DATABASE_URL", raising=False)
+        monkeypatch.delenv("KZ_TEST_LEGACY_DATABASE_URL", raising=False)
+        value = (
+            "${KZ_TEST_DATABASE_URL:-"
+            "${KZ_TEST_LEGACY_DATABASE_URL:-postgresql://postgres:dev@postgres/db}}"
+        )
+        compose = {"services": {"backend": {"environment": {"DATABASE_URL": value}}}}
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {
+            "DATABASE_URL": "postgresql://postgres:dev@postgres/db",
+        }
 
     def test_plain_values_pass_through(self, transformer):
         compose = {

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -496,7 +496,9 @@ class TestResolveEnvPlaceholders:
             "PLAIN_VAR=plain-value",
         ]
 
-    def test_resolves_default_substitution_embedded_in_value(self, transformer, monkeypatch):
+    def test_resolves_default_substitution_embedded_in_value(
+        self, transformer, monkeypatch
+    ):
         monkeypatch.delenv("KZ_TEST_NEO4J_PASSWORD", raising=False)
         compose = {
             "services": {
@@ -514,7 +516,9 @@ class TestResolveEnvPlaceholders:
             "NEO4J_AUTH": "neo4j/changeme",
         }
 
-    def test_drops_embedded_substitution_without_safe_default(self, transformer, monkeypatch):
+    def test_drops_embedded_substitution_without_safe_default(
+        self, transformer, monkeypatch
+    ):
         monkeypatch.delenv("KZ_TEST_NEO4J_PASSWORD", raising=False)
         compose = {
             "services": {
@@ -530,10 +534,11 @@ class TestResolveEnvPlaceholders:
 
         assert result["services"]["neo4j"]["environment"] == {}
 
-    def test_drops_kamiwaza_platform_vars(self, transformer):
+    def test_drops_kamiwaza_platform_vars(self, transformer, monkeypatch):
         """``KAMIWAZA_*`` vars are platform-injected via ConfigMap
         envFrom; an explicit env entry would shadow the cluster-internal
         value with the laptop-only default."""
+        monkeypatch.delenv("BACKEND_URL", raising=False)
         compose = {
             "services": {
                 "backend": {
@@ -632,6 +637,109 @@ class TestResolveEnvPlaceholders:
         assert result["services"]["backend"]["environment"] == {
             "DATABASE_URL": "postgresql://postgres:dev@postgres/db",
         }
+
+    @pytest.mark.parametrize("host_value", [None, "host-secret"])
+    def test_preserves_escaped_substitution_literal(
+        self, transformer, monkeypatch, host_value
+    ):
+        if host_value is None:
+            monkeypatch.delenv("KZ_TEST_ESCAPED", raising=False)
+        else:
+            monkeypatch.setenv("KZ_TEST_ESCAPED", host_value)
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": {
+                        "LITERAL": "$${KZ_TEST_ESCAPED:-fallback}",
+                        "MIXED": (
+                            "$${KZ_TEST_ESCAPED:-literal} "
+                            "${KZ_TEST_SUFFIX:-resolved}"
+                        ),
+                    },
+                },
+            },
+        }
+        monkeypatch.delenv("KZ_TEST_SUFFIX", raising=False)
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {
+            "LITERAL": "${KZ_TEST_ESCAPED:-fallback}",
+            "MIXED": "${KZ_TEST_ESCAPED:-literal} resolved",
+        }
+
+    @pytest.mark.parametrize(
+        ("host_value", "expected"),
+        [
+            (None, '{"a":1,"nested":{"enabled":true}}'),
+            ("from-host", "from-host"),
+        ],
+    )
+    def test_preserves_literal_braces_in_default(
+        self, transformer, monkeypatch, host_value, expected
+    ):
+        if host_value is None:
+            monkeypatch.delenv("KZ_TEST_JSON", raising=False)
+        else:
+            monkeypatch.setenv("KZ_TEST_JSON", host_value)
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": {
+                        "JSON_CONFIG": (
+                            '${KZ_TEST_JSON:-{"a":1,"nested":{"enabled":true}}}'
+                        ),
+                    },
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {
+            "JSON_CONFIG": expected,
+        }
+
+    def test_preserves_unmatched_literal_open_brace_in_default(
+        self, transformer, monkeypatch
+    ):
+        monkeypatch.delenv("KZ_TEST_TEMPLATE", raising=False)
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": {
+                        "TEMPLATE": '${KZ_TEST_TEMPLATE:-{"template":"{"}}',
+                    },
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {
+            "TEMPLATE": '{"template":"{"}',
+        }
+
+    def test_resolves_embedded_list_and_multiple_substitutions(
+        self, transformer, monkeypatch
+    ):
+        monkeypatch.delenv("KZ_TEST_USER", raising=False)
+        monkeypatch.delenv("KZ_TEST_PASSWORD", raising=False)
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": [
+                        "AUTH=${KZ_TEST_USER:-neo4j}/${KZ_TEST_PASSWORD:-changeme}",
+                    ],
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == [
+            "AUTH=neo4j/changeme",
+        ]
 
     def test_plain_values_pass_through(self, transformer):
         compose = {

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -574,9 +574,10 @@ class TestResolveEnvPlaceholders:
         result = transformer.resolve_env_placeholders(compose)
         assert result["services"]["backend"]["environment"] == {"PLAIN": "kept"}
 
-    def test_alternate_default_form_dash_only(self, transformer, monkeypatch):
-        """Compose accepts both ``${VAR:-default}`` (unset OR empty)
-        and ``${VAR-default}`` (unset only). Both collapse to default."""
+    def test_default_form_dash_only_uses_fallback_when_unset(
+        self, transformer, monkeypatch
+    ):
+        """``${VAR-default}`` uses its fallback when the variable is unset."""
         monkeypatch.delenv("KZ_TEST_UNSET_VALUE", raising=False)
         compose = {
             "services": {
@@ -638,6 +639,25 @@ class TestResolveEnvPlaceholders:
         result = transformer.resolve_env_placeholders(compose)
 
         assert result["services"]["backend"]["environment"] == {"VALUE": ""}
+
+    def test_resolves_nested_alternate_substitution(self, transformer, monkeypatch):
+        monkeypatch.setenv("KZ_TEST_VALUE", "selected")
+        monkeypatch.setenv("KZ_TEST_ALTERNATE", "nested-value")
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": {
+                        "VALUE": "${KZ_TEST_VALUE:+${KZ_TEST_ALTERNATE}}",
+                    },
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {
+            "VALUE": "nested-value",
+        }
 
     def test_resolves_nested_default_substitution(self, transformer, monkeypatch):
         monkeypatch.delenv("KZ_TEST_DATABASE_URL", raising=False)
@@ -760,6 +780,98 @@ class TestResolveEnvPlaceholders:
             "AUTH=neo4j/changeme",
             "LITERAL=cost$value",
         ]
+
+    def test_resolves_name_value_dict_list_entries(self, transformer, monkeypatch):
+        monkeypatch.delenv("KZ_TEST_PRICE", raising=False)
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": [
+                        {"name": "PRICE", "value": "cost$$value"},
+                        {
+                            "name": "RESOLVED",
+                            "value": "${KZ_TEST_PRICE:-cost$$value}",
+                        },
+                        {"name": "PLAIN", "value": "kept"},
+                    ],
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == [
+            {"name": "PRICE", "value": "cost$value"},
+            {"name": "RESOLVED", "value": "cost$value"},
+            {"name": "PLAIN", "value": "kept"},
+        ]
+
+    def test_deeply_nested_substitution_fails_closed(self, transformer, monkeypatch):
+        monkeypatch.delenv("KZ_TEST_DEEP", raising=False)
+        value = "fallback"
+        for _ in range(200):
+            value = f"${{KZ_TEST_DEEP:-{value}}}"
+        compose = {"services": {"backend": {"environment": {"VALUE": value}}}}
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {}
+
+    def test_unbraced_reference_remains_literal(self, transformer, monkeypatch):
+        monkeypatch.setenv("KZ_TEST_UNBRACED", "host-value")
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": {"VALUE": "$KZ_TEST_UNBRACED/data"},
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {
+            "VALUE": "$KZ_TEST_UNBRACED/data",
+        }
+
+    def test_malformed_and_empty_required_substitutions_fail_closed(
+        self, transformer, monkeypatch
+    ):
+        monkeypatch.delenv("KZ_TEST_MALFORMED", raising=False)
+        monkeypatch.setenv("KZ_TEST_EMPTY_REQUIRED", "")
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": {
+                        "MALFORMED": "${KZ_TEST_MALFORMED:-no-close",
+                        "REQUIRED": "${KZ_TEST_EMPTY_REQUIRED:?required}",
+                    },
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {}
+
+    def test_platform_key_with_escaped_placeholder_stays_literal(
+        self, transformer, monkeypatch
+    ):
+        monkeypatch.setenv("KZ_TEST_ESCAPED_PLATFORM", "host-value")
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": {
+                        "KAMIWAZA_LITERAL": "$${KZ_TEST_ESCAPED_PLATFORM:-fallback}",
+                    },
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == {
+            "KAMIWAZA_LITERAL": "${KZ_TEST_ESCAPED_PLATFORM:-fallback}",
+        }
 
     def test_plain_values_pass_through(self, transformer):
         compose = {

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -688,6 +688,7 @@ class TestResolveEnvPlaceholders:
                     "environment": {
                         "LITERAL": "$${KZ_TEST_ESCAPED:-fallback}",
                         "PLAIN_ESCAPE": "cost$$value",
+                        "RAW_MIXED": "cost$raw ${KZ_TEST_SUFFIX:-resolved}",
                         "MIXED": (
                             "$${KZ_TEST_ESCAPED:-literal} "
                             "${KZ_TEST_SUFFIX:-resolved}"
@@ -703,6 +704,7 @@ class TestResolveEnvPlaceholders:
         assert result["services"]["backend"]["environment"] == {
             "LITERAL": "${KZ_TEST_ESCAPED:-fallback}",
             "PLAIN_ESCAPE": "cost$value",
+            "RAW_MIXED": "cost$raw resolved",
             "MIXED": "${KZ_TEST_ESCAPED:-literal} resolved",
         }
 
@@ -806,6 +808,30 @@ class TestResolveEnvPlaceholders:
             {"name": "PLAIN", "value": "kept"},
         ]
 
+    def test_resolves_mapping_fragment_list_entries(self, transformer, monkeypatch):
+        monkeypatch.delenv("KZ_TEST_PRICE", raising=False)
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": [
+                        {
+                            "PRICE": "cost$$value",
+                            "RESOLVED": "${KZ_TEST_PRICE:-cost$$value}",
+                            "KAMIWAZA_API_URL": (
+                                "${KAMIWAZA_API_URL:-http://localhost}"
+                            ),
+                        },
+                    ],
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["backend"]["environment"] == [
+            {"PRICE": "cost$value", "RESOLVED": "cost$value"},
+        ]
+
     def test_deeply_nested_substitution_fails_closed(self, transformer, monkeypatch):
         monkeypatch.delenv("KZ_TEST_DEEP", raising=False)
         value = "fallback"
@@ -862,6 +888,7 @@ class TestResolveEnvPlaceholders:
                 "backend": {
                     "environment": {
                         "KAMIWAZA_LITERAL": "$${KZ_TEST_ESCAPED_PLATFORM:-fallback}",
+                        "KAMIWAZA_PRICE": "cost$5",
                     },
                 },
             },
@@ -871,6 +898,7 @@ class TestResolveEnvPlaceholders:
 
         assert result["services"]["backend"]["environment"] == {
             "KAMIWAZA_LITERAL": "${KZ_TEST_ESCAPED_PLATFORM:-fallback}",
+            "KAMIWAZA_PRICE": "cost$5",
         }
 
     def test_plain_values_pass_through(self, transformer):

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -496,6 +496,38 @@ class TestResolveEnvPlaceholders:
             "PLAIN_VAR=plain-value",
         ]
 
+    def test_resolves_default_substitution_embedded_in_value(self, transformer):
+        compose = {
+            "services": {
+                "neo4j": {
+                    "environment": {
+                        "NEO4J_AUTH": "neo4j/${NEO4J_PASSWORD:-changeme}",
+                    },
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["neo4j"]["environment"] == {
+            "NEO4J_AUTH": "neo4j/changeme",
+        }
+
+    def test_drops_embedded_substitution_without_safe_default(self, transformer):
+        compose = {
+            "services": {
+                "neo4j": {
+                    "environment": {
+                        "NEO4J_AUTH": "neo4j/${NEO4J_PASSWORD:?required}",
+                    },
+                },
+            },
+        }
+
+        result = transformer.resolve_env_placeholders(compose)
+
+        assert result["services"]["neo4j"]["environment"] == {}
+
     def test_drops_kamiwaza_platform_vars(self, transformer):
         """``KAMIWAZA_*`` vars are platform-injected via ConfigMap
         envFrom; an explicit env entry would shadow the cluster-internal

--- a/tests/unit/extensions/test_compose_transformer.py
+++ b/tests/unit/extensions/test_compose_transformer.py
@@ -785,6 +785,7 @@ class TestResolveEnvPlaceholders:
 
     def test_resolves_name_value_dict_list_entries(self, transformer, monkeypatch):
         monkeypatch.delenv("KZ_TEST_PRICE", raising=False)
+        value_from = {"secretKeyRef": {"name": "secret", "key": "token"}}
         compose = {
             "services": {
                 "backend": {
@@ -795,6 +796,7 @@ class TestResolveEnvPlaceholders:
                             "value": "${KZ_TEST_PRICE:-cost$$value}",
                         },
                         {"name": "PLAIN", "value": "kept"},
+                        {"name": "SECRET", "valueFrom": value_from},
                     ],
                 },
             },
@@ -806,6 +808,7 @@ class TestResolveEnvPlaceholders:
             {"name": "PRICE", "value": "cost$value"},
             {"name": "RESOLVED", "value": "cost$value"},
             {"name": "PLAIN", "value": "kept"},
+            {"name": "SECRET", "valueFrom": value_from},
         ]
 
     def test_resolves_mapping_fragment_list_entries(self, transformer, monkeypatch):
@@ -1082,6 +1085,32 @@ class TestDetectServiceUrlRewrites:
                     "to": "http://ext-backend:8000",
                 }
             }
+        }
+
+    def test_handles_mapping_fragment_list_environment(self):
+        from kamiwaza_extensions.compose_transformer import detect_service_url_rewrites
+
+        services = {
+            "frontend": {
+                "environment": [
+                    {
+                        "BACKEND_URL": "http://backend:8000",
+                        "PLAIN": "kept",
+                    },
+                ],
+            },
+            "backend": {"environment": []},
+        }
+
+        rewrites = detect_service_url_rewrites(services, "ext")
+
+        assert rewrites == {
+            "frontend": {
+                "BACKEND_URL": {
+                    "from": "http://backend:8000",
+                    "to": "http://ext-backend:8000",
+                },
+            },
         }
 
     def test_ignores_self_reference(self):

--- a/tests/unit/extensions/test_dev_env_image_refs.py
+++ b/tests/unit/extensions/test_dev_env_image_refs.py
@@ -332,6 +332,27 @@ class TestRewriteEnvImageRefsListForm:
             },
         ]
 
+    def test_mapping_fragment_agent_server_image(self):
+        ref_map = _ref_map(_kaizen_compose()["services"])
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": [
+                        {
+                            "AGENT_SERVER_IMAGE": f"{_AGENT_GHCR}:2.0.2",
+                            "FOO": "bar",
+                        },
+                    ],
+                },
+            },
+        }
+
+        result = rewrite_env_image_refs(compose, ref_map)
+
+        assert result["services"]["backend"]["environment"] == [
+            {"AGENT_SERVER_IMAGE": _AGENT_BUILT, "FOO": "bar"},
+        ]
+
 
 class TestDevRemoteWiresEnvRewrite:
     """``run_dev_remote`` must actually apply the env rewrite — guards against

--- a/tests/unit/extensions/test_dev_env_image_refs.py
+++ b/tests/unit/extensions/test_dev_env_image_refs.py
@@ -299,6 +299,39 @@ class TestRewriteEnvImageRefsListForm:
         assert f"AGENT_SERVER_IMAGE={_AGENT_BUILT}" in env
         assert "FOO=bar" in env
 
+    def test_name_value_dict_form_agent_server_image(self):
+        ref_map = _ref_map(_kaizen_compose()["services"])
+        value_from = {"secretKeyRef": {"name": "agent", "key": "image"}}
+        compose = {
+            "services": {
+                "backend": {
+                    "environment": [
+                        {
+                            "name": "AGENT_SERVER_IMAGE",
+                            "value": f"${{AGENT_SERVER_IMAGE:-{_AGENT_GHCR}:2.0.2}}",
+                        },
+                        {
+                            "name": "AGENT_SERVER_IMAGE_FROM_SECRET",
+                            "valueFrom": value_from,
+                        },
+                    ],
+                },
+            },
+        }
+
+        result = rewrite_env_image_refs(compose, ref_map)
+
+        assert result["services"]["backend"]["environment"] == [
+            {
+                "name": "AGENT_SERVER_IMAGE",
+                "value": f"${{AGENT_SERVER_IMAGE:-{_AGENT_BUILT}}}",
+            },
+            {
+                "name": "AGENT_SERVER_IMAGE_FROM_SECRET",
+                "valueFrom": value_from,
+            },
+        ]
+
 
 class TestDevRemoteWiresEnvRewrite:
     """``run_dev_remote`` must actually apply the env rewrite — guards against

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -4,6 +4,7 @@ import hashlib
 
 import pytest
 
+from kamiwaza_extensions.compose_transformer import ComposeTransformer
 from kamiwaza_extensions.connections import ConnectionInfo
 from kamiwaza_extensions.payload_builder import (
     ANNOTATION_BUILD_HOST,
@@ -522,6 +523,60 @@ class TestServiceRefRewritesAnnotation:
         annotations = (payload.model_extra or {}).get("annotations") or {}
         assert ANNOTATION_SERVICE_REF_REWRITES not in annotations
 
+    def test_name_value_dict_survives_resolution_and_payload_build(
+        self,
+        builder,
+        metadata,
+        connection,
+        monkeypatch,
+    ):
+        import json
+
+        monkeypatch.delenv("KZ_TEST_BACKEND_URL", raising=False)
+        compose = {
+            "services": {
+                "frontend": {
+                    "image": "reg/my-app-frontend:dev",
+                    "ports": ["3000"],
+                    "environment": [
+                        {
+                            "name": "BACKEND_URL",
+                            "value": (
+                                "${KZ_TEST_BACKEND_URL:-http://backend:8000}"
+                                "/cost$$value"
+                            ),
+                        },
+                    ],
+                },
+                "backend": {
+                    "image": "reg/my-app-backend:dev",
+                    "ports": ["8000"],
+                },
+            },
+        }
+        transformed = ComposeTransformer().resolve_env_placeholders(compose)
+
+        payload = builder.build(metadata, transformed, connection, "my-app-dev-abc")
+
+        frontend = next(service for service in payload.services if service.primary)
+        backend_url = next(
+            entry for entry in (frontend.env or []) if entry["name"] == "BACKEND_URL"
+        )
+        assert backend_url == {
+            "name": "BACKEND_URL",
+            "value": "http://backend:8000/cost$value",
+        }
+        annotations = (payload.model_extra or {}).get("annotations") or {}
+        rewrites = json.loads(annotations[ANNOTATION_SERVICE_REF_REWRITES])
+        assert rewrites == {
+            "frontend": {
+                "BACKEND_URL": {
+                    "from": "http://backend:8000/cost$value",
+                    "to": "http://my-app-dev-abc-backend:8000/cost$value",
+                },
+            },
+        }
+
 
 class TestComposeVolumes:
     """ENG-4834: named compose volumes must reach the kext payload."""
@@ -752,6 +807,18 @@ class TestEnvParsing:
         result = builder._parse_env({"KEY": "value", "NULL_KEY": None})
         assert {"name": "KEY", "value": "value"} in result
         assert {"name": "NULL_KEY"} in result
+
+    def test_name_value_dict_list_format(self, builder):
+        result = builder._parse_env(
+            [
+                {"name": "KEY", "value": "value"},
+                {"name": "NULL_KEY", "value": None},
+            ]
+        )
+        assert result == [
+            {"name": "KEY", "value": "value"},
+            {"name": "NULL_KEY"},
+        ]
 
     def test_empty(self, builder):
         assert builder._parse_env([]) == []

--- a/tests/unit/extensions/test_payload_builder.py
+++ b/tests/unit/extensions/test_payload_builder.py
@@ -813,11 +813,23 @@ class TestEnvParsing:
             [
                 {"name": "KEY", "value": "value"},
                 {"name": "NULL_KEY", "value": None},
+                {
+                    "name": "SECRET_KEY",
+                    "valueFrom": {
+                        "secretKeyRef": {"name": "secret", "key": "token"},
+                    },
+                },
             ]
         )
         assert result == [
             {"name": "KEY", "value": "value"},
             {"name": "NULL_KEY"},
+            {
+                "name": "SECRET_KEY",
+                "valueFrom": {
+                    "secretKeyRef": {"name": "secret", "key": "token"},
+                },
+            },
         ]
 
     def test_empty(self, builder):


### PR DESCRIPTION
## Summary

- Resolve exported host values for direct `kz-ext dev` deployments using supported braced Docker Compose substitution semantics.
- Support embedded substitutions, nested defaults, `$$` escapes, literal braces in defaults, and the unset-versus-empty behavior of `:-`, `-`, `:?`, `?`, `:+`, and `+`.
- Preserve tolerated environment-list mappings and Kubernetes `name`/`value`/`valueFrom` entries through resolution and payload serialization; apply image-reference and service-reference rewriting consistently to their literal values.
- Continue dropping unresolved/unsatisfied substitutions and placeholder-bearing entries whose keys start with `KAMIWAZA_` so platform ConfigMap injection wins; excessively deep nesting now fails closed rather than raising `RecursionError`.

## Customer impact

Direct developer deployments can now carry values such as `${SECRET_ENCRYPTION_KEY}` from the invoking shell and resolve compound forms such as `neo4j/${NEO4J_PASSWORD:-changeme}`. Catalog templates remain unresolved for platform install-time substitution.

## Security note

This behavior applies only to the direct `kz-ext dev` path. Values resolved from the developer process environment are included in the submitted extension environment, matching Docker Compose behavior; callers should treat the deployed extension resource as secret-bearing configuration. Compose `$$` escapes remain literal and never read the escaped host variable. Unbraced `$VAR` remains literal by design; after `$$` collapse, a resulting `$(VAR)` token can still be expanded by Kubernetes container-env handling.

## Validation

- `make test`: 3,396 passed, 2 skipped, 260 deselected
- Changed files pass Ruff and isort
- Targeted mypy passes for `compose_transformer.py`, `dev_env_image_refs.py`, and `payload_builder.py`
- Transformer suite: 137 passed
- Focused transformer/payload/image-rewrite suites: 233 passed
- Docker Compose 5.1 runtime parity checked for escaped dollars, all supported operator branches, nested/multiple substitutions, selected nested alternates, balanced JSON defaults, asymmetric literal braces, and host-set/unset/empty values
- End-to-end regression coverage verifies `name`/`value` resolution → payload env → `service-ref-rewrites` annotation consistency
- Regression coverage verifies tolerated mapping-fragment resolution and rewrite parity, `valueFrom` preservation, and `name`/`value` image-reference rewriting
- Repository-wide `make lint` remains red on unrelated pre-existing unused-import findings

Linear: https://linear.app/kamiwaza/issue/ENG-10260
