### PR TITLE
ENG-3068: Ignore stale Failed phase during extension PATCH rollout

### DIFF
--- a/kamiwaza_extensions/deployment_poller.py
+++ b/kamiwaza_extensions/deployment_poller.py
@@ -67,6 +67,12 @@ class DeploymentPoller:
                 last_phase = phase
 
             if phase == "Failed":
+                if use_status_endpoint and self._is_rolling_update(
+                    client, extension_name
+                ):
+                    console.print("  [dim]Status: rolling update in progress[/dim]")
+                    time.sleep(poll_interval)
+                    continue
                 msg = self._extract_failure_message(ext)
                 raise DeploymentFailedError(
                     f"Extension deployment failed: {msg}"
@@ -103,6 +109,15 @@ class DeploymentPoller:
             f"Extension did not reach Running state within {timeout}s "
             f"(last phase: {last_phase})"
         )
+
+    @staticmethod
+    def _is_rolling_update(client: KamiwazaClient, extension_name: str) -> bool:
+        """Return whether a newer PATCH generation is still rolling out."""
+        try:
+            status = client.extensions.get_extension_status(extension_name)
+        except Exception:
+            return False
+        return status.rolling_update is True
 
     @staticmethod
     def _check_via_status_endpoint(

--- a/tests/unit/extensions/test_deployment_poller.py
+++ b/tests/unit/extensions/test_deployment_poller.py
@@ -78,6 +78,29 @@ class TestWaitForReady:
         with pytest.raises(DeploymentFailedError, match="ImagePullBackOff"):
             poller.wait_for_ready(client, "test", timeout=10)
 
+    @patch.object(DeploymentPoller, "_check_via_status_endpoint", return_value=(None, ""))
+    @patch.object(DeploymentPoller, "_check_pods_ready", return_value=(True, "2/2 ready"))
+    @patch("kamiwaza_extensions.deployment_poller.time.sleep")
+    def test_ignores_stale_failed_phase_during_patch_rollout(
+        self, mock_sleep, mock_pods, mock_status, poller
+    ):
+        client = MagicMock()
+        client.extensions.get_extension.side_effect = [
+            _make_ext("Failed"),
+            _make_ext("Provisioning"),
+            _make_ext("Running"),
+        ]
+        client.extensions.get_extension_status.return_value = ExtensionStatus(
+            name="test",
+            phase="Failed",
+            rolling_update=True,
+        )
+
+        result = poller.wait_for_ready(client, "test", timeout=10)
+
+        assert result.phase == "Running"
+        client.extensions.get_extension_status.assert_called_once_with("test")
+
     @patch("kamiwaza_extensions.deployment_poller.time.monotonic")
     @patch("kamiwaza_extensions.deployment_poller.time.sleep")
     def test_raises_on_timeout(self, mock_sleep, mock_monotonic, poller):


### PR DESCRIPTION
## Summary

- Check the extension status endpoint before treating a top-level `Failed` phase as terminal.
- Continue polling when the status endpoint reports an active rolling update.
- Preserve fail-fast behavior when no rollout is active or status cannot be verified.

## Why

During PATCH, the extension resource can briefly retain the previous generation's `Failed` phase while the new generation is already rolling out. `kz-ext dev` should follow the active rollout instead of aborting on stale status.

## Validation

- `uv run pytest tests/unit/extensions/test_deployment_poller.py`: 8 passed
- Changed files pass Ruff

Linear: https://linear.app/kamiwaza/issue/ENG-3068