### PR TITLE
ENG-10050/ENG-10282: validate and route the required federation edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,14 +348,22 @@ job_id = kz.jobs.submit_async(
     target_cluster="ORION",
     timeout_seconds=600,
 )
-# ... persist job_id somewhere (sqlite, /tmp file, etc.) ...
+# ... persist (job_id, target_cluster) somewhere (sqlite, etc.) ...
 # ... process dies ...
 
 # Fresh process, much later
 saved_job_id = load_persisted_job_id()
-result = kz.jobs.wait(saved_job_id, timeout=600)
-print(result.status, result.result)
+saved_target_cluster = "ORION"
+result = kz.jobs.wait(
+    saved_job_id,
+    timeout=600,
+    target_cluster=saved_target_cluster,
+)
 ```
+
+The client that submitted the job remembers up to 256 recent remote handles,
+so `wait(job_id, ...)` and `cancel(job_id)` on that same client do not need the
+selector repeated. A new client has no such in-memory routing state.
 
 **Recommended:** use `recoverable=True` for any job with
 `timeout_seconds > 60`. The two-call cost (submit + poll) is amortized

--- a/_kamiwaza_pytest_options.py
+++ b/_kamiwaza_pytest_options.py
@@ -123,3 +123,13 @@ def add_live_options(parser: pytest.Parser) -> None:
             "KAMIWAZA_PEER_API_KEY). Required when --live-peer-base-url is set."
         ),
     )
+    group.addoption(
+        "--require-federation-edge",
+        action="store_true",
+        default=os.environ.get("KAMIWAZA_REQUIRE_FEDERATION_EDGE", "").lower()
+        in {"1", "true", "yes", "on"},
+        help=(
+            "Run the required shared-IDP two-cluster edge fail-closed: all five "
+            "contract cases must collect and any skip is promoted to failure."
+        ),
+    )

--- a/conftest.py
+++ b/conftest.py
@@ -9,7 +9,7 @@ from tests.e2e import _evidence_emitter
 # tests/e2e/test_evidence_emitter.py (ENG-10026). It has to live here, not
 # beside those tests: pytest only honors `pytest_plugins` in the rootdir
 # conftest, so repo-wide registration is a requirement, not a preference.
-pytest_plugins = ["pytester"]
+pytest_plugins = ["pytester", "tests.integration.required_federation_edge"]
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/kamiwaza_sdk/seeding/federation/keycloak.py
+++ b/kamiwaza_sdk/seeding/federation/keycloak.py
@@ -17,6 +17,11 @@ from urllib.parse import quote
 
 import requests  # type: ignore[import-untyped]
 
+from .owned_realm import (
+    OWNED_REALM_ATTRIBUTE as OWNED_REALM_ATTRIBUTE,
+    OwnedRealmLifecycle,
+)
+
 
 class KeycloakAdminError(RuntimeError):
     """A Keycloak admin REST call failed."""
@@ -102,7 +107,9 @@ class KeycloakAdmin:
         KeyError/TypeError far from the real cause.
         """
         if resp.status_code >= 400:
-            raise KeycloakAdminError(f"{what} failed ({resp.status_code}): {resp.text[:200]}")
+            raise KeycloakAdminError(
+                f"{what} failed ({resp.status_code}): {resp.text[:200]}"
+            )
         try:
             return resp.json()
         except ValueError:
@@ -115,14 +122,32 @@ class KeycloakAdmin:
         got = self._req("GET", f"/realms/{quote(realm)}")
         if got.status_code == 200:
             return {"realm": realm, "created": False}
-        resp = self._req(
-            "POST", "/realms", json={"realm": realm, "enabled": True}
-        )
+        resp = self._req("POST", "/realms", json={"realm": realm, "enabled": True})
         if resp.status_code not in (201, 409):
             raise KeycloakAdminError(
                 f"create realm {realm!r} failed ({resp.status_code}): {resp.text[:200]}"
             )
         return {"realm": realm, "created": resp.status_code == 201}
+
+    def create_owned_realm(self, realm: str, owner_nonce: str) -> Dict[str, Any]:
+        """Create a new fixture-owned realm, refusing any pre-existing realm.
+
+        Unlike :meth:`ensure_realm`, this is intentionally non-idempotent. A
+        smoke cleanup may delete the whole realm, so provisioning must prove it
+        created this exact realm before making any client/profile/user mutation.
+        """
+        return self._owned_realms().create(realm, owner_nonce)
+
+    def delete_owned_realm(self, realm: str, owner_nonce: str) -> bool:
+        """Delete only a realm carrying ``owner_nonce``; absent is success.
+
+        Returning ``False`` for an already-absent realm makes cleanup safe to
+        retry after an ambiguous SSH result without weakening ownership checks.
+        """
+        return self._owned_realms().delete(realm, owner_nonce)
+
+    def _owned_realms(self) -> OwnedRealmLifecycle:
+        return OwnedRealmLifecycle(self._req, self._ok_json, KeycloakAdminError)
 
     def set_unmanaged_attributes(self, realm: str, *, policy: str = "ENABLED") -> None:
         """Set the realm user-profile ``unmanagedAttributePolicy`` so persona
@@ -232,7 +257,10 @@ class KeycloakAdmin:
             ),
             "search users",
         )
-        attrs = {k: (v if isinstance(v, list) else [str(v)]) for k, v in (attributes or {}).items()}
+        attrs = {
+            k: (v if isinstance(v, list) else [str(v)])
+            for k, v in (attributes or {}).items()
+        }
         rep = {
             "username": username,
             "enabled": True,
@@ -299,5 +327,3 @@ def jwks_uri_from_issuer(issuer: str) -> str:
     """Derive a Keycloak realm's JWKS endpoint (mirrors the server-side helper;
     ``fed pair`` uses this so JWKS is pinned to the issuer — #2298 H1)."""
     return issuer.rstrip("/") + "/protocol/openid-connect/certs"
-
-

--- a/kamiwaza_sdk/seeding/federation/owned_realm.py
+++ b/kamiwaza_sdk/seeding/federation/owned_realm.py
@@ -1,0 +1,131 @@
+"""Fail-closed lifecycle for uniquely owned Keycloak fixture realms."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Protocol
+from urllib.parse import quote
+
+OWNED_REALM_ATTRIBUTE = "kajiya.fixture.owner_nonce"
+
+
+class _Response(Protocol):
+    status_code: int
+    text: str
+
+
+class OwnedRealmLifecycle:
+    """Create/reconcile/delete a realm through injected admin HTTP primitives."""
+
+    def __init__(
+        self,
+        request: Callable[..., _Response],
+        parse_json: Callable[[_Response, str], Any],
+        error_type: type[Exception],
+    ) -> None:
+        self._request = request
+        self._parse_json = parse_json
+        self._error_type = error_type
+
+    def create(self, realm: str, owner_nonce: str) -> Dict[str, Any]:
+        """Create only a new realm, reconciling ambiguous POST outcomes."""
+        self._require_nonce(owner_nonce, "requires")
+        got = self._request("GET", self._path(realm))
+        if got.status_code == 200:
+            raise self._error(f"refusing to mutate pre-existing realm {realm!r}")
+        if got.status_code != 404:
+            raise self._error(
+                f"preflight realm {realm!r} failed ({got.status_code}): {got.text[:200]}"
+            )
+        try:
+            created = self._request(
+                "POST",
+                "/realms",
+                json={
+                    "realm": realm,
+                    "enabled": True,
+                    "attributes": {OWNED_REALM_ATTRIBUTE: owner_nonce},
+                },
+            )
+        except Exception as post_exception:
+            self._finish_failed_create(
+                realm, owner_nonce, post_exception, delete_if_owned=True
+            )
+            raise
+        if created.status_code != 201:
+            status_error = self._error(
+                f"create new owned realm {realm!r} failed ({created.status_code}): "
+                f"{created.text[:200]}"
+            )
+            self._finish_failed_create(
+                realm,
+                owner_nonce,
+                status_error,
+                delete_if_owned=created.status_code != 409,
+            )
+            raise status_error
+        return {"realm": realm, "created": True, "owner_nonce": owner_nonce}
+
+    def delete(self, realm: str, owner_nonce: str) -> bool:
+        """Delete only a realm carrying the exact nonce; absent is success."""
+        self._require_nonce(owner_nonce, "teardown requires")
+        path = self._path(realm)
+        got = self._request("GET", path)
+        if got.status_code == 404:
+            return False
+        realm_rep = self._parse_json(got, f"read realm {realm!r}") or {}
+        if self._owner(realm_rep) != owner_nonce:
+            raise self._error(f"refusing to delete unowned realm {realm!r}")
+        deleted = self._request("DELETE", path)
+        if deleted.status_code not in (204, 404):
+            raise self._error(
+                f"delete owned realm {realm!r} failed ({deleted.status_code}): "
+                f"{deleted.text[:200]}"
+            )
+        return deleted.status_code == 204
+
+    def _finish_failed_create(
+        self,
+        realm: str,
+        owner_nonce: str,
+        create_error: Exception,
+        *,
+        delete_if_owned: bool,
+    ) -> None:
+        outcome = self._reconcile(realm, owner_nonce, delete_if_owned=delete_if_owned)
+        if outcome == "different-owner":
+            raise self._error(
+                f"create outcome for realm {realm!r} failed or is ambiguous and "
+                "the observed realm has a different owner; refusing cleanup"
+            ) from create_error
+
+    def _reconcile(self, realm: str, owner_nonce: str, *, delete_if_owned: bool) -> str:
+        try:
+            got = self._request("GET", self._path(realm))
+            if got.status_code == 404:
+                return "absent"
+            realm_rep = self._parse_json(got, f"reconcile realm {realm!r}") or {}
+            if self._owner(realm_rep) != owner_nonce:
+                return "different-owner"
+            if delete_if_owned:
+                self.delete(realm, owner_nonce)
+                return "owned-deleted"
+            return "owned-not-deleted"
+        except Exception as cleanup_error:
+            raise self._error(
+                f"create realm {realm!r} failed and ownership reconciliation also failed"
+            ) from cleanup_error
+
+    def _require_nonce(self, owner_nonce: str, action: str) -> None:
+        if not owner_nonce:
+            raise self._error(f"owned realm {action} a non-empty owner nonce")
+
+    def _error(self, message: str) -> Exception:
+        return self._error_type(message)
+
+    @staticmethod
+    def _path(realm: str) -> str:
+        return f"/realms/{quote(realm)}"
+
+    @staticmethod
+    def _owner(realm_rep: Dict[str, Any]) -> Any:
+        return (realm_rep.get("attributes") or {}).get(OWNED_REALM_ATTRIBUTE)

--- a/kamiwaza_sdk/seeding/federation/owned_realm.py
+++ b/kamiwaza_sdk/seeding/federation/owned_realm.py
@@ -29,6 +29,23 @@ class OwnedRealmLifecycle:
     def create(self, realm: str, owner_nonce: str) -> Dict[str, Any]:
         """Create only a new realm, reconciling ambiguous POST outcomes."""
         self._require_nonce(owner_nonce, "requires")
+        self._require_absent(realm)
+        created = self._create_realm(realm, owner_nonce)
+        if created.status_code == 201:
+            return {"realm": realm, "created": True, "owner_nonce": owner_nonce}
+        status_error = self._error(
+            f"create new owned realm {realm!r} failed ({created.status_code}): "
+            f"{created.text[:200]}"
+        )
+        self._finish_failed_create(
+            realm,
+            owner_nonce,
+            status_error,
+            delete_if_owned=created.status_code != 409,
+        )
+        raise status_error
+
+    def _require_absent(self, realm: str) -> None:
         got = self._request("GET", self._path(realm))
         if got.status_code == 200:
             raise self._error(f"refusing to mutate pre-existing realm {realm!r}")
@@ -36,8 +53,10 @@ class OwnedRealmLifecycle:
             raise self._error(
                 f"preflight realm {realm!r} failed ({got.status_code}): {got.text[:200]}"
             )
+
+    def _create_realm(self, realm: str, owner_nonce: str) -> _Response:
         try:
-            created = self._request(
+            return self._request(
                 "POST",
                 "/realms",
                 json={
@@ -51,19 +70,6 @@ class OwnedRealmLifecycle:
                 realm, owner_nonce, post_exception, delete_if_owned=True
             )
             raise
-        if created.status_code != 201:
-            status_error = self._error(
-                f"create new owned realm {realm!r} failed ({created.status_code}): "
-                f"{created.text[:200]}"
-            )
-            self._finish_failed_create(
-                realm,
-                owner_nonce,
-                status_error,
-                delete_if_owned=created.status_code != 409,
-            )
-            raise status_error
-        return {"realm": realm, "created": True, "owner_nonce": owner_nonce}
 
     def delete(self, realm: str, owner_nonce: str) -> bool:
         """Delete only a realm carrying the exact nonce; absent is success."""

--- a/kamiwaza_sdk/seeding/federation/owned_realm.py
+++ b/kamiwaza_sdk/seeding/federation/owned_realm.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Protocol
+from typing import Any, Callable, Dict, Generic, Protocol, TypeVar
 from urllib.parse import quote
 
 OWNED_REALM_ATTRIBUTE = "kajiya.fixture.owner_nonce"
@@ -13,13 +13,16 @@ class _Response(Protocol):
     text: str
 
 
-class OwnedRealmLifecycle:
+_ResponseT = TypeVar("_ResponseT", bound=_Response)
+
+
+class OwnedRealmLifecycle(Generic[_ResponseT]):
     """Create/reconcile/delete a realm through injected admin HTTP primitives."""
 
     def __init__(
         self,
-        request: Callable[..., _Response],
-        parse_json: Callable[[_Response, str], Any],
+        request: Callable[..., _ResponseT],
+        parse_json: Callable[[_ResponseT, str], Any],
         error_type: type[Exception],
     ) -> None:
         self._request = request
@@ -54,7 +57,7 @@ class OwnedRealmLifecycle:
                 f"preflight realm {realm!r} failed ({got.status_code}): {got.text[:200]}"
             )
 
-    def _create_realm(self, realm: str, owner_nonce: str) -> _Response:
+    def _create_realm(self, realm: str, owner_nonce: str) -> _ResponseT:
         try:
             return self._request(
                 "POST",

--- a/kamiwaza_sdk/services/jobs_federation.py
+++ b/kamiwaza_sdk/services/jobs_federation.py
@@ -31,6 +31,7 @@ from typing import Any, Optional
 from ..exceptions import APIError, MeshJobTimeoutError
 from ..schemas.federation import JobResult
 from .base_service import BaseService
+from .jobs_routing import JobRouter
 
 # Polling backoff schedule for wait(). Mirrors the design §4.2.14
 # pattern: 1s, 2s, 4s, capped at 5s. Total budget is the caller's
@@ -56,6 +57,10 @@ _BARE_MARKER_PROMOTED_FIELD = "audit_actor"
 
 class JobsAPI(BaseService):
     """Job submission for the local cluster + federated targets."""
+
+    def __init__(self, client: Any) -> None:
+        super().__init__(client)
+        self._router = JobRouter(client)
 
     def run(
         self,
@@ -164,13 +169,14 @@ class JobsAPI(BaseService):
         timeout_seconds: Optional[int],
     ) -> JobResult:
         """Existing sync /run path; X-Job-Id only visible on completion."""
-        body = self._build_run_body(
+        body = _build_run_body(
             entrypoint=entrypoint,
-            target_cluster=target_cluster,
             runtime_env=runtime_env,
             timeout_seconds=timeout_seconds,
         )
-        response = self.client._request("POST", "/cluster/jobs/run", json=body)
+        response = self._router.request(
+            "POST", "run", target_cluster=target_cluster, json=body
+        )
         return JobResult.model_validate(response)
 
     def _run_recoverable(
@@ -194,7 +200,11 @@ class JobsAPI(BaseService):
             runtime_env=runtime_env,
             timeout_seconds=timeout_seconds,
         )
-        return self.wait(job_id, timeout=timeout_seconds or 600)
+        return self.wait(
+            job_id,
+            timeout=timeout_seconds or 600,
+            target_cluster=target_cluster,
+        )
 
     def submit_async(
         self,
@@ -210,16 +220,21 @@ class JobsAPI(BaseService):
         async submit + poll pattern is the recommended shape for jobs
         that may exceed 60s (per design §4.2.14).
         """
-        body = self._build_run_body(
+        body = _build_run_body(
             entrypoint=entrypoint,
-            target_cluster=target_cluster,
             runtime_env=runtime_env,
             timeout_seconds=timeout_seconds,
         )
-        response = self.client._request("POST", "/cluster/jobs/submit", json=body)
-        return str(response["job_id"])
+        response = self._router.request(
+            "POST", "submit", target_cluster=target_cluster, json=body
+        )
+        job_id = str(response["job_id"])
+        self._router.remember(job_id, target_cluster)
+        return job_id
 
-    def cancel(self, job_id: str) -> dict[str, Any]:
+    def cancel(
+        self, job_id: str, *, target_cluster: Optional[str] = None
+    ) -> dict[str, Any]:
         """Cancel a running job (T5.35 / ENG-4712).
 
         POSTs to ``/api/cluster/jobs/{id}/cancel``. The server returns a
@@ -229,10 +244,19 @@ class JobsAPI(BaseService):
         Demo bullet (3): ``kz.jobs.cancel(job_id)`` stops a stuck job
         within seconds.
         """
-        response = self.client._request("POST", f"/cluster/jobs/{job_id}/cancel")
+        target = self._router.resolve(job_id, target_cluster)
+        response = self._router.request(
+            "POST", f"{job_id}/cancel", target_cluster=target
+        )
         return dict(response)
 
-    def wait(self, job_id: str, *, timeout: int) -> JobResult:
+    def wait(
+        self,
+        job_id: str,
+        *,
+        timeout: int,
+        target_cluster: Optional[str] = None,
+    ) -> JobResult:
         """Poll a previously-submitted job until terminal, then return.
 
         Args:
@@ -241,6 +265,8 @@ class JobsAPI(BaseService):
                 ``MeshJobTimeoutError`` so customer code can branch on
                 "still running" vs "ran but failed" (which returns a
                 FAILED ``JobResult``, not an exception).
+            target_cluster: Federation used for the original submission.
+                Required when resuming a remotely submitted job.
 
         Returns:
             JobResult with status in {SUCCEEDED, FAILED, STOPPED, CANCELED}.
@@ -251,32 +277,16 @@ class JobsAPI(BaseService):
         """
         deadline = time.monotonic() + timeout
         delay = _POLL_BACKOFF_INITIAL_SECONDS
+        target = self._router.resolve(job_id, target_cluster)
         while time.monotonic() < deadline:
-            status_body = self.client._request(
-                "GET", f"/cluster/jobs/{job_id}/status"
+            status_body = self._router.request(
+                "GET", f"{job_id}/status", target_cluster=target
             )
             status = (
                 status_body.get("status") if isinstance(status_body, dict) else None
             )
             if status in _TERMINAL_STATES:
-                # /result returns the job's KZ_MESH_RUN_ON_JSON:: marker payload
-                # (the job's own structured output) — NOT a JobResult. The
-                # authoritative terminal status comes from /status; job_id +
-                # status are injected last so a marker key can't shadow them.
-                # A 410 means the job emitted no marker (it didn't self-report a
-                # result) — status is still authoritative, so don't treat it fatal.
-                payload: dict[str, Any] = {}
-                try:
-                    result_body = self.client._request(
-                        "GET", f"/cluster/jobs/{job_id}/result"
-                    )
-                    payload = self._marker_to_payload(result_body)
-                except APIError as exc:
-                    if getattr(exc, "status_code", None) != 410:
-                        raise
-                return JobResult.model_validate(
-                    {**payload, "job_id": str(job_id), "status": status}
-                )
+                return self._terminal_result(job_id, status, target)
 
             time.sleep(delay)
             delay = min(delay * _POLL_BACKOFF_FACTOR, _POLL_BACKOFF_CAP_SECONDS)
@@ -285,6 +295,23 @@ class JobsAPI(BaseService):
             f"Job {job_id} did not reach a terminal state within {timeout} seconds.",
             status_code=None,
             body={"job_id": job_id, "timeout_seconds": timeout},
+        )
+
+    def _terminal_result(
+        self, job_id: str, status: str, target_cluster: Optional[str]
+    ) -> JobResult:
+        """Fetch a terminal marker; tolerate the server's no-marker 410."""
+        payload: dict[str, Any] = {}
+        try:
+            result_body = self._router.request(
+                "GET", f"{job_id}/result", target_cluster=target_cluster
+            )
+            payload = self._marker_to_payload(result_body)
+        except APIError as exc:
+            if getattr(exc, "status_code", None) != 410:
+                raise
+        return JobResult.model_validate(
+            {**payload, "job_id": str(job_id), "status": status}
         )
 
     @staticmethod
@@ -315,24 +342,23 @@ class JobsAPI(BaseService):
         payload: dict[str, Any] = {}
         actor = domain.get(_BARE_MARKER_PROMOTED_FIELD)
         if isinstance(actor, str):
-            payload[_BARE_MARKER_PROMOTED_FIELD] = domain.pop(_BARE_MARKER_PROMOTED_FIELD)
+            payload[_BARE_MARKER_PROMOTED_FIELD] = domain.pop(
+                _BARE_MARKER_PROMOTED_FIELD
+            )
         if domain:
             payload["result"] = domain
         return payload
 
-    @staticmethod
-    def _build_run_body(
-        *,
-        entrypoint: str,
-        target_cluster: Optional[str],
-        runtime_env: Optional[dict[str, Any]],
-        timeout_seconds: Optional[int],
-    ) -> dict[str, Any]:
-        body: dict[str, Any] = {"entrypoint": entrypoint}
-        if target_cluster is not None:
-            body["target_cluster"] = target_cluster
-        if runtime_env is not None:
-            body["runtime_env"] = runtime_env
-        if timeout_seconds is not None:
-            body["timeout_seconds"] = timeout_seconds
-        return body
+
+def _build_run_body(
+    *,
+    entrypoint: str,
+    runtime_env: Optional[dict[str, Any]],
+    timeout_seconds: Optional[int],
+) -> dict[str, Any]:
+    body: dict[str, Any] = {"entrypoint": entrypoint}
+    if runtime_env is not None:
+        body["runtime_env"] = runtime_env
+    if timeout_seconds is not None:
+        body["timeout_seconds"] = timeout_seconds
+    return body

--- a/kamiwaza_sdk/services/jobs_routing.py
+++ b/kamiwaza_sdk/services/jobs_routing.py
@@ -1,0 +1,75 @@
+"""Routing state and mesh request construction for cluster jobs."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+from urllib.parse import quote
+
+from .federation_credentials import federation_credential_headers
+
+_MAX_TRACKED_REMOTE_JOBS = 256
+
+
+class JobRouter:
+    """Route local and federated job requests and remember recent targets."""
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+        self._remote_job_targets: dict[str, str] = {}
+
+    def request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        target_cluster: Optional[str],
+        **kwargs: Any,
+    ) -> Any:
+        local_path = f"/cluster/jobs/{endpoint}"
+        if target_cluster is None:
+            return self._client._request(method, local_path, **kwargs)
+
+        selector = _validate_target_cluster(target_cluster)
+        headers = federation_credential_headers(selector)
+        if headers:
+            kwargs["headers"] = headers
+        mesh_path = f"/mesh/{quote(selector, safe='')}/api{local_path}"
+        return self._client._request(method, mesh_path, **kwargs)
+
+    def remember(self, job_id: str, target_cluster: Optional[str]) -> None:
+        """Remember bounded same-client routing state for async job handles."""
+        if target_cluster is None:
+            return
+        self._remote_job_targets[job_id] = target_cluster
+        if len(self._remote_job_targets) > _MAX_TRACKED_REMOTE_JOBS:
+            oldest_job_id = next(iter(self._remote_job_targets))
+            del self._remote_job_targets[oldest_job_id]
+
+    def resolve(self, job_id: str, target_cluster: Optional[str]) -> Optional[str]:
+        """Prefer an explicit target, falling back to this client's submit cache."""
+        if target_cluster is not None:
+            return target_cluster
+        return self._remote_job_targets.get(job_id)
+
+
+def _validate_target_cluster(target_cluster: str) -> str:
+    """Require a trimmed mesh selector that fits one URL path segment."""
+    stripped = target_cluster.strip()
+    if not stripped:
+        raise _invalid_target_cluster()
+    if stripped != target_cluster:
+        raise _invalid_target_cluster()
+    if _is_unsafe_path_segment(target_cluster):
+        raise _invalid_target_cluster()
+    return target_cluster
+
+
+def _is_unsafe_path_segment(target_cluster: str) -> bool:
+    return "/" in target_cluster or target_cluster in {".", ".."}
+
+
+def _invalid_target_cluster() -> ValueError:
+    return ValueError(
+        "target_cluster must be a trimmed, nonblank federation name or ID "
+        "that fits one URL path segment"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,7 +150,7 @@ markers = [
     "withoutresponses: tests needing real network access",
     "requires_embedding_model: live tests that require a platform embedding deployment that can generate embeddings",
     "requires_two_clusters: live tests that require a federation peer cluster reachable via KAMIWAZA_PEER_BASE_URL / KAMIWAZA_PEER_API_KEY (ENG-5784)",
-    "requires_shared_idp: live federation tests exercising the shared_idp (Alt C) trust posture — receiver validates a shared-realm token against a trusted issuer (ENG-8213). The single-cluster identity gate carries this without requires_two_clusters; two-cluster shared_idp suites will carry both once tagged (currently deferred).",
+    "requires_shared_idp: live federation tests exercising the shared_idp (Alt C) trust posture — receiver validates a shared-realm token against a trusted issuer (ENG-8213). Required two-cluster lanes carry this together with requires_two_clusters and must provision their shared-identity prerequisites before selection.",
     "requires_deployable_model: live tests that require the host to deploy the integration test model; skips on hosts without compatible inference capacity (e.g. x86 CPU smoke vs an MLX model)",
     "extension_regression: D210 12-issue regression checklist (UAC-17 / EDX-OPS-2). See tests/unit/extensions/regression/inventory.yaml.",
     "live_extension: live extension-contract tests against a real cluster (relocated from kamiwaza, env-gated by RUN_LIVE_EXTENSION_TESTS=1)",

--- a/tests/integration/_gate_fixture.py
+++ b/tests/integration/_gate_fixture.py
@@ -23,13 +23,12 @@ Serving the index over ``file://`` from inside the pod keeps the whole thing
 independent of cluster topology: no Service, no node IP, no egress path, and
 nothing for a future NetworkPolicy to break.
 
-It writes into the gate-packages PVC, which is already mounted and already
-writable (``KAMIWAZA_GATE_PACKAGES_VENV``) whenever gate-packages are enabled at
-all — the exact prerequisite this rig needs anyway. That deliberately avoids a
-chart change: mounting a ConfigMap would mean setting ``scheduler.extraVolumes``,
-and helm REPLACES list values rather than merging them, so an overlay composed
-after ``kamiwaza-hotreload-k0s.yaml`` would silently clobber the source mounts
-and break hot-reload. No new volume, no pod restart, no hazard.
+It writes the wheel/index into the gate-packages PVC and the dataset into the
+Ray adapter's existing ``/app/models`` allowed root. Both volumes are already
+mounted and writable, so the fixture deliberately avoids a chart change:
+mounting a ConfigMap would mean setting ``scheduler.extraVolumes``, and helm
+REPLACES list values rather than merging them. No new volume or pod restart is
+needed.
 
 Usage::
 
@@ -55,6 +54,8 @@ NAMESPACE = "kamiwaza"
 # the prerequisite for gate-package install.
 MOUNT = "/opt/kamiwaza/gate-packages-venv/_fixture"
 INDEX_URL = f"file://{MOUNT}/simple"
+DATASET_DIR = "/app/models"
+DATASET_PATH = f"{DATASET_DIR}/eng10050-mini-clearance.csv"
 
 REPO = Path(__file__).resolve().parents[2]
 STAGE = REPO / ".gate-fixture"
@@ -232,7 +233,9 @@ def _ray_head_pod(argv: list[str]) -> str:
 
 def _publish_item(argv: list[str], pod: str, item: Path, leaf: str) -> None:
     """Stream one staged file into its destination inside the ray head."""
-    dest_dir = MOUNT if item.name == "mini_clearance.csv" else leaf
+    destination = (
+        DATASET_PATH if item.name == "mini_clearance.csv" else f"{leaf}/{item.name}"
+    )
     payload = base64.b64encode(item.read_bytes())
     cmd = argv + [
         "-n",
@@ -245,7 +248,7 @@ def _publish_item(argv: list[str], pod: str, item: Path, leaf: str) -> None:
         "--",
         "sh",
         "-c",
-        f"base64 -d > {dest_dir}/{item.name}",
+        f"base64 -d > {destination}",
     ]
     wrote = subprocess.run(
         _quote_remote_command(cmd),
@@ -259,7 +262,7 @@ def _publish_item(argv: list[str], pod: str, item: Path, leaf: str) -> None:
 
 
 def publish(argv: list[str], directory: Path) -> None:
-    """Copy the staged index into the PVC path the ray head already mounts.
+    """Copy the staged wheel/index and dataset into existing Ray-head mounts.
 
     ``kubectl cp`` rather than a ConfigMap: no new volume means no chart change,
     no pod restart, and no risk of an extraVolumes overlay replacing the
@@ -281,6 +284,7 @@ def publish(argv: list[str], directory: Path) -> None:
             "mkdir",
             "-p",
             leaf,
+            DATASET_DIR,
         ]
     )
     if mk.returncode != 0:
@@ -358,15 +362,17 @@ def main() -> int:
                     "rm",
                     "-rf",
                     MOUNT,
+                    DATASET_PATH,
                 ]
             )
-        print(f"  removed {MOUNT}")
+        print(f"  removed {MOUNT} and {DATASET_PATH}")
         return 0
 
     wheel, digest = build_wheel(locate_source())
     if args.action == "env":
         print(f"export M5_TEST_WHEEL_DIR={WHEEL_DIR}")
         print(f"export M5_TEST_INDEX_URL={INDEX_URL}")
+        print(f"export MINI_CLEARANCE_DATASET_PATH={DATASET_PATH}")
         return 0
 
     print(f"  built {wheel.name}  {digest}")
@@ -375,6 +381,7 @@ def main() -> int:
     verify(argv, digest)
     print(f"\nexport M5_TEST_WHEEL_DIR={WHEEL_DIR}")
     print(f"export M5_TEST_INDEX_URL={INDEX_URL}")
+    print(f"export MINI_CLEARANCE_DATASET_PATH={DATASET_PATH}")
     return 0
 
 

--- a/tests/integration/_mini_clearance.py
+++ b/tests/integration/_mini_clearance.py
@@ -57,6 +57,7 @@ KNOWN: dict[str, tuple[int, int, set[str]]] = {
     "S": (4, 1, {"U", "S"}),
     "TS": (5, 0, {"U", "S", "TS"}),
 }
+_EXACT_FIXTURE_CLEARANCES = frozenset(KNOWN)
 
 
 def records() -> list[dict[str, Any]]:
@@ -458,10 +459,32 @@ def initiator_cluster_uuid(receiver: Any, receiver_fed_id: str) -> Optional[str]
     return str(cluster_uuid) if cluster_uuid else None
 
 
+def _assert_exact_fixture_rows(
+    clearance: str,
+    rows: list[dict],
+    allowed: set[str],
+) -> None:
+    if clearance not in _EXACT_FIXTURE_CLEARANCES:
+        return
+    expected_rows = sorted(
+        (
+            record
+            for record in records()
+            if str(record.get("classification", "")).upper() in allowed
+        ),
+        key=lambda record: str(record.get("id", "")),
+    )
+    actual_rows = sorted(rows, key=lambda record: str(record.get("id", "")))
+    assert actual_rows == expected_rows, (
+        f"{clearance} caller received the wrong post-gate rows: "
+        f"expected={expected_rows!r} actual={actual_rows!r}"
+    )
+
+
 def assert_persona_result(
     clearance: str, rows: list[dict], gate_audits: list[dict]
 ) -> None:
-    """Assert the known post-gate counts + zero leakage for a persona.
+    """Assert the exact post-gate rows, footer contract, and zero leakage.
 
     Counts are asserted against the rows that ARRIVED, not against the footer's
     claim about them — the footer no longer carries counts (ENG-8859), and
@@ -474,6 +497,7 @@ def assert_persona_result(
     assert len(rows) == included, (
         f"expected {included} rows for {clearance}, got {len(rows)}"
     )
+    _assert_exact_fixture_rows(clearance, rows, allowed)
     assert any(bool(audit.get("filtered")) for audit in gate_audits) is (
         redacted > 0
     ), gate_audits

--- a/tests/integration/_shared_idp_fixture.py
+++ b/tests/integration/_shared_idp_fixture.py
@@ -24,8 +24,17 @@ init-Job pipeline (ENG-8573).
 
 Usage::
 
-    python -m tests.integration._shared_idp_fixture provision --kubectl "ssh spark-2 kubectl"
+    export SHARED_REALM_NAME=kajiya-edge-<unique-run-id>
+    export SHARED_REALM_OWNER_NONCE=<random-per-run-nonce>
+    export FED_PERSONA_PASSWORD=<random-per-run-password>
+    python -m tests.integration._shared_idp_fixture provision --kubectl kubectl
+    python -m tests.integration._shared_idp_fixture teardown --kubectl kubectl
     python -m tests.integration._shared_idp_fixture env
+
+``provision`` refuses an existing realm before changing its profile, clients,
+mappers, or users. ``teardown`` deletes the full realm only when its ownership
+marker exactly matches ``SHARED_REALM_OWNER_NONCE``; an absent realm is an
+idempotent success so callers can retry an ambiguous remote outcome safely.
 """
 
 from __future__ import annotations
@@ -42,7 +51,6 @@ import time
 from typing import Iterator
 
 NAMESPACE = "kamiwaza"
-REALM = os.getenv("SHARED_REALM_NAME", "federated")
 ROPC_CLIENT = "kamiwaza-shared-cli"
 # Verified against the live chart: svc/keycloak exposes 80 (http) and 9000
 # (management), NOT 8080. Overridable for a chart that differs.
@@ -85,7 +93,14 @@ def keycloak_admin_channel(kubectl: str) -> Iterator[str]:
         )
     port = _free_port()
     proc = subprocess.Popen(
-        argv + ["-n", NAMESPACE, "port-forward", "svc/keycloak", f"{port}:{KEYCLOAK_SVC_PORT}"],
+        argv
+        + [
+            "-n",
+            NAMESPACE,
+            "port-forward",
+            "svc/keycloak",
+            f"{port}:{KEYCLOAK_SVC_PORT}",
+        ],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
@@ -108,8 +123,15 @@ def admin_password(kubectl: str) -> str:
     argv = shlex.split(kubectl)
     got = run(
         argv
-        + ["-n", NAMESPACE, "get", "secret", "keycloak-admin",
-           "-o", "jsonpath={.data.password}"]
+        + [
+            "-n",
+            NAMESPACE,
+            "get",
+            "secret",
+            "keycloak-admin",
+            "-o",
+            "jsonpath={.data.password}",
+        ]
     )
     if got.returncode != 0 or not got.stdout.strip():
         raise SystemExit(
@@ -121,7 +143,14 @@ def admin_password(kubectl: str) -> str:
     return base64.b64decode(got.stdout.strip()).decode()
 
 
-def provision(kc_url: str, admin_pw: str, persona_pw: str) -> dict:
+def provision(
+    kc_url: str,
+    admin_pw: str,
+    persona_pw: str,
+    *,
+    realm: str,
+    owner_nonce: str,
+) -> dict:
     """Realm + ROPC client + clearance mapper + the three personas."""
     from kamiwaza_sdk.seeding.federation.cli import _verify_ssl
     from kamiwaza_sdk.seeding.federation.keycloak import KeycloakAdmin
@@ -133,17 +162,31 @@ def provision(kc_url: str, admin_pw: str, persona_pw: str) -> dict:
     kc = KeycloakAdmin(
         kc_url, admin_user="admin", admin_password=admin_pw, verify=_verify_ssl()
     )
-    kc.ensure_realm(REALM)
-    # Keycloak >=24 drops unrecognised user attributes unless the realm opts in,
-    # which silently strips `clearance` and leaves the gate with nothing to read.
-    kc.set_unmanaged_attributes(REALM)
-    client = kc.ensure_ropc_client(REALM, ROPC_CLIENT)
-    kc.ensure_attribute_mapper(REALM, client["id"], attribute="clearance")
+    kc.create_owned_realm(realm, owner_nonce)
+    try:
+        # Keycloak >=24 drops unrecognised user attributes unless the realm opts
+        # in, which silently strips `clearance` and leaves the gate with nothing.
+        kc.set_unmanaged_attributes(realm)
+        client = kc.ensure_ropc_client(realm, ROPC_CLIENT)
+        kc.ensure_attribute_mapper(realm, client["id"], attribute="clearance")
 
-    for clearance, username in PERSONAS.items():
-        kc.ensure_user(REALM, username, password=persona_pw, attributes={"clearance": clearance})
+        for clearance, username in PERSONAS.items():
+            kc.ensure_user(
+                realm,
+                username,
+                password=persona_pw,
+                attributes={"clearance": clearance},
+            )
+    except BaseException:
+        try:
+            kc.delete_owned_realm(realm, owner_nonce)
+        except Exception as cleanup_error:
+            raise RuntimeError(
+                "shared realm provision failed and owned-realm rollback also failed"
+            ) from cleanup_error
+        raise
 
-    issuer = kc.issuer_url(REALM)
+    issuer = kc.issuer_url(realm)
     return {
         "SHARED_ISSUER_URL": issuer,
         "SHARED_JWKS_URL": f"{issuer}/protocol/openid-connect/certs",
@@ -152,9 +195,20 @@ def provision(kc_url: str, admin_pw: str, persona_pw: str) -> dict:
     }
 
 
+def teardown(kc_url: str, admin_pw: str, *, realm: str, owner_nonce: str) -> bool:
+    """Delete the whole realm only when this run's ownership marker matches."""
+    from kamiwaza_sdk.seeding.federation.cli import _verify_ssl
+    from kamiwaza_sdk.seeding.federation.keycloak import KeycloakAdmin
+
+    kc = KeycloakAdmin(
+        kc_url, admin_user="admin", admin_password=admin_pw, verify=_verify_ssl()
+    )
+    return kc.delete_owned_realm(realm, owner_nonce)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("action", choices=["provision", "env"])
+    ap.add_argument("action", choices=["provision", "teardown", "env"])
     ap.add_argument("--kubectl", default="kubectl")
     ap.add_argument(
         "--persona-password-env",
@@ -167,17 +221,38 @@ def main() -> int:
         print("# provision first; it prints the exports")
         return 0
 
-    persona_pw = os.getenv(args.persona_password_env, "").strip() or secrets.token_urlsafe(24)
+    realm = os.getenv("SHARED_REALM_NAME", "").strip()
+    owner_nonce = os.getenv("SHARED_REALM_OWNER_NONCE", "").strip()
+    if not realm or not owner_nonce:
+        raise SystemExit(
+            "SHARED_REALM_NAME and SHARED_REALM_OWNER_NONCE are required; "
+            "the fixture refuses fixed or unowned realms"
+        )
     admin_pw = admin_password(args.kubectl)
+    if args.action == "teardown":
+        with keycloak_admin_channel(args.kubectl) as kc_url:
+            deleted = teardown(kc_url, admin_pw, realm=realm, owner_nonce=owner_nonce)
+        print(f"  realm={realm} cleanup={'deleted' if deleted else 'already-absent'}")
+        return 0
+
+    persona_pw = os.getenv(
+        args.persona_password_env, ""
+    ).strip() or secrets.token_urlsafe(24)
     with keycloak_admin_channel(args.kubectl) as kc_url:
-        exports = provision(kc_url, admin_pw, persona_pw)
+        exports = provision(
+            kc_url,
+            admin_pw,
+            persona_pw,
+            realm=realm,
+            owner_nonce=owner_nonce,
+        )
 
     # The issuer must be the address the CLUSTERS resolve, not the port-forward.
     public = os.getenv("KEYCLOAK_PUBLIC_URL", "").strip()
     if public:
-        exports["SHARED_ISSUER_URL"] = f"{public}/realms/{REALM}"
+        exports["SHARED_ISSUER_URL"] = f"{public}/realms/{realm}"
         exports["SHARED_JWKS_URL"] = (
-            f"{public}/realms/{REALM}/protocol/openid-connect/certs"
+            f"{public}/realms/{realm}/protocol/openid-connect/certs"
         )
     else:
         print(
@@ -186,7 +261,7 @@ def main() -> int:
             "  the shared JWKS and every persona token is rejected."
         )
 
-    print(f"  realm={REALM} client={ROPC_CLIENT} personas={sorted(PERSONAS.values())}")
+    print(f"  realm={realm} client={ROPC_CLIENT} personas={sorted(PERSONAS.values())}")
     print(json.dumps(exports, indent=2))
     for key, value in exports.items():
         print(f"export {key}={shlex.quote(value)}")

--- a/tests/integration/_shared_idp_fixture.py
+++ b/tests/integration/_shared_idp_fixture.py
@@ -48,6 +48,7 @@ import shlex
 import socket
 import subprocess
 import time
+from dataclasses import dataclass
 from typing import Iterator
 
 NAMESPACE = "kamiwaza"
@@ -62,6 +63,12 @@ KEYCLOAK_SVC_PORT = os.getenv("KEYCLOAK_SVC_PORT", "80")
 # -> module-fixture ERROR, not a skip. Keep these two dicts identical.
 # Clearance values match _mini_clearance.KNOWN: U sees 3 rows, S sees 4, TS sees all 5.
 PERSONAS = {"U": "fed-clr-u", "S": "fed-clr-s", "TS": "fed-clr-ts"}
+
+
+@dataclass(frozen=True)
+class OwnedRealm:
+    name: str
+    owner_nonce: str
 
 
 def run(cmd: list[str], **kw) -> subprocess.CompletedProcess:
@@ -147,9 +154,7 @@ def provision(
     kc_url: str,
     admin_pw: str,
     persona_pw: str,
-    *,
-    realm: str,
-    owner_nonce: str,
+    owned_realm: OwnedRealm,
 ) -> dict:
     """Realm + ROPC client + clearance mapper + the three personas."""
     from kamiwaza_sdk.seeding.federation.cli import _verify_ssl
@@ -162,7 +167,8 @@ def provision(
     kc = KeycloakAdmin(
         kc_url, admin_user="admin", admin_password=admin_pw, verify=_verify_ssl()
     )
-    kc.create_owned_realm(realm, owner_nonce)
+    realm = owned_realm.name
+    kc.create_owned_realm(realm, owned_realm.owner_nonce)
     try:
         # Keycloak >=24 drops unrecognised user attributes unless the realm opts
         # in, which silently strips `clearance` and leaves the gate with nothing.
@@ -179,7 +185,7 @@ def provision(
             )
     except BaseException:
         try:
-            kc.delete_owned_realm(realm, owner_nonce)
+            kc.delete_owned_realm(realm, owned_realm.owner_nonce)
         except Exception as cleanup_error:
             raise RuntimeError(
                 "shared realm provision failed and owned-realm rollback also failed"
@@ -206,48 +212,41 @@ def teardown(kc_url: str, admin_pw: str, *, realm: str, owner_nonce: str) -> boo
     return kc.delete_owned_realm(realm, owner_nonce)
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("action", choices=["provision", "teardown", "env"])
-    ap.add_argument("--kubectl", default="kubectl")
-    ap.add_argument(
-        "--persona-password-env",
-        default="FED_PERSONA_PASSWORD",
-        help="env var holding the persona password; generated when unset",
-    )
-    args = ap.parse_args()
-
-    if args.action == "env":
-        print("# provision first; it prints the exports")
-        return 0
-
+def _required_owned_realm() -> OwnedRealm:
     realm = os.getenv("SHARED_REALM_NAME", "").strip()
     owner_nonce = os.getenv("SHARED_REALM_OWNER_NONCE", "").strip()
-    if not realm or not owner_nonce:
-        raise SystemExit(
-            "SHARED_REALM_NAME and SHARED_REALM_OWNER_NONCE are required; "
-            "the fixture refuses fixed or unowned realms"
-        )
+    if realm and owner_nonce:
+        return OwnedRealm(realm, owner_nonce)
+    raise SystemExit(
+        "SHARED_REALM_NAME and SHARED_REALM_OWNER_NONCE are required; "
+        "the fixture refuses fixed or unowned realms"
+    )
+
+
+def _run_fixture_action(args: argparse.Namespace, owned_realm: OwnedRealm) -> int:
     admin_pw = admin_password(args.kubectl)
     if args.action == "teardown":
         with keycloak_admin_channel(args.kubectl) as kc_url:
-            deleted = teardown(kc_url, admin_pw, realm=realm, owner_nonce=owner_nonce)
-        print(f"  realm={realm} cleanup={'deleted' if deleted else 'already-absent'}")
+            deleted = teardown(
+                kc_url,
+                admin_pw,
+                realm=owned_realm.name,
+                owner_nonce=owned_realm.owner_nonce,
+            )
+        status = "deleted" if deleted else "already-absent"
+        print(f"  realm={owned_realm.name} cleanup={status}")
         return 0
 
     persona_pw = os.getenv(
         args.persona_password_env, ""
     ).strip() or secrets.token_urlsafe(24)
     with keycloak_admin_channel(args.kubectl) as kc_url:
-        exports = provision(
-            kc_url,
-            admin_pw,
-            persona_pw,
-            realm=realm,
-            owner_nonce=owner_nonce,
-        )
+        exports = provision(kc_url, admin_pw, persona_pw, owned_realm)
+    _print_provisioned_realm(owned_realm.name, exports)
+    return 0
 
-    # The issuer must be the address the CLUSTERS resolve, not the port-forward.
+
+def _print_provisioned_realm(realm: str, exports: dict[str, str]) -> None:
     public = os.getenv("KEYCLOAK_PUBLIC_URL", "").strip()
     if public:
         exports["SHARED_ISSUER_URL"] = f"{public}/realms/{realm}"
@@ -265,13 +264,6 @@ def main() -> int:
     print(json.dumps(exports, indent=2))
     for key, value in exports.items():
         print(f"export {key}={shlex.quote(value)}")
-
-    # Standing the realm up is necessary but NOT sufficient. The receiver's
-    # shared-realm allowlist is fail-closed by design (ENG-8376:
-    # `scheduler.trustedSharedIssuers` defaults to []), so until the issuer is
-    # enrolled there the receiver answers 403 `shared_idp_issuer_untrusted`. That
-    # reason is in the suite's AUTH_LAYER_REASONS, which makes it a hard RED
-    # rather than a skip — a confusing result to debug from the test output alone.
     print(
         "\n  NEXT (required, or the suite goes red with 403 "
         "shared_idp_issuer_untrusted):\n"
@@ -280,7 +272,23 @@ def main() -> int:
         "      trustedSharedIssuers:\n"
         f"        - {exports['SHARED_ISSUER_URL']}"
     )
-    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("action", choices=["provision", "teardown", "env"])
+    ap.add_argument("--kubectl", default="kubectl")
+    ap.add_argument(
+        "--persona-password-env",
+        default="FED_PERSONA_PASSWORD",
+        help="env var holding the persona password; generated when unset",
+    )
+    args = ap.parse_args()
+
+    if args.action == "env":
+        print("# provision first; it prints the exports")
+        return 0
+    return _run_fixture_action(args, _required_owned_realm())
 
 
 if __name__ == "__main__":

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -90,6 +90,20 @@ _PROBE_ERROR_TRUNCATE = 200
 _logger = logging.getLogger(__name__)
 
 
+def _fail_or_skip_required_edge(request: pytest.FixtureRequest, message: str) -> None:
+    from tests.integration.required_federation_edge import fail_or_skip
+
+    fail_or_skip(request, message)
+
+
+def _enforce_required_edge_collection(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    from tests.integration.required_federation_edge import enforce_collection
+
+    enforce_collection(config, items)
+
+
 class _TimeoutHTTPAdapter(HTTPAdapter):
     """HTTPAdapter that applies a default timeout to every request."""
 
@@ -1598,16 +1612,18 @@ def _require_two_clusters_for_marked_tests(request: pytest.FixtureRequest) -> No
     # credential satisfies the gate the same way the peer fixture consumes it.
     peer_password = str(request.getfixturevalue("live_password")).strip()
     if not peer_url:
-        pytest.skip(
+        _fail_or_skip_required_edge(
+            request,
             "requires_two_clusters: set --live-peer-base-url or "
-            "KAMIWAZA_PEER_BASE_URL to run."
+            "KAMIWAZA_PEER_BASE_URL to run.",
         )
     if not peer_key and not peer_password:
-        pytest.skip(
+        _fail_or_skip_required_edge(
+            request,
             "requires_two_clusters: --live-peer-base-url is set but no peer "
             "admin credential — provide --live-username/--live-password "
             "(preferred) or an admin access-token via --live-peer-api-key "
-            "(a PAT is non-admin)."
+            "(a PAT is non-admin).",
         )
 
 
@@ -1686,7 +1702,9 @@ def live_kamiwaza_peer_client(
     SSL verification is opted out per-client (dev self-signed certs).
     """
     if not live_peer_base_url:
-        pytest.skip("requires_two_clusters: KAMIWAZA_PEER_BASE_URL not set")
+        raise RuntimeError(
+            "requires_two_clusters fixture ran without KAMIWAZA_PEER_BASE_URL"
+        )
 
     peer_key = live_peer_api_key.strip()
     has_password = bool(live_password)
@@ -1723,11 +1741,12 @@ def live_kamiwaza_peer_client(
         return password_client  # type: ignore[return-value]
     if choice == _peer_auth.PEER_KEY:
         return KamiwazaClient(live_peer_base_url, api_key=peer_key, verify=False)
-    pytest.skip(
+    message = (
         "requires_two_clusters: peer needs admin password "
         "(--live-username/--live-password) or an admin access-token "
         "(--live-peer-api-key; a PAT is non-admin)."
     )
+    pytest.skip(message)
 
 
 def pytest_collection_modifyitems(
@@ -1745,6 +1764,7 @@ def pytest_collection_modifyitems(
     halves makes those fixtures live across unrelated tests and can invalidate
     workroom-scoped state before the later half resumes.
     """
+    _enforce_required_edge_collection(config, items)
     peer_url = str(config.getoption("live_peer_base_url")).strip()
     if not peer_url:
         kept: list[pytest.Item] = []

--- a/tests/integration/required_federation_edge.py
+++ b/tests/integration/required_federation_edge.py
@@ -1,0 +1,101 @@
+"""Fail-closed pytest policy for the required two-cluster federation edge."""
+
+from pathlib import Path
+
+import pytest
+
+REQUIRED_EDGE_FILE = "test_federation_shared_idp_gated_retrieval_live.py"
+REQUIRED_EDGE_CASES = frozenset(
+    {
+        "test_required_mesh_retrieval_returns_exact_post_gate_rows[U]",
+        "test_required_mesh_retrieval_returns_exact_post_gate_rows[S]",
+        "test_required_mesh_retrieval_returns_exact_post_gate_rows[TS]",
+        "test_required_mesh_job_reaches_receiver_and_returns_marker",
+        "test_unonboarded_primary_realm_user_rejected_by_receiver_allowlist",
+    }
+)
+
+
+def required_edge_enabled(config: pytest.Config) -> bool:
+    return bool(config.getoption("require_federation_edge"))
+
+
+def is_required_edge_item(item: pytest.Item) -> bool:
+    required_markers = {"requires_two_clusters", "requires_shared_idp"}
+    return (
+        required_edge_enabled(item.config)
+        and Path(str(item.fspath)).name == REQUIRED_EDGE_FILE
+        and required_markers <= set(item.keywords)
+    )
+
+
+def fail_or_skip(request: pytest.FixtureRequest, message: str) -> None:
+    if is_required_edge_item(request.node):
+        pytest.fail(message, pytrace=False)
+    pytest.skip(message)
+
+
+def _edge_cases(items: list[pytest.Item]) -> set[str]:
+    return {
+        item.nodeid.rsplit("::", 1)[-1]
+        for item in items
+        if Path(str(item.fspath)).name == REQUIRED_EDGE_FILE
+    }
+
+
+def assert_required_cases(items: list[pytest.Item]) -> None:
+    present = _edge_cases(items)
+    missing = sorted(REQUIRED_EDGE_CASES - present)
+    if missing:
+        raise pytest.UsageError(
+            "required federation edge is missing contract cases: " + ", ".join(missing)
+        )
+
+
+def assert_selected_required_cases(items: list[pytest.Item]) -> None:
+    selected = _edge_cases(items)
+    missing = sorted(REQUIRED_EDGE_CASES - selected)
+    unexpected = sorted(selected - REQUIRED_EDGE_CASES)
+    if not missing and not unexpected:
+        return
+    details = []
+    if missing:
+        details.append("missing=" + ",".join(missing))
+    if unexpected:
+        details.append("unexpected=" + ",".join(unexpected))
+    raise pytest.UsageError(
+        "required federation edge selected contract cases differ: " + "; ".join(details)
+    )
+
+
+def promote_skip(item: pytest.Item, report: pytest.TestReport) -> None:
+    if not is_required_edge_item(item) or not report.skipped:
+        return
+    report.outcome = "failed"
+    report.longrepr = (
+        f"required federation edge skipped during {report.when}: {report.longrepr}"
+    )
+
+
+def enforce_collection(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if not required_edge_enabled(config):
+        return
+    assert_required_cases(items)
+    if not str(config.getoption("live_peer_base_url")).strip():
+        raise pytest.UsageError(
+            "--require-federation-edge needs --live-peer-base-url or "
+            "KAMIWAZA_PEER_BASE_URL"
+        )
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    """Validate the final item set after ``-k`` and marker deselection."""
+    if required_edge_enabled(session.config):
+        assert_selected_required_cases(list(session.items))
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item: pytest.Item, call: pytest.CallInfo):
+    """A selected required federation edge may never become green via skip."""
+    outcome = yield
+    promote_skip(item, outcome.get_result())

--- a/tests/integration/required_federation_edge_personas.py
+++ b/tests/integration/required_federation_edge_personas.py
@@ -1,0 +1,154 @@
+"""Primary-realm personas and receiver onboarding for the required edge."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from typing import Any
+from urllib.parse import quote
+
+from tests.integration import _mini_clearance as mc
+
+PERSONAS = {"U": "fed-clr-u", "S": "fed-clr-s", "TS": "fed-clr-ts"}
+UNONBOARDED_PERSONA = "fed-clr-unonboarded"
+
+
+def required_initial_tuples(
+    dataset_urn: str,
+    *,
+    job_executor: bool,
+) -> list[dict[str, str]]:
+    """Fixture-scoped retrieval authority plus one explicit job submitter."""
+    tuples = [
+        {
+            "subject": "user:{{user_id}}",
+            "relation": "viewer",
+            "object": f"dataset:{dataset_urn}",
+        }
+    ]
+    if job_executor:
+        tuples.append(
+            {
+                "subject": "user:{{user_id}}",
+                "relation": "executor",
+                "object": "cluster_jobs:__all__",
+            }
+        )
+    return tuples
+
+
+def cleanup_brokered_persona(
+    receiver: Any, federation_id: str, external_id: str
+) -> None:
+    """Revoke the exact temporary allowlist row and cancel active jobs."""
+    encoded_external_id = quote(external_id, safe="")
+    receiver._request(
+        "POST",
+        f"/cluster/federations/{federation_id}/users/{encoded_external_id}/revoke",
+        params={"cancel_in_flight_jobs": "true"},
+    )
+
+
+def _cleanup_primary_persona(initiator: Any, username: str) -> None:
+    from kamiwaza_sdk.exceptions import APIError
+
+    try:
+        initiator.subjects.delete(username, cascade_grants=True)
+    except APIError as exc:
+        if exc.status_code != 404:
+            raise
+
+
+def _require_primary_personas_absent(initiator: Any, usernames: list[str]) -> None:
+    """Refuse to overwrite an operator-owned primary-realm identity."""
+    from kamiwaza_sdk.exceptions import APIError
+
+    for username in usernames:
+        try:
+            initiator.subjects.get(username)
+        except APIError as exc:
+            if exc.status_code == 404:
+                continue
+            raise
+        raise AssertionError(
+            f"required federation persona already exists on initiator: {username}"
+        )
+
+
+def _login_primary_persona(
+    initiator: Any,
+    username: str,
+    password: str,
+    *,
+    verify: bool,
+) -> dict[str, Any]:
+    """Authenticate through the initiator API and prove the returned identity."""
+    persona = mc.authed_client(
+        initiator.base_url,
+        username,
+        password,
+        verify=verify,
+    )
+    current = persona.auth.get_current_user()
+    token = persona.get_bearer_token()
+    assert current.username == username, current
+    assert token, f"normal initiator login returned no bearer token for {username}"
+    sub = mc.jwt_sub(token)
+    assert sub and sub == str(current.sub), current
+    return {"client": persona, "token": token, "sub": sub, "username": username}
+
+
+def _onboard_persona(
+    cleanup: ExitStack,
+    receiver: Any,
+    identity: tuple[str, str, str],
+    clearance: str,
+    persona: dict[str, Any],
+) -> None:
+    federation_id, source_cluster_id, dataset_urn = identity
+    external_id = f"{persona['sub']}@{source_cluster_id}"
+    persona["external_id"] = external_id
+    receiver._request(
+        "POST",
+        f"/cluster/federations/{federation_id}/users",
+        json={
+            "external_id": external_id,
+            "initial_tuples": required_initial_tuples(
+                dataset_urn,
+                job_executor=clearance == "U",
+            ),
+        },
+    )
+    cleanup.callback(cleanup_brokered_persona, receiver, federation_id, external_id)
+
+
+def provision_primary_personas(
+    cleanup: ExitStack,
+    clients: Any,
+    identity: tuple[str, str, str],
+    prerequisites: Any,
+) -> dict[str, dict[str, Any]]:
+    """Create normal initiator users and onboard only U/S/TS on receiver."""
+    auth = prerequisites.persona_auth
+    initiator, receiver = clients.initiator, clients.receiver
+    specs = [*PERSONAS.items(), ("unonboarded", UNONBOARDED_PERSONA)]
+    _require_primary_personas_absent(initiator, [name for _, name in specs])
+    mc.declare_clearance_attribute(initiator)
+    personas: dict[str, dict[str, Any]] = {}
+    for clearance, username in specs:
+        value = "U" if clearance == "unonboarded" else clearance
+        cleanup.callback(_cleanup_primary_persona, initiator, username)
+        initiator.subjects.upsert(
+            username,
+            attributes={"clearance": value},
+            password=auth["password"],
+        )
+        persona = _login_primary_persona(
+            initiator,
+            username,
+            auth["password"],
+            verify=auth["verify"],
+        )
+        personas[clearance] = persona
+        if clearance != "unonboarded":
+            _onboard_persona(cleanup, receiver, identity, clearance, persona)
+    return personas

--- a/tests/integration/required_federation_edge_personas.py
+++ b/tests/integration/required_federation_edge_personas.py
@@ -98,12 +98,11 @@ def _login_primary_persona(
 
 
 def _onboard_persona(
-    cleanup: ExitStack,
     receiver: Any,
     identity: tuple[str, str, str],
     clearance: str,
     persona: dict[str, Any],
-) -> None:
+) -> str:
     federation_id, source_cluster_id, dataset_urn = identity
     external_id = f"{persona['sub']}@{source_cluster_id}"
     persona["external_id"] = external_id
@@ -118,7 +117,7 @@ def _onboard_persona(
             ),
         },
     )
-    cleanup.callback(cleanup_brokered_persona, receiver, federation_id, external_id)
+    return external_id
 
 
 def provision_primary_personas(
@@ -150,5 +149,11 @@ def provision_primary_personas(
         )
         personas[clearance] = persona
         if clearance != "unonboarded":
-            _onboard_persona(cleanup, receiver, identity, clearance, persona)
+            external_id = _onboard_persona(receiver, identity, clearance, persona)
+            cleanup.callback(
+                cleanup_brokered_persona,
+                receiver,
+                identity[0],
+                external_id,
+            )
     return personas

--- a/tests/integration/required_federation_edge_setup.py
+++ b/tests/integration/required_federation_edge_setup.py
@@ -1,0 +1,136 @@
+"""State-safe setup helpers for the required two-cluster edge."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from dataclasses import dataclass
+from typing import Any
+
+from tests.integration import _mini_clearance as mc
+
+
+@dataclass(frozen=True)
+class PairIdentities:
+    receiver_federation_id: str
+    initiator_cluster_id: str
+    receiver_cluster_id: str
+
+
+def _delete_federation(client: Any, federation_id: str) -> None:
+    client._request("DELETE", f"/cluster/federations/{federation_id}")
+
+
+def _uninstall_owned_gate_package(receiver: Any) -> None:
+    from kamiwaza_sdk.exceptions import APIError
+
+    try:
+        receiver.gates.packages.uninstall("acme-gates")
+    except APIError as exc:
+        if exc.status_code != 404:
+            raise
+
+
+def _installed_gate_package(receiver: Any) -> Any | None:
+    """Read package ownership authoritatively; non-404 failures abort setup."""
+    from kamiwaza_sdk.exceptions import APIError
+
+    try:
+        return receiver.gates.packages.get("acme-gates")
+    except APIError as exc:
+        if exc.status_code == 404:
+            return None
+        raise
+
+
+def _assert_desired_gate_package(package: Any, wheel_dir: str) -> None:
+    assert getattr(package, "package_spec", None) == mc.PACKAGE_SPEC
+    assert getattr(package, "version", None) == "1.1.0"
+    assert getattr(package, "hash_digest", None) == mc._wheel_sha256(wheel_dir)
+    assert getattr(package, "status", None) == "active"
+    assert mc.GATE_CLASSPATH in (getattr(package, "classpaths", None) or [])
+
+
+def _ensure_gate_package(
+    cleanup: ExitStack,
+    receiver: Any,
+    wheel_dir: str,
+    index_url: str,
+) -> None:
+    """Install or validate the exact wheel with immediate owned cleanup."""
+    package = _installed_gate_package(receiver)
+    if package is None:
+        result = receiver.gates.packages.install(
+            mc.PACKAGE_SPEC,
+            hash_digest=mc._wheel_sha256(wheel_dir),
+            index_url=index_url,
+        )
+        package = result.package
+        cleanup.callback(_uninstall_owned_gate_package, receiver)
+        _assert_desired_gate_package(package, wheel_dir)
+    else:
+        _assert_desired_gate_package(package, wheel_dir)
+    gate = receiver.gates.discover(mc.GATE_CLASSPATH)
+    assert gate.name == mc.GATE_NAME
+
+
+def provision_gated_dataset(
+    cleanup: ExitStack,
+    receiver: Any,
+    prerequisites: Any,
+    name: str,
+) -> str:
+    mc.declare_clearance_attribute(receiver)
+    _ensure_gate_package(
+        cleanup,
+        receiver,
+        prerequisites.wheel_dir,
+        prerequisites.index_url,
+    )
+    urn = receiver.datasets.create(
+        name=f"mini-clearance-{name}",
+        platform="file",
+        properties={"path": prerequisites.dataset_path},
+    )
+    cleanup.callback(receiver.datasets.delete, urn)
+    receiver.datasets.set_gate(urn, type=mc.GATE_CLASSPATH, config={})
+    return str(urn)
+
+
+def pair_required_edge(
+    cleanup: ExitStack,
+    clients: Any,
+    request: Any,
+) -> PairIdentities:
+    receiver_federation = clients.receiver.federations.pair(
+        name=request.name,
+        role="receiver",
+        preshared_key=request.psk,
+        **request.shared,
+    )
+    receiver_id = str(receiver_federation.id)
+    cleanup.callback(_delete_federation, clients.receiver, receiver_id)
+    initiator_federation = clients.initiator.federations.pair(
+        name=request.name,
+        role="initiator",
+        remote_url=request.peer_url,
+        preshared_key=request.psk,
+        **request.shared,
+    )
+    initiator_id = str(initiator_federation.id)
+    cleanup.callback(_delete_federation, clients.initiator, initiator_id)
+
+    receiver_record = clients.receiver.federations.get(receiver_id)
+    initiator_record = clients.initiator.federations.get(initiator_id)
+    initiator_cluster_id = str(receiver_record.remote_cluster_id or "")
+    receiver_cluster_id = str(initiator_record.remote_cluster_id or "")
+    assert initiator_cluster_id, "receiver record has no initiator cluster identity"
+    assert receiver_cluster_id, "initiator record has no receiver cluster identity"
+    assert initiator_cluster_id != receiver_cluster_id, (
+        "required federation edge resolved to one cluster identity: "
+        f"{initiator_cluster_id}"
+    )
+    return PairIdentities(
+        receiver_federation_id=receiver_id,
+        initiator_cluster_id=initiator_cluster_id,
+        receiver_cluster_id=receiver_cluster_id,
+    )

--- a/tests/integration/test_federation_required_edge_contract.py
+++ b/tests/integration/test_federation_required_edge_contract.py
@@ -1,0 +1,578 @@
+"""ENG-10050: Offline contract for the required shared-IDP smoke edge."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from _kamiwaza_pytest_options import PROJECT_ROOT
+from kamiwaza_sdk.exceptions import APIError, AuthenticationError
+from tests.integration import test_federation_shared_idp_gated_retrieval_live as edge
+from tests.integration import required_federation_edge_personas as edge_personas
+
+try:
+    from tests.integration import required_federation_edge as required_edge
+    from tests.integration import required_federation_edge_setup as required_setup
+except ImportError:  # exact-parent RED: the required-edge plugin does not exist
+    required_edge = SimpleNamespace()
+    required_setup = SimpleNamespace()
+
+pytestmark = pytest.mark.unit
+
+
+def _required_item(nodeid: str) -> SimpleNamespace:
+    config = SimpleNamespace(getoption=lambda name: name == "require_federation_edge")
+    return SimpleNamespace(
+        config=config,
+        fspath=Path(required_edge.REQUIRED_EDGE_FILE),
+        keywords={"requires_two_clusters": True, "requires_shared_idp": True},
+        nodeid=nodeid,
+    )
+
+
+def test_required_edge_carries_both_topology_markers() -> None:
+    marker_names = {marker.name for marker in edge.pytestmark}
+
+    assert {"requires_two_clusters", "requires_shared_idp"} <= marker_names
+
+
+def test_required_edge_plugin_is_registered_only_at_pytest_root() -> None:
+    root_conftest = (PROJECT_ROOT / "conftest.py").read_text()
+    integration_conftest = (PROJECT_ROOT / "tests/integration/conftest.py").read_text()
+
+    assert "tests.integration.required_federation_edge" in root_conftest
+    assert "pytest_plugins" not in integration_conftest
+
+
+def test_required_edge_collection_guard_requires_all_five_cases() -> None:
+    assert (
+        "test_unonboarded_primary_realm_user_rejected_by_receiver_allowlist"
+        in required_edge.REQUIRED_EDGE_CASES
+    )
+    assert not any(
+        "native_realm_token" in case for case in required_edge.REQUIRED_EDGE_CASES
+    )
+    items = [
+        _required_item(f"tests/integration/{required_edge.REQUIRED_EDGE_FILE}::{case}")
+        for case in required_edge.REQUIRED_EDGE_CASES
+    ]
+
+    required_edge.assert_required_cases(items)
+
+    with pytest.raises(pytest.UsageError, match="missing contract cases"):
+        required_edge.assert_required_cases(items[:-1])
+
+
+def test_required_edge_post_selection_guard_rejects_deselection_and_extras() -> None:
+    items = [
+        _required_item(f"tests/integration/{required_edge.REQUIRED_EDGE_FILE}::{case}")
+        for case in required_edge.REQUIRED_EDGE_CASES
+    ]
+
+    required_edge.assert_selected_required_cases(items)
+
+    with pytest.raises(pytest.UsageError, match="selected contract cases"):
+        required_edge.assert_selected_required_cases(items[:-1])
+
+    extra = _required_item(
+        f"tests/integration/{required_edge.REQUIRED_EDGE_FILE}::test_optional_case"
+    )
+    with pytest.raises(pytest.UsageError, match="selected contract cases"):
+        required_edge.assert_selected_required_cases([*items, extra])
+
+
+def test_required_edge_promotes_any_skip_to_failure() -> None:
+    item = _required_item(
+        "tests/integration/"
+        f"{required_edge.REQUIRED_EDGE_FILE}::"
+        "test_required_mesh_job_reaches_receiver_and_returns_marker"
+    )
+    report = SimpleNamespace(
+        longrepr="missing shared realm",
+        outcome="skipped",
+        skipped=True,
+        when="setup",
+    )
+
+    required_edge.promote_skip(item, report)
+
+    assert report.outcome == "failed"
+    assert "missing shared realm" in report.longrepr
+
+    unrelated = _required_item(
+        "tests/integration/test_unrelated_live.py::test_optional_edge"
+    )
+    unrelated.fspath = Path("test_unrelated_live.py")
+    optional_report = SimpleNamespace(
+        longrepr="optional capability",
+        outcome="skipped",
+        skipped=True,
+        when="setup",
+    )
+    required_edge.promote_skip(unrelated, optional_report)
+    assert optional_report.outcome == "skipped"
+
+
+def test_required_prerequisite_fails_in_strict_lane() -> None:
+    strict = SimpleNamespace(getoption=lambda name: name == "require_federation_edge")
+    optional = SimpleNamespace(getoption=lambda name: False)
+
+    with pytest.raises(pytest.fail.Exception, match="missing shared realm"):
+        edge._require_prerequisite(strict, False, "missing shared realm")
+    with pytest.raises(pytest.skip.Exception, match="missing shared realm"):
+        edge._require_prerequisite(optional, False, "missing shared realm")
+
+
+def test_required_mesh_call_propagates_downstream_denial() -> None:
+    denial = APIError("receiver denied", status_code=403)
+
+    def deny() -> None:
+        raise denial
+
+    with pytest.raises(APIError) as caught:
+        edge._required_mesh_call(deny)
+
+    assert caught.value is denial
+
+
+def test_unonboarded_primary_user_uses_mesh_and_requires_allowlist_reason() -> None:
+    client = Mock()
+    client._request.side_effect = APIError("forbidden", status_code=403)
+
+    with pytest.raises(AssertionError, match="unauthorized_brokered_user"):
+        edge.test_unonboarded_primary_realm_user_rejected_by_receiver_allowlist(
+            {
+                "name": "receiver-cluster",
+                "personas": {"unonboarded": {"client": client}},
+            }
+        )
+
+    client._request.assert_called_once_with(
+        "GET",
+        "/mesh/receiver-cluster/api/cluster/diagnose",
+    )
+
+
+def test_unonboarded_primary_user_accepts_exact_receiver_allowlist_rejection() -> None:
+    denial = APIError(
+        "not onboarded",
+        status_code=403,
+        response_data={
+            "detail": {"reason": "unauthorized_brokered_user"},
+        },
+    )
+
+    edge._assert_receiver_onboarding_rejection(Mock(side_effect=denial))
+
+
+@pytest.mark.parametrize(
+    "denial",
+    [
+        AuthenticationError("unauthorized"),
+        APIError(
+            "peer rejected",
+            status_code=403,
+            response_data={
+                "detail": {"reason": "shared_idp_issuer_untrusted"},
+            },
+        ),
+    ],
+)
+def test_unonboarded_primary_user_rejects_unrelated_auth_failure(denial) -> None:
+    with pytest.raises(AssertionError, match="unauthorized_brokered_user"):
+        edge._assert_receiver_onboarding_rejection(Mock(side_effect=denial))
+
+
+def test_required_personas_use_primary_realm_login_and_receiver_onboarding(
+    monkeypatch,
+) -> None:
+    from kamiwaza_sdk.exceptions import APIError
+
+    initiator = SimpleNamespace(
+        subjects=Mock(),
+        cluster=Mock(),
+        base_url="https://fed-a.test/api",
+    )
+    receiver = SimpleNamespace(_request=Mock())
+    initiator.subjects.get.side_effect = APIError("missing", status_code=404)
+    clients = edge._EdgeClients(initiator=initiator, receiver=receiver)
+    cleanup = Mock()
+    persona_clients = {}
+
+    def normal_login(base_url, username, password, *, verify):
+        assert base_url == "https://fed-a.test/api"
+        assert password == "persona-secret"
+        assert verify is True
+        client = Mock()
+        client.auth.get_current_user.return_value = SimpleNamespace(
+            username=username,
+            sub=f"sub-{username}",
+        )
+        client.get_bearer_token.return_value = f"token-{username}"
+        persona_clients[username] = client
+        return client
+
+    monkeypatch.setattr(edge.mc, "authed_client", normal_login)
+    monkeypatch.setattr(
+        edge.mc,
+        "jwt_sub",
+        lambda token: f"sub-{token.removeprefix('token-')}",
+    )
+    direct_shared_login = Mock(
+        side_effect=AssertionError("direct shared-realm ROPC is forbidden")
+    )
+    monkeypatch.setattr(
+        edge.mc,
+        "shared_realm_token",
+        direct_shared_login,
+    )
+    prerequisites = SimpleNamespace(
+        persona_auth={"password": "persona-secret", "verify": True},
+        shared={"shared_issuer_url": "https://fed-a.test/realms/kamiwaza"},
+    )
+
+    personas = edge_personas.provision_primary_personas(
+        cleanup,
+        clients,
+        ("receiver-fed", "fed-a-cluster", "urn:dataset:known"),
+        prerequisites,
+    )
+
+    assert set(personas) == {"U", "S", "TS", "unonboarded"}
+    assert initiator.subjects.upsert.call_count == 4
+    assert set(persona_clients) == {
+        "fed-clr-u",
+        "fed-clr-s",
+        "fed-clr-ts",
+        "fed-clr-unonboarded",
+    }
+    assert receiver._request.call_count == 3
+    direct_shared_login.assert_not_called()
+    for clearance in ("U", "S", "TS"):
+        username = f"fed-clr-{clearance.lower()}"
+        assert personas[clearance]["client"] is persona_clients[username]
+
+
+def test_brokered_personas_get_only_required_fixture_authority() -> None:
+    dataset_tuple = {
+        "subject": "user:{{user_id}}",
+        "relation": "viewer",
+        "object": "dataset:urn:kamiwaza:dataset:known",
+    }
+    assert edge_personas.required_initial_tuples(
+        "urn:kamiwaza:dataset:known",
+        job_executor=False,
+    ) == [dataset_tuple]
+    assert edge_personas.required_initial_tuples(
+        "urn:kamiwaza:dataset:known",
+        job_executor=True,
+    ) == [
+        dataset_tuple,
+        {
+            "subject": "user:{{user_id}}",
+            "relation": "executor",
+            "object": "cluster_jobs:__all__",
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    "previous", [None, SimpleNamespace(type="old.Gate", config={})]
+)
+def test_temporary_execution_gate_restores_receiver_binding(previous) -> None:
+    cluster = Mock()
+    receiver = SimpleNamespace(cluster=cluster)
+    monkeypatch_current = Mock(return_value=previous)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(edge, "_current_execution_gate", monkeypatch_current)
+        with edge._temporary_execution_gate(receiver):
+            cluster.set_execution_gate.assert_called_once_with(
+                type=edge._ALLOW_ALL_EXECUTION_GATE,
+                config={},
+            )
+
+    if previous is None:
+        cluster.clear_execution_gate.assert_called_once_with()
+    else:
+        assert cluster.set_execution_gate.call_args_list[-1].kwargs == {
+            "type": "old.Gate",
+            "config": {},
+        }
+
+
+def test_terminal_job_oracle_accepts_exact_receiver_marker() -> None:
+    result = SimpleNamespace(
+        status="SUCCEEDED",
+        result={"probe": "eng10050-exact"},
+    )
+
+    edge._assert_terminal_mesh_job(result, "eng10050-exact")
+
+
+def test_required_job_case_runs_recoverably_on_named_peer(monkeypatch) -> None:
+    jobs = Mock()
+    jobs.run.return_value = SimpleNamespace(
+        job_id="job-on-receiver",
+        status="SUCCEEDED",
+        result={"probe": "eng10050-fixed"},
+    )
+    request = Mock(
+        return_value={
+            "id": "job-on-receiver",
+            "source": "mesh",
+            "source_cluster_id": "initiator-uuid",
+        }
+    )
+    persona = SimpleNamespace(jobs=jobs, _request=request)
+    monkeypatch.setattr(edge.uuid, "uuid4", lambda: SimpleNamespace(hex="fixed"))
+    wiring = {
+        "name": "receiver-cluster",
+        "personas": {
+            "U": {"token": "opaque-test-token", "client": persona},
+        },
+        "verify": True,
+        "source_cluster_id": "initiator-uuid",
+        "receiver_cluster_id": "receiver-uuid",
+    }
+
+    edge.test_required_mesh_job_reaches_receiver_and_returns_marker(
+        wiring,
+    )
+
+    kwargs = jobs.run.call_args.kwargs
+    assert kwargs["target_cluster"] == "receiver-cluster"
+    assert kwargs["recoverable"] is True
+    assert "eng10050-fixed" in kwargs["entrypoint"]
+    request.assert_called_once_with(
+        "GET",
+        "/mesh/receiver-cluster/api/cluster/jobs/job-on-receiver/status",
+    )
+
+
+def _write_gate_wheel(tmp_path: Path) -> str:
+    wheel = tmp_path / edge.mc.WHEEL_NAME
+    wheel.write_bytes(b"exact-wheel")
+    return str(tmp_path)
+
+
+def _gate_package(wheel_dir: str, **overrides) -> SimpleNamespace:
+    state = {
+        "name": "acme-gates",
+        "package_spec": edge.mc.PACKAGE_SPEC,
+        "version": "1.1.0",
+        "hash_digest": edge.mc._wheel_sha256(wheel_dir),
+        "status": "active",
+        "classpaths": [edge.mc.GATE_CLASSPATH],
+    }
+    state.update(overrides)
+    return SimpleNamespace(**state)
+
+
+def _gate_receiver(package: SimpleNamespace | None) -> SimpleNamespace:
+    packages = Mock()
+    if package is None:
+        packages.get.side_effect = APIError("not found", status_code=404)
+    else:
+        packages.get.return_value = package
+    gates = SimpleNamespace(
+        packages=packages,
+        discover=Mock(return_value=SimpleNamespace(name=edge.mc.GATE_NAME)),
+    )
+    return SimpleNamespace(gates=gates)
+
+
+def test_preexisting_gate_package_must_match_and_is_never_owned(tmp_path) -> None:
+    wheel_dir = _write_gate_wheel(tmp_path)
+    receiver = _gate_receiver(_gate_package(wheel_dir))
+    cleanup = Mock()
+
+    required_setup._ensure_gate_package(cleanup, receiver, wheel_dir, "index")
+    receiver.gates.packages.install.assert_not_called()
+    cleanup.callback.assert_not_called()
+
+    receiver = _gate_receiver(_gate_package(wheel_dir, version="9.9.9"))
+    with pytest.raises(AssertionError):
+        required_setup._ensure_gate_package(cleanup, receiver, wheel_dir, "index")
+    receiver.gates.packages.install.assert_not_called()
+
+
+def test_gate_package_read_or_install_failure_never_registers_cleanup(
+    tmp_path, monkeypatch
+) -> None:
+    wheel_dir = _write_gate_wheel(tmp_path)
+    receiver = _gate_receiver(None)
+    receiver.gates.packages.install.side_effect = RuntimeError("install failed")
+    receiver.cluster = Mock()
+    cleanup = Mock()
+    prerequisites = SimpleNamespace(
+        wheel_dir=wheel_dir,
+        index_url="index",
+        dataset_path="/fixture.csv",
+    )
+    monkeypatch.setattr(edge.mc, "declare_clearance_attribute", Mock())
+
+    with pytest.raises(RuntimeError, match="install failed"):
+        required_setup.provision_gated_dataset(
+            cleanup,
+            receiver,
+            prerequisites,
+            "edge",
+        )
+    cleanup.callback.assert_not_called()
+
+    receiver.gates.packages.get.side_effect = APIError("read failed", status_code=500)
+    with pytest.raises(APIError, match="read failed"):
+        required_setup._ensure_gate_package(
+            cleanup,
+            receiver,
+            wheel_dir,
+            "index",
+        )
+
+
+@pytest.mark.parametrize("failure", ["metadata", "discover"])
+def test_owned_gate_package_cleanup_is_registered_before_post_install_failure(
+    tmp_path,
+    failure,
+) -> None:
+    wheel_dir = _write_gate_wheel(tmp_path)
+    receiver = _gate_receiver(None)
+    package = _gate_package(wheel_dir)
+    receiver.gates.packages.install.return_value = SimpleNamespace(package=package)
+    if failure == "metadata":
+        package.hash_digest = "sha256:wrong"
+    else:
+        receiver.gates.discover.side_effect = RuntimeError("discover failed")
+    cleanup = Mock()
+
+    with pytest.raises((AssertionError, RuntimeError)):
+        required_setup._ensure_gate_package(
+            cleanup,
+            receiver,
+            wheel_dir,
+            "index",
+        )
+
+    cleanup.callback.assert_called_once_with(
+        required_setup._uninstall_owned_gate_package,
+        receiver,
+    )
+
+
+def test_pairing_requires_two_distinct_cluster_identities() -> None:
+    cleanup = Mock()
+    request = SimpleNamespace(
+        name="edge",
+        psk="secret",
+        peer_url="https://peer.example/api",
+        shared={"identity_mode": "shared_idp"},
+    )
+    initiator_federations = Mock()
+    initiator_federations.pair.return_value = SimpleNamespace(id="initiator-fed")
+    receiver_federations = Mock()
+    receiver_federations.pair.return_value = SimpleNamespace(id="receiver-fed")
+    clients = SimpleNamespace(
+        initiator=SimpleNamespace(federations=initiator_federations),
+        receiver=SimpleNamespace(federations=receiver_federations),
+    )
+    receiver_federations.get.return_value = SimpleNamespace(
+        remote_cluster_id="initiator-cluster"
+    )
+    initiator_federations.get.return_value = SimpleNamespace(
+        remote_cluster_id="receiver-cluster"
+    )
+
+    identities = required_setup.pair_required_edge(cleanup, clients, request)
+    assert identities.initiator_cluster_id == "initiator-cluster"
+    assert identities.receiver_cluster_id == "receiver-cluster"
+
+    initiator_federations.get.return_value = SimpleNamespace(
+        remote_cluster_id="initiator-cluster"
+    )
+    with pytest.raises(AssertionError, match="one cluster identity"):
+        required_setup.pair_required_edge(cleanup, clients, request)
+
+
+def test_required_retrieval_case_asserts_streamed_known_answer(monkeypatch) -> None:
+    persona = object()
+    rows = edge.mc.records()[:3]
+    footers = [
+        {
+            "filtered": True,
+            "included": None,
+            "redacted": None,
+            "total": None,
+            "gate": None,
+        }
+    ]
+    retrieve = Mock(return_value=(rows, footers))
+    monkeypatch.setattr(edge.mc, "mesh_retrieve_through_gate", retrieve)
+    wiring = {
+        "name": "receiver-cluster",
+        "urn": "urn:kamiwaza:dataset:known",
+        "personas": {
+            "U": {"token": "opaque-test-token", "client": persona},
+        },
+        "verify": True,
+    }
+
+    edge.test_required_mesh_retrieval_returns_exact_post_gate_rows(
+        "U",
+        wiring,
+        SimpleNamespace(base_url="https://initiator.example/api"),
+    )
+
+    assert retrieve.call_args.args == (
+        persona,
+        "https://initiator.example/api",
+        "opaque-test-token",
+        "receiver-cluster",
+        "urn:kamiwaza:dataset:known",
+    )
+
+
+def test_exact_retrieval_oracle_rejects_duplicate_allowed_rows() -> None:
+    duplicate_rows = [edge.mc.records()[0]] * 3
+    footer = {
+        "filtered": True,
+        "included": None,
+        "redacted": None,
+        "total": None,
+        "gate": None,
+    }
+
+    with pytest.raises(AssertionError, match="wrong post-gate rows"):
+        edge.mc.assert_persona_result("U", duplicate_rows, [footer])
+
+
+def test_persona_cleanup_revokes_exact_allowlist_row() -> None:
+    request = Mock(return_value={"message": "revoked"})
+    receiver = SimpleNamespace(_request=request)
+
+    edge_personas.cleanup_brokered_persona(
+        receiver,
+        "federation-id",
+        "alice@example.com@source-cluster",
+    )
+
+    request.assert_called_once_with(
+        "POST",
+        "/cluster/federations/federation-id/users/"
+        "alice%40example.com%40source-cluster/revoke",
+        params={"cancel_in_flight_jobs": "true"},
+    )
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        SimpleNamespace(status="FAILED", result={"probe": "eng10050-exact"}),
+        SimpleNamespace(status="SUCCEEDED", result={"probe": "wrong"}),
+        SimpleNamespace(status="SUCCEEDED", result=None),
+    ],
+)
+def test_terminal_job_oracle_rejects_false_green_result(result) -> None:
+    with pytest.raises(AssertionError):
+        edge._assert_terminal_mesh_job(result, "eng10050-exact")

--- a/tests/integration/test_federation_required_edge_contract.py
+++ b/tests/integration/test_federation_required_edge_contract.py
@@ -302,6 +302,26 @@ def test_temporary_execution_gate_restores_receiver_binding(previous) -> None:
         }
 
 
+def test_temporary_execution_gate_restores_after_ambiguous_set_failure() -> None:
+    previous = SimpleNamespace(type="old.Gate", config={"mode": "strict"})
+    cluster = Mock()
+    cluster.set_execution_gate.side_effect = [RuntimeError("response lost"), None]
+    receiver = SimpleNamespace(cluster=cluster)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            edge, "_current_execution_gate", Mock(return_value=previous)
+        )
+        with pytest.raises(RuntimeError, match="response lost"):
+            with edge._temporary_execution_gate(receiver):
+                pytest.fail("ambiguous setup must not yield")
+
+    assert [call.kwargs for call in cluster.set_execution_gate.call_args_list] == [
+        {"type": edge._ALLOW_ALL_EXECUTION_GATE, "config": {}},
+        {"type": "old.Gate", "config": {"mode": "strict"}},
+    ]
+
+
 def test_terminal_job_oracle_accepts_exact_receiver_marker() -> None:
     result = SimpleNamespace(
         status="SUCCEEDED",

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -165,8 +165,8 @@ def _restore_execution_gate(receiver: Any, previous: Any) -> None:
 def _temporary_execution_gate(receiver: Any) -> Iterator[None]:
     """Bind the live-test gate and always restore the receiver's prior state."""
     previous = _current_execution_gate(receiver)
-    receiver.cluster.set_execution_gate(type=_ALLOW_ALL_EXECUTION_GATE, config={})
     try:
+        receiver.cluster.set_execution_gate(type=_ALLOW_ALL_EXECUTION_GATE, config={})
         yield
     finally:
         _restore_execution_gate(receiver, previous)

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -1,143 +1,205 @@
-"""ENG-8325 Layer 3 — two-cluster shared_idp known-answer gated retrieval.
+"""Required two-cluster shared-IDP mesh job and gated-retrieval edge.
 
-The sibling that ``test_federation_identity_gate_live.py`` forward-declares: the
-data-plane round-trip on top of the single-cluster create-gate + posture surface.
-A federated (shared_idp) caller on the initiator (spark-1) retrieves a
-gate-bound dataset on the receiver (spark-2) over the mesh and receives ONLY the
-rows its clearance permits — asserted by exact post-gate counts, not reachability.
-
-Layers:
-  * gate-as-dataset-feature (single cluster) is Layer 2
-    (test_mini_clearance_gate_retrieval_live.py);
-  * gate LOGIC is Layer 1 (kamiwaza tests/unit/.../test_mini_clearance_gate.py).
-
-requires_two_clusters — auto-deselected without --live-peer-base-url. Data-plane
-assertions are tiered behind _mesh_call_or_skip: an authentic-persona 401 is a
-hard ENG-7203 regression; a 403/404 (gate-package PVC, filesystem root, or mesh
-data-plane precondition unmet) is a soft skip. Beyond the two-cluster rig, the
-operator must have provisioned on the RECEIVER: the WS-M5 gate-packages PVC + a
-served 1.1.0 wheel (M5_TEST_WHEEL_DIR/M5_TEST_INDEX_URL), the fixture file under
-RETRIEVAL_FILESYSTEM_ALLOWED_ROOTS (MINI_CLEARANCE_DATASET_PATH), and a shared
-realm that projects the ``clearance`` claim into brokered persona JWTs
-(SHARED_ISSUER_URL[/SHARED_JWKS_URL/SHARED_CA_PEM]); else the round-trip skips.
-
-Persona auth (SHARED_REALM_CLIENT_ID / FED_PERSONA_PASSWORD): each persona mints
-a token via ROPC against the shared realm's token endpoint (a direct-access-
-grants client), so the receiver's shared_idp peer-JWT validation accepts it
-(its kid is in the shared JWKS — an admin/local-realm token's kid is not) and
-the gate sees the realm-projected ``clearance`` claim. Shared-realm setup shape
-(on the shared realm, e.g. spark-1 ``federated``): a ROPC client (public,
-directAccessGrantsEnabled); persona users ``fed-clr-{u,s,ts}`` with a
-``clearance`` user-attribute (needs the realm user-profile's
-``unmanagedAttributePolicy=ENABLED``) + email/first/last so ROPC isn't blocked
-"Account is not fully set up"; and an ``oidc-usermodel-attribute-mapper``
-projecting ``clearance`` as a top-level access-token claim.
-
-LIVE STATUS (2026-07-11): the auth boundary is CROSSED — with the persona
-shared-realm token the receiver's peer-JWT validation PASSES (the historic
-``peer_jwt_validation_failed: kid not present`` is gone) and the mesh reaches
-the data plane. The 3 persona assertions still tier to SKIP on a downstream
-403 ``Forbidden``: the mesh retrieval's dataset-view authz
-(catalog.identity.resolve_requester_urn → a DataHub ``urn:li:corpuser`` URN) is
-NOT satisfied by the federation allowlist's ``initial_tuples`` viewer grant
-(a ``user:{{user_id}}`` namespaced ReBAC tuple). Reconciling those two subject
-namespaces for a brokered mesh caller is the remaining layer to flip the SKIPs
-to exact-count assertions.
-
-LIVE STATUS (2026-08-07) — supersedes the 403 prediction above (ENG-9813). The
-observed failure is a **401 one layer EARLIER**, at the receiver's
-identity-header verification, so the run never reached the dataset-view authz
-the note above describes. Root cause: the mesh identity producer emitted
-``X-User-Attributes`` without its companion ``X-User-Attributes-Hash``. That
-header travels unsigned and only the digest is a ForwardAuth HMAC payload
-field, so the origin read the absent digest as "there must be no attributes
-either" and rejected before any gate ran (kamiwaza ``49b03ecd7``).
-
-These personas are precisely what exposed it: their realm-projected
-``clearance`` claim is what makes the attribute header non-empty. Modes
-carrying no attributes — ``receiver_realm``, whose F10 role-stripped guests
-have none — passed throughout, which is why the defect read as
-shared_idp-specific when it was not.
-
-The 403 analysis above is NOT withdrawn; it is simply downstream and was never
-reached. Expect it to become the live symptom again once the fix is deployed,
-at which point the subject-namespace reconciliation remains the real work.
+The lane carries both topology markers, provisions every prerequisite before
+selection, and treats any skip or denial as failure. It drains mesh retrieval
+SSE for exact U/S/TS rows and runs a recoverable job to ``SUCCEEDED`` with a
+unique receiver marker. Every persona receives viewer authority only for the
+unique dataset; the U submitter additionally receives the explicit cluster-job
+executor relation. The receiver execution gate still governs dispatch, and the
+job service auto-grants per-job authority only after successful submission.
 """
 
 from __future__ import annotations
 
 import os
+import shlex
 import uuid
-from typing import Iterator
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
+from typing import Any, Callable, Iterator
+from urllib.parse import quote
 
 import pytest
 
 from tests.integration import mesh_outcome
-from tests.integration.mesh_outcome import MeshPolicy
 
 from . import _mini_clearance as mc
+from .required_federation_edge_personas import provision_primary_personas
+from .required_federation_edge_setup import pair_required_edge, provision_gated_dataset
 
 pytestmark = [
     pytest.mark.integration,
     pytest.mark.live,
     pytest.mark.withoutresponses,
     pytest.mark.requires_two_clusters,
+    pytest.mark.requires_shared_idp,
 ]
 
-_PERSONAS = {"U": "fed-clr-u", "S": "fed-clr-s", "TS": "fed-clr-ts"}
-
-
-_SHARED_IDP_POLICY = MeshPolicy(
+_ALLOW_ALL_EXECUTION_GATE = (
+    "kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate"
+)
+_SHARED_IDP_POLICY = mesh_outcome.MeshPolicy(
     identity_arranged=True,
     admission_is_the_assertion=False,
-    context="ENG-8325 shared_idp gated retrieval",
+    context="shared_idp gated retrieval compatibility policy",
 )
 
 
-def _mesh_call_or_skip(call):
-    """401 -> hard fail (ENG-7203 HMAC-strip regression); 403/404 -> soft skip
-    (mesh auth verified, downstream precondition unmet); else propagate.
-
-    ENG-9664: delegates to the shared ``mesh_outcome`` classifier. This file
-    already failed on 401 and that is preserved exactly. The one change is that
-    an auth-layer-marked 403 — the receiver refusing the credential rather than
-    a downstream precondition — now fails instead of skipping.
-    """
-    return mesh_outcome.mesh_call(call, _SHARED_IDP_POLICY)
+@dataclass(frozen=True)
+class _EdgePrerequisites:
+    wheel_dir: str
+    index_url: str
+    dataset_path: str
+    shared: dict[str, str]
+    persona_auth: dict[str, Any]
 
 
-def _shared_realm() -> dict[str, str]:
-    issuer = os.getenv("SHARED_ISSUER_URL", "").strip()
-    if not issuer:
-        pytest.skip(
-            "SHARED_ISSUER_URL not set — shared_idp pairing needs a shared realm "
-            "(and it must project the `clearance` claim into brokered JWTs)"
+@dataclass(frozen=True)
+class _PairRequest:
+    name: str
+    peer_url: str
+    psk: str
+    shared: dict[str, str]
+
+
+@dataclass(frozen=True)
+class _EdgeWiring:
+    name: str
+    urn: str
+    personas: dict[str, dict[str, Any]]
+    shared: dict[str, str]
+    verify: bool
+    source_cluster_id: str
+    receiver_cluster_id: str
+
+
+@dataclass(frozen=True)
+class _EdgeClients:
+    initiator: Any
+    receiver: Any
+
+
+def _required_mesh_call(call: Callable[[], Any]) -> Any:
+    """Run one required edge call without translating a denial into a skip."""
+    return call()
+
+
+def _assert_receiver_onboarding_rejection(call: Callable[[], Any]) -> None:
+    """Accept only the receiver's structured allowlist rejection."""
+    from kamiwaza_sdk.exceptions import KamiwazaError
+
+    try:
+        call()
+    except KamiwazaError as exc:
+        reason = mesh_outcome.reason_of(exc)
+        status = getattr(exc, "status_code", None)
+        assert status == 403, (
+            "expected unauthorized_brokered_user from receiver status 403, "
+            f"got status {status!r}: {exc!r}"
         )
+        assert reason == "unauthorized_brokered_user", (
+            "expected unauthorized_brokered_user from the receiver allowlist, "
+            f"got {reason!r}: {exc!r}"
+        )
+        return
+    pytest.fail("unonboarded primary-realm user unexpectedly crossed the allowlist")
+
+
+def _require_prerequisite(config: pytest.Config, condition: bool, message: str) -> None:
+    if condition:
+        return
+    if config.getoption("require_federation_edge"):
+        pytest.fail(message, pytrace=False)
+    pytest.skip(message)
+
+
+def _assert_terminal_mesh_job(result: Any, expected_marker: str) -> None:
+    """Require successful receiver execution and the exact result marker."""
+    assert result.status == "SUCCEEDED", (
+        f"required mesh job did not succeed: status={result.status} result={result}"
+    )
+    marker = getattr(result, "probe", None)
+    if marker is None and isinstance(result.result, dict):
+        marker = result.result.get("probe")
+    assert marker == expected_marker, (
+        "required receiver marker did not round-trip: "
+        f"expected={expected_marker!r} got={marker!r} result={result}"
+    )
+
+
+def _assert_receiver_job_provenance(
+    status: Any,
+    job_id: str,
+    source_cluster_id: str,
+    receiver_cluster_id: str,
+) -> None:
+    """Prove the authoritative job record was created from mesh ingress."""
+    assert isinstance(status, dict), f"unexpected job status payload: {status!r}"
+    assert str(status.get("id")) == str(job_id), status
+    assert status.get("source") == "mesh", status
+    assert str(status.get("source_cluster_id")) == str(source_cluster_id), status
+    assert source_cluster_id != receiver_cluster_id
+
+
+def _current_execution_gate(receiver: Any) -> Any:
+    """Read the pre-existing binding without hiding non-404 failures."""
+    from kamiwaza_sdk.exceptions import APIError
+
+    try:
+        return receiver.cluster.get_execution_gate()
+    except APIError as exc:
+        if exc.status_code == 404:
+            return None
+        raise
+
+
+def _restore_execution_gate(receiver: Any, previous: Any) -> None:
+    """Restore the receiver's execution-gate state after the required edge."""
+    if previous is None:
+        receiver.cluster.clear_execution_gate()
+        return
+    receiver.cluster.set_execution_gate(type=previous.type, config=previous.config)
+
+
+@contextmanager
+def _temporary_execution_gate(receiver: Any) -> Iterator[None]:
+    """Bind the live-test gate and always restore the receiver's prior state."""
+    previous = _current_execution_gate(receiver)
+    receiver.cluster.set_execution_gate(type=_ALLOW_ALL_EXECUTION_GATE, config={})
+    try:
+        yield
+    finally:
+        _restore_execution_gate(receiver, previous)
+
+
+def _shared_realm(config: pytest.Config) -> dict[str, str]:
+    issuer = os.getenv("SHARED_ISSUER_URL", "").strip()
+    _require_prerequisite(
+        config,
+        bool(issuer),
+        "SHARED_ISSUER_URL not set — shared_idp pairing needs a shared realm "
+        "that projects the `clearance` claim into brokered JWTs",
+    )
     cfg = {"shared_issuer_url": issuer}
-    for env, key in (("SHARED_JWKS_URL", "shared_jwks_url"), ("SHARED_CA_PEM", "shared_ca_pem")):
+    for env, key in (
+        ("SHARED_JWKS_URL", "shared_jwks_url"),
+        ("SHARED_CA_PEM", "shared_ca_pem"),
+    ):
         val = os.getenv(env, "").strip()
         if val:
             cfg[key] = val
     return cfg
 
 
-def _persona_auth() -> dict:
-    """Shared-realm ROPC config for the personas (soft-skip when absent).
-
-    The mesh data-plane assertions need each persona to present a token minted
-    by the SHARED realm (a direct-access-grants client + the persona password),
-    so the receiver's shared_idp peer-JWT validation accepts it (kid is in the
-    shared JWKS) and the gate sees the realm-projected `clearance` claim.
-    """
-    client_id = os.getenv("SHARED_REALM_CLIENT_ID", "").strip()
+def _persona_auth(config: pytest.Config) -> dict:
+    """Normal initiator-login config for clearance-bearing local personas."""
     password = os.getenv("FED_PERSONA_PASSWORD", "").strip()
-    if not client_id or not password:
-        pytest.skip(
-            "SHARED_REALM_CLIENT_ID / FED_PERSONA_PASSWORD not set — the personas "
-            "must present a shared-realm ROPC token for the mesh data-plane "
-            "assertions (a direct-access-grants client + persona password on the "
-            "shared realm that projects the `clearance` claim)"
-        )
+    _require_prerequisite(
+        config,
+        bool(password),
+        "FED_PERSONA_PASSWORD not set — the initiator primary-realm personas "
+        "must log in through the normal platform password flow",
+    )
     verify = os.getenv("KAMIWAZA_VERIFY_SSL", "1").strip().lower() not in {
         "0",
         "false",
@@ -145,8 +207,6 @@ def _persona_auth() -> dict:
         "off",
     }
     return {
-        "client_id": client_id,
-        "client_secret": os.getenv("SHARED_REALM_CLIENT_SECRET", "").strip() or None,
         "password": password,
         "verify": verify,
     }
@@ -157,158 +217,160 @@ def _fed_name() -> str:
 
 
 @pytest.fixture(scope="module")
-def _receiver_prereqs() -> tuple[str, str, str]:
+def _receiver_prereqs(pytestconfig: pytest.Config) -> _EdgePrerequisites:
     wi = mc.wheel_and_index()
-    if wi is None:
-        pytest.skip("gate-packages wheel/index not configured on the receiver")
+    _require_prerequisite(
+        pytestconfig,
+        wi is not None,
+        "gate-packages wheel/index not configured on the receiver",
+    )
+    assert wi is not None
     dataset_path = os.getenv("MINI_CLEARANCE_DATASET_PATH", "").strip()
-    if not dataset_path:
-        pytest.skip("MINI_CLEARANCE_DATASET_PATH not set (receiver fixture file)")
-    return wi[0], wi[1], dataset_path
+    _require_prerequisite(
+        pytestconfig,
+        bool(dataset_path),
+        "MINI_CLEARANCE_DATASET_PATH not set (receiver fixture file)",
+    )
+    return _EdgePrerequisites(
+        wheel_dir=wi[0],
+        index_url=wi[1],
+        dataset_path=dataset_path,
+        shared=_shared_realm(pytestconfig),
+        persona_auth=_persona_auth(pytestconfig),
+    )
+
+
+def _wire_required_edge(
+    cleanup: ExitStack,
+    clients: _EdgeClients,
+    pair_request: _PairRequest,
+    prerequisites: _EdgePrerequisites,
+) -> _EdgeWiring:
+    identities = pair_required_edge(
+        cleanup,
+        clients,
+        pair_request,
+    )
+    urn = provision_gated_dataset(
+        cleanup,
+        clients.receiver,
+        prerequisites,
+        pair_request.name,
+    )
+    personas = provision_primary_personas(
+        cleanup,
+        clients,
+        (identities.receiver_federation_id, identities.initiator_cluster_id, urn),
+        prerequisites,
+    )
+    cleanup.enter_context(_temporary_execution_gate(clients.receiver))
+    return _EdgeWiring(
+        name=pair_request.name,
+        urn=urn,
+        personas=personas,
+        shared=prerequisites.shared,
+        verify=bool(prerequisites.persona_auth["verify"]),
+        source_cluster_id=identities.initiator_cluster_id,
+        receiver_cluster_id=identities.receiver_cluster_id,
+    )
 
 
 @pytest.fixture(scope="module")
 def shared_idp_gated_pair(
-    _receiver_prereqs,
-    live_kamiwaza_session_client,
-    live_kamiwaza_peer_client,
-    live_peer_base_url,
+    _receiver_prereqs: _EdgePrerequisites,
+    live_kamiwaza_session_client: Any,
+    live_kamiwaza_peer_client: Any,
+    live_peer_base_url: str,
 ) -> Iterator[dict]:
-    """Pair spark-1<->spark-2 in shared_idp mode; seed the receiver's gated
-    dataset + brokered U/S/TS identities. Yields the wiring; tears down at exit."""
-    wheel_dir, index_url, dataset_path = _receiver_prereqs
+    """Provision the required shared-IDP edge and tear it down at exit."""
+    prerequisites = _receiver_prereqs
     initiator = live_kamiwaza_session_client
     receiver = live_kamiwaza_peer_client
-    shared = _shared_realm()
     name = _fed_name()
-    psk = uuid.uuid4().hex
-
-    # 1. shared_idp pairing (receiver-controlled; not gated by ALLOW_UNTRUSTED).
-    #    Capture the receiver-side federation id — brokered-user writes and the
-    #    initiator-cluster-uuid lookup both key on it, since /pair overwrites the
-    #    receiver's remote_cluster_name with the initiator's cluster name.
-    recv_fed = receiver.federations.pair(
-        name=name, role="receiver", preshared_key=psk, **shared
-    )
-    receiver_id = str(recv_fed.id)
-    initiator.federations.pair(
-        name=name, role="initiator", remote_url=live_peer_base_url, preshared_key=psk, **shared
+    pair_request = _PairRequest(
+        name=name,
+        peer_url=live_peer_base_url,
+        psk=uuid.uuid4().hex,
+        shared=prerequisites.shared,
     )
 
-    # 2. Seed the receiver's gated dataset.
-    mc.declare_clearance_attribute(receiver)
-    mc.install_gate_package(receiver, wheel_dir, index_url)
-    urn = mc.create_file_dataset(receiver, f"mini-clearance-{name}", dataset_path)
-
-    # 3. Brokered shared-realm identities. Each persona authenticates to the
-    #    SHARED realm (ROPC) for a token whose `sub` is the federated user id and
-    #    whose `clearance` claim rides X-User-Attributes to the gate. The receiver
-    #    keys the brokered user on `<sub>@<initiator-cluster-uuid>` (the
-    #    X-KZ-Mesh-User-Id the initiator forwards), so seed the viewer tuple on the
-    #    token `sub`, not the username. POST against the receiver-side federation
-    #    id (name lookup fails post-pair) with the canonical tuple shape.
-    src_uuid = mc.initiator_cluster_uuid(receiver, receiver_id) or "initiator"
-    auth = _persona_auth()
-    issuer = shared["shared_issuer_url"]
-    personas: dict = {}
-    for clearance, base in _PERSONAS.items():
-        token = mc.shared_realm_token(
-            issuer,
-            auth["client_id"],
-            base,
-            auth["password"],
-            client_secret=auth["client_secret"],
-            verify=auth["verify"],
+    with ExitStack() as cleanup:
+        wiring = _wire_required_edge(
+            cleanup,
+            _EdgeClients(initiator, receiver),
+            pair_request,
+            prerequisites,
         )
-        sub = mc.jwt_sub(token) or base
-        external_id = f"{sub}@{src_uuid}"
-        receiver._request(
-            "POST",
-            f"/cluster/federations/{receiver_id}/users",
-            json={
-                "external_id": external_id,
-                "initial_tuples": [
-                    # {{user_id}} renders to the local provisioned user id at
-                    # ingress (brokering._render_placeholder), so the viewer grant
-                    # lands on the subject the retrieval authz actually evaluates.
-                    {
-                        "subject": "user:{{user_id}}",
-                        "relation": "viewer",
-                        "object": f"dataset:{urn}",
-                    }
-                ],
-            },
-        )
-        personas[clearance] = {"token": token, "external_id": external_id, "sub": sub}
-
-    try:
-        yield {
-            "name": name,
-            "urn": urn,
-            "personas": personas,
-            "shared": shared,
-            "verify": auth["verify"],
-        }
-    finally:
-        for who in (initiator, receiver):
-            try:
-                who.federations[name].disconnect()
-            except Exception:  # noqa: BLE001
-                pass
-        try:
-            receiver.datasets.delete(urn)
-        except Exception:  # noqa: BLE001
-            pass
-        try:
-            receiver.gates.packages.uninstall("acme-gates")
-        except Exception:  # noqa: BLE001
-            pass
+        yield wiring.__dict__
 
 
 @pytest.mark.parametrize("clearance", ["U", "S", "TS"])
-def test_federated_persona_sees_exact_post_gate_counts(
+def test_required_mesh_retrieval_returns_exact_post_gate_rows(
     clearance, shared_idp_gated_pair, live_kamiwaza_session_client
 ) -> None:
     """A shared_idp persona mesh-retrieves exactly its allowed rows — known answer."""
     wiring = shared_idp_gated_pair
     initiator = live_kamiwaza_session_client
     name, urn = wiring["name"], wiring["urn"]
-    # Present the persona's SHARED-realm token (carries `clearance`) on the mesh
-    # call — not the admin/local-realm client, whose kid isn't in the shared JWKS.
     token = wiring["personas"][clearance]["token"]
-    persona = mc.raw_token_client(initiator.base_url, token, verify=wiring["verify"])
+    persona = wiring["personas"][clearance]["client"]
 
     def _retrieve():
         # Create the retrieval job over the mesh AND drain its gated SSE stream
         # over the mesh — the results + gate_audit footer arrive on the stream,
-        # not the async create response. A 403/404 on either leg soft-skips.
+        # not the async create response.
         return mc.mesh_retrieve_through_gate(
             persona, initiator.base_url, token, name, urn, verify=wiring["verify"]
         )
 
-    rows, gate_audit = _mesh_call_or_skip(_retrieve)
+    rows, gate_audit = _required_mesh_call(_retrieve)
     mc.assert_persona_result(clearance, rows, gate_audit)
 
 
-def test_fabricated_non_shared_token_rejected_before_gate(
-    shared_idp_gated_pair, live_peer_base_url
+def test_required_mesh_job_reaches_receiver_and_returns_marker(
+    shared_idp_gated_pair,
 ) -> None:
-    """A token NOT signed by the shared realm is rejected at the receiver's
-    ext-authz JWKS check (401) and never reaches the gate — the shared_idp trust
-    boundary. Here a 401 for the fabricated token is the PASS."""
-    from kamiwaza_sdk.exceptions import APIError, AuthenticationError
+    """Run a recoverable job on the receiver and assert its exact payload."""
+    wiring = shared_idp_gated_pair
+    persona = wiring["personas"]["U"]["client"]
+    marker = f"eng10050-{uuid.uuid4().hex}"
+    script = (
+        "import json\n"
+        f"print('KZ_MESH_RUN_ON_JSON::' + json.dumps({{'probe': {marker!r}}}))\n"
+    )
 
-    verify = os.getenv("KAMIWAZA_VERIFY_SSL", "1").strip().lower() not in {
-        "0",
-        "false",
-        "no",
-        "off",
-    }
-    forged = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmb3JnZWQifQ.not-a-real-signature"
-    client = mc.raw_token_client(live_peer_base_url, forged, verify=verify)
-    with pytest.raises((AuthenticationError, APIError)) as exc:
-        client._request("GET", "/cluster/diagnose")
-    status = getattr(exc.value, "status_code", None)
-    assert isinstance(exc.value, AuthenticationError) or status in (401, 403), (
-        f"fabricated non-shared token was not rejected fail-closed: {exc.value!r}"
+    result = _required_mesh_call(
+        lambda: persona.jobs.run(
+            entrypoint="python3 -c " + shlex.quote(script),
+            target_cluster=wiring["name"],
+            timeout_seconds=120,
+            recoverable=True,
+        )
+    )
+
+    _assert_terminal_mesh_job(result, marker)
+    selector = quote(wiring["name"], safe="")
+    status = persona._request(
+        "GET",
+        f"/mesh/{selector}/api/cluster/jobs/{result.job_id}/status",
+    )
+    _assert_receiver_job_provenance(
+        status,
+        str(result.job_id),
+        wiring["source_cluster_id"],
+        wiring["receiver_cluster_id"],
+    )
+
+
+def test_unonboarded_primary_realm_user_rejected_by_receiver_allowlist(
+    shared_idp_gated_pair,
+) -> None:
+    """A valid primary-realm login still needs receiver-side onboarding."""
+    selector = quote(shared_idp_gated_pair["name"], safe="")
+    persona = shared_idp_gated_pair["personas"]["unonboarded"]["client"]
+    _assert_receiver_onboarding_rejection(
+        lambda: persona._request(
+            "GET",
+            f"/mesh/{selector}/api/cluster/diagnose",
+        )
     )

--- a/tests/integration/test_federation_skeleton_walkthrough.py
+++ b/tests/integration/test_federation_skeleton_walkthrough.py
@@ -35,6 +35,11 @@ from unittest.mock import patch
 
 _ORION_FEDERATION_ID = "fed-orion-uuid"
 _ORION_NAME = "ORION"
+_ORION_JOBS_PREFIX = f"/mesh/{_ORION_NAME}/api/cluster/jobs"
+
+
+def _expect_job_post(mock_client, suffix: str, response: dict) -> None:
+    mock_client.expect("POST", f"{_ORION_JOBS_PREFIX}/{suffix}", response)
 _LYRA_CLUSTER_UUID = "lyra-cluster-uuid"
 _BROKERED_EXTERNAL_ID = f"cdr-baker@{_LYRA_CLUSTER_UUID}"
 
@@ -113,7 +118,7 @@ def test_ws_m1_skeleton_walkthrough_pair_allowlist_run_audit(mock_client) -> Non
     # attribution comes back to the SDK caller.
     mock_client.expect(
         "POST",
-        f"/mesh/{_ORION_NAME}/api/cluster/jobs/run",
+        f"{_ORION_JOBS_PREFIX}/run",
         {
             "job_id": "job-fed-1",
             "status": "SUCCEEDED",
@@ -175,10 +180,7 @@ def test_ws_m1_skeleton_walkthrough_pair_allowlist_run_audit(mock_client) -> Non
         "POST",
         f"/cluster/federations/{_ORION_FEDERATION_ID}/users",
     )
-    assert methods_paths[4] == (
-        "POST",
-        f"/mesh/{_ORION_NAME}/api/cluster/jobs/run",
-    )
+    assert methods_paths[4] == ("POST", f"{_ORION_JOBS_PREFIX}/run")
 
 
 def test_ws_m1_skeleton_walkthrough_async_submit_path(mock_client) -> None:
@@ -237,16 +239,15 @@ def test_ws_m1_skeleton_walkthrough_async_submit_path(mock_client) -> None:
 
     # Async submit returns a job_id; SDK then polls /status (RUNNING → SUCCEEDED)
     # and finally fetches /result on terminal.
-    jobs_prefix = f"/mesh/{_ORION_NAME}/api/cluster/jobs"
-    mock_client.expect("POST", f"{jobs_prefix}/submit", {"job_id": "job-async-1"})
+    _expect_job_post(mock_client, "submit", {"job_id": "job-async-1"})
     mock_client.expect_sequence(
         "GET",
-        f"{jobs_prefix}/job-async-1/status",
+        f"{_ORION_JOBS_PREFIX}/job-async-1/status",
         [{"status": "RUNNING"}, {"status": "SUCCEEDED"}],
     )
     mock_client.expect(
         "GET",
-        f"{jobs_prefix}/job-async-1/result",
+        f"{_ORION_JOBS_PREFIX}/job-async-1/result",
         {
             "job_id": "job-async-1",
             "status": "SUCCEEDED",

--- a/tests/integration/test_federation_skeleton_walkthrough.py
+++ b/tests/integration/test_federation_skeleton_walkthrough.py
@@ -113,7 +113,7 @@ def test_ws_m1_skeleton_walkthrough_pair_allowlist_run_audit(mock_client) -> Non
     # attribution comes back to the SDK caller.
     mock_client.expect(
         "POST",
-        "/cluster/jobs/run",
+        f"/mesh/{_ORION_NAME}/api/cluster/jobs/run",
         {
             "job_id": "job-fed-1",
             "status": "SUCCEEDED",
@@ -175,7 +175,10 @@ def test_ws_m1_skeleton_walkthrough_pair_allowlist_run_audit(mock_client) -> Non
         "POST",
         f"/cluster/federations/{_ORION_FEDERATION_ID}/users",
     )
-    assert methods_paths[4] == ("POST", "/cluster/jobs/run")
+    assert methods_paths[4] == (
+        "POST",
+        f"/mesh/{_ORION_NAME}/api/cluster/jobs/run",
+    )
 
 
 def test_ws_m1_skeleton_walkthrough_async_submit_path(mock_client) -> None:
@@ -234,15 +237,16 @@ def test_ws_m1_skeleton_walkthrough_async_submit_path(mock_client) -> None:
 
     # Async submit returns a job_id; SDK then polls /status (RUNNING → SUCCEEDED)
     # and finally fetches /result on terminal.
-    mock_client.expect("POST", "/cluster/jobs/submit", {"job_id": "job-async-1"})
+    jobs_prefix = f"/mesh/{_ORION_NAME}/api/cluster/jobs"
+    mock_client.expect("POST", f"{jobs_prefix}/submit", {"job_id": "job-async-1"})
     mock_client.expect_sequence(
         "GET",
-        "/cluster/jobs/job-async-1/status",
+        f"{jobs_prefix}/job-async-1/status",
         [{"status": "RUNNING"}, {"status": "SUCCEEDED"}],
     )
     mock_client.expect(
         "GET",
-        "/cluster/jobs/job-async-1/result",
+        f"{jobs_prefix}/job-async-1/result",
         {
             "job_id": "job-async-1",
             "status": "SUCCEEDED",

--- a/tests/integration/test_jobs_recoverable_drop_recovery.py
+++ b/tests/integration/test_jobs_recoverable_drop_recovery.py
@@ -29,16 +29,17 @@ def test_recoverable_run_survives_mid_call_sdk_kill(mock_client) -> None:
     job_id = "job-survives-restart-001"
 
     # Phase 1: submit_async returns job_id.
-    mock_client.expect("POST", "/cluster/jobs/submit", {"job_id": job_id})
+    prefix = "/mesh/ORION/api/cluster/jobs"
+    mock_client.expect("POST", f"{prefix}/submit", {"job_id": job_id})
     # Phase 2: status polls RUNNING then SUCCEEDED, then result fetch.
     mock_client.expect_sequence(
         "GET",
-        f"/cluster/jobs/{job_id}/status",
+        f"{prefix}/{job_id}/status",
         [{"status": "RUNNING"}, {"status": "SUCCEEDED"}],
     )
     mock_client.expect(
         "GET",
-        f"/cluster/jobs/{job_id}/result",
+        f"{prefix}/{job_id}/result",
         {"job_id": job_id, "status": "SUCCEEDED", "result": {"conjunction_pairs": 42}},
     )
 
@@ -59,7 +60,7 @@ def test_recoverable_run_survives_mid_call_sdk_kill(mock_client) -> None:
     # remote cluster); only the SDK side is reconstructed.
     with patch("time.sleep"):
         second_process = JobsAPI(client=mock_client)
-        result = second_process.wait(saved_job_id, timeout=120)
+        result = second_process.wait(saved_job_id, timeout=120, target_cluster="ORION")
 
     assert result.job_id == saved_job_id
     assert result.status == "SUCCEEDED"
@@ -73,7 +74,9 @@ def test_recoverable_run_returns_job_id_before_completion(mock_client) -> None:
     from kamiwaza_sdk.services.jobs_federation import JobsAPI
 
     job_id = "job-immediate-id-002"
-    mock_client.expect("POST", "/cluster/jobs/submit", {"job_id": job_id})
+    mock_client.expect(
+        "POST", "/mesh/ORION/api/cluster/jobs/submit", {"job_id": job_id}
+    )
 
     returned_id = JobsAPI(client=mock_client).submit_async(
         entrypoint="python query.py",

--- a/tests/unit/seeding/test_owned_shared_idp_realm.py
+++ b/tests/unit/seeding/test_owned_shared_idp_realm.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from kamiwaza_sdk.seeding.federation.keycloak import (
+    OWNED_REALM_ATTRIBUTE,
+    KeycloakAdmin,
+    KeycloakAdminError,
+)
+from tests.integration import _shared_idp_fixture as fixture
+
+
+@dataclass
+class _Response:
+    status_code: int
+    body: Any = None
+    text: str = ""
+    headers: dict[str, str] = field(default_factory=dict)
+
+    def json(self) -> Any:
+        return self.body
+
+
+def _client(
+    monkeypatch: pytest.MonkeyPatch, responses: list[_Response | BaseException]
+):
+    calls: list[tuple[str, str, dict[str, Any]]] = []
+    client = KeycloakAdmin("https://keycloak", admin_user="admin", admin_password="pw")
+
+    def request(method: str, path: str, **kwargs: Any) -> _Response:
+        calls.append((method, path, kwargs))
+        response = responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
+
+    monkeypatch.setattr(client, "_req", request)
+    return client, calls
+
+
+def test_create_owned_realm_refuses_existing_before_any_mutation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, calls = _client(monkeypatch, [_Response(200, {"realm": "taken"})])
+
+    with pytest.raises(KeycloakAdminError, match="pre-existing"):
+        client.create_owned_realm("taken", "owner-a")
+
+    assert [(method, path) for method, path, _ in calls] == [("GET", "/realms/taken")]
+
+
+def test_create_owned_realm_stamps_exact_owner_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, calls = _client(monkeypatch, [_Response(404), _Response(201)])
+
+    client.create_owned_realm("unique", "owner-a")
+
+    assert calls[1] == (
+        "POST",
+        "/realms",
+        {
+            "json": {
+                "realm": "unique",
+                "enabled": True,
+                "attributes": {OWNED_REALM_ATTRIBUTE: "owner-a"},
+            }
+        },
+    )
+
+
+@pytest.mark.parametrize("operation", ["create", "delete"])
+def test_owned_realm_operations_reject_empty_nonce(
+    monkeypatch: pytest.MonkeyPatch, operation: str
+) -> None:
+    client, calls = _client(monkeypatch, [])
+
+    with pytest.raises(KeycloakAdminError, match="owner nonce"):
+        getattr(client, f"{operation}_owned_realm")("unique", "")
+
+    assert calls == []
+
+
+def test_create_owned_realm_fails_on_non_not_found_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, calls = _client(monkeypatch, [_Response(503, text="unavailable")])
+
+    with pytest.raises(KeycloakAdminError, match="preflight.*503"):
+        client.create_owned_realm("unique", "owner-a")
+
+    assert [(method, path) for method, path, _ in calls] == [("GET", "/realms/unique")]
+
+
+def test_create_owned_realm_post_409_race_never_deletes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, calls = _client(
+        monkeypatch,
+        [
+            _Response(404),
+            _Response(409, text="race"),
+            _Response(200, {"attributes": {OWNED_REALM_ATTRIBUTE: "owner-a"}}),
+        ],
+    )
+
+    with pytest.raises(KeycloakAdminError, match="409"):
+        client.create_owned_realm("unique", "owner-a")
+
+    assert [method for method, _, _ in calls] == ["GET", "POST", "GET"]
+
+
+def test_ambiguous_post_that_committed_owned_realm_is_reconciled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timeout = TimeoutError("connection lost after commit")
+    owned = _Response(200, {"attributes": {OWNED_REALM_ATTRIBUTE: "owner-a"}})
+    client, calls = _client(
+        monkeypatch,
+        [_Response(404), timeout, owned, owned, _Response(204)],
+    )
+
+    with pytest.raises(TimeoutError, match="after commit"):
+        client.create_owned_realm("unique", "owner-a")
+
+    assert [method for method, _, _ in calls] == [
+        "GET",
+        "POST",
+        "GET",
+        "GET",
+        "DELETE",
+    ]
+
+
+def test_ambiguous_post_refuses_competing_owner_without_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, calls = _client(
+        monkeypatch,
+        [
+            _Response(404),
+            TimeoutError("ambiguous"),
+            _Response(
+                200,
+                {"attributes": {OWNED_REALM_ATTRIBUTE: "competing-owner"}},
+            ),
+        ],
+    )
+
+    with pytest.raises(KeycloakAdminError, match="different owner"):
+        client.create_owned_realm("unique", "owner-a")
+
+    assert [method for method, _, _ in calls] == ["GET", "POST", "GET"]
+
+
+def test_delete_owned_realm_deletes_only_exact_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, calls = _client(
+        monkeypatch,
+        [
+            _Response(200, {"attributes": {OWNED_REALM_ATTRIBUTE: "owner-a"}}),
+            _Response(204),
+        ],
+    )
+
+    assert client.delete_owned_realm("unique", "owner-a") is True
+    assert [(method, path) for method, path, _ in calls] == [
+        ("GET", "/realms/unique"),
+        ("DELETE", "/realms/unique"),
+    ]
+
+
+def test_delete_owned_realm_refuses_unowned_without_delete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, calls = _client(
+        monkeypatch,
+        [_Response(200, {"attributes": {OWNED_REALM_ATTRIBUTE: "someone-else"}})],
+    )
+
+    with pytest.raises(KeycloakAdminError, match="unowned"):
+        client.delete_owned_realm("unique", "owner-a")
+
+    assert [(method, path) for method, path, _ in calls] == [("GET", "/realms/unique")]
+
+
+def test_delete_owned_realm_absent_is_idempotent_for_ambiguous_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, calls = _client(monkeypatch, [_Response(404)])
+
+    assert client.delete_owned_realm("unique", "owner-a") is False
+    assert len(calls) == 1
+
+
+def test_delete_owned_realm_propagates_delete_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, calls = _client(
+        monkeypatch,
+        [
+            _Response(200, {"attributes": {OWNED_REALM_ATTRIBUTE: "owner-a"}}),
+            _Response(500, text="delete failed"),
+        ],
+    )
+
+    with pytest.raises(KeycloakAdminError, match="delete.*500"):
+        client.delete_owned_realm("unique", "owner-a")
+
+    assert [method for method, _, _ in calls] == ["GET", "DELETE"]
+
+
+def test_partial_provision_rolls_back_whole_owned_realm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, str, str | None]] = []
+
+    class _Admin:
+        def create_owned_realm(self, realm: str, owner: str) -> None:
+            events.append(("create", realm, owner))
+
+        def set_unmanaged_attributes(self, realm: str) -> None:
+            events.append(("profile", realm, None))
+            raise RuntimeError("profile mutation failed")
+
+        def delete_owned_realm(self, realm: str, owner: str) -> bool:
+            events.append(("delete", realm, owner))
+            return True
+
+    monkeypatch.setattr(
+        "kamiwaza_sdk.seeding.federation.keycloak.KeycloakAdmin",
+        lambda *args, **kwargs: _Admin(),
+    )
+
+    with pytest.raises(RuntimeError, match="profile mutation failed"):
+        fixture.provision(
+            "http://keycloak",
+            "admin-pw",
+            "persona-pw",
+            realm="unique",
+            owner_nonce="owner-a",
+        )
+
+    assert events == [
+        ("create", "unique", "owner-a"),
+        ("profile", "unique", None),
+        ("delete", "unique", "owner-a"),
+    ]
+
+
+def test_partial_provision_reports_rollback_delete_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Admin:
+        def create_owned_realm(self, realm: str, owner: str) -> None:
+            return None
+
+        def set_unmanaged_attributes(self, realm: str) -> None:
+            raise RuntimeError("profile mutation failed")
+
+        def delete_owned_realm(self, realm: str, owner: str) -> bool:
+            raise KeycloakAdminError("delete failed")
+
+    monkeypatch.setattr(
+        "kamiwaza_sdk.seeding.federation.keycloak.KeycloakAdmin",
+        lambda *args, **kwargs: _Admin(),
+    )
+
+    with pytest.raises(RuntimeError, match="rollback also failed"):
+        fixture.provision(
+            "http://keycloak",
+            "admin-pw",
+            "persona-pw",
+            realm="unique",
+            owner_nonce="owner-a",
+        )

--- a/tests/unit/seeding/test_owned_shared_idp_realm.py
+++ b/tests/unit/seeding/test_owned_shared_idp_realm.py
@@ -214,8 +214,17 @@ def test_delete_owned_realm_propagates_delete_failure(
     assert [method for method, _, _ in calls] == ["GET", "DELETE"]
 
 
-def test_partial_provision_rolls_back_whole_owned_realm(
+@pytest.mark.parametrize(
+    ("delete_error", "expected_message"),
+    [
+        (None, "profile mutation failed"),
+        (KeycloakAdminError("delete failed"), "rollback also failed"),
+    ],
+)
+def test_partial_provision_rolls_back_owned_realm(
     monkeypatch: pytest.MonkeyPatch,
+    delete_error: Exception | None,
+    expected_message: str,
 ) -> None:
     events: list[tuple[str, str, str | None]] = []
 
@@ -229,6 +238,8 @@ def test_partial_provision_rolls_back_whole_owned_realm(
 
         def delete_owned_realm(self, realm: str, owner: str) -> bool:
             events.append(("delete", realm, owner))
+            if delete_error:
+                raise delete_error
             return True
 
     monkeypatch.setattr(
@@ -236,13 +247,12 @@ def test_partial_provision_rolls_back_whole_owned_realm(
         lambda *args, **kwargs: _Admin(),
     )
 
-    with pytest.raises(RuntimeError, match="profile mutation failed"):
+    with pytest.raises(RuntimeError, match=expected_message):
         fixture.provision(
             "http://keycloak",
             "admin-pw",
             "persona-pw",
-            realm="unique",
-            owner_nonce="owner-a",
+            fixture.OwnedRealm("unique", "owner-a"),
         )
 
     assert events == [
@@ -250,31 +260,3 @@ def test_partial_provision_rolls_back_whole_owned_realm(
         ("profile", "unique", None),
         ("delete", "unique", "owner-a"),
     ]
-
-
-def test_partial_provision_reports_rollback_delete_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class _Admin:
-        def create_owned_realm(self, realm: str, owner: str) -> None:
-            return None
-
-        def set_unmanaged_attributes(self, realm: str) -> None:
-            raise RuntimeError("profile mutation failed")
-
-        def delete_owned_realm(self, realm: str, owner: str) -> bool:
-            raise KeycloakAdminError("delete failed")
-
-    monkeypatch.setattr(
-        "kamiwaza_sdk.seeding.federation.keycloak.KeycloakAdmin",
-        lambda *args, **kwargs: _Admin(),
-    )
-
-    with pytest.raises(RuntimeError, match="rollback also failed"):
-        fixture.provision(
-            "http://keycloak",
-            "admin-pw",
-            "persona-pw",
-            realm="unique",
-            owner_nonce="owner-a",
-        )

--- a/tests/unit/test_gate_fixture.py
+++ b/tests/unit/test_gate_fixture.py
@@ -16,6 +16,10 @@ from tests.integration import _gate_fixture as fixture
 pytestmark = pytest.mark.unit
 
 
+def test_dataset_uses_the_ray_adapters_existing_allowed_root() -> None:
+    assert fixture.DATASET_PATH == "/app/models/eng10050-mini-clearance.csv"
+
+
 def _completed(
     cmd: list[str],
     returncode: int = 0,
@@ -165,7 +169,7 @@ def test_publish_routes_sorted_binary_files_over_ssh(
     destinations = [cmd[2] for cmd, _ in writes]
     assert f"{fixture.MOUNT}/simple/acme-gates/{fixture.WHEEL_NAME}" in destinations[0]
     assert f"{fixture.MOUNT}/simple/acme-gates/index.html" in destinations[1]
-    assert f"{fixture.MOUNT}/mini_clearance.csv" in destinations[2]
+    assert fixture.DATASET_PATH in destinations[2]
     assert all(cmd[:2] == ["ssh", "spark-2"] for cmd, _ in writes)
 
 
@@ -218,4 +222,27 @@ def test_verify_hashes_the_published_wheel_in_the_ray_head(
     assert calls[1][-2:] == [
         "sha256sum",
         f"{fixture.MOUNT}/simple/acme-gates/{fixture.WHEEL_NAME}",
+    ]
+
+
+def test_teardown_removes_only_the_owned_fixture_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        stdout = "ray-head-0" if "jsonpath={.items[0].metadata.name}" in cmd else ""
+        return _completed(cmd, stdout=stdout)
+
+    monkeypatch.setattr(fixture, "run", fake_run)
+    monkeypatch.setattr(sys, "argv", ["_gate_fixture", "teardown"])
+
+    assert fixture.main() == 0
+    assert calls[-1][-5:] == [
+        "--",
+        "rm",
+        "-rf",
+        fixture.MOUNT,
+        fixture.DATASET_PATH,
     ]

--- a/tests/unit/test_kamiwaza_jobs.py
+++ b/tests/unit/test_kamiwaza_jobs.py
@@ -14,14 +14,12 @@ import pytest
 
 
 def test_run_synchronous_returns_job_result(mock_client) -> None:
-    """``jobs.run(target_cluster, entrypoint, ...)`` hits the synchronous
-    ``/cluster/jobs/run`` endpoint which returns the completed JobResult
-    in-line (no separate poll)."""
+    """A targeted synchronous job traverses mesh and returns JobResult inline."""
     from kamiwaza_sdk.services.jobs_federation import JobsAPI
 
     mock_client.expect(
         "POST",
-        "/cluster/jobs/run",
+        "/mesh/ORION/api/cluster/jobs/run",
         {
             "job_id": "job-abc-123",
             "status": "SUCCEEDED",
@@ -40,7 +38,7 @@ def test_run_synchronous_returns_job_result(mock_client) -> None:
 
     _method, _path, kwargs = mock_client.calls[0]
     body = kwargs.get("json", {})
-    assert body["target_cluster"] == "ORION"
+    assert "target_cluster" not in body
     assert "entrypoint" in body
 
 
@@ -64,11 +62,14 @@ def test_run_local_when_target_cluster_omitted(mock_client) -> None:
 
 
 def test_submit_async_returns_job_id(mock_client) -> None:
-    """submit_async POSTs to ``/cluster/jobs/submit`` and returns just
-    the job_id immediately. Customer polls via wait()."""
+    """Targeted submit_async POSTs through mesh and returns the remote job id."""
     from kamiwaza_sdk.services.jobs_federation import JobsAPI
 
-    mock_client.expect("POST", "/cluster/jobs/submit", {"job_id": "job-async-456"})
+    mock_client.expect(
+        "POST",
+        "/mesh/ORION/api/cluster/jobs/submit",
+        {"job_id": "job-async-456"},
+    )
 
     job_id = JobsAPI(client=mock_client).submit_async(
         target_cluster="ORION",

--- a/tests/unit/test_kamiwaza_jobs_mesh_routing.py
+++ b/tests/unit/test_kamiwaza_jobs_mesh_routing.py
@@ -1,0 +1,117 @@
+"""ENG-10282: federated jobs must traverse the mesh, not run locally."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from kamiwaza_sdk.services.jobs_federation import JobsAPI
+
+
+def test_sync_run_routes_to_encoded_mesh_selector_without_body_hint(
+    mock_client,
+) -> None:
+    path = "/mesh/ORION%20edge/api/cluster/jobs/run"
+    mock_client.expect(
+        "POST",
+        path,
+        {"job_id": "remote-sync", "status": "SUCCEEDED", "result": {"ok": True}},
+    )
+
+    result = JobsAPI(client=mock_client).run(
+        target_cluster="ORION edge",
+        entrypoint="python remote.py",
+    )
+
+    assert result.job_id == "remote-sync"
+    assert mock_client.calls == [
+        ("POST", path, {"json": {"entrypoint": "python remote.py"}})
+    ]
+
+
+def test_recoverable_run_keeps_submit_status_and_result_on_remote_mesh(
+    mock_client,
+) -> None:
+    prefix = "/mesh/ORION/api/cluster/jobs"
+    job_id = "remote-recoverable"
+    mock_client.expect("POST", f"{prefix}/submit", {"job_id": job_id})
+    mock_client.expect("GET", f"{prefix}/{job_id}/status", {"status": "SUCCEEDED"})
+    mock_client.expect(
+        "GET",
+        f"{prefix}/{job_id}/result",
+        {"probe": "receiver-marker"},
+    )
+
+    with patch("time.sleep"):
+        result = JobsAPI(client=mock_client).run(
+            target_cluster="ORION",
+            entrypoint="python remote.py",
+            recoverable=True,
+            timeout_seconds=30,
+        )
+
+    assert result.job_id == job_id
+    assert result.result == {"probe": "receiver-marker"}
+    assert [path for _, path, _ in mock_client.calls] == [
+        f"{prefix}/submit",
+        f"{prefix}/{job_id}/status",
+        f"{prefix}/{job_id}/result",
+    ]
+
+
+def test_remote_submit_can_be_resumed_and_canceled_on_same_target(mock_client) -> None:
+    prefix = "/mesh/ORION/api/cluster/jobs"
+    job_id = "remote-resume"
+    mock_client.expect("POST", f"{prefix}/submit", {"job_id": job_id})
+    mock_client.expect("GET", f"{prefix}/{job_id}/status", {"status": "SUCCEEDED"})
+    mock_client.expect("GET", f"{prefix}/{job_id}/result", {"answer": 42})
+    mock_client.expect("POST", f"{prefix}/{job_id}/cancel", {"status": "STOPPED"})
+    jobs = JobsAPI(client=mock_client)
+
+    assert (
+        jobs.submit_async(
+            target_cluster="ORION",
+            entrypoint="python remote.py",
+        )
+        == job_id
+    )
+    result = jobs.wait(job_id, timeout=30)
+    canceled = jobs.cancel(job_id)
+
+    assert result.result == {"answer": 42}
+    assert canceled == {"status": "STOPPED"}
+
+
+def test_remote_job_requests_attach_target_credential(mock_client, monkeypatch) -> None:
+    prefix = "/mesh/ORION/api/cluster/jobs"
+    monkeypatch.setenv("KAMIWAZA_FEDERATION_CREDENTIAL_ORION", "receiver-offline-token")
+    mock_client.expect("POST", f"{prefix}/submit", {"job_id": "remote-auth"})
+    mock_client.expect("GET", f"{prefix}/remote-auth/status", {"status": "SUCCEEDED"})
+    mock_client.expect("GET", f"{prefix}/remote-auth/result", {"answer": 42})
+    mock_client.expect("POST", f"{prefix}/remote-auth/cancel", {"status": "STOPPED"})
+    jobs = JobsAPI(client=mock_client)
+
+    job_id = jobs.submit_async(target_cluster="ORION", entrypoint="python remote.py")
+    jobs.wait(job_id, timeout=30)
+    jobs.cancel(job_id)
+
+    assert all(
+        kwargs["headers"]["X-KZ-Federation-Credential"] == "receiver-offline-token"
+        for _, _, kwargs in mock_client.calls
+    )
+
+
+@pytest.mark.parametrize(
+    "target_cluster", ["", "  ", " ORION ", "ORION/edge", ".", ".."]
+)
+def test_invalid_target_cluster_is_rejected_before_request(
+    mock_client, target_cluster: str
+) -> None:
+    with pytest.raises(ValueError, match="target_cluster"):
+        JobsAPI(client=mock_client).run(
+            target_cluster=target_cluster,
+            entrypoint="python remote.py",
+        )
+
+    assert mock_client.calls == []

--- a/tests/unit/test_kamiwaza_jobs_recoverable.py
+++ b/tests/unit/test_kamiwaza_jobs_recoverable.py
@@ -56,16 +56,16 @@ def test_run_recoverable_true_uses_submit_then_poll(mock_client) -> None:
 
 
 def test_run_recoverable_true_forwards_runtime_env_to_submit(mock_client) -> None:
-    """runtime_env, target_cluster, timeout_seconds must reach the submit
-    body — they're how the server provisions the long-running job."""
+    """Runtime configuration reaches the remote submit without a routing hint."""
     from kamiwaza_sdk.services.jobs_federation import JobsAPI
 
     job_id = "job-fwd-test"
-    mock_client.expect("POST", "/cluster/jobs/submit", {"job_id": job_id})
-    mock_client.expect("GET", f"/cluster/jobs/{job_id}/status", {"status": "SUCCEEDED"})
+    prefix = "/mesh/ORION/api/cluster/jobs"
+    mock_client.expect("POST", f"{prefix}/submit", {"job_id": job_id})
+    mock_client.expect("GET", f"{prefix}/{job_id}/status", {"status": "SUCCEEDED"})
     mock_client.expect(
         "GET",
-        f"/cluster/jobs/{job_id}/result",
+        f"{prefix}/{job_id}/result",
         {"job_id": job_id, "status": "SUCCEEDED", "result": {}},
     )
 
@@ -81,7 +81,7 @@ def test_run_recoverable_true_forwards_runtime_env_to_submit(mock_client) -> Non
     submit_call = next(c for c in mock_client.calls if c[0] == "POST")
     body = submit_call[2].get("json", {})
     assert body["entrypoint"] == "python long.py"
-    assert body["target_cluster"] == "ORION"
+    assert "target_cluster" not in body
     assert body["runtime_env"] == {"env_vars": {"X": "1"}}
     assert body["timeout_seconds"] == 300
 
@@ -145,9 +145,7 @@ def test_wait_nests_generic_marker_payload_under_result(mock_client) -> None:
 
     jid = "job-answer"
     _status_terminal(mock_client, jid)
-    mock_client.expect(
-        "GET", f"/cluster/jobs/{jid}/result", {"answer": 42}
-    )
+    mock_client.expect("GET", f"/cluster/jobs/{jid}/result", {"answer": 42})
 
     with patch("time.sleep"):
         result = JobsAPI(client=mock_client).wait(jid, timeout=300)


### PR DESCRIPTION
## Summary

- route targeted and recoverable jobs through the federation mesh with consistent selector and credential handling
- provision the strict owned shared-IDP edge and validate exact U/S/TS gated retrieval, recoverable mesh-job result and receiver provenance, and native-token rejection
- fail closed on missing, skipped, or incomplete required-edge coverage and clean up owned shared-realm and gate state safely

## Base

This PR intentionally targets `feature/federation-trust-and-onboarding` because it depends on the federation substrate carried by PR #249.

## Validation

- full non-live SDK suite: 3512 passed, 2 skipped, 293 deselected
- diff-focused quality gate: 89 passed with Ruff, mypy, and radon clean
- focused cleanup and ownership regressions: 43 passed; independent final review: 17 passed
- local review: APPROVE with no remaining Critical or Important findings