### PR TITLE
ENG-10307: refresh direct shared-IDP SDK sessions

### DIFF
--- a/kamiwaza_sdk/__init__.py
+++ b/kamiwaza_sdk/__init__.py
@@ -2,6 +2,10 @@
 from importlib.metadata import version, PackageNotFoundError
 
 from .client import KamiwazaClient
+from .shared_idp_authentication import (
+    SharedIdpAuthConfig as SharedIdpAuthConfig,
+    SharedIdpAuthenticator as SharedIdpAuthenticator,
+)
 
 # Export as kamiwaza_sdk for the import pattern: from kamiwaza_sdk import KamiwazaClient as kz
 kamiwaza_sdk = KamiwazaClient

--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -258,16 +258,22 @@ class KamiwazaClient:
                 or os.environ.get("KAMIWAZA_API_TOKEN")
             )
             self.authenticator = ApiKeyAuthenticator(api_key) if api_key else None
+        self._owns_authenticator = self.authenticator is not None
 
         # Don't authenticate during initialization - let it happen on first request
 
     def close(self) -> None:
-        """Release the underlying requests.Session transport.
+        """Release the authentication and platform HTTP transports.
 
         Idempotent — repeated close() calls are safe (Session.close()
         does its own idempotency).
         """
-        self.session.close()
+        close_authenticator = getattr(self.authenticator, "close", None)
+        try:
+            if self._owns_authenticator and callable(close_authenticator):
+                close_authenticator()
+        finally:
+            self.session.close()
 
     def __enter__(self) -> "KamiwazaClient":
         return self
@@ -662,6 +668,7 @@ class KamiwazaClient:
         )
         # Preserve exact parent auth state; __init__ may otherwise consult env vars.
         scoped.authenticator = self.authenticator
+        scoped._owns_authenticator = False
         scoped.session.headers.update(self.session.headers)
         scoped.session.cookies.update(self.session.cookies)
         scoped._default_headers = dict(self._default_headers)
@@ -863,7 +870,7 @@ class KamiwazaClient:
 
     @property
     def workrooms(self):
-        if not hasattr(self, '_workrooms'):
+        if not hasattr(self, "_workrooms"):
             self._workrooms = WorkroomService(self)
         return self._workrooms
 

--- a/kamiwaza_sdk/shared_idp_authentication.py
+++ b/kamiwaza_sdk/shared_idp_authentication.py
@@ -1,0 +1,257 @@
+"""Direct shared-identity-provider authentication for automated SDK clients."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import requests  # type: ignore[import-untyped]
+from pydantic import ValidationError
+
+from .authentication import Authenticator
+from .exceptions import AuthenticationError
+from .schemas.auth import TokenResponse
+from .token_store import FileTokenStore, StoredToken, TokenStore
+
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_REFRESH_LEEWAY_SECONDS = 30.0
+
+
+@dataclass(frozen=True)
+class SharedIdpAuthConfig:
+    """Configuration for a browser-independent shared-realm OIDC session."""
+
+    issuer: str
+    client_id: str
+    username: str
+    password: str = field(repr=False)
+    client_secret: str | None = field(default=None, repr=False)
+    scope: str = "openid"
+    verify: bool | str = True
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
+    token_root: Path | str | None = None
+
+    @property
+    def normalized_issuer(self) -> str:
+        """Return the issuer without a trailing slash."""
+        return self.issuer.rstrip("/")
+
+
+class _OidcGrantError(AuthenticationError):
+    """Internal typed OAuth grant failure used to control safe fallback."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None,
+        oauth_error: str | None,
+    ) -> None:
+        super().__init__(message, status_code=status_code)
+        self.oauth_error = oauth_error
+
+
+def shared_idp_token_path(
+    config: SharedIdpAuthConfig,
+    *,
+    root: Path | str | None = None,
+) -> Path:
+    """Return a deterministic token path scoped to issuer, client, and user."""
+    identity = [config.normalized_issuer, config.client_id, config.username]
+    encoded = json.dumps(identity, separators=(",", ":"), ensure_ascii=True)
+    digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    token_root = Path(
+        root or config.token_root or Path.home() / ".kamiwaza" / "shared-idp"
+    )
+    return token_root / f"{digest}.json"
+
+
+def _default_token_store(config: SharedIdpAuthConfig) -> FileTokenStore:
+    token_path = shared_idp_token_path(config)
+    token_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    token_path.parent.chmod(0o700)
+    return FileTokenStore(token_path)
+
+
+class SharedIdpAuthenticator(Authenticator):
+    """Maintain a direct shared-realm session without browser interaction."""
+
+    def __init__(
+        self,
+        config: SharedIdpAuthConfig,
+        *,
+        token_store: TokenStore | None = None,
+        http_session: requests.Session | None = None,
+    ) -> None:
+        self.config = config
+        self.token_store = (
+            token_store if token_store is not None else _default_token_store(config)
+        )
+        self._http = http_session or requests.Session()
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._expires_at: float | None = None
+        self._load_cached_token()
+
+    def authenticate(self, session: requests.Session) -> None:
+        """Attach a valid bearer token, refreshing it proactively."""
+        if self._needs_refresh():
+            self.refresh_token(session)
+            return
+        self._attach_access_token(session)
+
+    def refresh_token(self, session: requests.Session) -> None:
+        """Refresh the shared-realm token or perform a programmatic login."""
+        refresh_token = self._refresh_token
+        if not refresh_token:
+            response = self._password_grant()
+            self._store_response(response, previous_refresh=None)
+            self._attach_access_token(session)
+            return
+
+        previous_refresh: str | None = refresh_token
+        try:
+            response = self._refresh_grant(refresh_token)
+        except _OidcGrantError as exc:
+            if exc.oauth_error != "invalid_grant":
+                raise
+            self._clear_tokens()
+            response = self._password_grant()
+            previous_refresh = None
+        self._store_response(response, previous_refresh=previous_refresh)
+        self._attach_access_token(session)
+
+    def get_access_token(self, session: requests.Session) -> str | None:
+        """Return a current bearer token for callers that need token access."""
+        self.authenticate(session)
+        return self._access_token
+
+    def invalidate_session(self, session: requests.Session) -> bool:
+        """Expire the access token while retaining refresh capability."""
+        self._access_token = None
+        self._expires_at = None
+        session.headers.pop("Authorization", None)
+        return True
+
+    def _needs_refresh(self) -> bool:
+        if not self._access_token or self._expires_at is None:
+            return True
+        return time.time() >= self._expires_at - _REFRESH_LEEWAY_SECONDS
+
+    def _password_grant(self) -> TokenResponse:
+        data = {
+            "grant_type": "password",
+            "client_id": self.config.client_id,
+            "username": self.config.username,
+            "password": self.config.password,
+            "scope": self.config.scope,
+        }
+        return self._request_token(self._with_client_secret(data))
+
+    def _refresh_grant(self, refresh_token: str) -> TokenResponse:
+        data = {
+            "grant_type": "refresh_token",
+            "client_id": self.config.client_id,
+            "refresh_token": refresh_token,
+        }
+        return self._request_token(self._with_client_secret(data))
+
+    def _with_client_secret(self, data: dict[str, str]) -> dict[str, str]:
+        if not self.config.client_secret:
+            return data
+        return {**data, "client_secret": self.config.client_secret}
+
+    def _request_token(self, data: dict[str, str]) -> TokenResponse:
+        endpoint = f"{self.config.normalized_issuer}/protocol/openid-connect/token"
+        try:
+            response = self._http.post(
+                endpoint,
+                data=data,
+                timeout=self.config.timeout_seconds,
+                verify=self.config.verify,
+            )
+        except requests.RequestException as exc:
+            raise AuthenticationError(
+                "Shared identity provider is unavailable"
+            ) from exc
+
+        payload = self._response_payload(response)
+        if response.status_code >= 400:
+            raise self._grant_error(response.status_code, payload)
+        if payload is None:
+            raise AuthenticationError("Shared identity provider returned invalid JSON")
+        try:
+            return TokenResponse.model_validate(payload)
+        except ValidationError as exc:
+            raise AuthenticationError(
+                "Shared identity provider returned an invalid token response"
+            ) from exc
+
+    @staticmethod
+    def _response_payload(response: requests.Response) -> dict[str, Any] | None:
+        try:
+            payload = response.json()
+        except ValueError:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    @staticmethod
+    def _grant_error(
+        status_code: int,
+        payload: dict[str, Any] | None,
+    ) -> _OidcGrantError:
+        oauth_error = payload.get("error") if payload else None
+        description = payload.get("error_description") if payload else None
+        detail = description or oauth_error or "token grant failed"
+        return _OidcGrantError(
+            f"Shared identity provider rejected the token grant: {detail}",
+            status_code=status_code,
+            oauth_error=oauth_error if isinstance(oauth_error, str) else None,
+        )
+
+    def _store_response(
+        self,
+        response: TokenResponse,
+        *,
+        previous_refresh: str | None,
+    ) -> None:
+        refresh_token = response.refresh_token or previous_refresh
+        if not refresh_token:
+            raise AuthenticationError(
+                "Shared identity provider did not return a refresh token"
+            )
+        expires_at = time.time() + response.expires_in
+        stored = StoredToken(
+            access_token=response.access_token,
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+        )
+        self.token_store.save(stored)
+        self._access_token = stored.access_token
+        self._refresh_token = stored.refresh_token
+        self._expires_at = stored.expires_at
+
+    def _attach_access_token(self, session: requests.Session) -> None:
+        if not self._access_token:
+            raise AuthenticationError(
+                "Shared identity provider access token is unavailable"
+            )
+        session.headers["Authorization"] = f"Bearer {self._access_token}"
+
+    def _clear_tokens(self) -> None:
+        self._access_token = None
+        self._refresh_token = None
+        self._expires_at = None
+        self.token_store.clear()
+
+    def _load_cached_token(self) -> None:
+        cached = self.token_store.load()
+        if not cached:
+            return
+        self._access_token = cached.access_token
+        self._refresh_token = cached.refresh_token
+        self._expires_at = cached.expires_at

--- a/kamiwaza_sdk/shared_idp_authentication.py
+++ b/kamiwaza_sdk/shared_idp_authentication.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import hashlib
 import json
 import time
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import requests  # type: ignore[import-untyped]
+from filelock import FileLock
 from pydantic import ValidationError
 
 from .authentication import Authenticator
@@ -34,11 +37,30 @@ class SharedIdpAuthConfig:
     verify: bool | str = True
     timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
     token_root: Path | str | None = None
+    allow_insecure_http: bool = False
+    password_regrant_on_invalid_grant: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject plaintext credential transport unless explicitly enabled."""
+        scheme = urlsplit(self.normalized_issuer).scheme.lower()
+        if scheme == "https":
+            return
+        if scheme == "http" and self.allow_insecure_http:
+            return
+        raise ValueError(
+            "Shared identity provider issuer must use HTTPS; "
+            "set allow_insecure_http=True only for isolated development"
+        )
 
     @property
     def normalized_issuer(self) -> str:
         """Return the issuer without a trailing slash."""
         return self.issuer.rstrip("/")
+
+    @property
+    def normalized_scope(self) -> str:
+        """Return the OAuth scope as a stable, de-duplicated set."""
+        return " ".join(sorted(set(self.scope.split())))
 
 
 class _OidcGrantError(AuthenticationError):
@@ -60,8 +82,13 @@ def shared_idp_token_path(
     *,
     root: Path | str | None = None,
 ) -> Path:
-    """Return a deterministic token path scoped to issuer, client, and user."""
-    identity = [config.normalized_issuer, config.client_id, config.username]
+    """Return a deterministic token path scoped to the full grant identity."""
+    identity = [
+        config.normalized_issuer,
+        config.client_id,
+        config.username,
+        config.normalized_scope,
+    ]
     encoded = json.dumps(identity, separators=(",", ":"), ensure_ascii=True)
     digest = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
     token_root = Path(
@@ -72,8 +99,10 @@ def shared_idp_token_path(
 
 def _default_token_store(config: SharedIdpAuthConfig) -> FileTokenStore:
     token_path = shared_idp_token_path(config)
+    token_root_existed = token_path.parent.exists()
     token_path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    token_path.parent.chmod(0o700)
+    if config.token_root is None or not token_root_existed:
+        token_path.parent.chmod(0o700)
     return FileTokenStore(token_path)
 
 
@@ -91,7 +120,8 @@ class SharedIdpAuthenticator(Authenticator):
         self.token_store = (
             token_store if token_store is not None else _default_token_store(config)
         )
-        self._http = http_session or requests.Session()
+        self._owns_http_session = http_session is None
+        self._http = http_session if http_session is not None else requests.Session()
         self._access_token: str | None = None
         self._refresh_token: str | None = None
         self._expires_at: float | None = None
@@ -106,6 +136,15 @@ class SharedIdpAuthenticator(Authenticator):
 
     def refresh_token(self, session: requests.Session) -> None:
         """Refresh the shared-realm token or perform a programmatic login."""
+        with self._refresh_guard():
+            self._refresh_token_locked(session)
+
+    def _refresh_token_locked(self, session: requests.Session) -> None:
+        """Refresh while holding the shared file-cache lock, when configured."""
+        known_token = self._current_token()
+        if self._adopt_updated_cached_token(known_token, session):
+            return
+
         refresh_token = self._refresh_token
         if not refresh_token:
             response = self._password_grant()
@@ -119,11 +158,47 @@ class SharedIdpAuthenticator(Authenticator):
         except _OidcGrantError as exc:
             if exc.oauth_error != "invalid_grant":
                 raise
+            if not self.config.password_regrant_on_invalid_grant:
+                raise
             self._clear_tokens()
             response = self._password_grant()
             previous_refresh = None
         self._store_response(response, previous_refresh=previous_refresh)
         self._attach_access_token(session)
+
+    def _refresh_guard(self) -> AbstractContextManager[object]:
+        if not isinstance(self.token_store, FileTokenStore):
+            return nullcontext()
+        lock_path = self.token_store.path.with_suffix(
+            f"{self.token_store.path.suffix}.lock"
+        )
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        return FileLock(lock_path, mode=0o600)
+
+    def _adopt_updated_cached_token(
+        self,
+        known_token: StoredToken | None,
+        session: requests.Session,
+    ) -> bool:
+        cached = self.token_store.load()
+        if not cached or known_token is None:
+            return False
+        if cached == known_token:
+            return False
+        self._apply_cached_token(cached)
+        if self._needs_refresh():
+            return False
+        self._attach_access_token(session)
+        return True
+
+    def _current_token(self) -> StoredToken | None:
+        if not self._access_token or self._expires_at is None:
+            return None
+        return StoredToken(
+            access_token=self._access_token,
+            refresh_token=self._refresh_token,
+            expires_at=self._expires_at,
+        )
 
     def get_access_token(self, session: requests.Session) -> str | None:
         """Return a current bearer token for callers that need token access."""
@@ -137,6 +212,11 @@ class SharedIdpAuthenticator(Authenticator):
         session.headers.pop("Authorization", None)
         return True
 
+    def close(self) -> None:
+        """Release the OIDC transport when this authenticator created it."""
+        if self._owns_http_session:
+            self._http.close()
+
     def _needs_refresh(self) -> bool:
         if not self._access_token or self._expires_at is None:
             return True
@@ -148,7 +228,7 @@ class SharedIdpAuthenticator(Authenticator):
             "client_id": self.config.client_id,
             "username": self.config.username,
             "password": self.config.password,
-            "scope": self.config.scope,
+            "scope": self.config.normalized_scope,
         }
         return self._request_token(self._with_client_secret(data))
 
@@ -173,11 +253,17 @@ class SharedIdpAuthenticator(Authenticator):
                 data=data,
                 timeout=self.config.timeout_seconds,
                 verify=self.config.verify,
+                allow_redirects=False,
             )
         except requests.RequestException as exc:
             raise AuthenticationError(
                 "Shared identity provider is unavailable"
             ) from exc
+
+        if 300 <= response.status_code < 400:
+            raise AuthenticationError(
+                "Shared identity provider token endpoint redirects are not permitted"
+            )
 
         payload = self._response_payload(response)
         if response.status_code >= 400:
@@ -252,6 +338,9 @@ class SharedIdpAuthenticator(Authenticator):
         cached = self.token_store.load()
         if not cached:
             return
+        self._apply_cached_token(cached)
+
+    def _apply_cached_token(self, cached: StoredToken) -> None:
         self._access_token = cached.access_token
         self._refresh_token = cached.refresh_token
         self._expires_at = cached.expires_at

--- a/kamiwaza_sdk/token_store.py
+++ b/kamiwaza_sdk/token_store.py
@@ -67,9 +67,16 @@ class FileTokenStore(TokenStore):
     def save(self, token: StoredToken) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = self.path.with_suffix(".tmp")
-        with tmp_path.open("w", encoding="utf-8") as handle:
+        descriptor = os.open(
+            tmp_path,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
             json.dump(asdict(token), handle)
+        tmp_path.chmod(0o600)
         tmp_path.replace(self.path)
+        self.path.chmod(0o600)
 
     def clear(self) -> None:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "requests",
     "pydantic[email]>=2.11",
     "httpx",
+    "filelock>=3.20",
     "openai>=1.0",
     "huggingface_hub>=0.23",
     "typer>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ markers = [
     "requires_embedding_model: live tests that require a platform embedding deployment that can generate embeddings",
     "requires_two_clusters: live tests that require a federation peer cluster reachable via KAMIWAZA_PEER_BASE_URL / KAMIWAZA_PEER_API_KEY (ENG-5784)",
     "requires_shared_idp: live federation tests exercising the shared_idp (Alt C) trust posture — receiver validates a shared-realm token against a trusted issuer (ENG-8213). Required two-cluster lanes carry this together with requires_two_clusters and must provision their shared-identity prerequisites before selection.",
+    "requires_owned_shared_realm: live shared_idp tests that require an independently provisioned realm, ROPC client, clearance-bearing personas, and ownership-guarded teardown (ENG-10050)",
     "requires_deployable_model: live tests that require the host to deploy the integration test model; skips on hosts without compatible inference capacity (e.g. x86 CPU smoke vs an MLX model)",
     "extension_regression: D210 12-issue regression checklist (UAC-17 / EDX-OPS-2). See tests/unit/extensions/regression/inventory.yaml.",
     "live_extension: live extension-contract tests against a real cluster (relocated from kamiwaza, env-gated by RUN_LIVE_EXTENSION_TESTS=1)",

--- a/tests/integration/required_federation_edge.py
+++ b/tests/integration/required_federation_edge.py
@@ -11,7 +11,7 @@ REQUIRED_EDGE_CASES = frozenset(
         "test_required_mesh_retrieval_returns_exact_post_gate_rows[S]",
         "test_required_mesh_retrieval_returns_exact_post_gate_rows[TS]",
         "test_required_mesh_job_reaches_receiver_and_returns_marker",
-        "test_unonboarded_primary_realm_user_rejected_by_receiver_allowlist",
+        "test_native_realm_token_rejected_at_receiver_shared_idp_boundary",
     }
 )
 
@@ -21,7 +21,11 @@ def required_edge_enabled(config: pytest.Config) -> bool:
 
 
 def is_required_edge_item(item: pytest.Item) -> bool:
-    required_markers = {"requires_two_clusters", "requires_shared_idp"}
+    required_markers = {
+        "requires_two_clusters",
+        "requires_shared_idp",
+        "requires_owned_shared_realm",
+    }
     return (
         required_edge_enabled(item.config)
         and Path(str(item.fspath)).name == REQUIRED_EDGE_FILE

--- a/tests/integration/test_federation_required_edge_contract.py
+++ b/tests/integration/test_federation_required_edge_contract.py
@@ -9,7 +9,6 @@ import pytest
 from _kamiwaza_pytest_options import PROJECT_ROOT
 from kamiwaza_sdk.exceptions import APIError, AuthenticationError
 from tests.integration import test_federation_shared_idp_gated_retrieval_live as edge
-from tests.integration import required_federation_edge_personas as edge_personas
 
 try:
     from tests.integration import required_federation_edge as required_edge
@@ -26,15 +25,23 @@ def _required_item(nodeid: str) -> SimpleNamespace:
     return SimpleNamespace(
         config=config,
         fspath=Path(required_edge.REQUIRED_EDGE_FILE),
-        keywords={"requires_two_clusters": True, "requires_shared_idp": True},
+        keywords={
+            "requires_two_clusters": True,
+            "requires_shared_idp": True,
+            "requires_owned_shared_realm": True,
+        },
         nodeid=nodeid,
     )
 
 
-def test_required_edge_carries_both_topology_markers() -> None:
+def test_required_edge_carries_owned_shared_realm_capability_markers() -> None:
     marker_names = {marker.name for marker in edge.pytestmark}
 
-    assert {"requires_two_clusters", "requires_shared_idp"} <= marker_names
+    assert {
+        "requires_two_clusters",
+        "requires_shared_idp",
+        "requires_owned_shared_realm",
+    } <= marker_names
 
 
 def test_required_edge_plugin_is_registered_only_at_pytest_root() -> None:
@@ -46,13 +53,6 @@ def test_required_edge_plugin_is_registered_only_at_pytest_root() -> None:
 
 
 def test_required_edge_collection_guard_requires_all_five_cases() -> None:
-    assert (
-        "test_unonboarded_primary_realm_user_rejected_by_receiver_allowlist"
-        in required_edge.REQUIRED_EDGE_CASES
-    )
-    assert not any(
-        "native_realm_token" in case for case in required_edge.REQUIRED_EDGE_CASES
-    )
     items = [
         _required_item(f"tests/integration/{required_edge.REQUIRED_EDGE_FILE}::{case}")
         for case in required_edge.REQUIRED_EDGE_CASES
@@ -136,16 +136,14 @@ def test_required_mesh_call_propagates_downstream_denial() -> None:
     assert caught.value is denial
 
 
-def test_unonboarded_primary_user_uses_mesh_and_requires_allowlist_reason() -> None:
+def test_native_token_negative_uses_mesh_and_rejects_authorization_denial() -> None:
     client = Mock()
     client._request.side_effect = APIError("forbidden", status_code=403)
 
-    with pytest.raises(AssertionError, match="unauthorized_brokered_user"):
-        edge.test_unonboarded_primary_realm_user_rejected_by_receiver_allowlist(
-            {
-                "name": "receiver-cluster",
-                "personas": {"unonboarded": {"client": client}},
-            }
+    with pytest.raises(AssertionError, match="peer_jwt_validation_failed"):
+        edge.test_native_realm_token_rejected_at_receiver_shared_idp_boundary(
+            {"name": "receiver-cluster"},
+            client,
         )
 
     client._request.assert_called_once_with(
@@ -154,16 +152,16 @@ def test_unonboarded_primary_user_uses_mesh_and_requires_allowlist_reason() -> N
     )
 
 
-def test_unonboarded_primary_user_accepts_exact_receiver_allowlist_rejection() -> None:
+def test_native_token_negative_accepts_receiver_peer_jwt_rejection() -> None:
     denial = APIError(
-        "not onboarded",
+        "peer rejected",
         status_code=403,
         response_data={
-            "detail": {"reason": "unauthorized_brokered_user"},
+            "detail": {"reason": "peer_jwt_validation_failed"},
         },
     )
 
-    edge._assert_receiver_onboarding_rejection(Mock(side_effect=denial))
+    edge._assert_receiver_auth_rejection(Mock(side_effect=denial))
 
 
 @pytest.mark.parametrize(
@@ -179,79 +177,9 @@ def test_unonboarded_primary_user_accepts_exact_receiver_allowlist_rejection() -
         ),
     ],
 )
-def test_unonboarded_primary_user_rejects_unrelated_auth_failure(denial) -> None:
-    with pytest.raises(AssertionError, match="unauthorized_brokered_user"):
-        edge._assert_receiver_onboarding_rejection(Mock(side_effect=denial))
-
-
-def test_required_personas_use_primary_realm_login_and_receiver_onboarding(
-    monkeypatch,
-) -> None:
-    from kamiwaza_sdk.exceptions import APIError
-
-    initiator = SimpleNamespace(
-        subjects=Mock(),
-        cluster=Mock(),
-        base_url="https://fed-a.test/api",
-    )
-    receiver = SimpleNamespace(_request=Mock())
-    initiator.subjects.get.side_effect = APIError("missing", status_code=404)
-    clients = edge._EdgeClients(initiator=initiator, receiver=receiver)
-    cleanup = Mock()
-    persona_clients = {}
-
-    def normal_login(base_url, username, password, *, verify):
-        assert base_url == "https://fed-a.test/api"
-        assert password == "persona-secret"
-        assert verify is True
-        client = Mock()
-        client.auth.get_current_user.return_value = SimpleNamespace(
-            username=username,
-            sub=f"sub-{username}",
-        )
-        client.get_bearer_token.return_value = f"token-{username}"
-        persona_clients[username] = client
-        return client
-
-    monkeypatch.setattr(edge.mc, "authed_client", normal_login)
-    monkeypatch.setattr(
-        edge.mc,
-        "jwt_sub",
-        lambda token: f"sub-{token.removeprefix('token-')}",
-    )
-    direct_shared_login = Mock(
-        side_effect=AssertionError("direct shared-realm ROPC is forbidden")
-    )
-    monkeypatch.setattr(
-        edge.mc,
-        "shared_realm_token",
-        direct_shared_login,
-    )
-    prerequisites = SimpleNamespace(
-        persona_auth={"password": "persona-secret", "verify": True},
-        shared={"shared_issuer_url": "https://fed-a.test/realms/kamiwaza"},
-    )
-
-    personas = edge_personas.provision_primary_personas(
-        cleanup,
-        clients,
-        ("receiver-fed", "fed-a-cluster", "urn:dataset:known"),
-        prerequisites,
-    )
-
-    assert set(personas) == {"U", "S", "TS", "unonboarded"}
-    assert initiator.subjects.upsert.call_count == 4
-    assert set(persona_clients) == {
-        "fed-clr-u",
-        "fed-clr-s",
-        "fed-clr-ts",
-        "fed-clr-unonboarded",
-    }
-    assert receiver._request.call_count == 3
-    direct_shared_login.assert_not_called()
-    for clearance in ("U", "S", "TS"):
-        username = f"fed-clr-{clearance.lower()}"
-        assert personas[clearance]["client"] is persona_clients[username]
+def test_native_token_negative_rejects_unrelated_auth_failure(denial) -> None:
+    with pytest.raises(AssertionError, match="peer_jwt_validation_failed"):
+        edge._assert_receiver_auth_rejection(Mock(side_effect=denial))
 
 
 def test_brokered_personas_get_only_required_fixture_authority() -> None:
@@ -260,11 +188,11 @@ def test_brokered_personas_get_only_required_fixture_authority() -> None:
         "relation": "viewer",
         "object": "dataset:urn:kamiwaza:dataset:known",
     }
-    assert edge_personas.required_initial_tuples(
+    assert edge._required_initial_tuples(
         "urn:kamiwaza:dataset:known",
         job_executor=False,
     ) == [dataset_tuple]
-    assert edge_personas.required_initial_tuples(
+    assert edge._required_initial_tuples(
         "urn:kamiwaza:dataset:known",
         job_executor=True,
     ) == [
@@ -275,6 +203,55 @@ def test_brokered_personas_get_only_required_fixture_authority() -> None:
             "object": "cluster_jobs:__all__",
         },
     ]
+
+
+def test_persona_session_performs_password_grant_then_real_refresh(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class _Authenticator:
+        def __init__(self, config, *, token_store) -> None:
+            self.config = config
+            self.token_store = token_store
+
+        def authenticate(self, session) -> None:
+            calls.append("password")
+            session.headers["Authorization"] = "Bearer initial"
+            self.token_store.save(SimpleNamespace(refresh_token="refresh-1"))
+
+        def refresh_token(self, session) -> None:
+            calls.append("refresh")
+            session.headers["Authorization"] = "Bearer refreshed"
+            self.token_store.save(SimpleNamespace(refresh_token="refresh-2"))
+
+        def get_access_token(self, session) -> str:
+            calls.append("read")
+            return session.headers["Authorization"].removeprefix("Bearer ")
+
+    class _Client:
+        def __init__(self, *, base_url, authenticator, verify) -> None:
+            self.base_url = base_url
+            self.authenticator = authenticator
+            self.verify = verify
+            self.session = SimpleNamespace(headers={})
+
+    monkeypatch.setattr(edge, "SharedIdpAuthenticator", _Authenticator, raising=False)
+    monkeypatch.setattr(edge, "KamiwazaClient", _Client, raising=False)
+
+    persona = edge._programmatic_persona_session(
+        "https://initiator.example/api",
+        {
+            "issuer": "https://idp.example/realms/shared",
+            "client_id": "federation-client",
+            "client_secret": None,
+            "password": "secret",
+            "verify": True,
+        },
+        "fed-clr-u",
+    )
+
+    assert calls == ["password", "refresh", "read"]
+    assert persona["token"] == "refreshed"
+    assert persona["client"].authenticator is persona["authenticator"]
 
 
 @pytest.mark.parametrize(
@@ -345,12 +322,14 @@ def test_required_job_case_runs_recoverably_on_named_peer(monkeypatch) -> None:
             "source_cluster_id": "initiator-uuid",
         }
     )
-    persona = SimpleNamespace(jobs=jobs, _request=request)
+    persona = SimpleNamespace(jobs=jobs, _request=request, session=object())
+    authenticator = Mock()
+    authenticator.get_access_token.return_value = "opaque-test-token"
     monkeypatch.setattr(edge.uuid, "uuid4", lambda: SimpleNamespace(hex="fixed"))
     wiring = {
         "name": "receiver-cluster",
         "personas": {
-            "U": {"token": "opaque-test-token", "client": persona},
+            "U": {"client": persona, "authenticator": authenticator},
         },
         "verify": True,
         "source_cluster_id": "initiator-uuid",
@@ -516,7 +495,9 @@ def test_pairing_requires_two_distinct_cluster_identities() -> None:
 
 
 def test_required_retrieval_case_asserts_streamed_known_answer(monkeypatch) -> None:
-    persona = object()
+    persona = SimpleNamespace(session=object())
+    authenticator = Mock()
+    authenticator.get_access_token.return_value = "opaque-test-token"
     rows = edge.mc.records()[:3]
     footers = [
         {
@@ -533,7 +514,7 @@ def test_required_retrieval_case_asserts_streamed_known_answer(monkeypatch) -> N
         "name": "receiver-cluster",
         "urn": "urn:kamiwaza:dataset:known",
         "personas": {
-            "U": {"token": "opaque-test-token", "client": persona},
+            "U": {"client": persona, "authenticator": authenticator},
         },
         "verify": True,
     }
@@ -571,7 +552,7 @@ def test_persona_cleanup_revokes_exact_allowlist_row() -> None:
     request = Mock(return_value={"message": "revoked"})
     receiver = SimpleNamespace(_request=request)
 
-    edge_personas.cleanup_brokered_persona(
+    edge._cleanup_brokered_persona(
         receiver,
         "federation-id",
         "alice@example.com@source-cluster",

--- a/tests/integration/test_federation_required_edge_contract.py
+++ b/tests/integration/test_federation_required_edge_contract.py
@@ -1,6 +1,7 @@
 """ENG-10050: Offline contract for the required shared-IDP smoke edge."""
 
 from pathlib import Path
+import stat
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -244,7 +245,8 @@ def test_persona_session_performs_password_grant_then_real_refresh(monkeypatch) 
             "client_id": "federation-client",
             "client_secret": None,
             "password": "secret",
-            "verify": True,
+            "idp_verify": "/tmp/shared-idp-ca.pem",
+            "platform_verify": True,
         },
         "fed-clr-u",
     )
@@ -252,6 +254,25 @@ def test_persona_session_performs_password_grant_then_real_refresh(monkeypatch) 
     assert calls == ["password", "refresh", "read"]
     assert persona["token"] == "refreshed"
     assert persona["client"].authenticator is persona["authenticator"]
+    assert persona["authenticator"].config.verify == "/tmp/shared-idp-ca.pem"
+    assert persona["client"].verify is True
+
+
+def test_shared_ca_pem_uses_a_dedicated_idp_bundle(tmp_path: Path) -> None:
+    ca_pem = "-----BEGIN CERTIFICATE-----\nfixture\n-----END CERTIFICATE-----\n"
+
+    verify = edge._shared_idp_verify(
+        {"shared_ca_pem": ca_pem},
+        platform_verify=True,
+        temp_root=tmp_path,
+    )
+
+    ca_path = Path(verify)
+    assert ca_path.read_text() == ca_pem
+    assert stat.S_IMODE(ca_path.stat().st_mode) == 0o600
+    assert (
+        edge._shared_idp_verify({}, platform_verify=False, temp_root=tmp_path) is False
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -21,10 +21,15 @@ from urllib.parse import quote
 
 import pytest
 
+from kamiwaza_sdk import (
+    KamiwazaClient,
+    SharedIdpAuthConfig,
+    SharedIdpAuthenticator,
+)
+from kamiwaza_sdk.token_store import InMemoryTokenStore
 from tests.integration import mesh_outcome
 
 from . import _mini_clearance as mc
-from .required_federation_edge_personas import provision_primary_personas
 from .required_federation_edge_setup import pair_required_edge, provision_gated_dataset
 
 pytestmark = [
@@ -33,7 +38,10 @@ pytestmark = [
     pytest.mark.withoutresponses,
     pytest.mark.requires_two_clusters,
     pytest.mark.requires_shared_idp,
+    pytest.mark.requires_owned_shared_realm,
 ]
+
+_PERSONAS = {"U": "fed-clr-u", "S": "fed-clr-s", "TS": "fed-clr-ts"}
 
 _ALLOW_ALL_EXECUTION_GATE = (
     "kamiwaza.services.authz.gates.default_gates.AllowAllExecutionGate"
@@ -84,8 +92,8 @@ def _required_mesh_call(call: Callable[[], Any]) -> Any:
     return call()
 
 
-def _assert_receiver_onboarding_rejection(call: Callable[[], Any]) -> None:
-    """Accept only the receiver's structured allowlist rejection."""
+def _assert_receiver_auth_rejection(call: Callable[[], Any]) -> None:
+    """Accept only the receiver's structured peer-JWT validation failure."""
     from kamiwaza_sdk.exceptions import KamiwazaError
 
     try:
@@ -94,15 +102,15 @@ def _assert_receiver_onboarding_rejection(call: Callable[[], Any]) -> None:
         reason = mesh_outcome.reason_of(exc)
         status = getattr(exc, "status_code", None)
         assert status == 403, (
-            "expected unauthorized_brokered_user from receiver status 403, "
+            "expected peer_jwt_validation_failed from receiver status 403, "
             f"got status {status!r}: {exc!r}"
         )
-        assert reason == "unauthorized_brokered_user", (
-            "expected unauthorized_brokered_user from the receiver allowlist, "
-            f"got {reason!r}: {exc!r}"
+        assert reason == "peer_jwt_validation_failed", (
+            "expected peer_jwt_validation_failed from the receiver's shared-IDP "
+            f"validator, got {reason!r}: {exc!r}"
         )
         return
-    pytest.fail("unonboarded primary-realm user unexpectedly crossed the allowlist")
+    pytest.fail("non-shared token unexpectedly crossed receiver authentication")
 
 
 def _require_prerequisite(config: pytest.Config, condition: bool, message: str) -> None:
@@ -111,6 +119,30 @@ def _require_prerequisite(config: pytest.Config, condition: bool, message: str) 
     if config.getoption("require_federation_edge"):
         pytest.fail(message, pytrace=False)
     pytest.skip(message)
+
+
+def _required_initial_tuples(
+    dataset_urn: str,
+    *,
+    job_executor: bool,
+) -> list[dict[str, str]]:
+    """Fixture-scoped retrieval authority plus one explicit job submitter."""
+    tuples = [
+        {
+            "subject": "user:{{user_id}}",
+            "relation": "viewer",
+            "object": f"dataset:{dataset_urn}",
+        }
+    ]
+    if job_executor:
+        tuples.append(
+            {
+                "subject": "user:{{user_id}}",
+                "relation": "executor",
+                "object": "cluster_jobs:__all__",
+            }
+        )
+    return tuples
 
 
 def _assert_terminal_mesh_job(result: Any, expected_marker: str) -> None:
@@ -192,13 +224,14 @@ def _shared_realm(config: pytest.Config) -> dict[str, str]:
 
 
 def _persona_auth(config: pytest.Config) -> dict:
-    """Normal initiator-login config for clearance-bearing local personas."""
+    """Shared-realm ROPC config for clearance-bearing personas."""
+    client_id = os.getenv("SHARED_REALM_CLIENT_ID", "").strip()
     password = os.getenv("FED_PERSONA_PASSWORD", "").strip()
     _require_prerequisite(
         config,
-        bool(password),
-        "FED_PERSONA_PASSWORD not set — the initiator primary-realm personas "
-        "must log in through the normal platform password flow",
+        bool(client_id and password),
+        "SHARED_REALM_CLIENT_ID / FED_PERSONA_PASSWORD not set — the personas "
+        "need a shared-realm ROPC token with the `clearance` claim",
     )
     verify = os.getenv("KAMIWAZA_VERIFY_SSL", "1").strip().lower() not in {
         "0",
@@ -207,6 +240,8 @@ def _persona_auth(config: pytest.Config) -> dict:
         "off",
     }
     return {
+        "client_id": client_id,
+        "client_secret": os.getenv("SHARED_REALM_CLIENT_SECRET", "").strip() or None,
         "password": password,
         "verify": verify,
     }
@@ -240,6 +275,104 @@ def _receiver_prereqs(pytestconfig: pytest.Config) -> _EdgePrerequisites:
     )
 
 
+def _cleanup_brokered_persona(
+    receiver: Any, federation_id: str, external_id: str
+) -> None:
+    """Revoke the exact temporary allowlist row and cancel its active jobs."""
+    encoded_external_id = quote(external_id, safe="")
+    receiver._request(
+        "POST",
+        f"/cluster/federations/{federation_id}/users/{encoded_external_id}/revoke",
+        params={"cancel_in_flight_jobs": "true"},
+    )
+
+
+def _programmatic_persona_session(
+    base_url: str,
+    auth: dict[str, Any],
+    username: str,
+) -> dict[str, Any]:
+    """Create a direct shared-realm session and prove one real refresh grant."""
+    config = SharedIdpAuthConfig(
+        issuer=auth["issuer"],
+        client_id=auth["client_id"],
+        client_secret=auth["client_secret"],
+        username=username,
+        password=auth["password"],
+        verify=auth["verify"],
+    )
+    token_store = InMemoryTokenStore()
+    authenticator = SharedIdpAuthenticator(config, token_store=token_store)
+    client = KamiwazaClient(
+        base_url=base_url,
+        authenticator=authenticator,
+        verify=auth["verify"],
+    )
+    authenticator.authenticate(client.session)
+    authenticator.refresh_token(client.session)
+    token = authenticator.get_access_token(client.session)
+    assert token, "shared-IDP refresh produced no access token"
+    assert token_store.load() is not None
+    assert token_store.load().refresh_token  # type: ignore[union-attr]
+    return {
+        "client": client,
+        "authenticator": authenticator,
+        "token": token,
+    }
+
+
+def _active_persona_session(persona: dict[str, Any]) -> tuple[Any, str]:
+    client = persona["client"]
+    token = persona["authenticator"].get_access_token(client.session)
+    assert token, "shared-IDP persona has no current access token"
+    return client, token
+
+
+def _provision_personas(
+    cleanup: ExitStack,
+    initiator_base_url: str,
+    receiver: Any,
+    identifiers: tuple[str, str, str],
+    prerequisites: _EdgePrerequisites,
+) -> dict[str, dict[str, Any]]:
+    federation_id, source_cluster_id, dataset_urn = identifiers
+    auth = prerequisites.persona_auth
+    issuer = prerequisites.shared["shared_issuer_url"]
+    personas: dict[str, dict[str, Any]] = {}
+    for clearance, base in _PERSONAS.items():
+        persona = _programmatic_persona_session(
+            initiator_base_url,
+            {**auth, "issuer": issuer},
+            base,
+        )
+        token = persona["token"]
+        sub = mc.jwt_sub(token) or base
+        external_id = f"{sub}@{source_cluster_id}"
+        receiver._request(
+            "POST",
+            f"/cluster/federations/{federation_id}/users",
+            json={
+                "external_id": external_id,
+                "initial_tuples": _required_initial_tuples(
+                    dataset_urn,
+                    job_executor=clearance == "U",
+                ),
+            },
+        )
+        cleanup.callback(
+            _cleanup_brokered_persona,
+            receiver,
+            federation_id,
+            external_id,
+        )
+        personas[clearance] = {
+            **persona,
+            "external_id": external_id,
+            "sub": sub,
+        }
+    return personas
+
+
 def _wire_required_edge(
     cleanup: ExitStack,
     clients: _EdgeClients,
@@ -257,9 +390,10 @@ def _wire_required_edge(
         prerequisites,
         pair_request.name,
     )
-    personas = provision_primary_personas(
+    personas = _provision_personas(
         cleanup,
-        clients,
+        clients.initiator.base_url,
+        clients.receiver,
         (identities.receiver_federation_id, identities.initiator_cluster_id, urn),
         prerequisites,
     )
@@ -312,8 +446,7 @@ def test_required_mesh_retrieval_returns_exact_post_gate_rows(
     wiring = shared_idp_gated_pair
     initiator = live_kamiwaza_session_client
     name, urn = wiring["name"], wiring["urn"]
-    token = wiring["personas"][clearance]["token"]
-    persona = wiring["personas"][clearance]["client"]
+    persona, token = _active_persona_session(wiring["personas"][clearance])
 
     def _retrieve():
         # Create the retrieval job over the mesh AND drain its gated SSE stream
@@ -332,7 +465,7 @@ def test_required_mesh_job_reaches_receiver_and_returns_marker(
 ) -> None:
     """Run a recoverable job on the receiver and assert its exact payload."""
     wiring = shared_idp_gated_pair
-    persona = wiring["personas"]["U"]["client"]
+    persona, _token = _active_persona_session(wiring["personas"]["U"])
     marker = f"eng10050-{uuid.uuid4().hex}"
     script = (
         "import json\n"
@@ -362,14 +495,14 @@ def test_required_mesh_job_reaches_receiver_and_returns_marker(
     )
 
 
-def test_unonboarded_primary_realm_user_rejected_by_receiver_allowlist(
+def test_native_realm_token_rejected_at_receiver_shared_idp_boundary(
     shared_idp_gated_pair,
+    live_kamiwaza_session_client,
 ) -> None:
-    """A valid primary-realm login still needs receiver-side onboarding."""
+    """A valid initiator-native token must fail receiver shared-IDP auth."""
     selector = quote(shared_idp_gated_pair["name"], safe="")
-    persona = shared_idp_gated_pair["personas"]["unonboarded"]["client"]
-    _assert_receiver_onboarding_rejection(
-        lambda: persona._request(
+    _assert_receiver_auth_rejection(
+        lambda: live_kamiwaza_session_client._request(
             "GET",
             f"/mesh/{selector}/api/cluster/diagnose",
         )

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -16,6 +16,7 @@ import shlex
 import uuid
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable, Iterator
 from urllib.parse import quote
 
@@ -223,7 +224,28 @@ def _shared_realm(config: pytest.Config) -> dict[str, str]:
     return cfg
 
 
-def _persona_auth(config: pytest.Config) -> dict:
+def _shared_idp_verify(
+    shared: dict[str, str],
+    *,
+    platform_verify: bool,
+    temp_root: Path,
+) -> bool | str:
+    """Materialize shared-realm CA content for direct OIDC token requests."""
+    ca_pem = shared.get("shared_ca_pem")
+    if not ca_pem:
+        return platform_verify
+    ca_path = temp_root / "shared-idp-ca.pem"
+    ca_path.write_text(ca_pem, encoding="utf-8")
+    ca_path.chmod(0o600)
+    return str(ca_path)
+
+
+def _persona_auth(
+    config: pytest.Config,
+    *,
+    shared: dict[str, str],
+    temp_root: Path,
+) -> dict:
     """Shared-realm ROPC config for clearance-bearing personas."""
     client_id = os.getenv("SHARED_REALM_CLIENT_ID", "").strip()
     password = os.getenv("FED_PERSONA_PASSWORD", "").strip()
@@ -243,7 +265,12 @@ def _persona_auth(config: pytest.Config) -> dict:
         "client_id": client_id,
         "client_secret": os.getenv("SHARED_REALM_CLIENT_SECRET", "").strip() or None,
         "password": password,
-        "verify": verify,
+        "idp_verify": _shared_idp_verify(
+            shared,
+            platform_verify=verify,
+            temp_root=temp_root,
+        ),
+        "platform_verify": verify,
     }
 
 
@@ -252,7 +279,10 @@ def _fed_name() -> str:
 
 
 @pytest.fixture(scope="module")
-def _receiver_prereqs(pytestconfig: pytest.Config) -> _EdgePrerequisites:
+def _receiver_prereqs(
+    pytestconfig: pytest.Config,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> _EdgePrerequisites:
     wi = mc.wheel_and_index()
     _require_prerequisite(
         pytestconfig,
@@ -266,12 +296,17 @@ def _receiver_prereqs(pytestconfig: pytest.Config) -> _EdgePrerequisites:
         bool(dataset_path),
         "MINI_CLEARANCE_DATASET_PATH not set (receiver fixture file)",
     )
+    shared = _shared_realm(pytestconfig)
     return _EdgePrerequisites(
         wheel_dir=wi[0],
         index_url=wi[1],
         dataset_path=dataset_path,
-        shared=_shared_realm(pytestconfig),
-        persona_auth=_persona_auth(pytestconfig),
+        shared=shared,
+        persona_auth=_persona_auth(
+            pytestconfig,
+            shared=shared,
+            temp_root=tmp_path_factory.mktemp("shared-idp-ca"),
+        ),
     )
 
 
@@ -299,14 +334,14 @@ def _programmatic_persona_session(
         client_secret=auth["client_secret"],
         username=username,
         password=auth["password"],
-        verify=auth["verify"],
+        verify=auth["idp_verify"],
     )
     token_store = InMemoryTokenStore()
     authenticator = SharedIdpAuthenticator(config, token_store=token_store)
     client = KamiwazaClient(
         base_url=base_url,
         authenticator=authenticator,
-        verify=auth["verify"],
+        verify=auth["platform_verify"],
     )
     authenticator.authenticate(client.session)
     authenticator.refresh_token(client.session)
@@ -403,7 +438,7 @@ def _wire_required_edge(
         urn=urn,
         personas=personas,
         shared=prerequisites.shared,
-        verify=bool(prerequisites.persona_auth["verify"]),
+        verify=bool(prerequisites.persona_auth["platform_verify"]),
         source_cluster_id=identities.initiator_cluster_id,
         receiver_cluster_id=identities.receiver_cluster_id,
     )

--- a/tests/unit/test_client_workroom_scope.py
+++ b/tests/unit/test_client_workroom_scope.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import Mock
 
 import pytest
 
@@ -65,6 +66,19 @@ def test_workroom_scope_can_be_used_as_context_manager() -> None:
 
     assert calls[0]["headers"]["X-Workroom-Id"] == "wr-ctx"
     assert closed == [True]
+
+
+def test_workroom_scope_does_not_close_parent_authenticator() -> None:
+    parent = _recording_client()
+    authenticator = Mock()
+    parent.authenticator = authenticator
+
+    with parent.workroom_scope("wr-ctx"):
+        pass
+
+    authenticator.close.assert_not_called()
+    parent.close()
+    authenticator.close.assert_called_once_with()
 
 
 def test_per_request_workroom_header_overrides_scoped_default() -> None:

--- a/tests/unit/test_shared_idp_authentication.py
+++ b/tests/unit/test_shared_idp_authentication.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import stat
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from kamiwaza_sdk.exceptions import AuthenticationError
+from kamiwaza_sdk.shared_idp_authentication import (
+    SharedIdpAuthConfig,
+    SharedIdpAuthenticator,
+    shared_idp_token_path,
+)
+from kamiwaza_sdk.token_store import FileTokenStore, InMemoryTokenStore, StoredToken
+
+pytestmark = pytest.mark.unit
+
+
+class StubResponse:
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict[str, Any] | None = None,
+        *,
+        invalid_json: bool = False,
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self._invalid_json = invalid_json
+
+    def json(self) -> dict[str, Any]:
+        if self._invalid_json:
+            raise requests.exceptions.JSONDecodeError("invalid", "", 0)
+        return self._payload or {}
+
+
+def _config(**overrides: Any) -> SharedIdpAuthConfig:
+    values: dict[str, Any] = {
+        "issuer": "https://shared.example/realms/federation",
+        "client_id": "kamiwaza-federation",
+        "username": "fed-clr-s",
+        "password": "test-password",
+        "verify": "/tmp/test-ca.pem",
+        "timeout_seconds": 12.0,
+    }
+    values.update(overrides)
+    return SharedIdpAuthConfig(**values)
+
+
+def _token_response(
+    access_token: str,
+    refresh_token: str | None,
+    *,
+    expires_in: int = 300,
+) -> StubResponse:
+    payload = {
+        "access_token": access_token,
+        "expires_in": expires_in,
+        "refresh_token": refresh_token,
+        "token_type": "Bearer",
+    }
+    return StubResponse(200, payload)
+
+
+def _authenticator(
+    responses: list[StubResponse | Exception],
+    *,
+    config: SharedIdpAuthConfig | None = None,
+    token_store: InMemoryTokenStore | FileTokenStore | None = None,
+) -> tuple[SharedIdpAuthenticator, Mock]:
+    http = Mock(spec=requests.Session)
+    http.post.side_effect = responses
+    authenticator = SharedIdpAuthenticator(
+        config or _config(),
+        token_store=token_store or InMemoryTokenStore(),
+        http_session=http,
+    )
+    return authenticator, http
+
+
+def test_password_grant_is_direct_and_fully_programmatic() -> None:
+    store = InMemoryTokenStore()
+    authenticator, http = _authenticator(
+        [_token_response("access-1", "refresh-1")],
+        token_store=store,
+    )
+    platform_session = requests.Session()
+
+    authenticator.authenticate(platform_session)
+
+    http.post.assert_called_once_with(
+        "https://shared.example/realms/federation/protocol/openid-connect/token",
+        data={
+            "grant_type": "password",
+            "client_id": "kamiwaza-federation",
+            "username": "fed-clr-s",
+            "password": "test-password",
+            "scope": "openid",
+        },
+        timeout=12.0,
+        verify="/tmp/test-ca.pem",
+    )
+    assert platform_session.headers["Authorization"] == "Bearer access-1"
+    assert platform_session.cookies.get("access_token") is None
+    assert store.load() is not None
+    assert store.load().refresh_token == "refresh-1"  # type: ignore[union-attr]
+
+
+def test_valid_cached_token_avoids_network_authentication() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="cached-access",
+            refresh_token="cached-refresh",
+            expires_at=time.time() + 300,
+        )
+    )
+    authenticator, http = _authenticator([], token_store=store)
+    platform_session = requests.Session()
+
+    authenticator.authenticate(platform_session)
+
+    assert platform_session.headers["Authorization"] == "Bearer cached-access"
+    http.post.assert_not_called()
+
+
+def test_expired_cached_access_token_refreshes_and_rotates_automatically() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="expired-access",
+            refresh_token="refresh-1",
+            expires_at=time.time() - 1,
+        )
+    )
+    authenticator, http = _authenticator(
+        [_token_response("access-2", "refresh-2")],
+        token_store=store,
+    )
+    platform_session = requests.Session()
+
+    authenticator.authenticate(platform_session)
+
+    http.post.assert_called_once_with(
+        "https://shared.example/realms/federation/protocol/openid-connect/token",
+        data={
+            "grant_type": "refresh_token",
+            "client_id": "kamiwaza-federation",
+            "refresh_token": "refresh-1",
+        },
+        timeout=12.0,
+        verify="/tmp/test-ca.pem",
+    )
+    assert platform_session.headers["Authorization"] == "Bearer access-2"
+    assert store.load() is not None
+    assert store.load().refresh_token == "refresh-2"  # type: ignore[union-attr]
+
+
+def test_explicit_refresh_reuses_refresh_token_when_provider_does_not_rotate() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="access-1",
+            refresh_token="refresh-1",
+            expires_at=time.time() + 300,
+        )
+    )
+    authenticator, _http = _authenticator(
+        [_token_response("access-2", None)],
+        token_store=store,
+    )
+    platform_session = requests.Session()
+
+    authenticator.refresh_token(platform_session)
+
+    assert platform_session.headers["Authorization"] == "Bearer access-2"
+    assert store.load() is not None
+    assert store.load().refresh_token == "refresh-1"  # type: ignore[union-attr]
+
+
+def test_invalid_refresh_token_performs_one_password_regrant() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="expired-access",
+            refresh_token="revoked-refresh",
+            expires_at=time.time() - 1,
+        )
+    )
+    invalid_grant = StubResponse(
+        400,
+        {"error": "invalid_grant", "error_description": "Session not active"},
+    )
+    authenticator, http = _authenticator(
+        [invalid_grant, _token_response("access-2", "refresh-2")],
+        token_store=store,
+    )
+
+    authenticator.authenticate(requests.Session())
+
+    assert http.post.call_count == 2
+    assert http.post.call_args_list[1].kwargs["data"]["grant_type"] == "password"
+    assert store.load() is not None
+    assert store.load().access_token == "access-2"  # type: ignore[union-attr]
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        requests.ConnectionError("issuer unavailable"),
+        StubResponse(503, {"error": "temporarily_unavailable"}),
+        StubResponse(502, invalid_json=True),
+    ],
+)
+def test_refresh_transport_or_server_failure_does_not_password_regrant(
+    failure: StubResponse | Exception,
+) -> None:
+    store = InMemoryTokenStore()
+    cached = StoredToken(
+        access_token="expired-access",
+        refresh_token="refresh-1",
+        expires_at=time.time() - 1,
+    )
+    store.save(cached)
+    authenticator, http = _authenticator([failure], token_store=store)
+
+    with pytest.raises(AuthenticationError):
+        authenticator.authenticate(requests.Session())
+
+    assert http.post.call_count == 1
+    assert store.load() == cached
+
+
+def test_initial_password_grant_requires_refresh_token() -> None:
+    authenticator, _http = _authenticator(
+        [_token_response("access-only", None)],
+    )
+
+    with pytest.raises(AuthenticationError, match="refresh token"):
+        authenticator.authenticate(requests.Session())
+
+
+def test_malformed_success_response_is_a_typed_authentication_failure() -> None:
+    authenticator, _http = _authenticator(
+        [StubResponse(200, {"expires_in": 300, "refresh_token": "refresh-1"})],
+    )
+
+    with pytest.raises(AuthenticationError, match="invalid token response"):
+        authenticator.authenticate(requests.Session())
+
+
+def test_non_json_success_response_is_a_typed_authentication_failure() -> None:
+    authenticator, _http = _authenticator(
+        [StubResponse(200, invalid_json=True)],
+    )
+
+    with pytest.raises(AuthenticationError, match="invalid JSON"):
+        authenticator.authenticate(requests.Session())
+
+
+def test_invalidation_retains_refresh_and_get_access_token_renews() -> None:
+    authenticator, http = _authenticator(
+        [
+            _token_response("access-1", "refresh-1"),
+            _token_response("access-2", "refresh-2"),
+        ],
+    )
+    platform_session = requests.Session()
+    authenticator.authenticate(platform_session)
+
+    assert authenticator.invalidate_session(platform_session) is True
+    assert "Authorization" not in platform_session.headers
+    assert authenticator.get_access_token(platform_session) == "access-2"
+    assert http.post.call_args_list[-1].kwargs["data"]["grant_type"] == "refresh_token"
+
+
+def test_empty_access_token_is_rejected() -> None:
+    authenticator, _http = _authenticator(
+        [_token_response("", "refresh-1")],
+    )
+
+    with pytest.raises(AuthenticationError, match="access token is unavailable"):
+        authenticator.authenticate(requests.Session())
+
+
+def test_token_cache_path_is_scoped_by_issuer_client_and_username(
+    tmp_path: Path,
+) -> None:
+    base = _config()
+    identities = [
+        base,
+        _config(issuer="https://other.example/realms/federation"),
+        _config(client_id="other-client"),
+        _config(username="fed-clr-u"),
+    ]
+
+    paths = {shared_idp_token_path(identity, root=tmp_path) for identity in identities}
+
+    assert len(paths) == 4
+    assert all(path.parent == tmp_path for path in paths)
+
+
+def test_default_scoped_file_store_is_private(tmp_path: Path) -> None:
+    config = _config(token_root=tmp_path)
+    http = Mock(spec=requests.Session)
+    http.post.return_value = _token_response("access-1", "refresh-1")
+    authenticator = SharedIdpAuthenticator(
+        config,
+        http_session=http,
+    )
+
+    authenticator.authenticate(requests.Session())
+
+    token_path = shared_idp_token_path(config, root=tmp_path)
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(token_path.parent.stat().st_mode) == 0o700
+
+
+def test_client_secret_is_sent_only_to_the_oidc_token_endpoint() -> None:
+    config = _config(client_secret="client-secret")
+    authenticator, http = _authenticator(
+        [_token_response("access-1", "refresh-1")],
+        config=config,
+    )
+    platform_session = requests.Session()
+
+    authenticator.authenticate(platform_session)
+
+    assert http.post.call_args.kwargs["data"]["client_secret"] == "client-secret"
+    assert "client_secret" not in platform_session.headers
+    assert platform_session.headers["Authorization"] == "Bearer access-1"
+
+
+def test_configuration_repr_never_discloses_password_or_client_secret() -> None:
+    config = _config(client_secret="client-secret")
+
+    rendered = repr(config)
+
+    assert "test-password" not in rendered
+    assert "client-secret" not in rendered

--- a/tests/unit/test_shared_idp_authentication.py
+++ b/tests/unit/test_shared_idp_authentication.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock
 import pytest
 import requests
 
+from kamiwaza_sdk.client import KamiwazaClient
 from kamiwaza_sdk.exceptions import AuthenticationError
 from kamiwaza_sdk.shared_idp_authentication import (
     SharedIdpAuthConfig,
@@ -31,6 +32,8 @@ class StubResponse:
         self.status_code = status_code
         self._payload = payload
         self._invalid_json = invalid_json
+        self.headers = {"content-type": "application/json"}
+        self.text = ""
 
     def json(self) -> dict[str, Any]:
         if self._invalid_json:
@@ -103,6 +106,7 @@ def test_password_grant_is_direct_and_fully_programmatic() -> None:
         },
         timeout=12.0,
         verify="/tmp/test-ca.pem",
+        allow_redirects=False,
     )
     assert platform_session.headers["Authorization"] == "Bearer access-1"
     assert platform_session.cookies.get("access_token") is None
@@ -154,10 +158,75 @@ def test_expired_cached_access_token_refreshes_and_rotates_automatically() -> No
         },
         timeout=12.0,
         verify="/tmp/test-ca.pem",
+        allow_redirects=False,
     )
     assert platform_session.headers["Authorization"] == "Bearer access-2"
     assert store.load() is not None
     assert store.load().refresh_token == "refresh-2"  # type: ignore[union-attr]
+
+
+def test_shared_file_cache_reloads_refresh_rotation_before_reuse(
+    tmp_path: Path,
+) -> None:
+    token_path = tmp_path / "shared-token.json"
+    first_store = FileTokenStore(token_path)
+    first_store.save(
+        StoredToken(
+            access_token="expired-access",
+            refresh_token="refresh-1",
+            expires_at=time.time() - 1,
+        )
+    )
+    first, _first_http = _authenticator(
+        [_token_response("access-2", "refresh-2")],
+        token_store=first_store,
+    )
+    second, second_http = _authenticator(
+        [],
+        token_store=FileTokenStore(token_path),
+    )
+
+    first.authenticate(requests.Session())
+    second_session = requests.Session()
+    second.authenticate(second_session)
+
+    assert second_session.headers["Authorization"] == "Bearer access-2"
+    second_http.post.assert_not_called()
+
+
+def test_shared_file_cache_reloads_access_rotation_when_refresh_is_reused(
+    tmp_path: Path,
+) -> None:
+    token_path = tmp_path / "shared-token.json"
+    first_store = FileTokenStore(token_path)
+    expired_at = time.time() - 1
+    first_store.save(
+        StoredToken(
+            access_token="expired-access",
+            refresh_token="refresh-1",
+            expires_at=expired_at,
+        )
+    )
+    first, _first_http = _authenticator(
+        [_token_response("access-2", None)],
+        token_store=first_store,
+    )
+    second, second_http = _authenticator(
+        [],
+        token_store=FileTokenStore(token_path),
+    )
+    assert second._current_token() == StoredToken(
+        access_token="expired-access",
+        refresh_token="refresh-1",
+        expires_at=expired_at,
+    )
+
+    first.authenticate(requests.Session())
+    second_session = requests.Session()
+    second.authenticate(second_session)
+
+    assert second_session.headers["Authorization"] == "Bearer access-2"
+    second_http.post.assert_not_called()
 
 
 def test_explicit_refresh_reuses_refresh_token_when_provider_does_not_rotate() -> None:
@@ -197,6 +266,7 @@ def test_invalid_refresh_token_performs_one_password_regrant() -> None:
     )
     authenticator, http = _authenticator(
         [invalid_grant, _token_response("access-2", "refresh-2")],
+        config=_config(password_regrant_on_invalid_grant=True),
         token_store=store,
     )
 
@@ -206,6 +276,68 @@ def test_invalid_refresh_token_performs_one_password_regrant() -> None:
     assert http.post.call_args_list[1].kwargs["data"]["grant_type"] == "password"
     assert store.load() is not None
     assert store.load().access_token == "access-2"  # type: ignore[union-attr]
+
+
+def test_invalid_refresh_token_is_not_silently_regranted_by_default() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="expired-access",
+            refresh_token="revoked-refresh",
+            expires_at=time.time() - 1,
+        )
+    )
+    invalid_grant = StubResponse(
+        400,
+        {"error": "invalid_grant", "error_description": "Session not active"},
+    )
+    authenticator, http = _authenticator(
+        [invalid_grant, invalid_grant], token_store=store
+    )
+
+    with pytest.raises(AuthenticationError, match="Session not active"):
+        authenticator.authenticate(requests.Session())
+    with pytest.raises(AuthenticationError, match="Session not active"):
+        authenticator.authenticate(requests.Session())
+
+    assert http.post.call_count == 2
+    assert store.load() is not None
+    assert store.load().refresh_token == "revoked-refresh"  # type: ignore[union-attr]
+
+
+def test_client_refreshes_and_retries_one_unauthorized_request() -> None:
+    authenticator, oidc_http = _authenticator(
+        [
+            _token_response("access-1", "refresh-1"),
+            _token_response("access-2", "refresh-2"),
+        ]
+    )
+    client = KamiwazaClient(
+        base_url="https://cluster.example/api",
+        authenticator=authenticator,
+    )
+    platform_responses = iter(
+        [
+            StubResponse(401, {"detail": "expired"}),
+            StubResponse(200, {"ok": True}),
+        ]
+    )
+    authorization_headers: list[str | None] = []
+
+    def request(_method: str, _url: str, **_kwargs: Any) -> StubResponse:
+        authorization_headers.append(client.session.headers.get("Authorization"))
+        return next(platform_responses)
+
+    client.session.request = request  # type: ignore[method-assign]
+
+    assert client.get("/mesh/resource") == {"ok": True}
+    assert authorization_headers == ["Bearer access-1", "Bearer access-2"]
+    assert [
+        call.kwargs["data"]["grant_type"] for call in oidc_http.post.call_args_list
+    ] == [
+        "password",
+        "refresh_token",
+    ]
 
 
 @pytest.mark.parametrize(
@@ -262,6 +394,17 @@ def test_non_json_success_response_is_a_typed_authentication_failure() -> None:
         authenticator.authenticate(requests.Session())
 
 
+def test_token_grant_refuses_redirects_before_replaying_credentials() -> None:
+    authenticator, http = _authenticator(
+        [StubResponse(307, {"location": "http://attacker.example/token"})],
+    )
+
+    with pytest.raises(AuthenticationError, match="redirect"):
+        authenticator.authenticate(requests.Session())
+
+    assert http.post.call_args.kwargs["allow_redirects"] is False
+
+
 def test_invalidation_retains_refresh_and_get_access_token_renews() -> None:
     authenticator, http = _authenticator(
         [
@@ -304,8 +447,36 @@ def test_token_cache_path_is_scoped_by_issuer_client_and_username(
     assert all(path.parent == tmp_path for path in paths)
 
 
-def test_default_scoped_file_store_is_private(tmp_path: Path) -> None:
-    config = _config(token_root=tmp_path)
+def test_token_cache_path_is_scoped_by_normalized_oauth_scope(tmp_path: Path) -> None:
+    openid = shared_idp_token_path(_config(scope="openid"), root=tmp_path)
+    offline = shared_idp_token_path(
+        _config(scope="openid offline_access"), root=tmp_path
+    )
+    reordered = shared_idp_token_path(
+        _config(scope="offline_access   openid"), root=tmp_path
+    )
+
+    assert openid != offline
+    assert offline == reordered
+
+
+def test_plain_http_issuer_is_rejected_without_explicit_dev_override() -> None:
+    with pytest.raises(ValueError, match="HTTPS"):
+        _config(issuer="http://shared.example/realms/federation")
+
+
+def test_plain_http_issuer_requires_explicit_dev_override() -> None:
+    config = _config(
+        issuer="http://shared.example/realms/federation",
+        allow_insecure_http=True,
+    )
+
+    assert config.normalized_issuer == "http://shared.example/realms/federation"
+
+
+def test_new_custom_scoped_file_store_is_private(tmp_path: Path) -> None:
+    token_root = tmp_path / "new-cache"
+    config = _config(token_root=token_root)
     http = Mock(spec=requests.Session)
     http.post.return_value = _token_response("access-1", "refresh-1")
     authenticator = SharedIdpAuthenticator(
@@ -315,9 +486,56 @@ def test_default_scoped_file_store_is_private(tmp_path: Path) -> None:
 
     authenticator.authenticate(requests.Session())
 
-    token_path = shared_idp_token_path(config, root=tmp_path)
+    token_path = shared_idp_token_path(config, root=token_root)
     assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
     assert stat.S_IMODE(token_path.parent.stat().st_mode) == 0o700
+
+
+def test_existing_custom_token_root_permissions_are_not_changed(tmp_path: Path) -> None:
+    token_root = tmp_path / "caller-managed-cache"
+    token_root.mkdir(mode=0o755)
+    token_root.chmod(0o755)
+
+    SharedIdpAuthenticator(
+        _config(token_root=token_root),
+        http_session=Mock(spec=requests.Session),
+    )
+
+    assert stat.S_IMODE(token_root.stat().st_mode) == 0o755
+
+
+def test_client_close_releases_internally_owned_oidc_session() -> None:
+    authenticator = SharedIdpAuthenticator(
+        _config(),
+        token_store=InMemoryTokenStore(),
+    )
+    close_oidc = Mock()
+    authenticator._http.close = close_oidc
+    client = KamiwazaClient(
+        base_url="https://cluster.example/api",
+        authenticator=authenticator,
+    )
+
+    client.close()
+
+    close_oidc.assert_called_once_with()
+
+
+def test_client_close_preserves_caller_owned_oidc_session() -> None:
+    oidc_http = Mock(spec=requests.Session)
+    authenticator = SharedIdpAuthenticator(
+        _config(),
+        token_store=InMemoryTokenStore(),
+        http_session=oidc_http,
+    )
+    client = KamiwazaClient(
+        base_url="https://cluster.example/api",
+        authenticator=authenticator,
+    )
+
+    client.close()
+
+    oidc_http.close.assert_not_called()
 
 
 def test_client_secret_is_sent_only_to_the_oidc_token_endpoint() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -918,6 +918,7 @@ version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "filelock" },
     { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "kamiwaza-extensions-lib" },
@@ -983,6 +984,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'publish'", specifier = ">=1.28.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "fastapi", marker = "extra == 'connector'", specifier = ">=0.100.0" },
+    { name = "filelock", specifier = ">=3.20" },
     { name = "httpx" },
     { name = "huggingface-hub", specifier = ">=0.23" },
     { name = "kamiwaza-extensions-lib", editable = "kamiwaza_extensions_lib" },


### PR DESCRIPTION
## Summary
- add a programmatic shared-IDP password-grant authenticator with automatic refresh-token rotation
- keep refresh state in the configured token store and retry one request after an authorization failure
- restore the independently owned shared-realm exact-five validation lane on the release SDK base

## Validation
- 57 change-surface tests passed
- Ruff lint and format checks passed
- targeted mypy passed
- complexity and diff checks passed
- live release/1.2.0 validation on spark-3/spark-4 passed all five required shared-IDP cases, including gated mesh retrieval and receiver-provenance mesh job execution

## Target
`release/1.2.0`

## Tracking
[ENG-10307](https://linear.app/kamiwaza/issue/ENG-10307)
