### PR TITLE
fix(auth): close shared-IDP session races (ENG-10307)

### DIFF
--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -249,7 +249,8 @@ class KamiwazaClient:
         self._auth_service = AuthService(self)
 
         self.authenticator: Optional[Authenticator] = None
-        if authenticator:
+        self._owned_authenticator: Optional[Authenticator] = None
+        if authenticator is not None:
             self.authenticator = authenticator
         else:
             api_key = (
@@ -258,7 +259,8 @@ class KamiwazaClient:
                 or os.environ.get("KAMIWAZA_API_TOKEN")
             )
             self.authenticator = ApiKeyAuthenticator(api_key) if api_key else None
-        self._owns_authenticator = self.authenticator is not None
+            self._owned_authenticator = self.authenticator
+        self._owns_authenticator = self._owned_authenticator is not None
 
         # Don't authenticate during initialization - let it happen on first request
 
@@ -268,7 +270,7 @@ class KamiwazaClient:
         Idempotent — repeated close() calls are safe (Session.close()
         does its own idempotency).
         """
-        close_authenticator = getattr(self.authenticator, "close", None)
+        close_authenticator = getattr(self._owned_authenticator, "close", None)
         try:
             if self._owns_authenticator and callable(close_authenticator):
                 close_authenticator()
@@ -668,6 +670,7 @@ class KamiwazaClient:
         )
         # Preserve exact parent auth state; __init__ may otherwise consult env vars.
         scoped.authenticator = self.authenticator
+        scoped._owned_authenticator = None
         scoped._owns_authenticator = False
         scoped.session.headers.update(self.session.headers)
         scoped.session.cookies.update(self.session.cookies)

--- a/kamiwaza_sdk/shared_idp_authentication.py
+++ b/kamiwaza_sdk/shared_idp_authentication.py
@@ -8,6 +8,7 @@ import time
 from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
+from threading import RLock
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -122,27 +123,42 @@ class SharedIdpAuthenticator(Authenticator):
         )
         self._owns_http_session = http_session is None
         self._http = http_session if http_session is not None else requests.Session()
+        self._refresh_lock = RLock()
         self._access_token: str | None = None
         self._refresh_token: str | None = None
         self._expires_at: float | None = None
+        self._invalidated_token: StoredToken | None = None
         self._load_cached_token()
 
     def authenticate(self, session: requests.Session) -> None:
         """Attach a valid bearer token, refreshing it proactively."""
-        if self._needs_refresh():
-            self.refresh_token(session)
-            return
-        self._attach_access_token(session)
+        with self._refresh_lock:
+            if not self._needs_refresh():
+                self._attach_access_token(session)
+                return
+        self._refresh_session(session, force=False)
 
     def refresh_token(self, session: requests.Session) -> None:
         """Refresh the shared-realm token or perform a programmatic login."""
-        with self._refresh_guard():
-            self._refresh_token_locked(session)
+        self._refresh_session(session, force=True)
 
-    def _refresh_token_locked(self, session: requests.Session) -> None:
+    def _refresh_session(self, session: requests.Session, *, force: bool) -> None:
+        with self._refresh_lock:
+            with self._refresh_guard():
+                self._refresh_token_locked(session, force=force)
+
+    def _refresh_token_locked(
+        self,
+        session: requests.Session,
+        *,
+        force: bool,
+    ) -> None:
         """Refresh while holding the shared file-cache lock, when configured."""
-        known_token = self._current_token()
+        known_token = self._current_token() or self._invalidated_token
         if self._adopt_updated_cached_token(known_token, session):
+            return
+        if not force and not self._needs_refresh():
+            self._attach_access_token(session)
             return
 
         refresh_token = self._refresh_token
@@ -202,14 +218,19 @@ class SharedIdpAuthenticator(Authenticator):
 
     def get_access_token(self, session: requests.Session) -> str | None:
         """Return a current bearer token for callers that need token access."""
-        self.authenticate(session)
-        return self._access_token
+        with self._refresh_lock:
+            self.authenticate(session)
+            return self._access_token
 
     def invalidate_session(self, session: requests.Session) -> bool:
         """Expire the access token while retaining refresh capability."""
-        self._access_token = None
-        self._expires_at = None
-        session.headers.pop("Authorization", None)
+        with self._refresh_lock:
+            current_token = self._current_token()
+            if current_token is not None:
+                self._invalidated_token = current_token
+            self._access_token = None
+            self._expires_at = None
+            session.headers.pop("Authorization", None)
         return True
 
     def close(self) -> None:
@@ -317,9 +338,7 @@ class SharedIdpAuthenticator(Authenticator):
             expires_at=expires_at,
         )
         self.token_store.save(stored)
-        self._access_token = stored.access_token
-        self._refresh_token = stored.refresh_token
-        self._expires_at = stored.expires_at
+        self._apply_cached_token(stored)
 
     def _attach_access_token(self, session: requests.Session) -> None:
         if not self._access_token:
@@ -332,6 +351,7 @@ class SharedIdpAuthenticator(Authenticator):
         self._access_token = None
         self._refresh_token = None
         self._expires_at = None
+        self._invalidated_token = None
         self.token_store.clear()
 
     def _load_cached_token(self) -> None:
@@ -344,3 +364,4 @@ class SharedIdpAuthenticator(Authenticator):
         self._access_token = cached.access_token
         self._refresh_token = cached.refresh_token
         self._expires_at = cached.expires_at
+        self._invalidated_token = None

--- a/tests/integration/test_federation_required_edge_contract.py
+++ b/tests/integration/test_federation_required_edge_contract.py
@@ -1,7 +1,7 @@
 """ENG-10050: Offline contract for the required shared-IDP smoke edge."""
 
-from pathlib import Path
 import stat
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -19,6 +19,16 @@ except ImportError:  # exact-parent RED: the required-edge plugin does not exist
     required_setup = SimpleNamespace()
 
 pytestmark = pytest.mark.unit
+
+_EXPECTED_REQUIRED_EDGE_CASES = frozenset(
+    {
+        "test_required_mesh_retrieval_returns_exact_post_gate_rows[U]",
+        "test_required_mesh_retrieval_returns_exact_post_gate_rows[S]",
+        "test_required_mesh_retrieval_returns_exact_post_gate_rows[TS]",
+        "test_required_mesh_job_reaches_receiver_and_returns_marker",
+        "test_native_realm_token_rejected_at_receiver_shared_idp_boundary",
+    }
+)
 
 
 def _required_item(nodeid: str) -> SimpleNamespace:
@@ -54,9 +64,26 @@ def test_required_edge_plugin_is_registered_only_at_pytest_root() -> None:
 
 
 def test_required_edge_collection_guard_requires_all_five_cases() -> None:
+    assert len(_EXPECTED_REQUIRED_EDGE_CASES) == 5
+    assert required_edge.REQUIRED_EDGE_CASES == _EXPECTED_REQUIRED_EDGE_CASES
+    assert edge._PERSONAS == {
+        "U": "fed-clr-u",
+        "S": "fed-clr-s",
+        "TS": "fed-clr-ts",
+    }
+    retrieval_marks = [
+        mark
+        for mark in edge.test_required_mesh_retrieval_returns_exact_post_gate_rows.pytestmark
+        if mark.name == "parametrize"
+    ]
+    assert len(retrieval_marks) == 1
+    assert retrieval_marks[0].args == ("clearance", ["U", "S", "TS"])
+    assert retrieval_marks[0].kwargs == {}
+    case_functions = {case.partition("[")[0] for case in _EXPECTED_REQUIRED_EDGE_CASES}
+    assert all(callable(getattr(edge, name, None)) for name in case_functions)
     items = [
         _required_item(f"tests/integration/{required_edge.REQUIRED_EDGE_FILE}::{case}")
-        for case in required_edge.REQUIRED_EDGE_CASES
+        for case in _EXPECTED_REQUIRED_EDGE_CASES
     ]
 
     required_edge.assert_required_cases(items)

--- a/tests/unit/test_client_workroom_scope.py
+++ b/tests/unit/test_client_workroom_scope.py
@@ -68,17 +68,20 @@ def test_workroom_scope_can_be_used_as_context_manager() -> None:
     assert closed == [True]
 
 
-def test_workroom_scope_does_not_close_parent_authenticator() -> None:
-    parent = _recording_client()
+def test_workroom_scope_and_parent_preserve_caller_authenticator() -> None:
     authenticator = Mock()
-    parent.authenticator = authenticator
+    parent = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=authenticator,
+        verify=False,
+    )
 
     with parent.workroom_scope("wr-ctx"):
         pass
 
     authenticator.close.assert_not_called()
     parent.close()
-    authenticator.close.assert_called_once_with()
+    authenticator.close.assert_not_called()
 
 
 def test_per_request_workroom_header_overrides_scoped_default() -> None:

--- a/tests/unit/test_shared_idp_authentication.py
+++ b/tests/unit/test_shared_idp_authentication.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import stat
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier, Event, Lock
 from typing import Any
 from unittest.mock import Mock
 
@@ -163,6 +165,242 @@ def test_expired_cached_access_token_refreshes_and_rotates_automatically() -> No
     assert platform_session.headers["Authorization"] == "Bearer access-2"
     assert store.load() is not None
     assert store.load().refresh_token == "refresh-2"  # type: ignore[union-attr]
+
+
+def test_concurrent_in_memory_refresh_issues_one_rotating_grant() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="expired-access",
+            refresh_token="refresh-1",
+            expires_at=time.time() - 1,
+        )
+    )
+    http = Mock(spec=requests.Session)
+    first_grant_started = Event()
+    release_first_grant = Event()
+    second_started = Event()
+    second_finished = Event()
+    grant_lock = Lock()
+    grant_numbers: list[int] = []
+
+    def post(*_args: Any, **_kwargs: Any) -> StubResponse:
+        with grant_lock:
+            grant_number = len(grant_numbers) + 1
+            grant_numbers.append(grant_number)
+        if grant_number == 1:
+            first_grant_started.set()
+            if not release_first_grant.wait(timeout=2):
+                raise AssertionError("test did not release the first token grant")
+        return _token_response(f"access-{grant_number}", f"refresh-{grant_number + 1}")
+
+    http.post.side_effect = post
+    authenticator = SharedIdpAuthenticator(
+        _config(),
+        token_store=store,
+        http_session=http,
+    )
+    first_session = requests.Session()
+    second_session = requests.Session()
+
+    def authenticate_second() -> None:
+        second_started.set()
+        authenticator.authenticate(second_session)
+        second_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first = executor.submit(authenticator.authenticate, first_session)
+        assert first_grant_started.wait(timeout=1)
+        second = executor.submit(authenticate_second)
+        assert second_started.wait(timeout=1)
+        try:
+            assert not second_finished.wait(timeout=0.1)
+        finally:
+            release_first_grant.set()
+        first.result(timeout=1)
+        second.result(timeout=1)
+
+    assert grant_numbers == [1]
+    assert first_session.headers["Authorization"] == "Bearer access-1"
+    assert second_session.headers["Authorization"] == "Bearer access-1"
+
+
+def test_proactive_refresh_rechecks_freshness_after_lock_contention() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="expired-access",
+            refresh_token="refresh-1",
+            expires_at=time.time() - 1,
+        )
+    )
+    authenticator, http = _authenticator(
+        [
+            _token_response("access-2", "refresh-2"),
+            AssertionError("fresh token was refreshed again"),
+        ],
+        token_store=store,
+    )
+    refresh_callers = Barrier(2)
+    original_refresh_session = authenticator._refresh_session
+
+    def synchronized_refresh(session: requests.Session, *, force: bool) -> None:
+        if not force:
+            refresh_callers.wait(timeout=1)
+        original_refresh_session(session, force=force)
+
+    authenticator._refresh_session = synchronized_refresh  # type: ignore[method-assign]
+    sessions = [requests.Session(), requests.Session()]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(authenticator.authenticate, sessions))
+
+    http.post.assert_called_once()
+    assert {session.headers["Authorization"] for session in sessions} == {
+        "Bearer access-2"
+    }
+
+
+def test_invalidation_waits_for_in_flight_refresh_to_attach() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="expired-access",
+            refresh_token="refresh-1",
+            expires_at=time.time() - 1,
+        )
+    )
+    authenticator, _http = _authenticator(
+        [_token_response("access-2", "refresh-2")],
+        token_store=store,
+    )
+    response_stored = Event()
+    release_attach = Event()
+    invalidation_started = Event()
+    invalidation_finished = Event()
+    original_store_response = authenticator._store_response
+
+    def store_response(response: Any, *, previous_refresh: str | None) -> None:
+        original_store_response(response, previous_refresh=previous_refresh)
+        response_stored.set()
+        if not release_attach.wait(timeout=2):
+            raise AssertionError("test did not release the token attachment")
+
+    authenticator._store_response = store_response  # type: ignore[method-assign]
+    refresh_session = requests.Session()
+    rejected_session = requests.Session()
+    rejected_session.headers["Authorization"] = "Bearer expired-access"
+
+    def invalidate() -> None:
+        invalidation_started.set()
+        authenticator.invalidate_session(rejected_session)
+        invalidation_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        refresh = executor.submit(authenticator.authenticate, refresh_session)
+        assert response_stored.wait(timeout=1)
+        invalidation = executor.submit(invalidate)
+        assert invalidation_started.wait(timeout=1)
+        try:
+            assert not invalidation_finished.wait(timeout=0.1)
+        finally:
+            release_attach.set()
+        refresh.result(timeout=1)
+        invalidation.result(timeout=1)
+
+    assert refresh_session.headers["Authorization"] == "Bearer access-2"
+    assert "Authorization" not in rejected_session.headers
+
+
+def test_invalidation_waits_for_valid_token_attachment() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="access-1",
+            refresh_token="refresh-1",
+            expires_at=time.time() + 300,
+        )
+    )
+    authenticator, _http = _authenticator([], token_store=store)
+    token_checked = Event()
+    release_attach = Event()
+    invalidation_started = Event()
+    invalidation_finished = Event()
+    original_needs_refresh = authenticator._needs_refresh
+
+    def paused_needs_refresh() -> bool:
+        needs_refresh = original_needs_refresh()
+        token_checked.set()
+        if not release_attach.wait(timeout=2):
+            raise AssertionError("test did not release valid-token attachment")
+        return needs_refresh
+
+    authenticator._needs_refresh = paused_needs_refresh  # type: ignore[method-assign]
+    attached_session = requests.Session()
+    rejected_session = requests.Session()
+
+    def invalidate() -> None:
+        invalidation_started.set()
+        authenticator.invalidate_session(rejected_session)
+        invalidation_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        attach = executor.submit(authenticator.authenticate, attached_session)
+        assert token_checked.wait(timeout=1)
+        invalidation = executor.submit(invalidate)
+        assert invalidation_started.wait(timeout=1)
+        try:
+            assert not invalidation_finished.wait(timeout=0.1)
+        finally:
+            release_attach.set()
+        attach.result(timeout=1)
+        invalidation.result(timeout=1)
+
+    assert attached_session.headers["Authorization"] == "Bearer access-1"
+
+
+def test_get_access_token_returns_before_concurrent_invalidation() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="access-1",
+            refresh_token="refresh-1",
+            expires_at=time.time() + 300,
+        )
+    )
+    authenticator, _http = _authenticator([], token_store=store)
+    authentication_finished = Event()
+    release_return = Event()
+    invalidation_started = Event()
+    invalidation_finished = Event()
+    original_authenticate = authenticator.authenticate
+
+    def paused_authenticate(session: requests.Session) -> None:
+        original_authenticate(session)
+        authentication_finished.set()
+        if not release_return.wait(timeout=2):
+            raise AssertionError("test did not release access-token return")
+
+    authenticator.authenticate = paused_authenticate  # type: ignore[method-assign]
+    token_session = requests.Session()
+    rejected_session = requests.Session()
+
+    def invalidate() -> None:
+        invalidation_started.set()
+        authenticator.invalidate_session(rejected_session)
+        invalidation_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        read_token = executor.submit(authenticator.get_access_token, token_session)
+        assert authentication_finished.wait(timeout=1)
+        invalidation = executor.submit(invalidate)
+        assert invalidation_started.wait(timeout=1)
+        try:
+            assert not invalidation_finished.wait(timeout=0.1)
+        finally:
+            release_return.set()
+        assert read_token.result(timeout=1) == "access-1"
+        invalidation.result(timeout=1)
 
 
 def test_shared_file_cache_reloads_refresh_rotation_before_reuse(
@@ -421,6 +659,38 @@ def test_invalidation_retains_refresh_and_get_access_token_renews() -> None:
     assert http.post.call_args_list[-1].kwargs["data"]["grant_type"] == "refresh_token"
 
 
+def test_invalidation_adopts_peer_rotated_cached_token_without_replay(
+    tmp_path: Path,
+) -> None:
+    token_path = tmp_path / "shared-token.json"
+    FileTokenStore(token_path).save(
+        StoredToken(
+            access_token="access-1",
+            refresh_token="refresh-1",
+            expires_at=time.time() + 300,
+        )
+    )
+    authenticator, http = _authenticator(
+        [AssertionError("stale refresh token was replayed")],
+        token_store=FileTokenStore(token_path),
+    )
+    platform_session = requests.Session()
+    authenticator.authenticate(platform_session)
+    FileTokenStore(token_path).save(
+        StoredToken(
+            access_token="access-2",
+            refresh_token="refresh-2",
+            expires_at=time.time() + 300,
+        )
+    )
+
+    authenticator.invalidate_session(platform_session)
+
+    assert authenticator.get_access_token(platform_session) == "access-2"
+    assert platform_session.headers["Authorization"] == "Bearer access-2"
+    http.post.assert_not_called()
+
+
 def test_empty_access_token_is_rejected() -> None:
     authenticator, _http = _authenticator(
         [_token_response("", "refresh-1")],
@@ -504,7 +774,7 @@ def test_existing_custom_token_root_permissions_are_not_changed(tmp_path: Path) 
     assert stat.S_IMODE(token_root.stat().st_mode) == 0o755
 
 
-def test_client_close_releases_internally_owned_oidc_session() -> None:
+def test_client_close_preserves_caller_supplied_authenticator() -> None:
     authenticator = SharedIdpAuthenticator(
         _config(),
         token_store=InMemoryTokenStore(),
@@ -518,7 +788,22 @@ def test_client_close_releases_internally_owned_oidc_session() -> None:
 
     client.close()
 
-    close_oidc.assert_called_once_with()
+    close_oidc.assert_not_called()
+
+
+def test_client_close_does_not_assume_ownership_after_authenticator_replacement() -> (
+    None
+):
+    client = KamiwazaClient(
+        base_url="https://cluster.example/api",
+        api_key="initial-api-key",
+    )
+    replacement = Mock()
+    client.authenticator = replacement
+
+    client.close()
+
+    replacement.close.assert_not_called()
 
 
 def test_client_close_preserves_caller_owned_oidc_session() -> None:


### PR DESCRIPTION
## Outcome

Correct the shared-IDP session defects admitted when SDK #264 merged into `release/1.2.0` at `8a03fe0f` despite an exact-head changes-requested review.

- Prevent an invalidated client from replaying a stale refresh token after a peer rotates the shared file cache.
- Coalesce concurrent proactive refreshes so one authenticator issues one rotating grant.
- Serialize valid-token attachment, access-token return, refresh, and invalidation within an authenticator.
- Preserve caller ownership of injected authenticators; client and workroom-scope teardown no longer close them.
- Pin the required federation edge to five literal cases and the actual U/S/TS parametrization.

## Implementation

`SharedIdpAuthenticator` now uses an in-process reentrant refresh lock. A contending proactive caller rechecks freshness inside the lock before issuing a grant. File-backed authenticators retain the existing cross-process file lock, and invalidation preserves the prior token identity long enough to adopt a different peer-rotated cache entry.

`KamiwazaClient` separately records only an authenticator it created internally. An injected authenticator remains caller-owned even when the client is closed or cloned into a workroom scope.

The offline required-edge contract no longer derives its expected cases solely from the production constant. It independently pins the five node IDs, the U/S/TS personas, the live test's exact parametrization decorator, and the referenced callables.

## Verification

- Red/green regressions cover stale refresh replay, concurrent duplicate grants, freshness recheck after lock contention, refresh/invalidation overlap, valid-token attachment/invalidation overlap, and access-token return/invalidation overlap.
- Caller-owned authenticator teardown and replacement regressions are covered.
- Focused auth, 401 retry, workroom, and required-edge surface: **140 passed**.
- Ruff, Black, isort, targeted mypy, complexity, and `git diff --check` pass.
- A broader non-live diagnostic completed **3545 passed / 2 skipped**; its only failure was an unrelated fixed-port test while local process `krisp` held port 59128. The focused test passed independently.

## Boundaries

The in-process lock coordinates callers sharing one authenticator. Separate file-backed authenticators continue to coordinate through the existing file lock. Deliberately sharing one `InMemoryTokenStore` across multiple authenticator instances is not a supported cross-instance synchronization mechanism.

This is a release-branch corrective patch, not candidate acceptance. The required two-cluster live edge and the authenticated Kajiya candidate still must pass before the SDK SHA is release-ready.

Linear: [ENG-10307](https://linear.app/kamiwaza/issue/ENG-10307)
