### PR TITLE
fix(auth): close remaining 1.2 session races (ENG-10307)

### DIFF
--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -344,7 +344,7 @@ class KamiwazaClient:
                     kwargs["headers"][key] = value
                     existing.add(key.lower())
 
-        if self.authenticator and not skip_auth:
+        if self.authenticator is not None and not skip_auth:
             self.authenticator.authenticate(self.session)
 
         # Always inject session.verify when the caller hasn't supplied an
@@ -403,7 +403,7 @@ class KamiwazaClient:
         logger.warning(
             f"Received 401 Unauthorized. Response: {_extract_server_detail(response)}"
         )
-        if not self.authenticator:
+        if self.authenticator is None:
             raise AuthenticationError(
                 "Authentication failed. No authenticator provided."
             )
@@ -804,7 +804,7 @@ class KamiwazaClient:
         return self._authz
 
     def get_bearer_token(self) -> Optional[str]:
-        if not self.authenticator:
+        if self.authenticator is None:
             return None
         try:
             return self.authenticator.get_access_token(self.session)

--- a/kamiwaza_sdk/client.py
+++ b/kamiwaza_sdk/client.py
@@ -253,7 +253,8 @@ class KamiwazaClient:
         self._auth_service = AuthService(self)
 
         self.authenticator: Optional[Authenticator] = None
-        if authenticator:
+        self._owned_authenticator: Optional[Authenticator] = None
+        if authenticator is not None:
             self.authenticator = authenticator
         else:
             api_key = (
@@ -262,7 +263,9 @@ class KamiwazaClient:
                 or os.environ.get("KAMIWAZA_API_TOKEN")
             )
             self.authenticator = ApiKeyAuthenticator(api_key) if api_key else None
-        self._owns_authenticator = bool(authenticator and owns_authenticator)
+        if authenticator is not None and owns_authenticator:
+            self._owned_authenticator = authenticator
+        self._owns_authenticator = self._owned_authenticator is not None
 
         # Don't authenticate during initialization - let it happen on first request
 
@@ -272,7 +275,7 @@ class KamiwazaClient:
         Idempotent — repeated close() calls are safe (Session.close()
         does its own idempotency).
         """
-        close_authenticator = getattr(self.authenticator, "close", None)
+        close_authenticator = getattr(self._owned_authenticator, "close", None)
         try:
             if self._owns_authenticator and callable(close_authenticator):
                 close_authenticator()
@@ -672,6 +675,7 @@ class KamiwazaClient:
         )
         # Preserve exact parent auth state; __init__ may otherwise consult env vars.
         scoped.authenticator = self.authenticator
+        scoped._owned_authenticator = None
         scoped._owns_authenticator = False
         scoped.session.headers.update(self.session.headers)
         scoped.session.cookies.update(self.session.cookies)

--- a/kamiwaza_sdk/shared_idp_authentication.py
+++ b/kamiwaza_sdk/shared_idp_authentication.py
@@ -226,13 +226,16 @@ class SharedIdpAuthenticator(Authenticator):
 
     def get_access_token(self, session: requests.Session) -> str | None:
         """Return a current bearer token for callers that need token access."""
-        self.authenticate(session)
-        return self._access_token
+        with self._refresh_lock:
+            self.authenticate(session)
+            return self._access_token
 
     def invalidate_session(self, session: requests.Session) -> bool:
         """Expire the access token while retaining refresh capability."""
         with self._refresh_lock:
-            self._invalidated_token = self._current_token()
+            current_token = self._current_token()
+            if current_token is not None:
+                self._invalidated_token = current_token
             self._access_token = None
             self._expires_at = None
             session.headers.pop("Authorization", None)

--- a/tests/integration/test_federation_required_edge_contract.py
+++ b/tests/integration/test_federation_required_edge_contract.py
@@ -35,6 +35,17 @@ def _required_item(nodeid: str) -> SimpleNamespace:
     )
 
 
+def _assert_live_retrieval_parametrization() -> None:
+    retrieval_marks = [
+        mark
+        for mark in edge.test_required_mesh_retrieval_returns_exact_post_gate_rows.pytestmark
+        if mark.name == "parametrize"
+    ]
+    assert len(retrieval_marks) == 1
+    assert retrieval_marks[0].args == ("clearance", ["U", "S", "TS"])
+    assert retrieval_marks[0].kwargs == {}
+
+
 def test_required_edge_carries_owned_shared_realm_capability_markers() -> None:
     marker_names = {marker.name for marker in edge.pytestmark}
 
@@ -63,14 +74,7 @@ def test_required_edge_collection_guard_requires_all_five_cases() -> None:
     }
     assert required_edge.REQUIRED_EDGE_CASES == expected_cases
     assert len(required_edge.REQUIRED_EDGE_CASES) == 5
-    retrieval_marks = [
-        mark
-        for mark in edge.test_required_mesh_retrieval_returns_exact_post_gate_rows.pytestmark
-        if mark.name == "parametrize"
-    ]
-    assert len(retrieval_marks) == 1
-    assert retrieval_marks[0].args == ("clearance", ["U", "S", "TS"])
-    assert retrieval_marks[0].kwargs == {}
+    _assert_live_retrieval_parametrization()
     for case in expected_cases:
         function_name = case.split("[", 1)[0]
         assert callable(getattr(edge, function_name, None)), case

--- a/tests/integration/test_federation_required_edge_contract.py
+++ b/tests/integration/test_federation_required_edge_contract.py
@@ -63,6 +63,14 @@ def test_required_edge_collection_guard_requires_all_five_cases() -> None:
     }
     assert required_edge.REQUIRED_EDGE_CASES == expected_cases
     assert len(required_edge.REQUIRED_EDGE_CASES) == 5
+    retrieval_marks = [
+        mark
+        for mark in edge.test_required_mesh_retrieval_returns_exact_post_gate_rows.pytestmark
+        if mark.name == "parametrize"
+    ]
+    assert len(retrieval_marks) == 1
+    assert retrieval_marks[0].args == ("clearance", ["U", "S", "TS"])
+    assert retrieval_marks[0].kwargs == {}
     for case in expected_cases:
         function_name = case.split("[", 1)[0]
         assert callable(getattr(edge, function_name, None)), case
@@ -75,6 +83,16 @@ def test_required_edge_collection_guard_requires_all_five_cases() -> None:
 
     with pytest.raises(pytest.UsageError, match="missing contract cases"):
         required_edge.assert_required_cases(items[:-1])
+
+
+def test_required_edge_collection_guard_inspects_live_parametrization(
+    monkeypatch,
+) -> None:
+    retrieval = edge.test_required_mesh_retrieval_returns_exact_post_gate_rows
+    monkeypatch.setattr(retrieval, "pytestmark", [])
+
+    with pytest.raises(AssertionError):
+        test_required_edge_collection_guard_requires_all_five_cases()
 
 
 def test_required_edge_post_selection_guard_rejects_deselection_and_extras() -> None:

--- a/tests/unit/test_client_workroom_scope.py
+++ b/tests/unit/test_client_workroom_scope.py
@@ -68,6 +68,27 @@ def test_workroom_scope_can_be_used_as_context_manager() -> None:
     assert closed == [True]
 
 
+def test_falsey_supplied_authenticator_is_preserved(monkeypatch) -> None:
+    class FalseyAuthenticator:
+        def __bool__(self) -> bool:
+            return False
+
+        def authenticate(self, _session) -> None:
+            pass
+
+    monkeypatch.delenv("KAMIWAZA_API_KEY", raising=False)
+    monkeypatch.delenv("KAMIWAZA_API_TOKEN", raising=False)
+    authenticator = FalseyAuthenticator()
+
+    client = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=authenticator,
+        verify=False,
+    )
+
+    assert client.authenticator is authenticator
+
+
 def test_workroom_scope_does_not_close_parent_authenticator() -> None:
     authenticator = Mock()
     parent = KamiwazaClient(
@@ -83,6 +104,23 @@ def test_workroom_scope_does_not_close_parent_authenticator() -> None:
     authenticator.close.assert_not_called()
     parent.close()
     authenticator.close.assert_called_once_with()
+
+
+def test_client_closes_owned_authenticator_after_public_replacement() -> None:
+    owned = Mock()
+    replacement = Mock()
+    client = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=owned,
+        owns_authenticator=True,
+        verify=False,
+    )
+    client.authenticator = replacement
+
+    client.close()
+
+    owned.close.assert_called_once_with()
+    replacement.close.assert_not_called()
 
 
 def test_per_request_workroom_header_overrides_scoped_default() -> None:

--- a/tests/unit/test_client_workroom_scope.py
+++ b/tests/unit/test_client_workroom_scope.py
@@ -4,7 +4,9 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+import requests
 
+from kamiwaza_sdk.authentication import Authenticator
 from kamiwaza_sdk.client import KamiwazaClient
 
 pytestmark = pytest.mark.unit
@@ -19,6 +21,37 @@ class _JSONResponse:
         return {"ok": True}
 
 
+class _UnauthorizedResponse:
+    status_code = 401
+    headers = {"content-type": "application/json"}
+    text = '{"detail": "token expired"}'
+
+    def json(self) -> dict[str, str]:
+        return {"detail": "token expired"}
+
+
+class _FalseyAuthenticator(Authenticator):
+    def __init__(self) -> None:
+        self.authenticate_calls = 0
+        self.access_token_calls = 0
+        self.refresh_calls = 0
+
+    def __bool__(self) -> bool:
+        return False
+
+    def authenticate(self, session: requests.Session) -> None:
+        self.authenticate_calls += 1
+        session.headers["Authorization"] = "Bearer falsey-token"
+
+    def refresh_token(self, session: requests.Session) -> None:
+        self.refresh_calls += 1
+        session.headers["Authorization"] = "Bearer refreshed-token"
+
+    def get_access_token(self, session: requests.Session) -> str:
+        self.access_token_calls += 1
+        return "falsey-token"
+
+
 def _recording_client(workroom_id: str | None = None) -> KamiwazaClient:
     client = KamiwazaClient(
         base_url="https://example.test/api",
@@ -26,6 +59,20 @@ def _recording_client(workroom_id: str | None = None) -> KamiwazaClient:
         verify=False,
     )
     return client.workroom_scope(workroom_id) if workroom_id is not None else client
+
+
+def _falsey_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[KamiwazaClient, _FalseyAuthenticator]:
+    monkeypatch.delenv("KAMIWAZA_API_KEY", raising=False)
+    monkeypatch.delenv("KAMIWAZA_API_TOKEN", raising=False)
+    authenticator = _FalseyAuthenticator()
+    client = KamiwazaClient(
+        base_url="https://example.test/api",
+        authenticator=authenticator,
+        verify=False,
+    )
+    return client, authenticator
 
 
 def _record_requests(client: KamiwazaClient) -> list[dict[str, Any]]:
@@ -68,25 +115,34 @@ def test_workroom_scope_can_be_used_as_context_manager() -> None:
     assert closed == [True]
 
 
-def test_falsey_supplied_authenticator_is_preserved(monkeypatch) -> None:
-    class FalseyAuthenticator:
-        def __bool__(self) -> bool:
-            return False
+def test_falsey_supplied_authenticator_authenticates_requests(monkeypatch) -> None:
+    client, authenticator = _falsey_client(monkeypatch)
+    _record_requests(client)
 
-        def authenticate(self, _session) -> None:
-            pass
-
-    monkeypatch.delenv("KAMIWAZA_API_KEY", raising=False)
-    monkeypatch.delenv("KAMIWAZA_API_TOKEN", raising=False)
-    authenticator = FalseyAuthenticator()
-
-    client = KamiwazaClient(
-        base_url="https://example.test/api",
-        authenticator=authenticator,
-        verify=False,
-    )
+    client.get("/context/health")
 
     assert client.authenticator is authenticator
+    assert authenticator.authenticate_calls == 1
+    assert client.session.headers["Authorization"] == "Bearer falsey-token"
+
+
+def test_falsey_supplied_authenticator_returns_bearer(monkeypatch) -> None:
+    client, authenticator = _falsey_client(monkeypatch)
+
+    assert client.get_bearer_token() == "falsey-token"
+    assert authenticator.access_token_calls == 1
+
+
+def test_falsey_supplied_authenticator_refreshes_after_401(monkeypatch) -> None:
+    client, authenticator = _falsey_client(monkeypatch)
+    request = Mock(side_effect=[_UnauthorizedResponse(), _JSONResponse()])
+    client.session.request = request
+
+    assert client.get("/context/health") == {"ok": True}
+    assert authenticator.authenticate_calls == 1
+    assert authenticator.refresh_calls == 1
+    assert client.session.headers["Authorization"] == "Bearer refreshed-token"
+    assert request.call_count == 2
 
 
 def test_workroom_scope_does_not_close_parent_authenticator() -> None:

--- a/tests/unit/test_shared_idp_authentication.py
+++ b/tests/unit/test_shared_idp_authentication.py
@@ -582,6 +582,81 @@ def test_invalidation_retains_refresh_and_get_access_token_renews() -> None:
     assert http.post.call_args_list[-1].kwargs["data"]["grant_type"] == "refresh_token"
 
 
+def test_get_access_token_returns_before_concurrent_invalidation() -> None:
+    store = InMemoryTokenStore()
+    store.save(
+        StoredToken(
+            access_token="access-1",
+            refresh_token="refresh-1",
+            expires_at=time.time() + 300,
+        )
+    )
+    authenticator, _http = _authenticator([], token_store=store)
+    authentication_finished = threading.Event()
+    release_return = threading.Event()
+    invalidation_started = threading.Event()
+    invalidation_finished = threading.Event()
+    original_authenticate = authenticator.authenticate
+
+    def paused_authenticate(session: requests.Session) -> None:
+        original_authenticate(session)
+        authentication_finished.set()
+        assert release_return.wait(timeout=2)
+
+    authenticator.authenticate = paused_authenticate  # type: ignore[method-assign]
+    token_session = requests.Session()
+    rejected_session = requests.Session()
+
+    def invalidate() -> None:
+        invalidation_started.set()
+        authenticator.invalidate_session(rejected_session)
+        invalidation_finished.set()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        read_token = executor.submit(authenticator.get_access_token, token_session)
+        assert authentication_finished.wait(timeout=1)
+        invalidation = executor.submit(invalidate)
+        assert invalidation_started.wait(timeout=1)
+        try:
+            assert not invalidation_finished.wait(timeout=0.1)
+        finally:
+            release_return.set()
+        assert read_token.result(timeout=1) == "access-1"
+        invalidation.result(timeout=1)
+
+
+def test_repeated_invalidation_preserves_token_identity_for_peer_adoption(
+    tmp_path: Path,
+) -> None:
+    token_path = tmp_path / "shared-token.json"
+    FileTokenStore(token_path).save(
+        StoredToken(
+            access_token="access-1",
+            refresh_token="refresh-1",
+            expires_at=time.time() + 300,
+        )
+    )
+    authenticator, http = _authenticator(
+        [AssertionError("stale refresh token was replayed")],
+        token_store=FileTokenStore(token_path),
+    )
+    platform_session = requests.Session()
+
+    authenticator.invalidate_session(platform_session)
+    FileTokenStore(token_path).save(
+        StoredToken(
+            access_token="access-2",
+            refresh_token="refresh-2",
+            expires_at=time.time() + 300,
+        )
+    )
+    authenticator.invalidate_session(platform_session)
+
+    assert authenticator.get_access_token(platform_session) == "access-2"
+    assert platform_session.headers["Authorization"] == "Bearer access-2"
+    http.post.assert_not_called()
+
+
 def test_access_token_inside_refresh_leeway_is_refreshed(monkeypatch) -> None:
     now = 1_000.0
     monkeypatch.setattr(shared_auth.time, "time", lambda: now)


### PR DESCRIPTION
## Outcome

Close the remaining shared-IDP session races and client-ownership gaps on top of the already-merged release fix in SDK #265.

- Return a current access token atomically with respect to concurrent invalidation.
- Preserve the last real token identity across repeated invalidation so a file-backed authenticator can adopt a peer-rotated cache entry instead of replaying stale refresh state.
- Keep ownership bound to the originally owned authenticator even if public client state is replaced; workroom scopes remain non-owning.
- Treat a supplied authenticator by identity rather than truthiness in construction, request authentication, 401 refresh, and bearer retrieval.
- Make the required federation edge inspect the live U/S/TS parametrization instead of only a duplicated case constant.

## Scope

This branch is a two-commit child of the exact `release/1.2.0` merge for SDK #265 (`326a38ef86597229647d17d7abc039f7f78a61b1`). It changes only the SDK client/authenticator implementation and the directly corresponding release-contract tests. It does not replace or revert the refresh coordination already merged in #265.

The in-process reentrant lock serializes callers sharing one authenticator. Separate file-backed authenticators continue to coordinate through the existing file lock. Deliberately sharing one in-memory token store across multiple authenticator instances remains outside the supported cross-instance contract.

## Verification

- Red/green regressions cover access-token return versus invalidation, repeated invalidation followed by peer-cache adoption, and all three falsey-authenticator execution paths.
- Focused auth, 401 retry, workroom, and required-edge surface: **91 passed**.
- Broader non-integration/non-live/non-e2e suite: **3,564 passed, 2 skipped, 294 deselected**. One unchanged environment-sensitive fixed-port assertion was explicitly deselected because local process `krisp` owns its hard-coded port 59128.
- Ruff, Black on all changed files, targeted mypy, changed-function complexity, and `git diff --check` pass.
- Independent review found no remaining behavioral or test-quality defect in this diff.

## Release boundary

This is release-branch source remediation, not candidate acceptance. Exact-head hosted checks and human approval are required before merge. The required two-cluster shared-IDP edge and authenticated Kajiya candidate still must pass before this SDK SHA is release-ready.

Linear: [ENG-10307](https://linear.app/kamiwaza/issue/ENG-10307)
