### PR TITLE
ENG-10399: Run strip-thinking live workflow sequentially

### DIFF
--- a/tests/integration/test_serving_workflow.py
+++ b/tests/integration/test_serving_workflow.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from model_targets import InferenceTarget
 
 from kamiwaza_sdk.exceptions import APIError
 from kamiwaza_sdk.schemas.models.model import CreateModelConfig
-from model_targets import InferenceTarget
 
 pytestmark = [pytest.mark.integration, pytest.mark.live, pytest.mark.withoutresponses]
 
@@ -32,6 +32,30 @@ def _sample_logs(client, deployment_id):
         return []
 
 
+def _wait_and_infer(client, deployment_id):
+    details = client.serving.wait_for_deployment(
+        deployment_id,
+        poll_interval=5,
+        timeout=WAIT_TIMEOUT,
+    )
+    assert details.instances, "Deployment should report instances"
+    _sample_logs(client, deployment_id)
+
+    openai_client = client.openai.get_client(deployment_id=deployment_id)
+    response = openai_client.chat.completions.create(
+        model="kamiwaza",
+        messages=[
+            {
+                "role": "user",
+                "content": "Think of 5 good names for a three-legged cat.",
+            }
+        ],
+        temperature=0.6,
+    )
+    assert response.choices, "Deployment returned no choices"
+    return response.choices[0].message.content or ""
+
+
 @pytest.mark.requires_deployable_model
 def test_deploy_qwen_and_infer_with_strip_thinking(
     live_kamiwaza_client,
@@ -42,9 +66,7 @@ def test_deploy_qwen_and_infer_with_strip_thinking(
     client = live_kamiwaza_client
     model = ensure_deployable_model_ready(client)
 
-    model_file_id = target_model_file_id(
-        model, deployable_model_target.quantization
-    )
+    model_file_id = target_model_file_id(model, deployable_model_target.quantization)
 
     configs = client.models.get_model_configs(model.id)
     if not configs:
@@ -65,8 +87,6 @@ def test_deploy_qwen_and_infer_with_strip_thinking(
 
     deployments = []
     try:
-        # wait=False: both deploys are launched back-to-back and the explicit
-        # wait_for_deployment calls below own the WAIT_TIMEOUT budget.
         default_deployment = client.serving.deploy_model(
             model_id=str(model.id),
             m_config_id=default_config.id,
@@ -79,6 +99,17 @@ def test_deploy_qwen_and_infer_with_strip_thinking(
             wait=False,
         )
         deployments.append(default_deployment)
+
+        default_text = _wait_and_infer(client, default_deployment)
+        if "<think>" not in default_text:
+            pytest.skip(
+                "target emits no <think>; strip_thinking unverifiable on this host"
+            )
+        stopped = client.serving.stop_deployment(
+            deployment_id=default_deployment, force=True
+        )
+        assert stopped, "Default deployment should stop before strip deployment"
+        deployments.remove(default_deployment)
 
         strip_deployment = client.serving.deploy_model(
             model_id=str(model.id),
@@ -93,51 +124,10 @@ def test_deploy_qwen_and_infer_with_strip_thinking(
         )
         deployments.append(strip_deployment)
 
-        default_details = client.serving.wait_for_deployment(
-            default_deployment,
-            poll_interval=5,
-            timeout=WAIT_TIMEOUT,
-        )
-        strip_details = client.serving.wait_for_deployment(
-            strip_deployment,
-            poll_interval=5,
-            timeout=WAIT_TIMEOUT,
-        )
-
-        assert default_details.instances, "Default deployment should report instances"
-        assert strip_details.instances, "Strip deployment should report instances"
-
-        _sample_logs(client, default_deployment)
-        _sample_logs(client, strip_deployment)
-
-        default_openai = client.openai.get_client(deployment_id=default_deployment)
-        strip_openai = client.openai.get_client(deployment_id=strip_deployment)
-
-        prompt = [
-            {
-                "role": "user",
-                "content": "Think of 5 good names for a three-legged cat.",
-            }
-        ]
-
-        default_resp = default_openai.chat.completions.create(model="kamiwaza", messages=prompt, temperature=0.6)
-        strip_resp = strip_openai.chat.completions.create(model="kamiwaza", messages=prompt, temperature=0.6)
-
-        assert default_resp.choices, "Default deployment returned no choices"
-        assert strip_resp.choices, "Strip deployment returned no choices"
-
-        default_text = default_resp.choices[0].message.content or ""
-        strip_text = strip_resp.choices[0].message.content or ""
-
-        default_contains = "<think>" in default_text
-        strip_contains = "<think>" in strip_text
-        if not default_contains:
-            pytest.skip(
-                "target emits no <think>; strip_thinking unverifiable on this host"
-            )
-        assert not strip_contains, (
-            "Strip-thinking deployment should remove <think> blocks"
-        )
+        strip_text = _wait_and_infer(client, strip_deployment)
+        assert (
+            "<think>" not in strip_text
+        ), "Strip-thinking deployment should remove <think> blocks"
     finally:
         for dep in deployments:
             try:


### PR DESCRIPTION
## Summary\n\n- run the default and strip-thinking serving checks sequentially\n- stop the default deployment before starting the strip-thinking deployment\n- retain robust cleanup for every deployment that was successfully created\n- preserve the topology-aware skip when the selected model emits no think block\n\nThis test-only change removes the assumption that two model deployments fit on the same live node.\n\n## Dependency and validation order\n\nDepends on Core #2573. Merge and deploy the Core fix first, then run this SDK integration workflow against that build.\n\n## Validation\n\n- integration file collection: 1 test collected\n- Black, isort, and Ruff on the changed file: passed\n- uv build: passed\n- broad suite: 3270 passed, 2 skipped, 1 transient scaffold npm dependency failure, 260 deselected\n- the exact failed scaffold node passed independently on the untouched release base and on this branch\n- repository-wide lint and mypy retain existing production-file failures; none involve the changed integration file\n- git diff --check: passed\n\nNo live cluster mutation was performed while another shared-node diagnostic was active.\n\nLinear: ENG-10399