### PR TITLE
ENG-10050: add mesh dataset discovery to required edge

### DIFF
--- a/docs/services/catalog/README.md
+++ b/docs/services/catalog/README.md
@@ -31,6 +31,9 @@ payload = DatasetCreate(
 dataset_urn = client.catalog.datasets.create(payload)
 dataset = client.catalog.datasets.get(dataset_urn)
 
+# List only datasets the receiver authorizes for this federated identity.
+remote_datasets = client.catalog.datasets.list(target_cluster="receiver-name")
+
 # Update tags/properties via URN
 client.catalog.datasets.update(
     dataset_urn,

--- a/kamiwaza_sdk/services/catalog.py
+++ b/kamiwaza_sdk/services/catalog.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
 from .base_service import BaseService
+from .federation_credentials import federation_credential_headers
+from .jobs_routing import _validate_target_cluster
 from ..exceptions import APIError
 from ..schemas.catalog import (
     Container,
@@ -89,9 +91,23 @@ class DatasetClient(BaseService):
                     return str(value)
         return str(response)
 
-    def list(self, query: Optional[str] = None) -> List[Dataset]:
+    def list(
+        self,
+        query: Optional[str] = None,
+        *,
+        target_cluster: Optional[str] = None,
+    ) -> List[Dataset]:
+        """List local datasets or receiver-authorized datasets through mesh."""
         params = {"query": query} if query else None
-        response = self.client.get(f"{self._BASE_PATH}/", params=params)
+        path = f"{self._BASE_PATH}/"
+        request_kwargs: Dict[str, Any] = {"params": params}
+        if target_cluster is not None:
+            selector = _validate_target_cluster(target_cluster)
+            path = f"/mesh/{quote(selector, safe='')}/api{path}"
+            headers = federation_credential_headers(selector)
+            if headers:
+                request_kwargs["headers"] = headers
+        response = self.client.get(path, **request_kwargs)
         return [Dataset.model_validate(item) for item in response]
 
     def get(self, dataset_urn: str) -> Dataset:

--- a/tests/integration/required_federation_edge.py
+++ b/tests/integration/required_federation_edge.py
@@ -10,6 +10,7 @@ REQUIRED_EDGE_CASES = frozenset(
         "test_required_mesh_retrieval_returns_exact_post_gate_rows[U]",
         "test_required_mesh_retrieval_returns_exact_post_gate_rows[S]",
         "test_required_mesh_retrieval_returns_exact_post_gate_rows[TS]",
+        "test_required_mesh_dataset_list_returns_only_authorized_fixture",
         "test_required_mesh_job_reaches_receiver_and_returns_marker",
         "test_unonboarded_shared_idp_user_rejected_by_receiver_allowlist",
     }

--- a/tests/integration/test_federation_required_edge_contract.py
+++ b/tests/integration/test_federation_required_edge_contract.py
@@ -53,16 +53,17 @@ def test_required_edge_plugin_is_registered_only_at_pytest_root() -> None:
     assert "pytest_plugins" not in integration_conftest
 
 
-def test_required_edge_collection_guard_requires_all_five_cases() -> None:
+def test_required_edge_collection_guard_requires_all_six_cases() -> None:
     expected_cases = {
         "test_required_mesh_retrieval_returns_exact_post_gate_rows[U]",
         "test_required_mesh_retrieval_returns_exact_post_gate_rows[S]",
         "test_required_mesh_retrieval_returns_exact_post_gate_rows[TS]",
+        "test_required_mesh_dataset_list_returns_only_authorized_fixture",
         "test_required_mesh_job_reaches_receiver_and_returns_marker",
         "test_unonboarded_shared_idp_user_rejected_by_receiver_allowlist",
     }
     assert required_edge.REQUIRED_EDGE_CASES == expected_cases
-    assert len(required_edge.REQUIRED_EDGE_CASES) == 5
+    assert len(required_edge.REQUIRED_EDGE_CASES) == 6
     for case in expected_cases:
         function_name = case.split("[", 1)[0]
         assert callable(getattr(edge, function_name, None)), case
@@ -353,6 +354,31 @@ def test_terminal_job_oracle_accepts_exact_receiver_marker() -> None:
     )
 
     edge._assert_terminal_mesh_job(result, "eng10050-exact")
+
+
+def test_required_dataset_list_uses_mesh_and_requires_exact_fixture() -> None:
+    list_datasets = Mock(
+        return_value=[SimpleNamespace(urn="urn:dataset:only-authorized")]
+    )
+    persona = SimpleNamespace(
+        catalog=SimpleNamespace(
+            datasets=SimpleNamespace(list=list_datasets),
+        ),
+        session=object(),
+    )
+    authenticator = Mock()
+    authenticator.get_access_token.return_value = "opaque-test-token"
+    wiring = {
+        "name": "receiver cluster",
+        "urn": "urn:dataset:only-authorized",
+        "personas": {
+            "U": {"client": persona, "authenticator": authenticator},
+        },
+    }
+
+    edge.test_required_mesh_dataset_list_returns_only_authorized_fixture(wiring)
+
+    list_datasets.assert_called_once_with(target_cluster="receiver cluster")
 
 
 def test_required_job_case_runs_recoverably_on_named_peer(monkeypatch) -> None:

--- a/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
+++ b/tests/integration/test_federation_shared_idp_gated_retrieval_live.py
@@ -508,6 +508,22 @@ def test_required_mesh_retrieval_returns_exact_post_gate_rows(
     mc.assert_persona_result(clearance, rows, gate_audit)
 
 
+def test_required_mesh_dataset_list_returns_only_authorized_fixture(
+    shared_idp_gated_pair,
+) -> None:
+    """List receiver datasets through mesh with receiver-local ReBAC filtering."""
+    wiring = shared_idp_gated_pair
+    persona, _token = _active_persona_session(wiring["personas"]["U"])
+
+    datasets = _required_mesh_call(
+        lambda: persona.catalog.datasets.list(
+            target_cluster=wiring["name"],
+        )
+    )
+
+    assert [str(dataset.urn) for dataset in datasets] == [wiring["urn"]]
+
+
 def test_required_mesh_job_reaches_receiver_and_returns_marker(
     shared_idp_gated_pair,
 ) -> None:

--- a/tests/unit/test_catalog_service.py
+++ b/tests/unit/test_catalog_service.py
@@ -9,6 +9,50 @@ from kamiwaza_sdk.services.catalog import CatalogService, ContainerClient, Datas
 pytestmark = pytest.mark.unit
 
 
+_DATASET = {
+    "urn": "urn:li:dataset:(file,mesh-demo,PROD)",
+    "name": "mesh-demo",
+    "platform": "file",
+    "environment": "PROD",
+    "tags": [],
+    "properties": {},
+}
+
+
+def test_dataset_list_routes_to_mesh_target(mock_client, monkeypatch):
+    path = "/mesh/receiver%20edge/api/catalog/datasets/"
+    monkeypatch.setenv(
+        "KAMIWAZA_FEDERATION_CREDENTIAL_RECEIVER_EDGE",
+        "receiver-token",
+    )
+    mock_client.expect("GET", path, [_DATASET])
+
+    datasets = DatasetClient(mock_client).list(
+        query="mesh-demo",
+        target_cluster="receiver edge",
+    )
+
+    assert [dataset.urn for dataset in datasets] == [_DATASET["urn"]]
+    assert mock_client.calls == [
+        (
+            "GET",
+            path,
+            {
+                "params": {"query": "mesh-demo"},
+                "headers": {"X-KZ-Federation-Credential": "receiver-token"},
+            },
+        )
+    ]
+
+
+@pytest.mark.parametrize("target_cluster", ["", " receiver", "receiver/edge", "."])
+def test_dataset_list_rejects_unsafe_mesh_target(mock_client, target_cluster):
+    with pytest.raises(ValueError, match="target_cluster"):
+        DatasetClient(mock_client).list(target_cluster=target_cluster)
+
+    assert mock_client.calls == []
+
+
 def test_catalog_service_create_dataset_roundtrip(dummy_client):
     dataset_response = {
         "urn": "urn:li:dataset:(s3,my,PROD)",


### PR DESCRIPTION
## Summary

- add optional `target_cluster` mesh routing to `client.catalog.datasets.list()`
- attach per-target federation credentials and reuse the jobs selector safety contract
- expand the strict shared-IDP edge from five to six exact cases with receiver-filtered dataset discovery
- document the federated dataset-list call

## Validation

- RED on stock `release/1.2.0`: `DatasetClient.list()` rejected `target_cluster`, while the raw mesh route returned HTTP 403
- `44 passed`: catalog service and required-edge contracts
- strict collection produced exactly six named cases
- Ruff, mypy, radon, and diff checks passed
- Azure fed-a/fed-b with the Core companion hot-loaded: exact 6/6 passed with no skips

## Coordination

- depends on Core companion [kamiwaza#2578](https://github.com/kamiwaza-internal/kamiwaza/pull/2578), which admits only the receiver-filtered dataset-list read
- merge Core first, then this SDK PR
- after both land, update the UAT playbook's stock-release signoff from five to six

## Tracking

- ENG-10050
